### PR TITLE
test(contracts): register @granit/bank-accounts in conformance oracle

### DIFF
--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -297,6 +297,20 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'PaymentProviderCatalogResponse',
     ],
   },
+  // ─── Business bank accounts (granit-business / Granit.BankAccounts.Endpoints) ─
+  // `BankAccountResponse` (masked CRUD projection) + `BankAccount` (raw QE grid
+  // entity) + the create request. Standalone enums (BankAccountScheme/Status/Type)
+  // are verified indirectly via referencing fields. The admin grid (GET '' +
+  // '/meta') is served by the query-engine generic helper, so those routes are
+  // ignored — POST '' (create) shares the base route and is therefore unchecked
+  // here, but covered by the package's own unit tests.
+  {
+    slug: 'bank-accounts',
+    package: 'bank-accounts',
+    types: ['CreateBankAccountRequest', 'BankAccountResponse', 'BankAccount'],
+    checkEndpoints: true,
+    endpointIgnore: ['', '/meta'],
+  },
   {
     slug: 'sepa-transfer',
     package: 'payments-sepa-transfer',


### PR DESCRIPTION
## Context
Drift audit follow-up. `#655` vendored `contracts/openapi/bank-accounts.json` and shipped the `@granit/bank-accounts` DTOs but never registered the module in the `@granit/contract-tests` manifest — so its DTOs and routes were **not** oracle-checked (a coverage gap, not a snapshot drift; the snapshot is already in sync).

## Changes
Register `bank-accounts` in the conformance manifest:
- Types: `CreateBankAccountRequest`, `BankAccountResponse` (masked CRUD projection), `BankAccount` (raw QueryEngine grid entity).
- `checkEndpoints: true` with `endpointIgnore: ['', '/meta']` — the admin grid is served by the query-engine generic helper; `POST ''` (create) shares the base route so it is unchecked here but covered by the package's own unit tests.
- Standalone enums (`BankAccountScheme`/`Status`/`Type`) verified indirectly via referencing fields, per the field-by-field oracle.

## Verification
- Conformance: 167 passed (4 new bank-accounts checks — 3 DTOs + route conformance). All conformant against the vendored spec, no DTO changes needed.
- `tsc --noEmit`, ESLint clean.