### PR TITLE
test(contracts): re-sync + cover 8 framework modules in the oracle

### DIFF
--- a/contracts/openapi/hostnames.json
+++ b/contracts/openapi/hostnames.json
@@ -7,9 +7,7 @@
   "paths": {
     "/hostnames": {
       "get": {
-        "tags": [
-          "Hostnames"
-        ],
+        "tags": ["Hostnames"],
         "summary": "Lists the hostnames registered for an owning resource.",
         "description": "Returns hostnames registered for the specified owner (ownerType + ownerId pair), ordered by host name. At most maxResults entries are returned (capped at 500). An empty list is returned when the owner has no registered hostnames. Requires the Hostnames.Read permission.",
         "operationId": "ListManagedHostnames",
@@ -88,9 +86,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Hostnames"
-        ],
+        "tags": ["Hostnames"],
         "summary": "Registers a new managed hostname.",
         "description": "Registers a fully-qualified hostname against an owning resource. The hostname must be globally unique — a second registration for the same host, regardless of owner, is rejected with 409. Returns the created hostname record with a 201 status. Requires the Hostnames.Manage permission.",
         "operationId": "CreateManagedHostname",
@@ -180,9 +176,7 @@
     },
     "/hostnames/availability": {
       "get": {
-        "tags": [
-          "Hostnames"
-        ],
+        "tags": ["Hostnames"],
         "summary": "Checks whether a hostname is available for registration.",
         "description": "Pre-flight check: returns whether the given fully-qualified hostname is free. A hostname is unavailable when it is already registered by any owner (globally unique constraint). Use before CreateManagedHostname to give immediate feedback. Requires the Hostnames.Read permission.",
         "operationId": "CheckHostnameAvailability",
@@ -252,9 +246,7 @@
     },
     "/hostnames/{id}": {
       "get": {
-        "tags": [
-          "Hostnames"
-        ],
+        "tags": ["Hostnames"],
         "summary": "Returns a managed hostname by id.",
         "description": "Returns the full hostname record for the given id. Returns 404 when no hostname with that id exists. Requires the Hostnames.Read permission.",
         "operationId": "GetManagedHostname",
@@ -324,9 +316,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Hostnames"
-        ],
+        "tags": ["Hostnames"],
         "summary": "Deletes a managed hostname.",
         "description": "Removes a hostname registration, freeing the host for re-registration by any owner. Returns 204 on success, 404 when not found. Requires the Hostnames.Manage permission.",
         "operationId": "DeleteManagedHostname",
@@ -391,9 +381,7 @@
     },
     "/hostnames/{id}/primary": {
       "post": {
-        "tags": [
-          "Hostnames"
-        ],
+        "tags": ["Hostnames"],
         "summary": "Marks a hostname as the owner's canonical hostname.",
         "description": "Sets the IsPrimary flag on the specified hostname. This does not automatically clear the flag on other hostnames owned by the same resource — manage that explicitly. Returns 204 on success, 404 when not found. Requires the Hostnames.Manage permission.",
         "operationId": "SetPrimaryHostname",
@@ -456,9 +444,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Hostnames"
-        ],
+        "tags": ["Hostnames"],
         "summary": "Clears the canonical hostname flag.",
         "description": "Removes the IsPrimary flag from the specified hostname. Returns 204 on success, 404 when not found. Requires the Hostnames.Manage permission.",
         "operationId": "ClearPrimaryHostname",
@@ -523,9 +509,7 @@
     },
     "/hostnames/{id}/verify-now": {
       "post": {
-        "tags": [
-          "Hostnames"
-        ],
+        "tags": ["Hostnames"],
         "summary": "Manually triggers DNS verification for a hostname.",
         "description": "For Verifying, Error, or Active hostnames: resets exponential backoff and re-queues the DNS check (transitions to Verifying). For Pending hostnames: initializes verification by minting the challenge token and expected DNS records, then transitions to Verifying. Returns 409 when the hostname is Pending and the platform ingress target is not configured. Returns 202 Accepted with the updated hostname record. Returns 404 when not found. Requires the Hostnames.Manage permission.",
         "operationId": "VerifyHostnameNow",
@@ -607,9 +591,7 @@
     },
     "/hostnames/{id}/certificate-status": {
       "post": {
-        "tags": [
-          "Hostnames"
-        ],
+        "tags": ["Hostnames"],
         "summary": "Reports the SSL/TLS certificate status from the edge provider.",
         "description": "Webhook endpoint called by the edge provider (e.g. Cloudflare, AWS) when the certificate state changes. The request must carry a valid HMAC-SHA-256 signature in the configured header when Hostnames:CertificateWebhookSecret is set. Stores the new CertificateStatus and expiry date, and dispatches the appropriate integration event (HostnameCertificateSecuredEto or HostnameCertificateFailedEto). Idempotent: repeated delivery of the same status does not re-raise events. Returns 204 on success, 404 when not found. Requires the Hostnames.Certificates.Report permission.",
         "operationId": "ReportHostnameCertificateStatus",
@@ -696,25 +678,18 @@
   "components": {
     "schemas": {
       "CertificateStatus": {
-        "enum": [
-          "Unprovisioned",
-          "Provisioning",
-          "Secured",
-          "Error"
-        ]
+        "enum": ["Unprovisioned", "Provisioning", "Secured", "Error"]
       },
       "CreateManagedHostnameRequest": {
-        "required": [
-          "host",
-          "ownerType",
-          "ownerId"
-        ],
+        "required": ["host", "ownerType", "ownerId"],
         "type": "object",
         "properties": {
           "host": {
+            "maxLength": 253,
             "type": "string"
           },
           "ownerType": {
+            "maxLength": 100,
             "type": "string"
           },
           "ownerId": {
@@ -722,10 +697,7 @@
             "format": "uuid"
           },
           "tenantId": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "uuid"
           },
           "isPrimary": {
@@ -735,10 +707,7 @@
         }
       },
       "DnsConflict": {
-        "required": [
-          "conflictType",
-          "details"
-        ],
+        "required": ["conflictType", "details"],
         "type": "object",
         "properties": {
           "conflictType": {
@@ -760,19 +729,10 @@
         ]
       },
       "DnsRecordType": {
-        "enum": [
-          "A",
-          "Aaaa",
-          "Cname",
-          "Txt"
-        ]
+        "enum": ["A", "Aaaa", "Cname", "Txt"]
       },
       "ExpectedDnsRecord": {
-        "required": [
-          "recordType",
-          "name",
-          "value"
-        ],
+        "required": ["recordType", "name", "value"],
         "type": "object",
         "properties": {
           "recordType": {
@@ -787,10 +747,7 @@
         }
       },
       "HostnameAvailabilityResponse": {
-        "required": [
-          "host",
-          "isAvailable"
-        ],
+        "required": ["host", "isAvailable"],
         "type": "object",
         "properties": {
           "host": {
@@ -805,35 +762,20 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "title": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "status": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "detail": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "instance": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "errors": {
             "type": "object",
@@ -886,10 +828,7 @@
             "format": "uuid"
           },
           "tenantId": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "uuid"
           },
           "isPrimary": {
@@ -899,10 +838,7 @@
             "type": "string"
           },
           "verificationToken": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "expectedDnsRecords": {
             "type": "array",
@@ -911,10 +847,7 @@
             }
           },
           "lastCheckedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "conflicts": {
@@ -928,20 +861,14 @@
             "format": "int32"
           },
           "nextCheckAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "certificateStatus": {
             "type": "string"
           },
           "certExpiresAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "createdAt": {
@@ -952,17 +879,11 @@
             "type": "string"
           },
           "modifiedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "modifiedBy": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "concurrencyStamp": {
             "type": "string"
@@ -995,19 +916,14 @@
         }
       },
       "ReportCertificateStatusRequest": {
-        "required": [
-          "status"
-        ],
+        "required": ["status"],
         "type": "object",
         "properties": {
           "status": {
             "$ref": "#/components/schemas/CertificateStatus"
           },
           "expiresAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           }
         }

--- a/contracts/openapi/multi-tenancy.json
+++ b/contracts/openapi/multi-tenancy.json
@@ -7,9 +7,7 @@
   "paths": {
     "/multi-tenancy/tenants/{id}": {
       "get": {
-        "tags": [
-          "Platform - Tenants"
-        ],
+        "tags": ["Multi-Tenancy - Tenants"],
         "summary": "Returns a tenant by ID.",
         "description": "Fetches the full tenant details by unique identifier. Returns 404 if the tenant does not exist. Requires the MultiTenancy.Tenants.Read permission.",
         "operationId": "GetTenant",
@@ -79,9 +77,7 @@
         }
       },
       "put": {
-        "tags": [
-          "Platform - Tenants"
-        ],
+        "tags": ["Multi-Tenancy - Tenants"],
         "summary": "Updates a tenant's details.",
         "description": "Updates the display name and contact email of an existing tenant. Returns 404 if the tenant does not exist. Returns 409 if the concurrency stamp does not match the stored value. Requires the MultiTenancy.Tenants.Update permission.",
         "operationId": "UpdateTenant",
@@ -186,9 +182,7 @@
     },
     "/multi-tenancy/tenants": {
       "post": {
-        "tags": [
-          "Platform - Tenants"
-        ],
+        "tags": ["Multi-Tenancy - Tenants"],
         "summary": "Creates a new tenant.",
         "description": "Creates a new active tenant with the specified name and identifier. The identifier must be unique, lowercase alphanumeric with hyphens (slug format). Returns the created tenant. Requires the MultiTenancy.Tenants.Create permission.",
         "operationId": "CreateTenant",
@@ -268,9 +262,7 @@
     },
     "/multi-tenancy/tenants/{id}/activate": {
       "post": {
-        "tags": [
-          "Platform - Tenants"
-        ],
+        "tags": ["Multi-Tenancy - Tenants"],
         "summary": "Activates a tenant.",
         "description": "Activates a previously deactivated tenant, allowing it to be resolved by the tenant resolution middleware. Returns 404 if the tenant does not exist. Requires the MultiTenancy.Tenants.Manage permission.",
         "operationId": "ActivateTenant",
@@ -335,9 +327,7 @@
     },
     "/multi-tenancy/tenants/{id}/deactivate": {
       "post": {
-        "tags": [
-          "Platform - Tenants"
-        ],
+        "tags": ["Multi-Tenancy - Tenants"],
         "summary": "Deactivates a tenant.",
         "description": "Deactivates a tenant, preventing it from being resolved by the tenant resolution middleware. Raises a TenantDeactivatedEvent that can trigger session invalidation. Returns 404 if the tenant does not exist. Requires the MultiTenancy.Tenants.Manage permission.",
         "operationId": "DeactivateTenant",
@@ -404,29 +394,26 @@
   "components": {
     "schemas": {
       "CreateTenantRequest": {
-        "required": [
-          "name",
-          "identifier"
-        ],
+        "required": ["name", "identifier"],
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 256,
             "type": "string"
           },
           "identifier": {
+            "maxLength": 64,
+            "pattern": "^[a-z0-9-]+$",
             "type": "string"
           },
           "contactEmail": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "maxLength": 256,
+            "type": ["null", "string"],
+            "format": "email"
           },
           "jurisdiction": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "maxLength": 16,
+            "type": ["null", "string"]
           }
         }
       },
@@ -434,35 +421,20 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "title": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "status": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "detail": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "instance": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "errors": {
             "type": "object",
@@ -524,19 +496,13 @@
             "type": "string"
           },
           "contactEmail": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "activated": {
             "type": "boolean"
           },
           "jurisdiction": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "createdAt": {
             "type": "string",
@@ -548,29 +514,24 @@
         }
       },
       "UpdateTenantRequest": {
-        "required": [
-          "name",
-          "concurrencyStamp"
-        ],
+        "required": ["name", "concurrencyStamp"],
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 256,
             "type": "string"
           },
           "concurrencyStamp": {
             "type": "string"
           },
           "contactEmail": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "maxLength": 256,
+            "type": ["null", "string"],
+            "format": "email"
           },
           "jurisdiction": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "maxLength": 16,
+            "type": ["null", "string"]
           }
         }
       }
@@ -578,7 +539,7 @@
   },
   "tags": [
     {
-      "name": "Platform - Tenants"
+      "name": "Multi-Tenancy - Tenants"
     }
   ]
 }

--- a/contracts/openapi/presence.json
+++ b/contracts/openapi/presence.json
@@ -7,9 +7,7 @@
   "paths": {
     "/presence/my": {
       "get": {
-        "tags": [
-          "Presence"
-        ],
+        "tags": ["Presence"],
         "summary": "Returns the caller's current presence snapshot.",
         "description": "Computes the effective presence status for the authenticated user by blending their manual override (if any) with their last reported heartbeat.",
         "operationId": "GetMyPresence",
@@ -57,9 +55,7 @@
         }
       },
       "put": {
-        "tags": [
-          "Presence"
-        ],
+        "tags": ["Presence"],
         "summary": "Sets or clears the caller's manual presence override.",
         "description": "Replaces the caller's manual override. Passing ManualStatus=Available clears the override. UntilUtc is optional and bounded by Presence:MaxOverrideDuration.",
         "operationId": "SetMyPresence",
@@ -149,9 +145,7 @@
     },
     "/presence/my/override": {
       "delete": {
-        "tags": [
-          "Presence"
-        ],
+        "tags": ["Presence"],
         "summary": "Clears the caller's manual presence override.",
         "description": "Removes any active manual override so the effective status is derived from the heartbeat alone.",
         "operationId": "ClearMyPresenceOverride",
@@ -211,9 +205,7 @@
     },
     "/presence/my/poll": {
       "post": {
-        "tags": [
-          "Presence"
-        ],
+        "tags": ["Presence"],
         "summary": "Records a heartbeat and returns the caller's presence snapshot.",
         "description": "Clients should call this every 30-60 seconds with the user's local idle duration (in seconds). The server reconstructs the LastActivityUtc using its own clock to avoid client clock-skew issues, and applies a MAX merge across concurrent tabs.",
         "operationId": "PollMyPresence",
@@ -303,9 +295,7 @@
     },
     "/presence/users/{userId}": {
       "get": {
-        "tags": [
-          "Presence"
-        ],
+        "tags": ["Presence"],
         "summary": "Returns the presence snapshot of one user.",
         "description": "Computes the effective presence status for the specified user. Always returns 200 OK — unknown, never-seen, and policy-denied targets are canonicalized to Offline with a null LastSeenUtc so the response shape cannot be used as an enumeration oracle. Visibility is decided by IPresenceVisibilityPolicy (default: allow-all; multi-tenant apps MUST register a tenant-aware policy).",
         "operationId": "GetUserPresence",
@@ -377,9 +367,7 @@
     },
     "/presence/users/batch": {
       "post": {
-        "tags": [
-          "Presence"
-        ],
+        "tags": ["Presence"],
         "summary": "Returns presence snapshots for a batch of users.",
         "description": "Returns a dictionary keyed by user id. POST is used because UUID lists exceed practical URL length around 50 entries. Targets the caller is not allowed to read (per IPresenceVisibilityPolicy) are silently omitted from the response — not 403'd — to avoid leaking an enumeration channel.",
         "operationId": "GetBatchPresence",
@@ -469,9 +457,7 @@
     },
     "/presence/rooms/{kind}/{id}/heartbeat": {
       "post": {
-        "tags": [
-          "Presence - Rooms"
-        ],
+        "tags": ["Presence - Rooms"],
         "summary": "Joins or refreshes the caller's heartbeat in a resource room.",
         "description": "Acts as both join and refresh — clients should call this every 30-60 s while the user remains in the room. Returns the full room snapshot to save a round-trip; participants are filtered through IResourcePresenceVisibilityPolicy.",
         "operationId": "HeartbeatPresenceRoom",
@@ -596,9 +582,7 @@
     },
     "/presence/rooms/{kind}/{id}": {
       "get": {
-        "tags": [
-          "Presence - Rooms"
-        ],
+        "tags": ["Presence - Rooms"],
         "summary": "Returns the participants currently active in a resource room.",
         "description": "Filters stale entries (older than Presence:OfflineThreshold) and consults IResourcePresenceVisibilityPolicy. Policy denial surfaces as 404 to avoid leaking room existence — same anti-enumeration contract as user presence reads.",
         "operationId": "GetPresenceRoom",
@@ -695,9 +679,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Presence - Rooms"
-        ],
+        "tags": ["Presence - Rooms"],
         "summary": "Removes the caller from a resource room.",
         "description": "Idempotent — returns 204 whether or not the caller was present. The room cache entry is evicted entirely when the last participant leaves.",
         "operationId": "LeavePresenceRoom",
@@ -781,9 +763,7 @@
   "components": {
     "schemas": {
       "BatchPresenceRequest": {
-        "required": [
-          "userIds"
-        ],
+        "required": ["userIds"],
         "type": "object",
         "properties": {
           "userIds": {
@@ -796,9 +776,7 @@
         }
       },
       "BatchPresenceResponse": {
-        "required": [
-          "presences"
-        ],
+        "required": ["presences"],
         "type": "object",
         "properties": {
           "presences": {
@@ -810,12 +788,11 @@
         }
       },
       "HeartbeatRequest": {
-        "required": [
-          "idleSeconds"
-        ],
+        "required": ["idleSeconds"],
         "type": "object",
         "properties": {
           "idleSeconds": {
+            "minimum": 0,
             "type": "integer",
             "format": "int32"
           }
@@ -825,10 +802,7 @@
         "type": "object",
         "properties": {
           "metadata": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
@@ -836,35 +810,20 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "title": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "status": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "detail": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "instance": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "errors": {
             "type": "object",
@@ -878,13 +837,7 @@
         }
       },
       "ManualPresenceStatus": {
-        "enum": [
-          "Available",
-          "Busy",
-          "DoNotDisturb",
-          "AppearOffline",
-          null
-        ]
+        "enum": ["Available", "Busy", "DoNotDisturb", "AppearOffline", null]
       },
       "PresenceResponse": {
         "required": [
@@ -914,29 +867,17 @@
             ]
           },
           "overrideUntilUtc": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "lastSeenUtc": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           }
         }
       },
       "PresenceStatus": {
-        "enum": [
-          "Online",
-          "Away",
-          "Offline",
-          "Busy",
-          "DoNotDisturb"
-        ]
+        "enum": ["Online", "Away", "Offline", "Busy", "DoNotDisturb"]
       },
       "ProblemDetails": {
         "type": "object",
@@ -964,11 +905,7 @@
         }
       },
       "ResourcePresenceParticipantResponse": {
-        "required": [
-          "userId",
-          "lastSeenUtc",
-          "metadata"
-        ],
+        "required": ["userId", "lastSeenUtc", "metadata"],
         "type": "object",
         "properties": {
           "userId": {
@@ -980,19 +917,12 @@
             "format": "date-time"
           },
           "metadata": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "ResourceRoomResponse": {
-        "required": [
-          "kind",
-          "id",
-          "participants"
-        ],
+        "required": ["kind", "id", "participants"],
         "type": "object",
         "properties": {
           "kind": {
@@ -1010,19 +940,14 @@
         }
       },
       "SetPresenceRequest": {
-        "required": [
-          "manualStatus"
-        ],
+        "required": ["manualStatus"],
         "type": "object",
         "properties": {
           "manualStatus": {
             "$ref": "#/components/schemas/ManualPresenceStatus"
           },
           "untilUtc": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           }
         }

--- a/contracts/openapi/privacy.json
+++ b/contracts/openapi/privacy.json
@@ -7,11 +7,9 @@
   "paths": {
     "/privacy/regulation": {
       "get": {
-        "tags": [
-          "Privacy"
-        ],
-        "summary": "Returns the privacy regulation profile applicable to the current tenant.",
-        "description": "Resolves the privacy regulation for the current tenant context via IPrivacyRegulationResolver. Returns the full regulation profile including consent model, response timelines, breach notification deadlines, age thresholds, cookie consent rules, and cross-border transfer requirements.",
+        "tags": ["Privacy"],
+        "summary": "Returns the effective privacy regulation profile for the current tenant.",
+        "description": "Resolves the effective privacy regulation for the current tenant via IPrivacyRegulationResolver. For multi-jurisdiction tenants, returns a composite profile (most restrictive rules win) with contributingRegulations listing the source regulations. Single-jurisdiction response is backward-compatible: contributingRegulations contains one entry.",
         "operationId": "GetApplicableRegulation",
         "responses": {
           "200": {
@@ -59,9 +57,7 @@
     },
     "/privacy/purposes": {
       "get": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Returns all registered processing purposes with their legal bases.",
         "description": "Lists all processing purposes declared at application startup via RegisterProcessingPurpose(). Each purpose includes its legal basis, whether explicit consent is required, and an optional data category.",
         "operationId": "ListProcessingPurposes",
@@ -114,9 +110,7 @@
     },
     "/privacy/opt-out": {
       "post": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Opts out of data sale/sharing (CCPA).",
         "description": "Records a 'Do Not Sell or Share My Personal Information' request. Supports both authenticated users and anonymous visitors (CCPA compliance). For anonymous visitors, a _optout_id HTTP-Only cookie is set to track the opt-out. Anonymous opt-outs are stored tenant-less by default (PrivacyEndpointsOptions.BindAnonymousOptOutToCurrentTenant) to prevent tenant injection via a spoofable resolver. Rate-limited via the `privacy-optout-create` policy.",
         "operationId": "RequestOptOut",
@@ -162,16 +156,12 @@
             }
           }
         },
-        "security": [
-          { }
-        ]
+        "security": [{}]
       }
     },
     "/privacy/opt-out/status": {
       "get": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Returns the current opt-out status.",
         "description": "Checks whether the requesting user or visitor has an active opt-out. For authenticated users, checks by UserId. For anonymous visitors, checks the _optout_id cookie.",
         "operationId": "GetOptOutStatus",
@@ -197,16 +187,12 @@
             }
           }
         },
-        "security": [
-          { }
-        ]
+        "security": [{}]
       }
     },
     "/privacy/exports/scopes": {
       "get": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Lists the export scopes visible to the current user.",
         "description": "Returns one entry per IPrivacyDataProvider the subject can include in an export, after applying the framework visibility gates: module loaded, HasDataAsync probe (Takeout-style \"if you never used it, it doesn't appear\"), and the host IPrivacyScopeVisibilityPolicy. Use the returned ProviderName values to populate the POST /privacy/exports `Scopes` field; unknown / hidden scopes in that POST are silently skipped.",
         "operationId": "ListPrivacyExportScopes",
@@ -259,9 +245,7 @@
     },
     "/privacy/exports/on-behalf-of": {
       "post": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Requests a personal data export on behalf of another data subject (admin DSR).",
         "description": "Admin-driven counterpart to POST /privacy/exports — gated by the dedicated Privacy.Exports.ExecuteOnBehalfOf permission so RBAC can hand it to a narrow operator role without unlocking it for every authenticated user. The body's SubjectUserId identifies the data subject; the authenticated caller is recorded separately on the audit row so the substitution is fully reconstructable for GDPR Art. 30 ROPA. Uses the dedicated `privacy-export-create-on-behalf-of` rate-limit policy (distinct from the self-service `privacy-export-create`). The subject id is validated against the caller's tenant via IPrivacySubjectValidator — a subject absent from the tenant returns 404 (same status as a non-existent request id, so cross-tenant existence cannot be probed).",
         "operationId": "RequestPrivacyExportOnBehalfOf",
@@ -341,9 +325,7 @@
     },
     "/privacy/exports": {
       "post": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Requests a personal data export for the current user.",
         "description": "Triggers the scatter-gather export saga (GDPR Art. 15/20). Each registered data provider prepares its fragment asynchronously. The saga assembles fragments into a downloadable archive. The optional `Scopes` array narrows the export to a subset of provider scopes (see GET /privacy/exports/scopes); omitting it exports everything visible to the subject. Poll GET /exports/{requestId} for status, or wire a Granit.Notifications handler on ExportCompletedEto to notify the user when the archive is ready. Rate-limited via the `privacy-export-create` policy (hosts configure quotas in `RateLimiting:Policies` — defaults to 1 export per subject per 24 hours). Honours an optional `Idempotency-Key` header (Granit.Http.Idempotency) so accidental double-clicks don't spawn two scatter-gather sagas.",
         "operationId": "RequestPrivacyExport",
@@ -427,9 +409,7 @@
         }
       },
       "get": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Lists all export requests for the current user.",
         "description": "Returns all export requests submitted by the current user, ordered by most recent first. Each entry includes the request state, timestamps, and archive reference when available.",
         "operationId": "ListPrivacyExports",
@@ -482,9 +462,7 @@
     },
     "/privacy/exports/{requestId}": {
       "get": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Returns the status of a personal data export request.",
         "description": "Queries the export request tracker for the specified request ID. Only the user who created the request can view its status. Returns the current state (Pending, Completed, PartiallyCompleted, TimedOut), the archive blob reference when available, and any missing providers. Returns 404 if the request ID is not found or belongs to another user.",
         "operationId": "GetPrivacyExportStatus",
@@ -556,9 +534,7 @@
     },
     "/privacy/exports/{requestId}/download": {
       "get": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Downloads the personal data export archive (compat — single-shard or manifest).",
         "description": "Convenience route that resolves to shard 0 when the export produced a single archive, or to the manifest sidecar when sharded into multiple ZIPs. For deterministic multi-shard downloads, use GET /exports/{requestId}/download/{shardIndex} per shard plus GET /exports/{requestId}/download/manifest to discover the shard count. Step-up authentication required when DownloadStepUpRequired is enabled (default).",
         "operationId": "DownloadPrivacyExport",
@@ -576,7 +552,15 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -633,9 +617,7 @@
     },
     "/privacy/exports/{requestId}/download/manifest": {
       "get": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Downloads the manifest sidecar describing the export's shards.",
         "description": "Returns the signed JSON manifest produced by the assembly job. Clients use it to discover the shard count and per-shard sha256/integrity tag before pulling each ZIP. Step-up authentication required when DownloadStepUpRequired is enabled (default).",
         "operationId": "DownloadPrivacyExportManifest",
@@ -653,7 +635,10 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -710,9 +695,7 @@
     },
     "/privacy/exports/{requestId}/download/{shardIndex}": {
       "get": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Downloads a single shard of a sharded personal data export.",
         "description": "Streams the shard ZIP indexed by 0..(ShardCount-1) from the export's archive set. Shard indices outside the manifest's bounds return 404. Step-up authentication required when DownloadStepUpRequired is enabled (default).",
         "operationId": "DownloadPrivacyExportShard",
@@ -741,7 +724,15 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -798,9 +789,7 @@
     },
     "/privacy/deletions": {
       "post": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Requests personal data deletion for the current user.",
         "description": "Publishes a distributed deletion event (GDPR Art. 17 — right to erasure). When Defer is false, deletion is immediate. When Defer is true, a cooling-off period starts — the user receives a reminder email before the deadline and can cancel via POST /deletion/{requestId}/cancel. A confirmation email is sent in both cases after deletion is executed. Do not include personally identifiable information in the Reason field.",
         "operationId": "RequestPrivacyDeletion",
@@ -888,9 +877,7 @@
         }
       },
       "get": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Lists all deletion requests for the current user.",
         "description": "Returns all deferred deletion requests submitted by the current user, ordered by most recent first. Immediate deletions are not tracked.",
         "operationId": "ListPrivacyDeletions",
@@ -943,9 +930,7 @@
     },
     "/privacy/deletions/{requestId}/cancel": {
       "post": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Cancels a deferred deletion request during the grace period.",
         "description": "Cancels a deferred deletion request. Only requests in Deferred state can be cancelled. Returns 404 if the request is not found, 409 if already executed or cancelled.",
         "operationId": "CancelPrivacyDeletion",
@@ -1020,9 +1005,7 @@
     },
     "/privacy/deletions/{requestId}": {
       "get": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Returns the status of a deferred deletion request.",
         "description": "Queries the deletion request tracker for the specified request ID. Only the user who created the request can view its status. Returns the current state (Deferred, Executed, Cancelled), scheduled deletion date, and timestamps. Returns 404 if the request is not found or belongs to another user.",
         "operationId": "GetPrivacyDeletionStatus",
@@ -1094,9 +1077,7 @@
     },
     "/privacy/agreements/documents": {
       "get": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Returns all registered legal documents.",
         "description": "Returns all legal documents registered in the consent registry (GDPR Art. 7). Each document includes its identifier, current version, and display name. Use GET /agreements/status to check the user's consent per document.",
         "operationId": "ListPrivacyLegalDocuments",
@@ -1149,9 +1130,7 @@
     },
     "/privacy/agreements/status": {
       "get": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Returns the consent status for all legal documents.",
         "description": "For each registered legal document, returns whether the current user has accepted the latest version and when the last acceptance occurred. Documents where HasAcceptedLatest is false require re-consent.",
         "operationId": "GetPrivacyConsentStatus",
@@ -1204,9 +1183,7 @@
     },
     "/privacy/agreements/history": {
       "get": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Returns the consent history for the current user.",
         "description": "Returns all consent records for the current user, ordered by most recent first. Each record includes the document ID, accepted version, timestamp, and whether it matches the current document version.",
         "operationId": "ListPrivacyAgreementHistory",
@@ -1259,9 +1236,7 @@
     },
     "/privacy/agreements/accept": {
       "post": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Records acceptance of a legal agreement.",
         "description": "Records the user's consent for a specific legal document version (GDPR Art. 7). The version must match the current version — stale consent is rejected (422). If the user has already accepted the latest version, returns 409. The client IP address is captured and pseudonymized for the audit trail. Ensure ForwardedHeadersMiddleware is enabled when running behind a reverse proxy.",
         "operationId": "AcceptPrivacyAgreement",
@@ -1344,9 +1319,7 @@
     },
     "/privacy/legal-documents": {
       "post": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Creates a new legal document draft.",
         "description": "Creates a new legal document version in Draft status. The document can be edited and then published to become the active version. Publishing auto-archives the previous active version.",
         "operationId": "CreateLegalDocument",
@@ -1424,9 +1397,7 @@
         }
       },
       "get": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Lists all versions of a legal document.",
         "description": "Returns the version history for the specified document ID, ordered by version descending. Includes drafts, published, and archived versions.",
         "operationId": "ListLegalDocumentVersions",
@@ -1489,9 +1460,7 @@
     },
     "/privacy/legal-documents/{id}": {
       "get": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Returns a legal document by ID, including drafts and archived versions.",
         "description": "Returns the full detail of a legal document version, regardless of its lifecycle status. Requires admin read permission.",
         "operationId": "GetLegalDocument",
@@ -1561,9 +1530,7 @@
         }
       },
       "put": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Updates a legal document draft.",
         "description": "Updates metadata of a legal document in Draft status. Returns 400 if the document is not in Draft status. Returns 409 if the concurrency stamp does not match the stored value.",
         "operationId": "UpdateLegalDocument",
@@ -1675,9 +1642,7 @@
     },
     "/privacy/legal-documents/{id}/publish": {
       "post": {
-        "tags": [
-          "Privacy"
-        ],
+        "tags": ["Privacy"],
         "summary": "Publishes a legal document draft, auto-archiving the previous published version.",
         "description": "Promotes the draft to Published status. If a published version already exists for the same document ID, it is archived in the same transaction and LegalAgreementObsoleteEto is dispatched to trigger re-consent flows.",
         "operationId": "PublishLegalDocument",
@@ -1767,35 +1732,20 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "title": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "status": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "detail": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "instance": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "errors": {
             "type": "object",
@@ -1809,29 +1759,24 @@
         }
       },
       "LegalDocumentCreateRequest": {
-        "required": [
-          "documentId",
-          "displayName"
-        ],
+        "required": ["documentId", "displayName"],
         "type": "object",
         "properties": {
           "documentId": {
+            "maxLength": 200,
             "type": "string"
           },
           "displayName": {
+            "maxLength": 500,
             "type": "string"
           },
           "description": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "maxLength": 2000,
+            "type": ["null", "string"]
           },
           "templateName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "maxLength": 500,
+            "type": ["null", "string"]
           }
         }
       },
@@ -1869,22 +1814,13 @@
             "type": "string"
           },
           "description": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "templateName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "documentBlobId": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "uuid"
           },
           "createdAt": {
@@ -1901,61 +1837,46 @@
         }
       },
       "LegalDocumentUpdateRequest": {
-        "required": [
-          "displayName",
-          "concurrencyStamp"
-        ],
+        "required": ["displayName", "concurrencyStamp"],
         "type": "object",
         "properties": {
           "displayName": {
+            "maxLength": 500,
             "type": "string"
           },
           "concurrencyStamp": {
             "type": "string"
           },
           "description": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "maxLength": 2000,
+            "type": ["null", "string"]
           },
           "templateName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "maxLength": 500,
+            "type": ["null", "string"]
           },
           "documentBlobId": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "uuid"
           }
         }
       },
       "PrivacyAcceptAgreementRequest": {
-        "required": [
-          "documentId",
-          "version"
-        ],
+        "required": ["documentId", "version"],
         "type": "object",
         "properties": {
           "documentId": {
+            "maxLength": 200,
             "type": "string"
           },
           "version": {
+            "maxLength": 50,
             "type": "string"
           }
         }
       },
       "PrivacyConsentStatusResponse": {
-        "required": [
-          "documentId",
-          "currentVersion",
-          "hasAcceptedLatest",
-          "lastAcceptedAt"
-        ],
+        "required": ["documentId", "currentVersion", "hasAcceptedLatest", "lastAcceptedAt"],
         "type": "object",
         "properties": {
           "documentId": {
@@ -1968,21 +1889,17 @@
             "type": "boolean"
           },
           "lastAcceptedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           }
         }
       },
       "PrivacyDeletionRequest": {
-        "required": [
-          "reason"
-        ],
+        "required": ["reason"],
         "type": "object",
         "properties": {
           "reason": {
+            "maxLength": 2000,
             "type": "string"
           },
           "defer": {
@@ -1992,10 +1909,7 @@
         }
       },
       "PrivacyDeletionRequestResponse": {
-        "required": [
-          "requestId",
-          "scheduledDeletionAt"
-        ],
+        "required": ["requestId", "scheduledDeletionAt"],
         "type": "object",
         "properties": {
           "requestId": {
@@ -2039,25 +1953,17 @@
             "format": "date-time"
           },
           "cancelledAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "executedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           }
         }
       },
       "PrivacyExportOnBehalfOfRequest": {
-        "required": [
-          "subjectUserId"
-        ],
+        "required": ["subjectUserId"],
         "type": "object",
         "properties": {
           "subjectUserId": {
@@ -2065,10 +1971,8 @@
             "format": "uuid"
           },
           "scopes": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "maxLength": 200,
+            "type": ["null", "array"],
             "items": {
               "type": "string"
             }
@@ -2079,10 +1983,8 @@
         "type": "object",
         "properties": {
           "scopes": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "maxLength": 200,
+            "type": ["null", "array"],
             "items": {
               "type": "string"
             }
@@ -2090,10 +1992,7 @@
         }
       },
       "PrivacyExportRequestResponse": {
-        "required": [
-          "requestId",
-          "requestedAt"
-        ],
+        "required": ["requestId", "requestedAt"],
         "type": "object",
         "properties": {
           "requestId": {
@@ -2123,21 +2022,14 @@
             "type": "string"
           },
           "featureName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "defaultSelected": {
             "type": "boolean"
           },
           "estimatedSizeBytes": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "null",
-              "integer",
-              "string"
-            ],
+            "type": ["null", "integer", "string"],
             "format": "int64"
           }
         }
@@ -2165,10 +2057,7 @@
             "format": "date-time"
           },
           "completedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "archiveBlobReferenceId": {
@@ -2190,11 +2079,7 @@
         }
       },
       "PrivacyLegalDocumentResponse": {
-        "required": [
-          "documentId",
-          "currentVersion",
-          "displayName"
-        ],
+        "required": ["documentId", "currentVersion", "displayName"],
         "type": "object",
         "properties": {
           "documentId": {
@@ -2209,28 +2094,18 @@
         }
       },
       "PrivacyOptOutStatusResponse": {
-        "required": [
-          "isOptedOut",
-          "optedOutAt",
-          "regulation"
-        ],
+        "required": ["isOptedOut", "optedOutAt", "regulation"],
         "type": "object",
         "properties": {
           "isOptedOut": {
             "type": "boolean"
           },
           "optedOutAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "regulation": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
@@ -2261,10 +2136,7 @@
             "type": "boolean"
           },
           "dataCategory": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
@@ -2273,6 +2145,7 @@
           "regulation",
           "displayName",
           "jurisdictionCode",
+          "contributingRegulations",
           "consentModel",
           "availableLegalBases",
           "subjectAccessRequestDays",
@@ -2303,6 +2176,12 @@
           "jurisdictionCode": {
             "type": "string"
           },
+          "contributingRegulations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "consentModel": {
             "type": "string"
           },
@@ -2317,17 +2196,11 @@
             "format": "int32"
           },
           "subjectAccessRequestExtensionDays": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "deletionRequestDays": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "defaultDeletionGracePeriodDays": {
@@ -2339,17 +2212,11 @@
             "format": "int32"
           },
           "breachNotifyAuthorityHours": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "breachNotifyIndividualsHours": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "minimumConsentAge": {
@@ -2389,13 +2256,7 @@
         }
       },
       "PrivacyUserAgreementResponse": {
-        "required": [
-          "id",
-          "documentId",
-          "version",
-          "acceptedAt",
-          "isLatest"
-        ],
+        "required": ["id", "documentId", "version", "acceptedAt", "isLatest"],
         "type": "object",
         "properties": {
           "id": {

--- a/contracts/openapi/settings.json
+++ b/contracts/openapi/settings.json
@@ -7,9 +7,7 @@
   "paths": {
     "/settings/user": {
       "get": {
-        "tags": [
-          "Settings - User"
-        ],
+        "tags": ["Settings - User"],
         "summary": "Returns all client-visible settings resolved for the current user.",
         "description": "Returns all settings marked as client-visible, resolved through the cascading chain (User → Tenant → Global). Only settings with the ClientVisible flag are included. The values reflect the effective configuration for the authenticated user.",
         "operationId": "GetAllUserSettings",
@@ -66,9 +64,7 @@
     },
     "/settings/user/{name}": {
       "get": {
-        "tags": [
-          "Settings - User"
-        ],
+        "tags": ["Settings - User"],
         "summary": "Returns a single setting resolved for the current user.",
         "description": "Returns the effective value of a single setting resolved through the cascading chain (User → Tenant → Global). Returns 404 if the setting name does not match any registered setting definition.",
         "operationId": "GetUserSetting",
@@ -76,7 +72,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -137,9 +133,7 @@
         }
       },
       "put": {
-        "tags": [
-          "Settings - User"
-        ],
+        "tags": ["Settings - User"],
         "summary": "Sets a user-level setting value.",
         "description": "Sets a user-level override for the specified setting. This value takes precedence over tenant and global values for this user. Pass null to clear. Returns 404 if the setting name is not defined. Returns 400 if the User provider is not allowed for this setting.",
         "operationId": "UpdateUserSetting",
@@ -147,7 +141,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -231,9 +225,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Settings - User"
-        ],
+        "tags": ["Settings - User"],
         "summary": "Clears the user-level setting value (falls back to tenant/global).",
         "description": "Removes the user-level override for the specified setting. The effective value reverts to the tenant or global value. Returns 404 if the setting name is not defined.",
         "operationId": "DeleteUserSetting",
@@ -241,7 +233,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -297,9 +289,7 @@
     },
     "/settings/global": {
       "get": {
-        "tags": [
-          "Settings - Global"
-        ],
+        "tags": ["Settings - Global"],
         "summary": "Returns all settings at the global scope.",
         "description": "Returns all settings defined at the global (application-wide) scope as a key-value dictionary. Global settings serve as the base layer in the cascading resolution chain (User → Tenant → Global). Requires the Settings.Global.Read permission.",
         "operationId": "GetAllGlobalSettings",
@@ -356,9 +346,7 @@
     },
     "/settings/global/definitions": {
       "get": {
-        "tags": [
-          "Settings - Global"
-        ],
+        "tags": ["Settings - Global"],
         "summary": "Returns all global settings enriched with their definition metadata.",
         "description": "Returns every declared setting alongside its metadata (display label, description, default value, value kind, optional allow-list) and the current resolved value at the global scope. Intended for admin UIs that need to render a typed form per setting without guessing value types. The IsVisibleToClients flag is ignored — admins see all settings. Encrypted values are returned masked as '***'. Requires the Settings.Global.Read permission.",
         "operationId": "GetAllGlobalSettingDefinitions",
@@ -411,9 +399,7 @@
     },
     "/settings/global/{name}": {
       "put": {
-        "tags": [
-          "Settings - Global"
-        ],
+        "tags": ["Settings - Global"],
         "summary": "Sets a global-level setting value.",
         "description": "Sets or clears a global-level setting value. Pass null to remove the override and revert to the definition's default. The setting name must match a registered setting definition (returns 404 otherwise). Returns 400 if the Global provider is not allowed for this setting. Requires the Settings.Global.Manage permission.",
         "operationId": "UpdateGlobalSetting",
@@ -421,7 +407,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -507,9 +493,7 @@
     },
     "/settings/global/bulk": {
       "put": {
-        "tags": [
-          "Settings - Global"
-        ],
+        "tags": ["Settings - Global"],
         "summary": "Applies multiple global setting updates in a single request.",
         "description": "Applies every entry individually — a failure on one entry (unknown key, disallowed provider, invalid value) does not roll back the others. Returns HTTP 200 with a per-entry outcome envelope; clients inspect each BulkSettingResult to determine success. Pass null in Value to clear an override. Malformed request bodies (empty list, too many entries) return 400. Requires the Settings.Global.Manage permission.",
         "operationId": "BulkUpdateGlobalSettings",
@@ -589,9 +573,7 @@
     },
     "/settings/tenant": {
       "get": {
-        "tags": [
-          "Settings - Tenant"
-        ],
+        "tags": ["Settings - Tenant"],
         "summary": "Returns all settings at the current tenant scope.",
         "description": "Returns all settings defined at the tenant scope for the current tenant. Tenant settings override global values in the cascading resolution chain. Requires the Settings.Tenant.Read permission. Returns 400 if no tenant context is available.",
         "operationId": "GetAllTenantSettings",
@@ -658,9 +640,7 @@
     },
     "/settings/tenant/definitions": {
       "get": {
-        "tags": [
-          "Settings - Tenant"
-        ],
+        "tags": ["Settings - Tenant"],
         "summary": "Returns all tenant settings enriched with their definition metadata.",
         "description": "Returns every declared setting alongside its metadata (display label, description, default value, value kind, optional allow-list) and the current resolved value for the current tenant. Intended for tenant-admin UIs that need to render a typed form per setting. The IsVisibleToClients flag is ignored — tenant admins see all settings. Encrypted values are returned masked as '***'. Returns 400 if no tenant context is available. Requires the Settings.Tenant.Read permission.",
         "operationId": "GetAllTenantSettingDefinitions",
@@ -723,9 +703,7 @@
     },
     "/settings/tenant/{name}": {
       "put": {
-        "tags": [
-          "Settings - Tenant"
-        ],
+        "tags": ["Settings - Tenant"],
         "summary": "Sets a tenant-level setting value.",
         "description": "Sets or clears a tenant-level setting value for the current tenant. Pass null to remove the tenant override and fall back to the global value. The setting name must match a registered setting definition (returns 404 otherwise). Returns 400 if no tenant context is available or if the Tenant provider is not allowed for this setting. Requires the Settings.Tenant.Manage permission.",
         "operationId": "UpdateTenantSetting",
@@ -733,7 +711,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -819,9 +797,7 @@
     },
     "/settings/tenant/bulk": {
       "put": {
-        "tags": [
-          "Settings - Tenant"
-        ],
+        "tags": ["Settings - Tenant"],
         "summary": "Applies multiple tenant setting updates in a single request.",
         "description": "Applies every entry individually for the current tenant — a failure on one entry (unknown key, disallowed provider, invalid value) does not roll back the others. Returns HTTP 200 with a per-entry outcome envelope; clients inspect each BulkSettingResult to determine success. Pass null in Value to clear an override. Returns 400 if no tenant context is available or if the request body is malformed. Requires the Settings.Tenant.Manage permission.",
         "operationId": "BulkUpdateTenantSettings",
@@ -919,37 +895,22 @@
             "type": "string"
           },
           "label": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "description": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "defaultValue": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "value": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "valueKind": {
             "$ref": "#/components/schemas/ValueKind"
           },
           "allowedValues": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "type": "string"
             }
@@ -960,37 +921,22 @@
         }
       },
       "BulkSettingEntry": {
-        "required": [
-          "key",
-          "value"
-        ],
+        "required": ["key", "value"],
         "type": "object",
         "properties": {
           "key": {
             "type": "string"
           },
           "value": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "BulkSettingOutcome": {
-        "enum": [
-          "Updated",
-          "NotFound",
-          "ProviderNotAllowed",
-          "ValidationFailed"
-        ]
+        "enum": ["Updated", "NotFound", "ProviderNotAllowed", "ValidationFailed"]
       },
       "BulkSettingResult": {
-        "required": [
-          "key",
-          "outcome",
-          "errorCode"
-        ],
+        "required": ["key", "outcome", "errorCode"],
         "type": "object",
         "properties": {
           "key": {
@@ -1000,31 +946,25 @@
             "$ref": "#/components/schemas/BulkSettingOutcome"
           },
           "errorCode": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "BulkUpdateSettingsRequest": {
-        "required": [
-          "settings"
-        ],
+        "required": ["settings"],
         "type": "object",
         "properties": {
           "settings": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/BulkSettingEntry"
-            }
+            },
+            "x-granit-validator": "Validation:BulkSettingsTooLarge"
           }
         }
       },
       "BulkUpdateSettingsResponse": {
-        "required": [
-          "results"
-        ],
+        "required": ["results"],
         "type": "object",
         "properties": {
           "results": {
@@ -1039,35 +979,20 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "title": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "status": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "detail": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "instance": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "errors": {
             "type": "object",
@@ -1106,20 +1031,14 @@
         }
       },
       "SettingValueResponse": {
-        "required": [
-          "name",
-          "value"
-        ],
+        "required": ["name", "value"],
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
           "value": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
@@ -1127,21 +1046,13 @@
         "type": "object",
         "properties": {
           "value": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "maxLength": 4000,
+            "type": ["null", "string"]
           }
         }
       },
       "ValueKind": {
-        "enum": [
-          "String",
-          "Bool",
-          "Int",
-          "Double",
-          "Json"
-        ]
+        "enum": ["String", "Bool", "Int", "Double", "Json"]
       }
     }
   },

--- a/contracts/openapi/validation.json
+++ b/contracts/openapi/validation.json
@@ -7,9 +7,7 @@
   "paths": {
     "/validation/validate": {
       "post": {
-        "tags": [
-          "Validation"
-        ],
+        "tags": ["Validation"],
         "summary": "Validates a single field value against a registered server-side validator.",
         "description": "Looks up the validator by error code and returns the validation result. Returns 404 if no validator is registered for the specified error code. Use the GET /validators endpoint to discover available validators.",
         "operationId": "ValidateField",
@@ -69,9 +67,7 @@
     },
     "/validation/validate-batch": {
       "post": {
-        "tags": [
-          "Validation"
-        ],
+        "tags": ["Validation"],
         "summary": "Validates multiple field values in a single round-trip (max 20).",
         "description": "For each field, looks up the validator by error code and returns the result. Unknown error codes return ValidatorNotFound status instead of failing the entire batch.",
         "operationId": "ValidateFieldBatch",
@@ -131,9 +127,7 @@
     },
     "/validation/validators": {
       "get": {
-        "tags": [
-          "Validation"
-        ],
+        "tags": ["Validation"],
         "summary": "Lists all registered server-side validator error codes.",
         "description": "Returns the list of error codes that can be used with the validate and validate-batch endpoints. Useful for frontend discovery: only error codes listed here can be validated in real-time.",
         "operationId": "GetRegisteredValidators",
@@ -171,35 +165,20 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "title": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "status": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "detail": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "instance": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "errors": {
             "type": "object",
@@ -238,30 +217,23 @@
         }
       },
       "ValidationFieldStatus": {
-        "enum": [
-          "Valid",
-          "Invalid",
-          "ValidatorNotFound"
-        ]
+        "enum": ["Valid", "Invalid", "ValidatorNotFound"]
       },
       "ValidationFieldValidateBatchRequest": {
-        "required": [
-          "fields"
-        ],
+        "required": ["fields"],
         "type": "object",
         "properties": {
           "fields": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ValidationFieldValidateRequest"
-            }
+            },
+            "x-granit-validator": "Validation:Rule:MaxBatchSize"
           }
         }
       },
       "ValidationFieldValidateBatchResponse": {
-        "required": [
-          "results"
-        ],
+        "required": ["results"],
         "type": "object",
         "properties": {
           "results": {
@@ -273,27 +245,22 @@
         }
       },
       "ValidationFieldValidateRequest": {
-        "required": [
-          "errorCode"
-        ],
+        "required": ["errorCode"],
         "type": "object",
         "properties": {
           "errorCode": {
+            "maxLength": 128,
+            "pattern": "^[A-Za-z0-9:._]+$",
             "type": "string"
           },
           "value": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "maxLength": 500,
+            "type": ["null", "string"]
           }
         }
       },
       "ValidationFieldValidateResponse": {
-        "required": [
-          "errorCode",
-          "status"
-        ],
+        "required": ["errorCode", "status"],
         "type": "object",
         "properties": {
           "errorCode": {

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -168,6 +168,98 @@ export const CONTRACTS: readonly ModuleContract[] = [
     ],
     checkEndpoints: true,
   },
+  // ─── Framework — additional module coverage (granit-dotnet) ─────────────────
+  // Object DTOs only (types-only — route conformance can be layered on later).
+  // String-union enums and raw query-engine grid entities are verified
+  // indirectly (via referencing fields / the grid), not listed here.
+  {
+    slug: 'cookies',
+    package: 'cookies',
+    types: ['CookieConsentConfigResponse', 'CookieDefinitionResponse', 'ThirdPartyServiceResponse'],
+  },
+  {
+    slug: 'diagnostics',
+    package: 'diagnostics',
+    types: ['MonitoringHealthResponse', 'ServiceHealthResponse'],
+  },
+  {
+    slug: 'hostnames',
+    package: 'hostnames',
+    types: [
+      'ManagedHostnameResponse',
+      'HostnameAvailabilityResponse',
+      'CreateManagedHostnameRequest',
+      'ReportCertificateStatusRequest',
+      'DnsConflict',
+      'ExpectedDnsRecord',
+    ],
+  },
+  {
+    slug: 'multi-tenancy',
+    package: 'multi-tenancy',
+    types: ['TenantResponse', 'CreateTenantRequest', 'UpdateTenantRequest'],
+  },
+  {
+    slug: 'presence',
+    package: 'presence',
+    types: [
+      'PresenceResponse',
+      'SetPresenceRequest',
+      'HeartbeatRequest',
+      'HeartbeatRoomRequest',
+      'BatchPresenceRequest',
+      'BatchPresenceResponse',
+      'ResourceRoomResponse',
+      'ResourcePresenceParticipantResponse',
+    ],
+  },
+  {
+    slug: 'privacy',
+    package: 'privacy',
+    types: [
+      'PrivacyConsentStatusResponse',
+      'PrivacyUserAgreementResponse',
+      'PrivacyAcceptAgreementRequest',
+      'PrivacyLegalDocumentResponse',
+      'LegalDocumentDetailResponse',
+      'LegalDocumentCreateRequest',
+      'LegalDocumentUpdateRequest',
+      'PrivacyProcessingPurposeResponse',
+      'PrivacyRegulationProfileResponse',
+      'PrivacyOptOutStatusResponse',
+      'PrivacyExportRequest',
+      'PrivacyExportOnBehalfOfRequest',
+      'PrivacyExportRequestResponse',
+      'PrivacyExportStatusResponse',
+      'PrivacyExportScopeResponse',
+      'PrivacyDeletionRequest',
+      'PrivacyDeletionRequestResponse',
+      'PrivacyDeletionStatusResponse',
+    ],
+  },
+  {
+    slug: 'settings',
+    package: 'settings',
+    types: [
+      'SettingValueResponse',
+      'AdminAppSettingResponse',
+      'UpdateSettingValueRequest',
+      'BulkUpdateSettingsRequest',
+      'BulkUpdateSettingsResponse',
+      'BulkSettingEntry',
+      'BulkSettingResult',
+    ],
+  },
+  {
+    slug: 'validation',
+    package: 'validation',
+    types: [
+      'ValidationFieldValidateRequest',
+      'ValidationFieldValidateResponse',
+      'ValidationFieldValidateBatchRequest',
+      'ValidationFieldValidateBatchResponse',
+    ],
+  },
   // ─── CMS bounded context (granit-website / Granit.Cms.*.Endpoints) ──────────
   // Specs vendored from Granit.Cms.OpenApi.Generator. Object DTOs only — the
   // oracle is a field-by-field checker, so standalone string-union enums


### PR DESCRIPTION
## Context
Coverage campaign for `@granit/contract-tests` — **Tier A (framework)**. Companion to the business Tier A PR (#661).

## Changes
- **Re-vendor 6 stale framework snapshots** from `Granit.OpenApi.Generator`: `hostnames`, `multi-tenancy`, `presence`, `privacy`, `settings`, `validation` (drift was undetected — these modules weren't registered).
- **Register 8 framework modules** in `manifest.ts` (**types-only**): `cookies`, `diagnostics`, `hostnames`, `multi-tenancy`, `presence`, `privacy`, `settings`, `validation`.

Entries are placed in the framework section (after `features`), not the array tail, to avoid a merge conflict with #661. String-union enums and raw query-engine grid entities are verified indirectly, not listed.

## Verification
- Conformance: **234 passed** — no DTO drift surfaced; all 8 modules conform against the re-synced specs.
- `tsc --noEmit`, ESLint clean.

## Follow-up
Tier A complete after this + #661 (17 modules newly covered). Remaining: Tier B (modules needing DTO additions) and Tier C (front DTO renames — openiddict, timeline, data-lookup, analytics, data-exchange).