### PR TITLE
fix(cms): re-sync CMS OpenAPI snapshots & add SiteResponse.homePageId

### DIFF
--- a/contracts/openapi/cms-hostnames.json
+++ b/contracts/openapi/cms-hostnames.json
@@ -492,6 +492,7 @@
         "type": "object",
         "properties": {
           "host": {
+            "maxLength": 253,
             "type": "string"
           },
           "isPrimary": {

--- a/contracts/openapi/cms-redirects.json
+++ b/contracts/openapi/cms-redirects.json
@@ -1484,9 +1484,13 @@
         "type": "object",
         "properties": {
           "source": {
+            "maxLength": 2048,
+            "pattern": "^/",
             "type": "string"
           },
           "target": {
+            "maxLength": 2048,
+            "pattern": "^(https?://|/)",
             "type": "string"
           },
           "type": {
@@ -1496,6 +1500,7 @@
             "$ref": "#/components/schemas/RedirectMatchType"
           },
           "culture": {
+            "maxLength": 20,
             "type": ["null", "string"]
           },
           "isActive": {
@@ -1609,6 +1614,8 @@
         "type": "object",
         "properties": {
           "target": {
+            "maxLength": 2048,
+            "pattern": "^(https?://|/)",
             "type": "string"
           },
           "type": {

--- a/contracts/openapi/cms-seo.json
+++ b/contracts/openapi/cms-seo.json
@@ -25,7 +25,10 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/xml": {}
+            }
           },
           "304": {
             "description": "Not Modified"
@@ -72,7 +75,10 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/xml": {}
+            }
           },
           "304": {
             "description": "Not Modified"
@@ -121,7 +127,10 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {}
+            }
           },
           "500": {
             "description": "Internal Server Error",
@@ -157,7 +166,15 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/manifest+json": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
@@ -1079,7 +1096,15 @@
             "description": "No Content"
           },
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/ld+json": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -3057,12 +3082,15 @@
         "type": "object",
         "properties": {
           "title": {
+            "maxLength": 300,
             "type": ["null", "string"]
           },
           "titleTemplate": {
+            "maxLength": 300,
             "type": ["null", "string"]
           },
           "description": {
+            "maxLength": 2000,
             "type": ["null", "string"]
           },
           "keywords": {
@@ -3072,6 +3100,8 @@
             }
           },
           "canonicalUrl": {
+            "maxLength": 2048,
+            "pattern": "^https://",
             "type": ["null", "string"]
           },
           "robots": {
@@ -3105,6 +3135,7 @@
             ]
           },
           "structuredDataExtras": {
+            "maxLength": 32768,
             "type": ["null", "string"]
           },
           "disableAutoJsonLd": {
@@ -3118,6 +3149,7 @@
             }
           },
           "xDefaultCulture": {
+            "maxLength": 20,
             "type": ["null", "string"]
           }
         }
@@ -3303,6 +3335,7 @@
         "type": "object",
         "properties": {
           "reason": {
+            "maxLength": 1000,
             "type": ["null", "string"]
           }
         }
@@ -3420,6 +3453,7 @@
             "format": "uuid"
           },
           "contentType": {
+            "maxLength": 100,
             "type": "string"
           },
           "contentId": {
@@ -3427,12 +3461,15 @@
             "format": "uuid"
           },
           "culture": {
+            "maxLength": 20,
             "type": ["null", "string"]
           },
           "contentTitle": {
+            "maxLength": 300,
             "type": "string"
           },
           "contentBody": {
+            "maxLength": 50000,
             "type": ["null", "string"]
           },
           "scope": {
@@ -3478,12 +3515,15 @@
         "type": "object",
         "properties": {
           "titleTemplate": {
+            "maxLength": 300,
             "type": ["null", "string"]
           },
           "siteName": {
+            "maxLength": 200,
             "type": ["null", "string"]
           },
           "defaultDescription": {
+            "maxLength": 2000,
             "type": ["null", "string"]
           },
           "defaultRobots": {
@@ -3497,9 +3537,13 @@
             ]
           },
           "canonicalHost": {
+            "maxLength": 2048,
+            "pattern": "^https://",
             "type": ["null", "string"]
           },
           "sitemapMaxUrlsPerFile": {
+            "maximum": 50000,
+            "minimum": 1,
             "type": "integer",
             "format": "int32",
             "default": 45000
@@ -3545,6 +3589,7 @@
             }
           },
           "robotsTxtExtra": {
+            "maxLength": 4096,
             "type": ["null", "string"]
           },
           "manifest": {

--- a/contracts/openapi/cms.json
+++ b/contracts/openapi/cms.json
@@ -483,6 +483,178 @@
         }
       }
     },
+    "/api/cms/sites/{id}/home-page": {
+      "put": {
+        "tags": ["CMS - Sites"],
+        "summary": "Designates the page served at the site root path '/'.",
+        "description": "Promotes an existing, non-root page of this site to the homepage: its public per-culture path becomes '/' (it stops resolving at its own slug). Any previously designated homepage reverts to its structural slug path. Returns 404 if the site or page does not exist, 400 if the page belongs to another site or is the technical site root.",
+        "operationId": "SetCmsSiteHomePage",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetSiteHomePageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["CMS - Sites"],
+        "summary": "Clears the homepage designation.",
+        "description": "Removes the page designated at '/'; the previously designated page reverts to its slug path and '/' stops resolving. Returns 404 if the site does not exist.",
+        "operationId": "ClearCmsSiteHomePage",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SiteResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/cms/sites/meta": {
       "get": {
         "tags": ["CMS - Sites"],
@@ -1932,7 +2104,7 @@
         "tags": ["CMS - Pages"],
         "summary": "Records or refreshes the caller's presence in the page-editing room.",
         "description": "Idempotent — calling on an already-active participant just refreshes the timestamp. The user id is resolved from the authenticated principal.",
-        "operationId": "PageEditingPresenceHeartbeat",
+        "operationId": "HeartbeatCmsPageEditingPresence",
         "parameters": [
           {
             "name": "id",
@@ -2014,7 +2186,7 @@
         "tags": ["CMS - Pages"],
         "summary": "Removes the caller from the page-editing room.",
         "description": "Called by the editor on tab close so the room reflects the truth immediately rather than waiting for the heartbeat TTL to expire.",
-        "operationId": "PageEditingPresenceLeave",
+        "operationId": "LeaveCmsPageEditingPresence",
         "parameters": [
           {
             "name": "id",
@@ -2087,7 +2259,7 @@
         "tags": ["CMS - Pages"],
         "summary": "Lists the editors currently in the page-editing room.",
         "description": "Ordered freshest first. Stale entries (older than the configured threshold) are filtered at read time.",
-        "operationId": "PageEditingPresenceList",
+        "operationId": "ListCmsPageEditingPresence",
         "parameters": [
           {
             "name": "id",
@@ -4095,6 +4267,7 @@
         "type": "object",
         "properties": {
           "contentType": {
+            "maxLength": 100,
             "type": "string"
           },
           "contentId": {
@@ -4102,6 +4275,7 @@
             "format": "uuid"
           },
           "culture": {
+            "maxLength": 20,
             "type": ["null", "string"]
           },
           "type": {
@@ -4174,9 +4348,11 @@
         "type": "object",
         "properties": {
           "dataSourceKey": {
+            "maxLength": 256,
             "type": "string"
           },
           "query": {
+            "maxLength": 10000,
             "type": ["null", "string"]
           },
           "siteId": {
@@ -4184,6 +4360,7 @@
             "format": "uuid"
           },
           "culture": {
+            "maxLength": 20,
             "type": "string"
           }
         }
@@ -4311,9 +4488,13 @@
             "format": "uuid"
           },
           "slugSegment": {
+            "maxLength": 200,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
             "type": "string"
           },
           "layoutKey": {
+            "maxLength": 100,
+            "pattern": "^[a-z0-9]+([._-][a-z0-9]+)*$",
             "type": ["null", "string"]
           }
         }
@@ -4327,6 +4508,7 @@
             "format": "uuid"
           },
           "name": {
+            "maxLength": 200,
             "type": "string"
           }
         }
@@ -4336,9 +4518,12 @@
         "type": "object",
         "properties": {
           "slug": {
+            "maxLength": 200,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
             "type": "string"
           },
           "defaultCulture": {
+            "maxLength": 20,
             "type": "string"
           },
           "allowedCultures": {
@@ -4802,9 +4987,12 @@
             "format": "uuid"
           },
           "key": {
+            "maxLength": 100,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
             "type": "string"
           },
           "title": {
+            "maxLength": 200,
             "type": "string"
           },
           "items": {
@@ -4848,6 +5036,7 @@
         "type": "object",
         "properties": {
           "label": {
+            "maxLength": 200,
             "type": "string"
           },
           "kind": {
@@ -4981,6 +5170,7 @@
         "type": "object",
         "properties": {
           "title": {
+            "maxLength": 200,
             "type": "string"
           },
           "items": {
@@ -5888,6 +6078,10 @@
                 "activated": {
                   "type": "boolean"
                 },
+                "homePageId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
                 "tenantId": {
                   "type": ["null", "string"],
                   "format": "uuid"
@@ -5934,6 +6128,10 @@
                           "activated": {
                             "type": "boolean"
                           },
+                          "homePageId": {
+                            "type": ["null", "string"],
+                            "format": "uuid"
+                          },
                           "tenantId": {
                             "type": ["null", "string"],
                             "format": "uuid"
@@ -5969,6 +6167,10 @@
                                     },
                                     "activated": {
                                       "type": "boolean"
+                                    },
+                                    "homePageId": {
+                                      "type": ["null", "string"],
+                                      "format": "uuid"
                                     },
                                     "tenantId": {
                                       "type": ["null", "string"],
@@ -6874,6 +7076,8 @@
         "type": "object",
         "properties": {
           "slugSegment": {
+            "maxLength": 200,
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
             "type": "string"
           }
         }
@@ -6883,6 +7087,7 @@
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 200,
             "type": "string"
           }
         }
@@ -6940,9 +7145,11 @@
         "type": "object",
         "properties": {
           "contentJson": {
+            "maxLength": 2097152,
             "type": "string"
           },
           "title": {
+            "maxLength": 500,
             "type": ["null", "string"]
           }
         }
@@ -6956,6 +7163,7 @@
             "format": "date-time"
           },
           "timeZoneId": {
+            "maxLength": 64,
             "type": "string"
           }
         }
@@ -6968,7 +7176,18 @@
             "type": "string"
           },
           "title": {
+            "maxLength": 500,
             "type": "string"
+          }
+        }
+      },
+      "SetSiteHomePageRequest": {
+        "required": ["pageId"],
+        "type": "object",
+        "properties": {
+          "pageId": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       },
@@ -6998,6 +7217,10 @@
           },
           "activated": {
             "type": "boolean"
+          },
+          "homePageId": {
+            "type": ["null", "string"],
+            "format": "uuid"
           },
           "tenantId": {
             "type": ["null", "string"],
@@ -7069,7 +7292,8 @@
           "defaultTheme",
           "activated",
           "tenantId",
-          "displayNames"
+          "displayNames",
+          "homePageId"
         ],
         "type": "object",
         "properties": {
@@ -7110,6 +7334,10 @@
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "homePageId": {
+            "type": ["null", "string"],
+            "format": "uuid"
           }
         }
       },
@@ -7175,6 +7403,7 @@
         "type": "object",
         "properties": {
           "defaultCulture": {
+            "maxLength": 20,
             "type": "string"
           },
           "allowedCultures": {
@@ -7190,6 +7419,7 @@
             }
           },
           "defaultTheme": {
+            "maxLength": 100,
             "type": "string"
           },
           "activated": {

--- a/packages/@granit/cms/src/__tests__/sites.test.ts
+++ b/packages/@granit/cms/src/__tests__/sites.test.ts
@@ -18,6 +18,7 @@ const site: SiteResponse = {
   activated: true,
   tenantId: null,
   displayNames: { fr: 'ACME', en: 'ACME' },
+  homePageId: null,
 };
 
 describe('listSites', () => {

--- a/packages/@granit/cms/src/types/index.ts
+++ b/packages/@granit/cms/src/types/index.ts
@@ -176,6 +176,8 @@ export interface SiteResponse {
   readonly activated: boolean;
   readonly tenantId: string | null;
   readonly displayNames: Readonly<Record<string, string>>;
+  /** Page designated at `/` (the site home page); `null` when none is set. */
+  readonly homePageId: string | null;
 }
 
 /** Request body for `POST /api/cms/sites`. */

--- a/packages/@granit/react-cms/src/__tests__/use-site-mutations.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-site-mutations.test.ts
@@ -29,6 +29,7 @@ const site: SiteResponse = {
   activated: true,
   tenantId: null,
   displayNames: {},
+  homePageId: null,
 };
 
 function createWrapper(client: AxiosInstance) {

--- a/packages/@granit/react-cms/src/__tests__/use-sites.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-sites.test.ts
@@ -29,6 +29,7 @@ const site: SiteResponse = {
   activated: true,
   tenantId: null,
   displayNames: {},
+  homePageId: null,
 };
 
 function createWrapper(client: AxiosInstance) {

--- a/packages/@granit/react-cms/src/testing/data.ts
+++ b/packages/@granit/react-cms/src/testing/data.ts
@@ -31,6 +31,7 @@ export const mockSites: SiteResponse[] = [
       'fr-FR': 'Site corporatif',
       'nl-BE': 'Bedrijfswebsite',
     },
+    homePageId: null,
   },
   {
     id: 'c2e1d4b5-2e3f-4a6b-9c7d-2b3c4d5e6f70',
@@ -45,6 +46,7 @@ export const mockSites: SiteResponse[] = [
       'en-GB': 'Support Portal',
       'fr-FR': 'Portail de support',
     },
+    homePageId: null,
   },
   {
     id: 'd3f2e5c6-3f40-4b7c-ad8e-3c4d5e6f7081',
@@ -58,6 +60,7 @@ export const mockSites: SiteResponse[] = [
     displayNames: {
       'fr-FR': 'Campagne 2026',
     },
+    homePageId: null,
   },
 ];
 

--- a/packages/@granit/react-cms/src/testing/handlers.ts
+++ b/packages/@granit/react-cms/src/testing/handlers.ts
@@ -77,6 +77,7 @@ export function createSitesHandlers(baseUrl = '/api/cms/sites'): RequestHandler[
         activated: true,
         tenantId: null,
         displayNames: { [dto.defaultCulture]: dto.slug },
+        homePageId: null,
       };
       sites.push(site);
       return HttpResponse.json(site, { status: 201 });


### PR DESCRIPTION
## Context
Drift audit against `granit-website/.../Granit.Cms.OpenApi.Generator/generated` (CMS bounded context — 4 oracle-checked modules). The CMS specs were regenerated but the vendored front snapshots were stale.

## Changes
- **Re-vendor** `cms`, `cms-redirects`, `cms-seo`, `cms-hostnames` via `scripts/sync-openapi-contracts.mjs` — now `jq`-semantically equal to the generated specs.
- **`SiteResponse.homePageId: string | null`** — the regenerated `cms` schema adds this as a **required** field; added to the `@granit/cms` DTO (required key, nullable value per the OpenAPI `required`-array rule) and to the test/MSW fixtures that build `SiteResponse` (`null` = no home page set).

The bulk of the snapshot delta is non-structural: validation-constraint extensions (`maxLength`/`pattern`/`min`/`max`), new `application/manifest+json` & `application/ld+json` response media types, and `operationId` renames (none read by the field-by-field oracle).

## Verification
- Conformance: 179 passed — `SiteResponse` now mirrors the backend (was the only real DTO break the re-sync surfaced).
- `tsc --noEmit`, ESLint clean, 444 `@granit/cms` + `@granit/react-cms` + conformance tests green.

## Deferred (feature, not drift)
The regenerated spec also adds **`SetSiteHomePageRequest`** + the `PUT/DELETE /api/cms/sites/{id}/home-page` endpoints (set/clear home page). The front `@granit/cms` does not yet implement that endpoint surface — out of scope for a drift re-sync; track as a feature. (CMS endpoint-route conformance is intentionally not oracle-checked, so this does not fail the suite.)