### PR TITLE
test(contracts): cover 9 business modules in the conformance oracle

### DIFF
--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -335,4 +335,95 @@ export const CONTRACTS: readonly ModuleContract[] = [
     checkEndpoints: true,
     endpointIgnore: ['/mandates', '/mandates/meta'],
   },
+  // ─── Business — additional module coverage (granit-business) ────────────────
+  // Object DTOs only (types-only — route conformance can be layered on later).
+  // Raw query-engine grid entities and string-union enums are verified
+  // indirectly (via the grid / referencing fields), not listed here.
+  {
+    slug: 'activities',
+    package: 'activities',
+    types: [
+      'ActivityResponse',
+      'ActivityListResponse',
+      'ActivityCalendarItemResponse',
+      'CreateActivityRequest',
+      'ReassignActivityRequest',
+      'RescheduleActivityRequest',
+    ],
+    // CompleteActivityRequest / CancelActivityRequest are empty-body DTOs
+    // (`Record<string, never>`) — no fields to verify, not listed.
+  },
+  {
+    slug: 'customer-balance',
+    package: 'customer-balance',
+    types: [
+      'CustomerBalanceResponse',
+      'BalanceTransactionResponse',
+      'AdminCreditRequest',
+      'AdminDebitRequest',
+    ],
+  },
+  {
+    slug: 'documents-properties',
+    package: 'documents',
+    types: ['DocumentPropertiesResponse'],
+  },
+  {
+    slug: 'documents-public-links',
+    package: 'documents',
+    types: [
+      'PublicLinkResponse',
+      'CreatePublicLinkRequest',
+      'CreatePublicLinkResponse',
+      'RevokePublicLinkRequest',
+    ],
+  },
+  {
+    slug: 'documents-renditions',
+    package: 'documents',
+    types: ['RenditionResponse', 'ListRenditionsResponse', 'RenditionDownloadUrlResponse'],
+  },
+  {
+    slug: 'documents-resolution',
+    package: 'documents',
+    types: ['ResolvedDocumentResponse', 'BatchResolveRequest', 'ResolveItemRequest'],
+  },
+  {
+    slug: 'metering',
+    package: 'metering',
+    types: [
+      'MeterDefinitionResponse',
+      'MeterDefinitionCreateRequest',
+      'MeterDefinitionUpdateRequest',
+      'MeterDefinition',
+      'MeterEventRequest',
+      'RecordUsageRequest',
+      'BackfillUsageRequest',
+      'BackfillUsageResponse',
+      'RecomputeUsageRequest',
+      'RecomputeUsageResponse',
+      'DeprecateEventRequest',
+      'DeprecateEventResponse',
+      'MeteringQuotaStatusResponse',
+      'UsageAggregate',
+      'UsageAggregateResponse',
+    ],
+  },
+  {
+    slug: 'tax',
+    package: 'tax',
+    types: ['TaxRateResponse', 'TaxRateEntry', 'TaxValidateRequest', 'TaxValidateResponse'],
+  },
+  {
+    slug: 'workspaces',
+    package: 'workspaces',
+    types: [
+      'WorkspaceResponse',
+      'WorkspaceSectionResponse',
+      'WorkspaceItemResponse',
+      'WorkspaceTreeResponse',
+      'LandingRouteResponse',
+      'SetPinnedLandingRouteRequest',
+    ],
+  },
 ];


### PR DESCRIPTION
## Context
Coverage audit of `@granit/contract-tests`: only 19 of 63 vendored snapshots were registered. This PR is **Tier A (business)** of the campaign to close that gap — drop-in registrations of modules whose snapshots are already in sync (#658) and whose DTOs match the spec schema names.

## Changes
Register 9 business modules in `manifest.ts` (**types-only**, route conformance deferred):
`activities`, `customer-balance`, `documents-properties`, `documents-public-links`, `documents-renditions`, `documents-resolution`, `metering`, `tax`, `workspaces`.

Excluded by design: raw query-engine grid entities (verified via the grid), string-union enums (verified via referencing fields), and empty-body request DTOs modeled as `Record<string, never>` (`CompleteActivityRequest`, `CancelActivityRequest` — no fields to check, not parseable by the field-by-field oracle).

## Verification
- Conformance: **229 passed** (no DTO drift surfaced — all 9 modules conform as-is).
- `tsc --noEmit`, ESLint clean. Snapshot-free change (manifest only).

## Follow-up
Part of a multi-PR campaign. Next: Tier A framework (re-sync stale snapshots + register), then Tier B (modules needing DTO additions) and Tier C (modules needing front DTO renames).