### PR TITLE
chore(contracts): re-sync stale business OpenAPI snapshots

### DIFF
--- a/contracts/openapi/activities.json
+++ b/contracts/openapi/activities.json
@@ -9,7 +9,7 @@
       "get": {
         "tags": ["Activities"],
         "summary": "Returns a paginated list of activities matching the query filter.",
-        "description": "Filter by entity (entityType + entityId), assignee (assignedToUserId or 'me'), status (open / done / cancelled), or due-date window (dueAtFrom / dueAtTo, half-open). Ordered by DueAt ascending. Caps page size at ActivitiesEndpointsOptions.MaxPageSize (default 100). Activities pinned to hosts the caller cannot read are filtered out (IActivityHostAuthorizationProvider). Listing peers' activities (assignedToUserId != caller) requires Activities.Activities.ReadOthers.",
+        "description": "Filter by entity (entityType + entityId), assignee (assignedToUserId or 'me'), status (open / done / cancelled), or due-date window (dueAtFrom / dueAtTo, half-open). Ordered by DueAt ascending with page size capped at ActivitiesEndpointsOptions.MaxPageSize (default 100). Activities pinned to hosts the caller cannot read are filtered out by IActivityHostAuthorizationProvider. Listing peers' activities (assignedToUserId != caller) requires Activities.Activities.ReadOthers.",
         "operationId": "ListActivities",
         "parameters": [
           {
@@ -537,6 +537,16 @@
               }
             }
           },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -624,7 +634,7 @@
             "content": {
               "application/problem+json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
                 }
               }
             }
@@ -696,7 +706,7 @@
       "get": {
         "tags": ["Activities"],
         "summary": "Returns activities positioned on the cross-entity calendar within a time window.",
-        "description": "Spans every entity type the caller can read. The window must be <= ActivitiesEndpointsOptions.MaxCalendarRangeDays (default 90 days) and (To > From) — otherwise 400. Filter by assignee ('me' resolves from the JWT 'sub' claim or any string-form Guid), entityType (polymorphic FK), type (comma-separated), or status (defaults to OpenOrOverdue). FusionCache TTL is 1 minute by default; the cache key includes the resolved tenant id, the user permission hash, the window, and every filter. Per-tenant eviction tags drop every cached calendar window when an Activity row changes (handler in this same package). Returns 304 on If-None-Match match.",
+        "description": "Spans every entity type the caller can read. The window must be <= ActivitiesEndpointsOptions.MaxCalendarRangeDays (default 90 days) and To > From — otherwise 400. Filter by assignee ('me' resolves from the JWT 'sub' claim), entityType (polymorphic FK), type (comma-separated), or status (defaults to OpenOrOverdue). Results are cached 1 minute per (tenant, user permission hash, window, filters); per-tenant eviction tags invalidate all windows when an Activity row changes. Returns 304 on If-None-Match match.",
         "operationId": "GetActivityCalendar",
         "parameters": [
           {
@@ -968,6 +978,7 @@
         "type": "object",
         "properties": {
           "entityType": {
+            "maxLength": 256,
             "type": "string"
           },
           "entityId": {
@@ -975,6 +986,7 @@
             "format": "uuid"
           },
           "type": {
+            "maxLength": 64,
             "type": "string"
           },
           "assignedToUserId": {
@@ -986,6 +998,7 @@
             "format": "date-time"
           },
           "description": {
+            "maxLength": 2000,
             "type": ["null", "string"]
           }
         }

--- a/contracts/openapi/analytics.json
+++ b/contracts/openapi/analytics.json
@@ -15,7 +15,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -53,8 +53,8 @@
               }
             }
           },
-          "422": {
-            "description": "Unprocessable Entity",
+          "400": {
+            "description": "Bad Request",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -75,6 +75,16 @@
           },
           "403": {
             "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -706,7 +716,7 @@
             "type": ["null", "string"]
           },
           "color": {
-            "type": ["null", "string"]
+            "description": "A colour expressed as a hex code with a leading `#` and 3, 4, 6 or 8 hex digits\n(`#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`). Trimmed and normalised to\nupper-case. The accepted set matches the framework `Validation:Format:ColorHex` server\nvalidator, so a value that passes endpoint validation is always constructible here. EF Core and\nJSON conversions are applied automatically (`ApplyGranitConventions` /\nSingleValueObjectJsonConverterFactory)."
           },
           "unit": {
             "type": ["null", "string"]

--- a/contracts/openapi/catalog.json
+++ b/contracts/openapi/catalog.json
@@ -62,7 +62,7 @@
       "get": {
         "tags": ["Catalog - Products"],
         "summary": "Returns a product by ID (any lifecycle status).",
-        "description": "Returns the full product details including external mappings and metadata.",
+        "description": "Returns the full product details including external mappings, metadata, and current lifecycle status. Returns 404 if no product with that id exists.",
         "operationId": "GetCatalogProductById",
         "parameters": [
           {
@@ -244,7 +244,7 @@
       "get": {
         "tags": ["Catalog - Products"],
         "summary": "Returns a product by SKU (any lifecycle status).",
-        "description": "Useful for SKU-based reverse lookups during Stripe / Avalara / Odoo integration syncs.",
+        "description": "Returns a product by its unique SKU, regardless of lifecycle status. Useful for reverse lookups during Stripe / Avalara / Odoo integration syncs. Returns 404 if no product with that SKU exists.",
         "operationId": "GetCatalogProductBySku",
         "parameters": [
           {
@@ -734,7 +734,7 @@
       "post": {
         "tags": ["Catalog - Products"],
         "summary": "Archives a Published product.",
-        "description": "Existing references (meters, plan prices) are unaffected; the product becomes unavailable for new attachments.",
+        "description": "Transitions a Published product to Archived, preventing new attachments (meters, plan prices) while keeping existing references valid. Returns 404 if the product does not exist. Returns 409 if the product is not in Published state.",
         "operationId": "ArchiveCatalogProduct",
         "parameters": [
           {
@@ -921,7 +921,7 @@
       "delete": {
         "tags": ["Catalog - Products"],
         "summary": "Removes an external provider mapping from a product.",
-        "description": "Returns 404 if either the product or the mapping does not exist.",
+        "description": "Removes an external provider mapping by its id. Returns 404 if either the product or the mapping does not exist. Idempotent — multiple deletes of the same mapping return 204.",
         "operationId": "RemoveCatalogProductExternalMapping",
         "parameters": [
           {
@@ -1050,9 +1050,11 @@
         "type": "object",
         "properties": {
           "providerName": {
+            "maxLength": 64,
             "type": "string"
           },
           "externalId": {
+            "maxLength": 256,
             "type": "string"
           }
         }
@@ -1541,18 +1543,22 @@
         "type": "object",
         "properties": {
           "sku": {
+            "maxLength": 64,
             "type": "string"
           },
           "name": {
+            "maxLength": 200,
             "type": "string"
           },
           "type": {
             "type": "string"
           },
           "unit": {
+            "maxLength": 64,
             "type": "string"
           },
           "description": {
+            "maxLength": 2000,
             "type": ["null", "string"]
           }
         }
@@ -1643,17 +1649,20 @@
         "enum": ["Service", "Metered", "Physical", "Digital"]
       },
       "ProductUpdateRequest": {
-        "required": ["name", "description", "unit"],
+        "required": ["name", "unit"],
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 200,
+            "type": "string"
+          },
+          "unit": {
+            "maxLength": 64,
             "type": "string"
           },
           "description": {
+            "maxLength": 2000,
             "type": ["null", "string"]
-          },
-          "unit": {
-            "type": "string"
           }
         }
       },

--- a/contracts/openapi/customer-balance.json
+++ b/contracts/openapi/customer-balance.json
@@ -334,7 +334,7 @@
   "components": {
     "schemas": {
       "AdminCreditRequest": {
-        "required": ["partyId", "amount", "currency", "source", "reason", "expiresAt"],
+        "required": ["partyId", "amount", "currency", "source", "reason"],
         "type": "object",
         "properties": {
           "partyId": {
@@ -342,17 +342,22 @@
             "format": "uuid"
           },
           "amount": {
+            "exclusiveMinimum": 0,
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
             "type": ["number", "string"],
             "format": "double"
           },
           "currency": {
+            "maxLength": 3,
+            "minLength": 3,
             "type": "string"
           },
           "source": {
+            "maxLength": 50,
             "type": "string"
           },
           "reason": {
+            "maxLength": 500,
             "type": "string"
           },
           "expiresAt": {
@@ -370,14 +375,18 @@
             "format": "uuid"
           },
           "amount": {
+            "exclusiveMinimum": 0,
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
             "type": ["number", "string"],
             "format": "double"
           },
           "currency": {
+            "maxLength": 3,
+            "minLength": 3,
             "type": "string"
           },
           "reason": {
+            "maxLength": 500,
             "type": "string"
           },
           "referenceId": {
@@ -385,6 +394,7 @@
             "format": "uuid"
           },
           "referenceType": {
+            "maxLength": 64,
             "type": ["null", "string"]
           }
         }

--- a/contracts/openapi/dashboards.json
+++ b/contracts/openapi/dashboards.json
@@ -77,7 +77,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -187,6 +187,16 @@
               }
             }
           },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -199,16 +209,6 @@
           },
           "403": {
             "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -439,6 +439,16 @@
               }
             }
           },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -451,16 +461,6 @@
           },
           "403": {
             "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -895,6 +895,16 @@
               }
             }
           },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -907,16 +917,6 @@
           },
           "403": {
             "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1007,6 +1007,16 @@
               }
             }
           },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -1019,16 +1029,6 @@
           },
           "403": {
             "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1138,33 +1138,42 @@
         "type": "object",
         "properties": {
           "widgetType": {
+            "maxLength": 100,
             "type": "string"
           },
           "position": {
+            "minimum": 0,
             "type": "integer",
             "format": "int32"
           },
           "width": {
+            "exclusiveMinimum": 0,
             "type": "integer",
             "format": "int32"
           },
           "height": {
+            "exclusiveMinimum": 0,
             "type": "integer",
             "format": "int32"
           },
           "titleLocalizationKey": {
+            "maxLength": 200,
             "type": "string"
           },
           "configJson": {
+            "maxLength": 16000,
             "type": "string"
           },
           "metricName": {
+            "maxLength": 200,
             "type": ["null", "string"]
           },
           "queryName": {
+            "maxLength": 200,
             "type": ["null", "string"]
           },
           "requiredPermission": {
+            "maxLength": 200,
             "type": ["null", "string"]
           }
         }
@@ -1310,13 +1319,16 @@
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 200,
             "type": "string"
           },
           "layoutColumns": {
+            "exclusiveMinimum": 0,
             "type": "integer",
             "format": "int32"
           },
           "layoutRowHeight": {
+            "exclusiveMinimum": 0,
             "type": "integer",
             "format": "int32"
           }
@@ -1687,21 +1699,26 @@
         "type": "object",
         "properties": {
           "position": {
+            "minimum": 0,
             "type": "integer",
             "format": "int32"
           },
           "width": {
+            "exclusiveMinimum": 0,
             "type": "integer",
             "format": "int32"
           },
           "height": {
+            "exclusiveMinimum": 0,
             "type": "integer",
             "format": "int32"
           },
           "titleLocalizationKey": {
+            "maxLength": 200,
             "type": "string"
           },
           "configJson": {
+            "maxLength": 16000,
             "type": "string"
           }
         }

--- a/contracts/openapi/documents-public-links.json
+++ b/contracts/openapi/documents-public-links.json
@@ -208,6 +208,16 @@
               }
             }
           },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -355,17 +365,20 @@
   "components": {
     "schemas": {
       "CreatePublicLinkRequest": {
-        "required": ["scope", "ttlDays", "maxUses"],
+        "required": ["scope", "ttlDays"],
         "type": "object",
         "properties": {
           "scope": {
             "$ref": "#/components/schemas/PublicLinkScope"
           },
           "ttlDays": {
+            "maximum": 90,
+            "minimum": 1,
             "type": "integer",
             "format": "int32"
           },
           "maxUses": {
+            "exclusiveMinimum": 0,
             "type": ["null", "integer"],
             "format": "int32"
           }
@@ -511,10 +524,10 @@
         "enum": ["Download", "View"]
       },
       "RevokePublicLinkRequest": {
-        "required": ["reason"],
         "type": "object",
         "properties": {
           "reason": {
+            "maxLength": 500,
             "type": ["null", "string"]
           }
         }

--- a/contracts/openapi/documents-resolution.json
+++ b/contracts/openapi/documents-resolution.json
@@ -158,7 +158,8 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ResolveItemRequest"
-            }
+            },
+            "x-granit-validator": "Validation:Rule:MaxBatchSize"
           }
         }
       },

--- a/contracts/openapi/documents.json
+++ b/contracts/openapi/documents.json
@@ -524,6 +524,16 @@
               }
             }
           },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -1484,6 +1494,16 @@
               "application/problem+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
                 }
               }
             }
@@ -2765,7 +2785,7 @@
   "components": {
     "schemas": {
       "AppendVersionRequest": {
-        "required": ["blobId", "commitMessage"],
+        "required": ["blobId"],
         "type": "object",
         "properties": {
           "blobId": {
@@ -2773,6 +2793,7 @@
             "format": "uuid"
           },
           "commitMessage": {
+            "maxLength": 1000,
             "type": ["null", "string"]
           }
         }
@@ -2817,16 +2838,21 @@
           }
         }
       },
+      "ContentType": {
+        "description": "MIME content type (e.g. `text/html`, `application/pdf`).\nValidates the `type/subtype` format per RFC 6838."
+      },
       "CreateFolderRequest": {
-        "required": ["parentFolderId", "name"],
+        "required": ["name"],
         "type": "object",
         "properties": {
+          "name": {
+            "maxLength": 255,
+            "pattern": "^[^/]+$",
+            "type": "string"
+          },
           "parentFolderId": {
             "type": ["null", "string"],
             "format": "uuid"
-          },
-          "name": {
-            "type": "string"
           }
         }
       },
@@ -2882,7 +2908,14 @@
             "format": "int64"
           },
           "currentVersionContentType": {
-            "type": ["null", "string"]
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ContentType"
+              }
+            ]
           },
           "status": {
             "$ref": "#/components/schemas/DocumentStatus"
@@ -3197,24 +3230,27 @@
         ]
       },
       "FinalizeUploadRequest": {
-        "required": ["blobId", "folderId", "name", "description", "commitMessage"],
+        "required": ["blobId", "name"],
         "type": "object",
         "properties": {
           "blobId": {
             "type": "string",
             "format": "uuid"
           },
+          "name": {
+            "maxLength": 255,
+            "type": "string"
+          },
           "folderId": {
             "type": ["null", "string"],
             "format": "uuid"
           },
-          "name": {
-            "type": "string"
-          },
           "description": {
+            "maxLength": 2000,
             "type": ["null", "string"]
           },
           "commitMessage": {
+            "maxLength": 1000,
             "type": ["null", "string"]
           }
         }
@@ -3514,7 +3550,6 @@
         "default": "QueryEngine"
       },
       "MoveDocumentRequest": {
-        "required": ["newFolderId"],
         "type": "object",
         "properties": {
           "newFolderId": {
@@ -3524,7 +3559,6 @@
         }
       },
       "MoveFolderRequest": {
-        "required": ["newParentFolderId"],
         "type": "object",
         "properties": {
           "newParentFolderId": {
@@ -3570,7 +3604,7 @@
                   "format": "int64"
                 },
                 "currentVersionContentType": {
-                  "type": ["null", "string"]
+                  "description": "MIME content type (e.g. `text/html`, `application/pdf`).\nValidates the `type/subtype` format per RFC 6838."
                 },
                 "status": {
                   "enum": ["Active", "Trashed", "PermanentlyDeleted"]
@@ -3774,13 +3808,14 @@
         }
       },
       "RenameDocumentRequest": {
-        "required": ["name", "description"],
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 255,
             "type": ["null", "string"]
           },
           "description": {
+            "maxLength": 2000,
             "type": ["null", "string"]
           },
           "clearDescription": {
@@ -3794,6 +3829,8 @@
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 255,
+            "pattern": "^[^/]+$",
             "type": "string"
           }
         }
@@ -3959,12 +3996,16 @@
         "type": "object",
         "properties": {
           "fileName": {
+            "maxLength": 500,
             "type": "string"
           },
           "contentType": {
+            "maxLength": 127,
             "type": "string"
           },
           "maxAllowedBytes": {
+            "maximum": 10737418240,
+            "exclusiveMinimum": 0,
             "pattern": "^-?(?:0|[1-9]\\d*)$",
             "type": ["integer", "string"],
             "format": "int64"

--- a/contracts/openapi/entities-customization.json
+++ b/contracts/openapi/entities-customization.json
@@ -51,8 +51,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -61,8 +61,8 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -133,26 +133,6 @@
             "content": {
               "application/problem+json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
                   "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
@@ -160,6 +140,16 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -218,8 +208,8 @@
           "204": {
             "description": "No Content"
           },
-          "403": {
-            "description": "Forbidden",
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -228,8 +218,8 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -284,36 +274,6 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/LayoutDelta"
-            }
-          }
-        }
-      },
-      "HttpValidationProblemDetails": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": ["null", "string"]
-          },
-          "title": {
-            "type": ["null", "string"]
-          },
-          "status": {
-            "type": ["null", "integer"],
-            "format": "int32"
-          },
-          "detail": {
-            "type": ["null", "string"]
-          },
-          "instance": {
-            "type": ["null", "string"]
-          },
-          "errors": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
             }
           }
         }

--- a/contracts/openapi/entities-views.json
+++ b/contracts/openapi/entities-views.json
@@ -8,7 +8,7 @@
     "/entities/{entityName}/views": {
       "get": {
         "tags": ["Entities - Views"],
-        "summary": "Lists every saved view accessible to the current user for the given entity.",
+        "summary": "List every saved view accessible to the current user for the given entity.",
         "description": "Returns Personal views owned by the user, Shared views whose audience targets the user (by role or user id), and every Tenant view in the current tenant. Sorted by SortOrder ascending then Name.",
         "operationId": "ListEntityViews",
         "parameters": [
@@ -36,8 +36,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -46,8 +46,8 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -70,7 +70,7 @@
       },
       "post": {
         "tags": ["Entities - Views"],
-        "summary": "Creates a Personal saved view for the current user.",
+        "summary": "Create a Personal saved view for the current user.",
         "description": "Requires the Entities.Views.Create permission. The created view is owned by the caller and bound to the supplied compiled collection (BasedOn) and kind. Returns 201 with the created descriptor.",
         "operationId": "CreateEntityView",
         "parameters": [
@@ -105,16 +105,6 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -127,6 +117,16 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -161,7 +161,7 @@
     "/entities/{entityName}/views/{id}": {
       "get": {
         "tags": ["Entities - Views"],
-        "summary": "Gets one saved view by id.",
+        "summary": "Get one saved view by id.",
         "description": "Returns 404 when the view does not exist or is not accessible to the current user (defense-in-depth: same response shape, no scope leakage).",
         "operationId": "GetEntityView",
         "parameters": [
@@ -240,10 +240,19 @@
       },
       "put": {
         "tags": ["Entities - Views"],
-        "summary": "Updates the name / description / icon / state of a saved view.",
-        "description": "Requires ownership for Personal / Shared views, or Entities.Views.Manage for Tenant views. BasedOn and Kind are immutable post-creation and rejected if changed.",
+        "summary": "Update the name / description / icon / state of a saved view.",
+        "description": "Requires ownership for Personal / Shared views, or Entities.Views.Manage for Tenant views (enforced in the writer). BasedOn and Kind are immutable post-creation and rejected if changed.",
         "operationId": "UpdateEntityView",
         "parameters": [
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Entity definition name (matches the registered Granit.Entities entity).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "id",
             "in": "path",
@@ -272,16 +281,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EntityViewResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -316,6 +315,16 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "422": {
             "description": "Unprocessable Entity",
             "content": {
@@ -340,10 +349,19 @@
       },
       "delete": {
         "tags": ["Entities - Views"],
-        "summary": "Deletes a saved view.",
-        "description": "The owner can delete their own views; moderation deletes require Entities.Views.DeleteAny. Returns 204 on success.",
+        "summary": "Delete a saved view.",
+        "description": "The owner can delete their own views; moderation deletes require Entities.Views.DeleteAny (enforced in the writer). Returns 204 on success.",
         "operationId": "DeleteEntityView",
         "parameters": [
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Entity definition name (matches the registered Granit.Entities entity).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "id",
             "in": "path",
@@ -359,16 +377,6 @@
           "204": {
             "description": "No Content"
           },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -381,6 +389,16 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -405,7 +423,7 @@
     "/entities/{entityName}/views/_default": {
       "get": {
         "tags": ["Entities - Views"],
-        "summary": "Resolves the user's effective default saved view for the entity.",
+        "summary": "Resolve the user's effective default saved view for the entity.",
         "description": "Precedence per ADR-047 §4: IsPersonalDefault > IsDefault > compiled fallback. Returns 204 when no saved or pinned view exists — the renderer falls back to the compiled default collection.",
         "operationId": "GetEntityDefaultView",
         "parameters": [
@@ -469,10 +487,19 @@
     "/entities/{entityName}/views/{id}/pin": {
       "post": {
         "tags": ["Entities - Views"],
-        "summary": "Pins or unpins a saved view in the workspace tab strip.",
+        "summary": "Pin or unpin a saved view in the workspace tab strip.",
         "description": "Requires Entities.Views.Manage. The pinned flag is independent from IsDefault / IsPersonalDefault.",
         "operationId": "ToggleEntityViewPinned",
         "parameters": [
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Entity definition name (matches the registered Granit.Entities entity).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "id",
             "in": "path",
@@ -505,16 +532,6 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -527,6 +544,16 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -561,10 +588,19 @@
     "/entities/{entityName}/views/{id}/set-default": {
       "post": {
         "tags": ["Entities - Views"],
-        "summary": "Sets or clears the tenant-default flag.",
+        "summary": "Set or clear the tenant-default flag.",
         "description": "Requires Entities.Views.Manage. At most one IsDefault view per (entity, tenant) — setting one clears any existing tenant default.",
         "operationId": "ToggleEntityViewTenantDefault",
         "parameters": [
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Entity definition name (matches the registered Granit.Entities entity).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "id",
             "in": "path",
@@ -597,16 +633,6 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -619,6 +645,16 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -653,10 +689,19 @@
     "/entities/{entityName}/views/{id}/star": {
       "post": {
         "tags": ["Entities - Views"],
-        "summary": "Sets or clears the personal-default flag for the current user.",
+        "summary": "Set or clear the personal-default flag for the current user.",
         "description": "Requires the caller to own the view (group-level Read permission suffices — ownership is enforced in the writer). At most one IsPersonalDefault view per (entity, user) — setting one clears any existing personal default.",
         "operationId": "ToggleEntityViewPersonalDefault",
         "parameters": [
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Entity definition name (matches the registered Granit.Entities entity).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "id",
             "in": "path",
@@ -689,16 +734,6 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -711,6 +746,16 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -745,10 +790,19 @@
     "/entities/{entityName}/views/{id}/share": {
       "post": {
         "tags": ["Entities - Views"],
-        "summary": "Promotes a Personal view to Shared with the given audience.",
+        "summary": "Promote a Personal view to Shared with the given audience.",
         "description": "Requires Entities.Views.Share. The audience must include at least one role or user — empty audiences are rejected.",
         "operationId": "ShareEntityView",
         "parameters": [
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Entity definition name (matches the registered Granit.Entities entity).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "id",
             "in": "path",
@@ -781,16 +835,6 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -813,6 +857,16 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -848,26 +902,31 @@
   "components": {
     "schemas": {
       "EntityViewCreateBodyRequest": {
-        "required": ["basedOn", "kind", "name", "description", "icon", "state"],
+        "required": ["basedOn", "kind", "name", "state"],
         "type": "object",
         "properties": {
           "basedOn": {
+            "maxLength": 128,
             "type": "string"
           },
           "kind": {
+            "maxLength": 64,
             "type": "string"
           },
           "name": {
+            "maxLength": 200,
             "type": "string"
-          },
-          "description": {
-            "type": ["null", "string"]
-          },
-          "icon": {
-            "type": ["null", "string"]
           },
           "state": {
             "$ref": "#/components/schemas/JsonObject"
+          },
+          "description": {
+            "maxLength": 2000,
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "maxLength": 64,
+            "type": ["null", "string"]
           }
         }
       },
@@ -996,20 +1055,23 @@
         }
       },
       "EntityViewUpdateBodyRequest": {
-        "required": ["name", "description", "icon", "state"],
+        "required": ["name", "state"],
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 200,
             "type": "string"
-          },
-          "description": {
-            "type": ["null", "string"]
-          },
-          "icon": {
-            "type": ["null", "string"]
           },
           "state": {
             "$ref": "#/components/schemas/JsonObject"
+          },
+          "description": {
+            "maxLength": 2000,
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "maxLength": 64,
+            "type": ["null", "string"]
           }
         }
       },

--- a/contracts/openapi/entities.json
+++ b/contracts/openapi/entities.json
@@ -65,7 +65,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name of the entity definition.",
             "required": true,
             "schema": {
               "type": "string"
@@ -146,7 +146,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name of the entity definition.",
             "required": true,
             "schema": {
               "type": "string"
@@ -158,7 +158,8 @@
             "description": "Resource identifier (UUID).",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -246,20 +247,20 @@
       "get": {
         "tags": ["Entities"],
         "summary": "Returns calendar items for one entity within a time window.",
-        "description": "Reads the entity's CalendarLayoutDescriptor (selected by the optional ?calendar= name when an entity exposes more than one) and returns the events whose Start/End falls inside [from, to]. The range is enforced server-side: a window wider than 366 days or with To < From is rejected with 400. Permission gate inherited from the underlying entity's Read permission — same defense-in-depth as the manifest endpoint (no calendar-specific permission, rationale: the calendar exposes an aggregate of data the user could already see via the list endpoint). FusionCache TTL is 1 minute by default; the cache key includes the resolved user permission hash plus the From/To window, and the response carries a strong ETag so callers can short-circuit unchanged windows with If-None-Match → 304. Per-entity eviction tags allow the EF Core companion package's CalendarRangeCacheInvalidator<T> to drop every cached window for the entity in one call when one of its rows is created, updated, or deleted (story #1691). Returns an empty list when the entity declares no calendar layout, no item matches, or the host has not yet wired a real ICalendarRangeService implementation.",
+        "description": "Reads the entity's CalendarLayoutDescriptor (selected by the optional ?calendar= name) and returns events whose Start/End falls inside [from, to]. The range is enforced server-side: a window wider than 366 days or with To < From is rejected with 400. Permission gate inherited from the underlying entity's Read permission; response carries a strong ETag so callers can short-circuit with If-None-Match → 304. Returns an empty list when the entity declares no calendar layout, no item falls in range, or the host has not wired a real ICalendarRangeService.",
         "operationId": "GetEntityCalendarRange",
         "parameters": [
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name of the entity definition.",
             "required": true,
             "schema": {
               "type": "string"
             }
           },
           {
-            "name": "From",
+            "name": "from",
             "in": "query",
             "required": true,
             "schema": {
@@ -268,7 +269,7 @@
             }
           },
           {
-            "name": "To",
+            "name": "to",
             "in": "query",
             "required": true,
             "schema": {
@@ -277,7 +278,7 @@
             }
           },
           {
-            "name": "Calendar",
+            "name": "calendar",
             "in": "query",
             "schema": {
               "type": "string"
@@ -364,7 +365,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name of the entity definition.",
             "required": true,
             "schema": {
               "type": "string"
@@ -373,6 +374,7 @@
           {
             "name": "action",
             "in": "path",
+            "description": "Name of the registered bulk action to execute.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1555,10 +1557,10 @@
         "enum": ["Count", "Sum", "Avg", "Min", "Max"]
       },
       "RelationAggregatesRequest": {
-        "required": ["relations"],
         "type": "object",
         "properties": {
           "relations": {
+            "maxLength": 256,
             "type": ["null", "array"],
             "items": {
               "type": "string"

--- a/contracts/openapi/invoicing.json
+++ b/contracts/openapi/invoicing.json
@@ -97,7 +97,15 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
@@ -424,6 +432,9 @@
               }
             }
           },
+          "202": {
+            "description": "Accepted"
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -542,6 +553,9 @@
               }
             }
           },
+          "202": {
+            "description": "Accepted"
+          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -649,6 +663,9 @@
                 }
               }
             }
+          },
+          "202": {
+            "description": "Accepted"
           },
           "404": {
             "description": "Not Found",
@@ -960,6 +977,7 @@
         "type": "object",
         "properties": {
           "reason": {
+            "maxLength": 1000,
             "type": ["null", "string"]
           }
         }
@@ -1007,6 +1025,9 @@
           }
         }
       },
+      "ContentType": {
+        "description": "MIME content type (e.g. `text/html`, `application/pdf`).\nValidates the `type/subtype` format per RFC 6838."
+      },
       "DateFilterMeta": {
         "required": ["name", "defaultPeriod", "availablePeriods"],
         "type": "object",
@@ -1027,6 +1048,9 @@
       },
       "DatePeriod": {
         "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+      },
+      "FileName": {
+        "description": "A file name validated for safety: non-empty, max 260 characters, no path traversal."
       },
       "FilterableField": {
         "required": ["name", "type", "operators"],
@@ -1095,7 +1119,7 @@
         ]
       },
       "FinalizeInvoiceRequest": {
-        "required": ["issuedAt", "dueAt"],
+        "required": ["issuedAt"],
         "type": "object",
         "properties": {
           "issuedAt": {
@@ -1107,6 +1131,7 @@
             "format": "date-time"
           },
           "comment": {
+            "maxLength": 500,
             "type": ["null", "string"]
           }
         }
@@ -1379,6 +1404,7 @@
             "$ref": "#/components/schemas/InvoiceDocumentType"
           },
           "currency": {
+            "maxLength": 3,
             "type": "string"
           },
           "collectionMethod": {
@@ -1392,6 +1418,7 @@
             "format": "uuid"
           },
           "creditNoteReason": {
+            "maxLength": 500,
             "type": ["null", "string"]
           },
           "periodStart": {
@@ -1423,10 +1450,10 @@
             "format": "uuid"
           },
           "fileName": {
-            "type": "string"
+            "$ref": "#/components/schemas/FileName"
           },
           "contentType": {
-            "type": "string"
+            "$ref": "#/components/schemas/ContentType"
           },
           "generatedAt": {
             "type": "string",
@@ -1776,6 +1803,7 @@
         "type": "object",
         "properties": {
           "reason": {
+            "maxLength": 1000,
             "type": ["null", "string"]
           }
         }
@@ -1989,10 +2017,10 @@
                         "format": "uuid"
                       },
                       "fileName": {
-                        "type": "string"
+                        "description": "A file name validated for safety: non-empty, max 260 characters, no path traversal."
                       },
                       "contentType": {
-                        "type": "string"
+                        "description": "MIME content type (e.g. `text/html`, `application/pdf`).\nValidates the `type/subtype` format per RFC 6838."
                       },
                       "generatedAt": {
                         "type": "string",

--- a/contracts/openapi/metering.json
+++ b/contracts/openapi/metering.json
@@ -1002,13 +1002,13 @@
             "content": {
               "application/problem+json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           },
-          "422": {
-            "description": "Unprocessable Entity",
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1017,8 +1017,8 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
+          "422": {
+            "description": "Unprocessable Entity",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1444,7 +1444,8 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/MeterEventRequest"
-            }
+            },
+            "x-granit-validator": "Validation:Rule:MaxBatchSize"
           }
         }
       },
@@ -1532,6 +1533,7 @@
         "type": "object",
         "properties": {
           "reason": {
+            "maxLength": 500,
             "type": "string"
           }
         }
@@ -1860,15 +1862,18 @@
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 200,
             "type": "string"
           },
           "unit": {
+            "maxLength": 64,
             "type": "string"
           },
           "aggregationType": {
             "$ref": "#/components/schemas/AggregationType"
           },
           "description": {
+            "maxLength": 1024,
             "type": ["null", "string"]
           },
           "productId": {
@@ -1876,6 +1881,7 @@
             "format": "uuid"
           },
           "distinctProperty": {
+            "maxLength": 200,
             "type": ["null", "string"]
           }
         }
@@ -1926,12 +1932,15 @@
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 200,
             "type": "string"
           },
           "unit": {
+            "maxLength": 64,
             "type": "string"
           },
           "description": {
+            "maxLength": 1024,
             "type": ["null", "string"]
           }
         }
@@ -2332,7 +2341,8 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/MeterEventRequest"
-            }
+            },
+            "x-granit-validator": "Validation:Rule:MaxBatchSize"
           }
         }
       },

--- a/contracts/openapi/parties.json
+++ b/contracts/openapi/parties.json
@@ -401,7 +401,7 @@
         "tags": ["Parties"],
         "summary": "Updates the party's identity (name, website, locale, timezone).",
         "description": "Updates the party's display fields. Emails / phones / addresses live in their own child collections — see the dedicated /emails, /phones, /addresses endpoints. Currency is intentionally not editable here. Returns 404 if the party does not exist; 400 on validation failure.",
-        "operationId": "UpdateIdentity",
+        "operationId": "UpdatePartyIdentity",
         "parameters": [
           {
             "name": "id",
@@ -1684,6 +1684,16 @@
               }
             }
           },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -1696,16 +1706,6 @@
           },
           "403": {
             "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2204,7 +2204,10 @@
             }
           },
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/vcard": {}
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -3671,24 +3674,32 @@
             "$ref": "#/components/schemas/AddressKind"
           },
           "line1": {
+            "maxLength": 200,
             "type": "string"
           },
           "city": {
+            "maxLength": 100,
             "type": "string"
           },
           "postalCode": {
+            "maxLength": 20,
             "type": "string"
           },
           "country": {
+            "maxLength": 2,
+            "minLength": 2,
             "type": "string"
           },
           "companyName": {
+            "maxLength": 200,
             "type": ["null", "string"]
           },
           "line2": {
+            "maxLength": 200,
             "type": ["null", "string"]
           },
           "state": {
+            "maxLength": 100,
             "type": ["null", "string"]
           },
           "isDefault": {
@@ -3696,6 +3707,7 @@
             "default": false
           },
           "label": {
+            "maxLength": 128,
             "type": ["null", "string"]
           }
         }
@@ -3799,9 +3811,12 @@
             "$ref": "#/components/schemas/PartyKind"
           },
           "name": {
+            "maxLength": 256,
             "type": "string"
           },
           "defaultCurrency": {
+            "maxLength": 3,
+            "minLength": 3,
             "type": "string"
           },
           "roles": {
@@ -3815,21 +3830,27 @@
             ]
           },
           "website": {
+            "maxLength": 2048,
             "type": ["null", "string"]
           },
           "language": {
+            "maxLength": 16,
             "type": ["null", "string"]
           },
           "timezone": {
+            "maxLength": 64,
             "type": ["null", "string"]
           },
           "taxId": {
+            "maxLength": 64,
             "type": ["null", "string"]
           },
           "registrationNumber": {
+            "maxLength": 64,
             "type": ["null", "string"]
           },
           "internalNotes": {
+            "maxLength": 8000,
             "type": ["null", "string"]
           }
         }
@@ -3949,6 +3970,7 @@
             }
           },
           "reason": {
+            "maxLength": 1000,
             "type": ["null", "string"]
           }
         }
@@ -3983,13 +4005,16 @@
         "type": "object",
         "properties": {
           "address": {
-            "type": "string"
+            "maxLength": 320,
+            "type": "string",
+            "format": "email"
           },
           "isPrimary": {
             "type": "boolean",
             "default": false
           },
           "label": {
+            "maxLength": 64,
             "type": ["null", "string"]
           }
         }
@@ -4034,9 +4059,11 @@
         "type": "object",
         "properties": {
           "providerName": {
+            "maxLength": 64,
             "type": "string"
           },
           "externalId": {
+            "maxLength": 256,
             "type": "string"
           }
         }
@@ -4076,6 +4103,7 @@
             }
           },
           "reason": {
+            "maxLength": 1000,
             "type": ["null", "string"]
           },
           "dryRun": {
@@ -4162,6 +4190,7 @@
             "$ref": "#/components/schemas/PhoneKind"
           },
           "number": {
+            "maxLength": 64,
             "type": "string"
           },
           "isPrimary": {
@@ -4169,6 +4198,7 @@
             "default": false
           },
           "label": {
+            "maxLength": 64,
             "type": ["null", "string"]
           }
         }
@@ -4328,12 +4358,13 @@
         "type": "object",
         "properties": {
           "reason": {
+            "maxLength": 512,
             "type": ["null", "string"]
           }
         }
       },
       "PartyTaxStatusRequest": {
-        "required": ["isExempt", "reverseCharge", "vatin", "evidenceBlobId"],
+        "required": ["isExempt", "reverseCharge"],
         "type": "object",
         "properties": {
           "isExempt": {
@@ -4343,6 +4374,7 @@
             "type": "boolean"
           },
           "vatin": {
+            "maxLength": 32,
             "type": ["null", "string"]
           },
           "evidenceBlobId": {
@@ -4375,18 +4407,23 @@
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 256,
             "type": "string"
           },
           "website": {
+            "maxLength": 2048,
             "type": ["null", "string"]
           },
           "language": {
+            "maxLength": 16,
             "type": ["null", "string"]
           },
           "timezone": {
+            "maxLength": 64,
             "type": ["null", "string"]
           },
           "internalNotes": {
+            "maxLength": 8000,
             "type": ["null", "string"]
           }
         }

--- a/contracts/openapi/subscriptions.json
+++ b/contracts/openapi/subscriptions.json
@@ -244,7 +244,7 @@
       "post": {
         "tags": ["Subscriptions - Plans"],
         "summary": "Creates a new plan in Draft status.",
-        "description": "Creates a plan that can be configured with prices and features before publishing.",
+        "description": "Creates a plan in Draft status that can be configured with prices and features before publishing. Draft plans are not yet purchasable. Use the publish endpoint to make the plan available for subscription.",
         "operationId": "CreatePlan",
         "requestBody": {
           "content": {
@@ -562,7 +562,7 @@
       "post": {
         "tags": ["Subscriptions - Plans"],
         "summary": "Archives a published plan.",
-        "description": "Archived plans are no longer purchasable but remain usable by existing subscribers.",
+        "description": "Archives a published plan, preventing new subscriptions while keeping existing ones active. An archived plan's price history and seat assignments remain valid. This action cannot be undone.",
         "operationId": "ArchivePlan",
         "parameters": [
           {
@@ -1136,7 +1136,7 @@
       "get": {
         "tags": ["Subscriptions - Instances"],
         "summary": "Returns a subscription by ID.",
-        "description": "Returns the full subscription details including seat count and dunning status.",
+        "description": "Returns the full subscription details including plan, seat count, dunning status, and cancellation schedule. Returns 404 if no subscription with that id exists. Requires tenant context or host access.",
         "operationId": "GetSubscriptionById",
         "parameters": [
           {
@@ -1461,7 +1461,7 @@
       "post": {
         "tags": ["Subscriptions - Instances"],
         "summary": "Cancels a subscription.",
-        "description": "Cancels immediately or schedules cancellation at period end based on the request.",
+        "description": "Cancels the subscription immediately or at the end of the current billing period depending on the cancelAtPeriodEnd flag. Returns 404 if the subscription does not exist. Returns 409 if the subscription is already cancelled.",
         "operationId": "CancelSubscription",
         "parameters": [
           {
@@ -1711,7 +1711,7 @@
       "get": {
         "tags": ["Subscriptions - Seats"],
         "summary": "Returns all seat assignments for a subscription.",
-        "description": "Lists users assigned to seats on the specified subscription.",
+        "description": "Returns all seat assignments for the specified subscription, including user identifiers and assignment metadata. Returns 404 if the subscription does not exist.",
         "operationId": "ListSeats",
         "parameters": [
           {
@@ -1906,7 +1906,7 @@
       "delete": {
         "tags": ["Subscriptions - Seats"],
         "summary": "Revokes a seat from a user.",
-        "description": "Removes the user's seat assignment from the subscription.",
+        "description": "Revokes the seat assignment for the specified user, freeing up a seat slot on the subscription. Returns 404 if the subscription or user seat does not exist.",
         "operationId": "RevokeSeat",
         "parameters": [
           {
@@ -2066,11 +2066,13 @@
         "type": "object",
         "properties": {
           "amount": {
+            "minimum": 0,
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
             "type": ["number", "string"],
             "format": "double"
           },
           "currency": {
+            "maxLength": 3,
             "type": "string"
           },
           "interval": {
@@ -2842,14 +2844,12 @@
         }
       },
       "PlanCreateRequest": {
-        "required": ["name", "description", "pricingModel", "defaultInterval"],
+        "required": ["name", "pricingModel", "defaultInterval"],
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 200,
             "type": "string"
-          },
-          "description": {
-            "type": ["null", "string"]
           },
           "pricingModel": {
             "type": "string"
@@ -2857,11 +2857,17 @@
           "defaultInterval": {
             "type": "string"
           },
+          "description": {
+            "maxLength": 2000,
+            "type": ["null", "string"]
+          },
           "trialDays": {
+            "minimum": 0,
             "type": ["null", "integer"],
             "format": "int32"
           },
           "seatLimit": {
+            "exclusiveMinimum": 0,
             "type": ["null", "integer"],
             "format": "int32"
           }
@@ -3051,18 +3057,21 @@
         }
       },
       "PlanUpdateRequest": {
-        "required": ["name", "description", "sortOrder"],
+        "required": ["name", "sortOrder"],
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 200,
             "type": "string"
           },
-          "description": {
-            "type": ["null", "string"]
-          },
           "sortOrder": {
+            "minimum": 0,
             "type": "integer",
             "format": "int32"
+          },
+          "description": {
+            "maxLength": 2000,
+            "type": ["null", "string"]
           }
         }
       },
@@ -3369,6 +3378,7 @@
         "type": "object",
         "properties": {
           "reason": {
+            "maxLength": 500,
             "type": ["null", "string"]
           },
           "atPeriodEnd": {
@@ -3400,6 +3410,7 @@
             "format": "uuid"
           },
           "currency": {
+            "maxLength": 3,
             "type": "string"
           },
           "trialEndsAt": {

--- a/contracts/openapi/tax.json
+++ b/contracts/openapi/tax.json
@@ -908,9 +908,12 @@
         "type": "object",
         "properties": {
           "taxId": {
+            "maxLength": 30,
             "type": "string"
           },
           "countryCode": {
+            "maxLength": 2,
+            "minLength": 2,
             "type": "string"
           }
         }

--- a/contracts/openapi/taxonomy.json
+++ b/contracts/openapi/taxonomy.json
@@ -460,6 +460,9 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden"
+          },
           "422": {
             "description": "Unprocessable Entity",
             "content": {
@@ -482,16 +485,6 @@
           },
           "401": {
             "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -564,18 +557,11 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden"
+          },
           "401": {
             "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1044,6 +1030,16 @@
               }
             }
           },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad Request",
             "content": {
@@ -1066,16 +1062,6 @@
           },
           "403": {
             "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1456,6 +1442,7 @@
         "type": "object",
         "properties": {
           "targetType": {
+            "maxLength": 256,
             "type": "string"
           },
           "targetId": {
@@ -1469,6 +1456,7 @@
         "type": "object",
         "properties": {
           "targetType": {
+            "maxLength": 256,
             "type": "string"
           },
           "targetId": {
@@ -1581,20 +1569,24 @@
         }
       },
       "CreateCategoryRequest": {
-        "required": ["scope", "parentId", "name", "iconName", "hideOnEntityCard"],
+        "required": ["scope", "name"],
         "type": "object",
         "properties": {
           "scope": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "name": {
+            "maxLength": 100,
+            "pattern": "^[^/]+$",
             "type": "string"
           },
           "parentId": {
             "type": ["null", "string"],
             "format": "uuid"
           },
-          "name": {
-            "type": "string"
-          },
           "iconName": {
+            "maxLength": 100,
             "type": ["null", "string"]
           },
           "hideOnEntityCard": {
@@ -1603,16 +1595,19 @@
         }
       },
       "CreateTagRequest": {
-        "required": ["scope", "name", "color", "hideOnEntityCard"],
+        "required": ["scope", "name", "color"],
         "type": "object",
         "properties": {
           "scope": {
+            "maxLength": 64,
             "type": "string"
           },
           "name": {
+            "maxLength": 50,
             "type": "string"
           },
           "color": {
+            "pattern": "^#[0-9A-Fa-f]{6}$",
             "type": "string"
           },
           "hideOnEntityCard": {
@@ -1675,7 +1670,6 @@
         }
       },
       "MoveCategoryRequest": {
-        "required": ["newParentId"],
         "type": "object",
         "properties": {
           "newParentId": {
@@ -1846,13 +1840,15 @@
         }
       },
       "UpdateCategoryRequest": {
-        "required": ["name", "iconName", "hideOnEntityCard"],
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 100,
+            "pattern": "^[^/]+$",
             "type": ["null", "string"]
           },
           "iconName": {
+            "maxLength": 100,
             "type": ["null", "string"]
           },
           "hideOnEntityCard": {
@@ -1861,13 +1857,14 @@
         }
       },
       "UpdateTagRequest": {
-        "required": ["name", "color", "hideOnEntityCard"],
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 50,
             "type": ["null", "string"]
           },
           "color": {
+            "pattern": "^#[0-9A-Fa-f]{6}$",
             "type": ["null", "string"]
           },
           "hideOnEntityCard": {

--- a/contracts/openapi/workspaces.json
+++ b/contracts/openapi/workspaces.json
@@ -9,7 +9,7 @@
       "get": {
         "tags": ["Workspaces"],
         "summary": "Returns the workspace tree filtered for the requesting user.",
-        "description": "Returns every WorkspaceDefinition the user is allowed to see — workspaces, sections, and items gated by a permission the user does NOT hold are absent from the payload (defense in depth, ADR-040). Empty branches (workspaces / sections with zero surviving items) are dropped. Pass ?includeShells=false to omit Framework shells. Cached 5 minutes per (user-perms-hash, culture, includeShells).",
+        "description": "Returns every WorkspaceDefinition the user is allowed to see — workspaces, sections, and items gated by a permission the user does NOT hold are absent from the payload (defense in depth, ADR-044 §6). Empty branches (workspaces / sections with zero surviving items) are dropped. Pass ?includeShells=false to omit Framework shells. Cached 5 minutes per (user-perms-hash, culture, includeShells).",
         "operationId": "GetWorkspacesTree",
         "parameters": [
           {
@@ -68,7 +68,7 @@
       "get": {
         "tags": ["Workspaces"],
         "summary": "Resolves the requesting user's landing route via the 5-tier precedence chain.",
-        "description": "Precedence per ADR-048: personal-sticky > personal-pinned > role-default > tenant-default > framework. Each tier may be null (provider not configured, no preference) — the resolver falls through. Routes that fail the URL whitelist (configured prefixes) or the access guard are also skipped to the next tier. The framework fallback is configured (not user-supplied) and always wins as the closing tier.",
+        "description": "Precedence per ADR-049: personal-sticky > personal-pinned > role-default > tenant-default > framework. Each tier may be null (provider not configured, no preference) — the resolver falls through. Routes that fail the URL whitelist (configured prefixes) or the access guard are also skipped to the next tier. The framework fallback is configured (not user-supplied) and always wins as the closing tier.",
         "operationId": "GetLandingRoute",
         "responses": {
           "200": {
@@ -261,10 +261,10 @@
         }
       },
       "SetPinnedLandingRouteRequest": {
-        "required": ["route"],
         "type": "object",
         "properties": {
           "route": {
+            "maxLength": 2048,
             "type": ["null", "string"]
           }
         }


### PR DESCRIPTION
## Context
Drift audit against `granit-business/.../Granit.Business.OpenApi.Generator/generated`. The backend specs were bulk-regenerated (validation-constraint extensions, `*Response` schema renames, ADR renumbering, `required`-set changes) but the vendored front snapshots had not been refreshed since the prior generation.

## Changes
Re-vendored 18 drifted business module snapshots via `scripts/sync-openapi-contracts.mjs`, prettier-normalized as the pre-commit hook does:

`activities, analytics, catalog, customer-balance, dashboards, documents, documents-public-links, documents-resolution, entities, entities-customization, entities-views, invoicing, metering, parties, subscriptions, tax, taxonomy, workspaces`

Snapshot-only change — no `@granit/*` source touched. (`payments` and `bank-accounts` handled in separate PRs.)

## Verification
- Each file is now `jq`-semantically equal to its generated spec. `invoicing` differs only in prettier number normalization of **example** values (`0.00` → `0.0`, same numeric value; not read by the oracle).
- Conformance suite: 163 passed.

## Note
None of these 18 modules are registered in the `@granit/contract-tests` manifest, so their DTO conformance is not yet oracle-checked — a pre-existing coverage gap, out of scope here.