### PR TITLE
test(contracts): re-sync + cover 5 framework modules (Tier B)

### DIFF
--- a/contracts/openapi/localization.json
+++ b/contracts/openapi/localization.json
@@ -7,9 +7,7 @@
   "paths": {
     "/localization": {
       "get": {
-        "tags": [
-          "Localization"
-        ],
+        "tags": ["Localization"],
         "summary": "Returns all localization resources for the requested culture.",
         "description": "Returns all localization resources (key-value pairs) for the requested culture, grouped by resource name. Accepts an optional cultureName query parameter (BCP 47 format); defaults to the Accept-Language header culture. Also returns the list of supported languages. Response is cached for 1 hour (Cache-Control: public, max-age=3600, Vary: Accept-Language). Anonymous — no authentication required.",
         "operationId": "GetLocalization",
@@ -57,16 +55,12 @@
             }
           }
         },
-        "security": [
-          { }
-        ]
+        "security": [{}]
       }
     },
     "/localization/overrides": {
       "get": {
-        "tags": [
-          "Localization"
-        ],
+        "tags": ["Localization"],
         "summary": "Returns a filtered, sorted, and paginated list of LocalizationOverride entries.",
         "description": "Executes a dynamic query against LocalizationOverride using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
         "operationId": "QueryLocalizationOverride",
@@ -77,10 +71,7 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": [
-                "null",
-                "integer"
-              ],
+              "type": ["null", "integer"],
               "format": "int32"
             }
           },
@@ -91,10 +82,7 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": [
-                "null",
-                "integer"
-              ],
+              "type": ["null", "integer"],
               "format": "int32"
             }
           },
@@ -103,10 +91,7 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -114,10 +99,7 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -125,10 +107,7 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -136,10 +115,7 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -147,10 +123,7 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -158,10 +131,7 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": [
-                "null",
-                "boolean"
-              ]
+              "type": ["null", "boolean"]
             }
           },
           {
@@ -171,10 +141,7 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": [
-                "null",
-                "object"
-              ],
+              "type": ["null", "object"],
               "additionalProperties": {
                 "type": "string"
               }
@@ -187,10 +154,7 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": [
-                "null",
-                "object"
-              ],
+              "type": ["null", "object"],
               "additionalProperties": {
                 "type": "string"
               }
@@ -261,9 +225,7 @@
     },
     "/localization/overrides/meta": {
       "get": {
-        "tags": [
-          "Localization"
-        ],
+        "tags": ["Localization"],
         "summary": "Returns query metadata for LocalizationOverride (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for LocalizationOverride: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetLocalizationOverrideMeta",
@@ -313,9 +275,7 @@
     },
     "/localization/overrides/{resourceName}/{cultureName}/{key}": {
       "put": {
-        "tags": [
-          "Localization"
-        ],
+        "tags": ["Localization"],
         "summary": "Creates or updates a translation override.",
         "description": "Sets a translation override for a specific resource, culture, and key. If an override already exists, it is replaced. The culture name must be a valid BCP 47 tag. Returns 501 if no override store is registered.",
         "operationId": "PutLocalizationOverride",
@@ -425,9 +385,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Localization"
-        ],
+        "tags": ["Localization"],
         "summary": "Removes a translation override.",
         "description": "Removes the translation override for the specified resource, culture, and key. The original value from the resource file becomes effective again. No-op if the override does not exist. Returns 501 if no override store is registered.",
         "operationId": "DeleteLocalizationOverride",
@@ -521,11 +479,7 @@
   "components": {
     "schemas": {
       "ApplicationLocalizationResponse": {
-        "required": [
-          "cultureName",
-          "resources",
-          "languages"
-        ],
+        "required": ["cultureName", "resources", "languages"],
         "type": "object",
         "properties": {
           "cultureName": {
@@ -584,19 +538,12 @@
             "type": "boolean"
           },
           "format": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "DateFilterMeta": {
-        "required": [
-          "name",
-          "defaultPeriod",
-          "availablePeriods"
-        ],
+        "required": ["name", "defaultPeriod", "availablePeriods"],
         "type": "object",
         "properties": {
           "name": {
@@ -614,22 +561,10 @@
         }
       },
       "DatePeriod": {
-        "enum": [
-          "Today",
-          "ThisWeek",
-          "ThisMonth",
-          "LastMonth",
-          "ThisQuarter",
-          "ThisYear",
-          "Custom"
-        ]
+        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
       },
       "FilterableField": {
-        "required": [
-          "name",
-          "type",
-          "operators"
-        ],
+        "required": ["name", "type", "operators"],
         "type": "object",
         "properties": {
           "name": {
@@ -645,10 +580,7 @@
             }
           },
           "enumValues": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "type": "string"
             }
@@ -666,11 +598,7 @@
         }
       },
       "FilterGroupMeta": {
-        "required": [
-          "name",
-          "label",
-          "presets"
-        ],
+        "required": ["name", "label", "presets"],
         "type": "object",
         "properties": {
           "name": {
@@ -702,10 +630,7 @@
         ]
       },
       "GroupByField": {
-        "required": [
-          "name",
-          "type"
-        ],
+        "required": ["name", "type"],
         "type": "object",
         "properties": {
           "name": {
@@ -717,10 +642,7 @@
         }
       },
       "GroupedResultOfLocalizationOverride": {
-        "required": [
-          "groups",
-          "totalCount"
-        ],
+        "required": ["groups", "totalCount"],
         "type": "object",
         "properties": {
           "groups": {
@@ -736,18 +658,13 @@
         }
       },
       "GroupEntryOfLocalizationOverride": {
-        "required": [
-          "field",
-          "value",
-          "label",
-          "count"
-        ],
+        "required": ["field", "value", "label", "count"],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": { },
+          "value": {},
           "label": {
             "type": "string"
           },
@@ -756,16 +673,10 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": [
-              "null",
-              "object"
-            ]
+            "type": ["null", "object"]
           },
           "items": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "$ref": "#/components/schemas/LocalizationOverride"
             }
@@ -776,35 +687,20 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "title": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "status": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "detail": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "instance": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "errors": {
             "type": "object",
@@ -818,12 +714,7 @@
         }
       },
       "LanguageInfoResponse": {
-        "required": [
-          "cultureName",
-          "displayName",
-          "flagIcon",
-          "isDefault"
-        ],
+        "required": ["cultureName", "displayName", "flagIcon", "isDefault"],
         "type": "object",
         "properties": {
           "cultureName": {
@@ -833,10 +724,7 @@
             "type": "string"
           },
           "flagIcon": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "isDefault": {
             "type": "boolean"
@@ -847,10 +735,7 @@
         "type": "object",
         "properties": {
           "tenantId": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "uuid"
           },
           "resourceName": {
@@ -866,18 +751,12 @@
             "type": "string"
           },
           "modifiedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "description": "Last modification timestamp (UTC).",
             "format": "date-time"
           },
           "modifiedBy": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "description": "Identifier of the user who last modified the entity."
           },
           "createdAt": {
@@ -900,38 +779,23 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "endpoint": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "kind": {
             "$ref": "#/components/schemas/LookupKind"
           },
           "requiredPermission": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "searchParam": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "default": "search"
           },
           "scopeKeys": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "type": "string"
             }
@@ -939,20 +803,11 @@
         }
       },
       "LookupKind": {
-        "enum": [
-          "QueryEngine",
-          "Simple",
-          "ReferenceData",
-          "Enum"
-        ],
+        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
         "default": "QueryEngine"
       },
       "PagedResultOfLocalizationOverride": {
-        "required": [
-          "items",
-          "totalCount",
-          "hasMore"
-        ],
+        "required": ["items", "totalCount", "hasMore"],
         "type": "object",
         "properties": {
           "items": {
@@ -961,10 +816,7 @@
               "type": "object",
               "properties": {
                 "tenantId": {
-                  "type": [
-                    "null",
-                    "string"
-                  ],
+                  "type": ["null", "string"],
                   "format": "uuid"
                 },
                 "resourceName": {
@@ -980,18 +832,12 @@
                   "type": "string"
                 },
                 "modifiedAt": {
-                  "type": [
-                    "null",
-                    "string"
-                  ],
+                  "type": ["null", "string"],
                   "description": "Last modification timestamp (UTC).",
                   "format": "date-time"
                 },
                 "modifiedBy": {
-                  "type": [
-                    "null",
-                    "string"
-                  ],
+                  "type": ["null", "string"],
                   "description": "Identifier of the user who last modified the entity."
                 },
                 "createdAt": {
@@ -1012,30 +858,19 @@
             }
           },
           "totalCount": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "PaginationMeta": {
-        "required": [
-          "defaultPageSize",
-          "maxPageSize",
-          "maxStreamSize",
-          "supportsCursor"
-        ],
+        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
         "type": "object",
         "properties": {
           "defaultPageSize": {
@@ -1056,11 +891,7 @@
         }
       },
       "PresetMeta": {
-        "required": [
-          "name",
-          "label",
-          "isDefault"
-        ],
+        "required": ["name", "label", "isDefault"],
         "type": "object",
         "properties": {
           "name": {
@@ -1158,19 +989,12 @@
             "$ref": "#/components/schemas/PaginationMeta"
           },
           "defaultSort": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "QuickFilterMeta": {
-        "required": [
-          "name",
-          "label",
-          "isDefault"
-        ],
+        "required": ["name", "label", "isDefault"],
         "type": "object",
         "properties": {
           "name": {
@@ -1185,20 +1009,17 @@
         }
       },
       "SetLocalizationOverrideRequest": {
-        "required": [
-          "value"
-        ],
+        "required": ["value"],
         "type": "object",
         "properties": {
           "value": {
+            "maxLength": 4000,
             "type": "string"
           }
         }
       },
       "SortableField": {
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "type": "object",
         "properties": {
           "name": {

--- a/contracts/openapi/notifications.json
+++ b/contracts/openapi/notifications.json
@@ -7,9 +7,7 @@
   "paths": {
     "/notifications": {
       "get": {
-        "tags": [
-          "Notifications"
-        ],
+        "tags": ["Notifications"],
         "summary": "Returns the user's notification inbox, newest first.",
         "description": "Returns a paginated list of the current user's notifications. Supports filtering by read/unread status. Results are sorted by creation date, newest first.",
         "operationId": "GetNotifications",
@@ -81,9 +79,7 @@
     },
     "/notifications/unread/count": {
       "get": {
-        "tags": [
-          "Notifications"
-        ],
+        "tags": ["Notifications"],
         "summary": "Returns the number of unread notifications for the current user.",
         "description": "Returns the total count of unread notifications for the authenticated user within the current tenant. Use this to display a badge count in the UI.",
         "operationId": "GetUnreadCount",
@@ -133,9 +129,7 @@
     },
     "/notifications/{id}/read": {
       "post": {
-        "tags": [
-          "Notifications"
-        ],
+        "tags": ["Notifications"],
         "summary": "Marks a single notification as read.",
         "description": "Marks the specified notification as read by setting its read timestamp. Idempotent — marking an already-read notification is a no-op.",
         "operationId": "MarkAsRead",
@@ -190,9 +184,7 @@
     },
     "/notifications/read-all": {
       "post": {
-        "tags": [
-          "Notifications"
-        ],
+        "tags": ["Notifications"],
         "summary": "Marks all notifications as read for the current user.",
         "description": "Marks all unread notifications as read for the authenticated user within the current tenant. Useful for a 'mark all as read' bulk action.",
         "operationId": "MarkAllAsRead",
@@ -235,9 +227,7 @@
     },
     "/notifications/entity/{entityType}/{entityId}": {
       "get": {
-        "tags": [
-          "Notifications"
-        ],
+        "tags": ["Notifications"],
         "summary": "Returns the activity feed for a specific entity.",
         "description": "Returns a paginated list of notifications related to a specific entity. Useful for displaying an activity log on an entity detail page. Results are sorted by creation date, newest first.",
         "operationId": "GetEntityActivityFeed",
@@ -327,9 +317,7 @@
     },
     "/notifications/preferences": {
       "get": {
-        "tags": [
-          "Notifications"
-        ],
+        "tags": ["Notifications"],
         "summary": "Returns notification delivery preferences for the current user.",
         "description": "Returns all notification delivery preferences for the authenticated user within the current tenant. Each preference indicates whether a specific notification type is enabled or disabled for a given channel.",
         "operationId": "GetPreferences",
@@ -380,9 +368,7 @@
         }
       },
       "put": {
-        "tags": [
-          "Notifications"
-        ],
+        "tags": ["Notifications"],
         "summary": "Creates or updates a notification delivery preference.",
         "description": "Creates or updates a delivery preference for a specific notification type and channel. If a preference already exists for the same type and channel, it is replaced (upsert).",
         "operationId": "UpdatePreference",
@@ -455,9 +441,7 @@
     },
     "/notifications/types": {
       "get": {
-        "tags": [
-          "Notifications"
-        ],
+        "tags": ["Notifications"],
         "summary": "Returns all registered notification type definitions.",
         "description": "Returns all notification types registered in the system with their metadata. Use this to build the preferences UI, showing which notification types are available and their supported channels.",
         "operationId": "GetNotificationTypes",
@@ -510,9 +494,7 @@
     },
     "/notifications/subscriptions": {
       "get": {
-        "tags": [
-          "Notifications"
-        ],
+        "tags": ["Notifications"],
         "summary": "Returns all notification subscriptions for the current user.",
         "description": "Returns all notification type subscriptions for the authenticated user within the current tenant. Each subscription indicates a notification type the user has opted into.",
         "operationId": "GetSubscriptions",
@@ -565,9 +547,7 @@
     },
     "/notifications/subscriptions/{typeName}": {
       "post": {
-        "tags": [
-          "Notifications"
-        ],
+        "tags": ["Notifications"],
         "summary": "Subscribes the current user to a notification type.",
         "description": "Subscribes the authenticated user to the specified notification type within the current tenant. Idempotent — subscribing to an already-subscribed type is a no-op.",
         "operationId": "Subscribe",
@@ -619,9 +599,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Notifications"
-        ],
+        "tags": ["Notifications"],
         "summary": "Unsubscribes the current user from a notification type.",
         "description": "Removes the authenticated user's subscription to the specified notification type within the current tenant. Idempotent — unsubscribing from a non-subscribed type is a no-op.",
         "operationId": "Unsubscribe",
@@ -675,9 +653,7 @@
     },
     "/notifications/entity/{entityType}/{entityId}/follow": {
       "post": {
-        "tags": [
-          "Notifications"
-        ],
+        "tags": ["Notifications"],
         "summary": "Subscribes the current user as a follower of an entity.",
         "description": "Adds the authenticated user as a follower of the specified entity within the current tenant. Followers receive notifications when activity occurs on the entity. Idempotent.",
         "operationId": "FollowEntity",
@@ -738,9 +714,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Notifications"
-        ],
+        "tags": ["Notifications"],
         "summary": "Unsubscribes the current user from an entity.",
         "description": "Removes the authenticated user from the follower list of the specified entity within the current tenant. The user will no longer receive entity-level notifications. Idempotent.",
         "operationId": "UnfollowEntity",
@@ -803,9 +777,7 @@
     },
     "/notifications/entity/{entityType}/{entityId}/followers": {
       "get": {
-        "tags": [
-          "Notifications"
-        ],
+        "tags": ["Notifications"],
         "summary": "Returns all followers of a specific entity.",
         "description": "Returns all users following the specified entity within the current tenant. Each entry includes the user ID and subscription metadata.",
         "operationId": "GetEntityFollowers",
@@ -883,35 +855,20 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "title": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "status": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "detail": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "instance": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "errors": {
             "type": "object",
@@ -925,9 +882,7 @@
         }
       },
       "NotificationDefinition": {
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "type": "object",
         "properties": {
           "name": {
@@ -943,22 +898,13 @@
             }
           },
           "displayName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "description": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "groupName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "allowUserOptOut": {
             "type": "boolean"
@@ -967,27 +913,15 @@
             "type": "boolean"
           },
           "requiredPermission": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "requiredFeature": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "NotificationPreferenceResponse": {
-        "required": [
-          "id",
-          "userId",
-          "notificationTypeName",
-          "channelName",
-          "isEnabled"
-        ],
+        "required": ["id", "userId", "notificationTypeName", "channelName", "isEnabled"],
         "type": "object",
         "properties": {
           "id": {
@@ -1009,17 +943,15 @@
         }
       },
       "NotificationPreferenceUpdateRequest": {
-        "required": [
-          "notificationTypeName",
-          "channelName",
-          "isEnabled"
-        ],
+        "required": ["notificationTypeName", "channelName", "isEnabled"],
         "type": "object",
         "properties": {
           "notificationTypeName": {
+            "maxLength": 256,
             "type": "string"
           },
           "channelName": {
+            "maxLength": 64,
             "type": "string"
           },
           "isEnabled": {
@@ -1028,22 +960,10 @@
         }
       },
       "NotificationSeverity": {
-        "enum": [
-          "Info",
-          "Success",
-          "Warning",
-          "Error",
-          "Fatal"
-        ]
+        "enum": ["Info", "Success", "Warning", "Error", "Fatal"]
       },
       "NotificationSubscriptionResponse": {
-        "required": [
-          "id",
-          "userId",
-          "notificationTypeName",
-          "entityType",
-          "entityId"
-        ],
+        "required": ["id", "userId", "notificationTypeName", "entityType", "entityId"],
         "type": "object",
         "properties": {
           "id": {
@@ -1057,25 +977,15 @@
             "type": "string"
           },
           "entityType": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "entityId": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "PagedResultOfUserNotificationResponse": {
-        "required": [
-          "items",
-          "totalCount",
-          "hasMore"
-        ],
+        "required": ["items", "totalCount", "hasMore"],
         "type": "object",
         "properties": {
           "items": {
@@ -1085,20 +995,14 @@
             }
           },
           "totalCount": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
@@ -1128,9 +1032,7 @@
         }
       },
       "UnreadCountResponse": {
-        "required": [
-          "count"
-        ],
+        "required": ["count"],
         "type": "object",
         "properties": {
           "count": {
@@ -1172,7 +1074,7 @@
           "recipientUserId": {
             "type": "string"
           },
-          "data": { },
+          "data": {},
           "state": {
             "$ref": "#/components/schemas/UserNotificationState"
           },
@@ -1181,31 +1083,19 @@
             "format": "date-time"
           },
           "readAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "relatedEntityType": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "relatedEntityId": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "UserNotificationState": {
-        "enum": [
-          "Unread",
-          "Read"
-        ]
+        "enum": ["Unread", "Read"]
       }
     }
   },

--- a/contracts/openapi/scheduling.json
+++ b/contracts/openapi/scheduling.json
@@ -7,9 +7,7 @@
   "paths": {
     "/scheduling/scheduled-actions/{id}": {
       "get": {
-        "tags": [
-          "Scheduling"
-        ],
+        "tags": ["Scheduling"],
         "summary": "Returns a scheduled action by ID.",
         "description": "Returns the full details of a single scheduled action identified by its GUID. Returns 404 if the action does not exist or belongs to a different tenant.",
         "operationId": "GetScheduledActionById",
@@ -79,9 +77,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Scheduling"
-        ],
+        "tags": ["Scheduling"],
         "summary": "Cancels a pending scheduled action.",
         "description": "Cancels a scheduled action that has not yet been executed. Returns 204 on success. Returns 404 if the action does not exist, or 409 if the action is no longer in Pending status.",
         "operationId": "CancelScheduledAction",
@@ -156,9 +152,7 @@
     },
     "/scheduling/scheduled-actions/{id}/reschedule": {
       "put": {
-        "tags": [
-          "Scheduling"
-        ],
+        "tags": ["Scheduling"],
         "summary": "Reschedules a pending action to a new date.",
         "description": "Changes the execution date of a pending scheduled action. Returns 200 on success. Returns 404 if the action does not exist, or 409 if the action is no longer in Pending status.",
         "operationId": "RescheduleScheduledAction",
@@ -263,9 +257,7 @@
     },
     "/scheduling/scheduled-actions": {
       "get": {
-        "tags": [
-          "Scheduling"
-        ],
+        "tags": ["Scheduling"],
         "summary": "Returns a filtered, sorted, and paginated list of ScheduledAction entries.",
         "description": "Executes a dynamic query against ScheduledAction using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
         "operationId": "QueryScheduledAction",
@@ -276,10 +268,7 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": [
-                "null",
-                "integer"
-              ],
+              "type": ["null", "integer"],
               "format": "int32"
             }
           },
@@ -290,10 +279,7 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": [
-                "null",
-                "integer"
-              ],
+              "type": ["null", "integer"],
               "format": "int32"
             }
           },
@@ -302,10 +288,7 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -313,10 +296,7 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -324,10 +304,7 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -335,10 +312,7 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -346,10 +320,7 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -357,10 +328,7 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": [
-                "null",
-                "boolean"
-              ]
+              "type": ["null", "boolean"]
             }
           },
           {
@@ -370,10 +338,7 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": [
-                "null",
-                "object"
-              ],
+              "type": ["null", "object"],
               "additionalProperties": {
                 "type": "string"
               }
@@ -386,10 +351,7 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": [
-                "null",
-                "object"
-              ],
+              "type": ["null", "object"],
               "additionalProperties": {
                 "type": "string"
               }
@@ -460,9 +422,7 @@
     },
     "/scheduling/scheduled-actions/meta": {
       "get": {
-        "tags": [
-          "Scheduling"
-        ],
+        "tags": ["Scheduling"],
         "summary": "Returns query metadata for ScheduledAction (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for ScheduledAction: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetScheduledActionMeta",
@@ -549,19 +509,12 @@
             "type": "boolean"
           },
           "format": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "DateFilterMeta": {
-        "required": [
-          "name",
-          "defaultPeriod",
-          "availablePeriods"
-        ],
+        "required": ["name", "defaultPeriod", "availablePeriods"],
         "type": "object",
         "properties": {
           "name": {
@@ -579,22 +532,10 @@
         }
       },
       "DatePeriod": {
-        "enum": [
-          "Today",
-          "ThisWeek",
-          "ThisMonth",
-          "LastMonth",
-          "ThisQuarter",
-          "ThisYear",
-          "Custom"
-        ]
+        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
       },
       "FilterableField": {
-        "required": [
-          "name",
-          "type",
-          "operators"
-        ],
+        "required": ["name", "type", "operators"],
         "type": "object",
         "properties": {
           "name": {
@@ -610,10 +551,7 @@
             }
           },
           "enumValues": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "type": "string"
             }
@@ -631,11 +569,7 @@
         }
       },
       "FilterGroupMeta": {
-        "required": [
-          "name",
-          "label",
-          "presets"
-        ],
+        "required": ["name", "label", "presets"],
         "type": "object",
         "properties": {
           "name": {
@@ -667,10 +601,7 @@
         ]
       },
       "GroupByField": {
-        "required": [
-          "name",
-          "type"
-        ],
+        "required": ["name", "type"],
         "type": "object",
         "properties": {
           "name": {
@@ -682,10 +613,7 @@
         }
       },
       "GroupedResultOfScheduledAction": {
-        "required": [
-          "groups",
-          "totalCount"
-        ],
+        "required": ["groups", "totalCount"],
         "type": "object",
         "properties": {
           "groups": {
@@ -701,18 +629,13 @@
         }
       },
       "GroupEntryOfScheduledAction": {
-        "required": [
-          "field",
-          "value",
-          "label",
-          "count"
-        ],
+        "required": ["field", "value", "label", "count"],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": { },
+          "value": {},
           "label": {
             "type": "string"
           },
@@ -721,16 +644,10 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": [
-              "null",
-              "object"
-            ]
+            "type": ["null", "object"]
           },
           "items": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "$ref": "#/components/schemas/ScheduledAction"
             }
@@ -741,35 +658,20 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "title": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "status": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "detail": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "instance": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "errors": {
             "type": "object",
@@ -794,38 +696,23 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "endpoint": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "kind": {
             "$ref": "#/components/schemas/LookupKind"
           },
           "requiredPermission": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "searchParam": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "default": "search"
           },
           "scopeKeys": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "type": "string"
             }
@@ -833,20 +720,11 @@
         }
       },
       "LookupKind": {
-        "enum": [
-          "QueryEngine",
-          "Simple",
-          "ReferenceData",
-          "Enum"
-        ],
+        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
         "default": "QueryEngine"
       },
       "PagedResultOfScheduledAction": {
-        "required": [
-          "items",
-          "totalCount",
-          "hasMore"
-        ],
+        "required": ["items", "totalCount", "hasMore"],
         "type": "object",
         "properties": {
           "items": {
@@ -865,76 +743,43 @@
                   "format": "date-time"
                 },
                 "correlationId": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
+                  "type": ["null", "string"]
                 },
                 "status": {
-                  "enum": [
-                    "Pending",
-                    "Executed",
-                    "Cancelled",
-                    "Failed",
-                    "Processing"
-                  ]
+                  "enum": ["Pending", "Executed", "Cancelled", "Failed", "Processing"]
                 },
                 "executedAt": {
-                  "type": [
-                    "null",
-                    "string"
-                  ],
+                  "type": ["null", "string"],
                   "format": "date-time"
                 },
                 "cancelledBy": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
+                  "type": ["null", "string"]
                 },
                 "failureReason": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
+                  "type": ["null", "string"]
                 },
                 "tenantId": {
-                  "type": [
-                    "null",
-                    "string"
-                  ],
+                  "type": ["null", "string"],
                   "format": "uuid"
                 },
                 "modifiedAt": {
-                  "type": [
-                    "null",
-                    "string"
-                  ],
+                  "type": ["null", "string"],
                   "description": "Last modification timestamp (UTC).",
                   "format": "date-time"
                 },
                 "modifiedBy": {
-                  "type": [
-                    "null",
-                    "string"
-                  ],
+                  "type": ["null", "string"],
                   "description": "Identifier of the user who last modified the entity."
                 },
                 "domainEvents": {
-                  "type": [
-                    "null",
-                    "array"
-                  ],
+                  "type": ["null", "array"],
                   "items": {
                     "type": "object",
                     "description": "Marker interface for domain events."
                   }
                 },
                 "integrationEvents": {
-                  "type": [
-                    "null",
-                    "array"
-                  ],
+                  "type": ["null", "array"],
                   "items": {
                     "type": "object",
                     "description": "Marker interface for integration events (ETO — Event Transfer Object)."
@@ -958,30 +803,19 @@
             }
           },
           "totalCount": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "PaginationMeta": {
-        "required": [
-          "defaultPageSize",
-          "maxPageSize",
-          "maxStreamSize",
-          "supportsCursor"
-        ],
+        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
         "type": "object",
         "properties": {
           "defaultPageSize": {
@@ -1002,11 +836,7 @@
         }
       },
       "PresetMeta": {
-        "required": [
-          "name",
-          "label",
-          "isDefault"
-        ],
+        "required": ["name", "label", "isDefault"],
         "type": "object",
         "properties": {
           "name": {
@@ -1104,19 +934,12 @@
             "$ref": "#/components/schemas/PaginationMeta"
           },
           "defaultSort": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "QuickFilterMeta": {
-        "required": [
-          "name",
-          "label",
-          "isDefault"
-        ],
+        "required": ["name", "label", "isDefault"],
         "type": "object",
         "properties": {
           "name": {
@@ -1131,14 +954,13 @@
         }
       },
       "RescheduleActionRequest": {
-        "required": [
-          "newExecuteAt"
-        ],
+        "required": ["newExecuteAt"],
         "type": "object",
         "properties": {
           "newExecuteAt": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "x-granit-validator": "Validation:ScheduledAction:FutureDate"
           }
         }
       },
@@ -1156,69 +978,42 @@
             "format": "date-time"
           },
           "correlationId": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "status": {
             "$ref": "#/components/schemas/ScheduledActionStatus"
           },
           "executedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "cancelledBy": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "failureReason": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "tenantId": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "uuid"
           },
           "modifiedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "description": "Last modification timestamp (UTC).",
             "format": "date-time"
           },
           "modifiedBy": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "description": "Identifier of the user who last modified the entity."
           },
           "domainEvents": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "$ref": "#/components/schemas/IDomainEvent"
             }
           },
           "integrationEvents": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "$ref": "#/components/schemas/IIntegrationEvent"
             }
@@ -1265,32 +1060,20 @@
             "format": "date-time"
           },
           "correlationId": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "status": {
             "$ref": "#/components/schemas/ScheduledActionStatus"
           },
           "executedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "cancelledBy": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "failureReason": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "createdAt": {
             "type": "string",
@@ -1299,18 +1082,10 @@
         }
       },
       "ScheduledActionStatus": {
-        "enum": [
-          "Pending",
-          "Executed",
-          "Cancelled",
-          "Failed",
-          "Processing"
-        ]
+        "enum": ["Pending", "Executed", "Cancelled", "Failed", "Processing"]
       },
       "SortableField": {
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "type": "object",
         "properties": {
           "name": {

--- a/contracts/openapi/templating.json
+++ b/contracts/openapi/templating.json
@@ -7,9 +7,7 @@
   "paths": {
     "/templating/templates": {
       "get": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Returns a filtered, sorted, and paginated list of TemplateSummary entries.",
         "description": "Executes a dynamic query against TemplateSummary using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
         "operationId": "QueryTemplateSummary",
@@ -20,10 +18,7 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": [
-                "null",
-                "integer"
-              ],
+              "type": ["null", "integer"],
               "format": "int32"
             }
           },
@@ -34,10 +29,7 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": [
-                "null",
-                "integer"
-              ],
+              "type": ["null", "integer"],
               "format": "int32"
             }
           },
@@ -46,10 +38,7 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -57,10 +46,7 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -68,10 +54,7 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -79,10 +62,7 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -90,10 +70,7 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -101,10 +78,7 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": [
-                "null",
-                "boolean"
-              ]
+              "type": ["null", "boolean"]
             }
           },
           {
@@ -114,10 +88,7 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": [
-                "null",
-                "object"
-              ],
+              "type": ["null", "object"],
               "additionalProperties": {
                 "type": "string"
               }
@@ -130,10 +101,7 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": [
-                "null",
-                "object"
-              ],
+              "type": ["null", "object"],
               "additionalProperties": {
                 "type": "string"
               }
@@ -202,9 +170,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Creates a new template draft.",
         "description": "Creates a new template with an initial draft revision. The template name must be unique. The draft can be previewed and edited before publishing. Returns 201 Created with the template detail.",
         "operationId": "CreateTemplateDraft",
@@ -294,9 +260,7 @@
     },
     "/templating/templates/meta": {
       "get": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Returns query metadata for TemplateSummary (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for TemplateSummary: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetTemplateSummaryMeta",
@@ -346,9 +310,7 @@
     },
     "/templating/templates/{name}": {
       "get": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Returns detail of a template (current draft and published revision).",
         "description": "Returns the full detail of a template including both the current draft revision (if any) and the published revision (if any). Includes content, metadata, category, and variable bindings. Returns 404 if the template name does not exist.",
         "operationId": "GetTemplateDetail",
@@ -356,7 +318,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -444,9 +406,7 @@
         }
       },
       "put": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Updates an existing template draft.",
         "description": "Replaces the draft revision content and metadata. Only the draft revision is affected — published and archived revisions are immutable. Creates a new draft if none exists. Returns 409 if the concurrency stamp does not match the stored draft. Returns 404 if the template does not exist.",
         "operationId": "UpdateTemplateDraft",
@@ -454,7 +414,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -557,9 +517,7 @@
     },
     "/templating/templates/{name}/draft": {
       "delete": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Deletes the draft revision of a template (published/archived are preserved).",
         "description": "Removes only the draft revision. Published and archived revisions remain unaffected. Returns 404 if the template does not exist or has no draft revision.",
         "operationId": "DeleteTemplateDraft",
@@ -567,7 +525,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -640,9 +598,7 @@
     },
     "/templating/templates/{name}/lifecycle": {
       "get": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Returns lifecycle status, workflow state, and available transitions.",
         "description": "Returns the current lifecycle state of the template (draft, published, archived), the workflow state if workflow integration is enabled, and the list of available state transitions for the current user.",
         "operationId": "GetTemplateLifecycle",
@@ -650,7 +606,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -740,9 +696,7 @@
     },
     "/templating/templates/{name}/publish": {
       "post": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Publishes the current draft, archiving any previous published revision.",
         "description": "Promotes the current draft to published status. If a published revision already exists, it is archived first. The draft is consumed — a new draft must be created for further edits. Returns 404 if the template or draft does not exist.",
         "operationId": "PublishTemplate",
@@ -750,7 +704,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -840,9 +794,7 @@
     },
     "/templating/templates/{name}/unpublish": {
       "post": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Unpublishes the template (archives the published revision).",
         "description": "Archives the currently published revision. The template will no longer be available for rendering until a new revision is published. Returns 404 if the template has no published revision.",
         "operationId": "UnpublishTemplate",
@@ -850,7 +802,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -923,9 +875,7 @@
     },
     "/templating/templates/{name}/preview": {
       "post": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Renders the current draft with optional test data and returns the HTML output.",
         "description": "Renders the template's current draft content using the configured template engine (Liquid, Razor, etc.) with optional test data. Returns the rendered HTML. Useful for live preview in the template editor. Returns 404 if the template or draft does not exist.",
         "operationId": "PreviewTemplate",
@@ -933,7 +883,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1036,9 +986,7 @@
     },
     "/templating/templates/{name}/variables": {
       "get": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Returns all available template variables (global, model, enriched) for autocompletion.",
         "description": "Returns all variables available for use in the template: global variables (application-wide), model variables (bound to the template's entity type), and enriched variables (computed at render time). Used to power autocompletion in the template editor.",
         "operationId": "GetTemplateVariables",
@@ -1046,7 +994,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1109,9 +1057,7 @@
     },
     "/templating/templates/{name}/history": {
       "get": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Returns a paginated revision history for the template (without content).",
         "description": "Returns a paginated list of all revisions for the template, ordered by creation date descending. Each entry includes revision ID, status, author, and timestamp — but not the content. Use the revision detail endpoint to retrieve content.",
         "operationId": "GetTemplateHistory",
@@ -1119,7 +1065,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1219,9 +1165,7 @@
     },
     "/templating/templates/{name}/history/{revisionId}": {
       "get": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Returns the full detail of a specific template revision (including content).",
         "description": "Returns the complete content and metadata of a specific historical revision, identified by its GUID. Useful for comparing versions or restoring a previous revision. Returns 404 if the revision does not exist.",
         "operationId": "GetTemplateRevisionDetail",
@@ -1229,7 +1173,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1329,9 +1273,7 @@
     },
     "/templating/layouts": {
       "get": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Returns all available layout template names.",
         "description": "Returns a deduplicated list of layout template names from both the code-level ILayoutRegistry and database-assigned LayoutName values. Used by the admin UI to populate layout dropdowns.",
         "operationId": "ListAvailableLayouts",
@@ -1384,9 +1326,7 @@
     },
     "/templating/categories": {
       "get": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Returns all template categories ordered by sort order then name.",
         "description": "Returns all template categories for organizing templates. Categories are sorted by their sort order, then alphabetically by name. Each category includes its ID, name, and template count.",
         "operationId": "ListTemplateCategories",
@@ -1447,9 +1387,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Creates a new template category.",
         "description": "Creates a new template category with the given name and sort order. The name must be unique.",
         "operationId": "CreateTemplateCategory",
@@ -1549,9 +1487,7 @@
     },
     "/templating/categories/{id}": {
       "put": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Updates an existing template category.",
         "description": "Updates the name and sort order of an existing category. Returns 404 if the category does not exist.",
         "operationId": "UpdateTemplateCategory",
@@ -1671,9 +1607,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Templates"
-        ],
+        "tags": ["Templates"],
         "summary": "Deletes a template category (409 if templates are still associated).",
         "description": "Deletes the template category. Returns 409 Conflict if templates are still associated with this category — reassign or delete them first. Returns 404 if the category does not exist.",
         "operationId": "DeleteTemplateCategory",
@@ -1795,19 +1729,12 @@
             "type": "boolean"
           },
           "format": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "DateFilterMeta": {
-        "required": [
-          "name",
-          "defaultPeriod",
-          "availablePeriods"
-        ],
+        "required": ["name", "defaultPeriod", "availablePeriods"],
         "type": "object",
         "properties": {
           "name": {
@@ -1825,22 +1752,10 @@
         }
       },
       "DatePeriod": {
-        "enum": [
-          "Today",
-          "ThisWeek",
-          "ThisMonth",
-          "LastMonth",
-          "ThisQuarter",
-          "ThisYear",
-          "Custom"
-        ]
+        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
       },
       "FilterableField": {
-        "required": [
-          "name",
-          "type",
-          "operators"
-        ],
+        "required": ["name", "type", "operators"],
         "type": "object",
         "properties": {
           "name": {
@@ -1856,10 +1771,7 @@
             }
           },
           "enumValues": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "type": "string"
             }
@@ -1877,11 +1789,7 @@
         }
       },
       "FilterGroupMeta": {
-        "required": [
-          "name",
-          "label",
-          "presets"
-        ],
+        "required": ["name", "label", "presets"],
         "type": "object",
         "properties": {
           "name": {
@@ -1913,10 +1821,7 @@
         ]
       },
       "GroupByField": {
-        "required": [
-          "name",
-          "type"
-        ],
+        "required": ["name", "type"],
         "type": "object",
         "properties": {
           "name": {
@@ -1928,10 +1833,7 @@
         }
       },
       "GroupedResultOfTemplateSummary": {
-        "required": [
-          "groups",
-          "totalCount"
-        ],
+        "required": ["groups", "totalCount"],
         "type": "object",
         "properties": {
           "groups": {
@@ -1947,18 +1849,13 @@
         }
       },
       "GroupEntryOfTemplateSummary": {
-        "required": [
-          "field",
-          "value",
-          "label",
-          "count"
-        ],
+        "required": ["field", "value", "label", "count"],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": { },
+          "value": {},
           "label": {
             "type": "string"
           },
@@ -1967,16 +1864,10 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": [
-              "null",
-              "object"
-            ]
+            "type": ["null", "object"]
           },
           "items": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "$ref": "#/components/schemas/TemplateSummary"
             }
@@ -1987,35 +1878,20 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "title": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "status": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "detail": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "instance": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "errors": {
             "type": "object",
@@ -2032,38 +1908,23 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "endpoint": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "kind": {
             "$ref": "#/components/schemas/LookupKind"
           },
           "requiredPermission": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "searchParam": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "default": "search"
           },
           "scopeKeys": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "type": "string"
             }
@@ -2071,20 +1932,11 @@
         }
       },
       "LookupKind": {
-        "enum": [
-          "QueryEngine",
-          "Simple",
-          "ReferenceData",
-          "Enum"
-        ],
+        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
         "default": "QueryEngine"
       },
       "PagedResultOfTemplateSummary": {
-        "required": [
-          "items",
-          "totalCount",
-          "hasMore"
-        ],
+        "required": ["items", "totalCount", "hasMore"],
         "type": "object",
         "properties": {
           "items": {
@@ -2102,31 +1954,20 @@
               "type": "object",
               "properties": {
                 "tenantId": {
-                  "type": [
-                    "null",
-                    "string"
-                  ],
+                  "type": ["null", "string"],
                   "format": "uuid"
                 },
                 "name": {
                   "type": "string"
                 },
                 "culture": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
+                  "type": ["null", "string"]
                 },
                 "mimeType": {
                   "type": "string"
                 },
                 "currentStatus": {
-                  "enum": [
-                    "Draft",
-                    "PendingReview",
-                    "Published",
-                    "Archived"
-                  ]
+                  "enum": ["Draft", "PendingReview", "Published", "Archived"]
                 },
                 "lastModifiedAt": {
                   "type": "string",
@@ -2139,46 +1980,29 @@
                   "type": "boolean"
                 },
                 "layoutName": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
+                  "type": ["null", "string"]
                 },
                 "categoryId": {
-                  "type": [
-                    "null",
-                    "string"
-                  ],
+                  "type": ["null", "string"],
                   "format": "uuid"
                 }
               }
             }
           },
           "totalCount": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "PaginationMeta": {
-        "required": [
-          "defaultPageSize",
-          "maxPageSize",
-          "maxStreamSize",
-          "supportsCursor"
-        ],
+        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
         "type": "object",
         "properties": {
           "defaultPageSize": {
@@ -2199,11 +2023,7 @@
         }
       },
       "PresetMeta": {
-        "required": [
-          "name",
-          "label",
-          "isDefault"
-        ],
+        "required": ["name", "label", "isDefault"],
         "type": "object",
         "properties": {
           "name": {
@@ -2301,19 +2121,12 @@
             "$ref": "#/components/schemas/PaginationMeta"
           },
           "defaultSort": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "QuickFilterMeta": {
-        "required": [
-          "name",
-          "label",
-          "isDefault"
-        ],
+        "required": ["name", "label", "isDefault"],
         "type": "object",
         "properties": {
           "name": {
@@ -2328,25 +2141,20 @@
         }
       },
       "SaveTemplateCategoryRequest": {
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 200,
             "type": "string"
           },
           "description": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "maxLength": 500,
+            "type": ["null", "string"]
           },
           "icon": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "maxLength": 100,
+            "type": ["null", "string"]
           },
           "sortOrder": {
             "type": "integer",
@@ -2356,48 +2164,39 @@
         }
       },
       "SaveTemplateRequest": {
-        "required": [
-          "content"
-        ],
+        "required": ["content", "mimeType"],
         "type": "object",
         "properties": {
           "content": {
+            "maxLength": 1048576,
             "type": "string"
           },
           "name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "maxLength": 200,
+            "pattern": "^[A-Za-z][A-Za-z0-9]*(\\.[A-Za-z][A-Za-z0-9]*)+$",
+            "type": ["null", "string"]
           },
           "culture": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "maxLength": 10,
+            "pattern": "^[a-zA-Z]{2,8}(-[a-zA-Z0-9]{1,8})*$",
+            "type": ["null", "string"]
           },
           "mimeType": {
+            "maxLength": 127,
             "type": "string",
-            "default": "text/html"
+            "default": "text/html",
+            "x-granit-validator": "Validation:UnsupportedMimeType"
           },
           "layoutName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "concurrencyStamp": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "SortableField": {
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "type": "object",
         "properties": {
           "name": {
@@ -2406,14 +2205,7 @@
         }
       },
       "TemplateCategoryResponse": {
-        "required": [
-          "id",
-          "name",
-          "description",
-          "icon",
-          "sortOrder",
-          "templateCount"
-        ],
+        "required": ["id", "name", "description", "icon", "sortOrder", "templateCount"],
         "type": "object",
         "properties": {
           "id": {
@@ -2424,16 +2216,10 @@
             "type": "string"
           },
           "description": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "icon": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "sortOrder": {
             "type": "integer",
@@ -2446,23 +2232,14 @@
         }
       },
       "TemplateDetailResponse": {
-        "required": [
-          "name",
-          "culture",
-          "draft",
-          "published",
-          "layoutName"
-        ],
+        "required": ["name", "culture", "draft", "published", "layoutName"],
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
           "culture": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "draft": {
             "oneOf": [
@@ -2485,20 +2262,12 @@
             ]
           },
           "layoutName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "TemplateHistoryResponse": {
-        "required": [
-          "revisions",
-          "totalCount",
-          "page",
-          "pageSize"
-        ],
+        "required": ["revisions", "totalCount", "page", "pageSize"],
         "type": "object",
         "properties": {
           "revisions": {
@@ -2522,23 +2291,14 @@
         }
       },
       "TemplateLifecycleResponse": {
-        "required": [
-          "name",
-          "culture",
-          "currentStatus",
-          "workflowEnabled",
-          "availableTransitions"
-        ],
+        "required": ["name", "culture", "currentStatus", "workflowEnabled", "availableTransitions"],
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
           "culture": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "currentStatus": {
             "$ref": "#/components/schemas/WorkflowLifecycleStatus"
@@ -2558,48 +2318,30 @@
         "type": "object",
         "properties": {
           "culture": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "maxLength": 10,
+            "pattern": "^[a-zA-Z]{2,8}(-[a-zA-Z0-9]{1,8})*$",
+            "type": ["null", "string"]
           },
           "data": {
-            "type": [
-              "null",
-              "boolean",
-              "number",
-              "string",
-              "object",
-              "array"
-            ],
+            "type": ["null", "boolean", "number", "string", "object", "array"],
             "description": "Arbitrary JSON value (object, array, string, number, boolean, or null)."
           }
         }
       },
       "TemplatePreviewResponse": {
-        "required": [
-          "html",
-          "revisionId",
-          "renderTimeMs"
-        ],
+        "required": ["html", "revisionId", "renderTimeMs"],
         "type": "object",
         "properties": {
           "html": {
             "type": "string"
           },
           "revisionId": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "uuid"
           },
           "renderTimeMs": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "integer",
-              "string"
-            ],
+            "type": ["integer", "string"],
             "format": "int64"
           }
         }
@@ -2640,23 +2382,14 @@
             "type": "string"
           },
           "publishedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "publishedBy": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "layoutName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "concurrencyStamp": {
             "type": "string"
@@ -2690,17 +2423,11 @@
             "type": "string"
           },
           "publishedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "publishedBy": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "contentLength": {
             "type": "integer",
@@ -2721,20 +2448,14 @@
         "type": "object",
         "properties": {
           "tenantId": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "uuid"
           },
           "name": {
             "type": "string"
           },
           "culture": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "mimeType": {
             "type": "string"
@@ -2753,26 +2474,16 @@
             "type": "boolean"
           },
           "layoutName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "categoryId": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "uuid"
           }
         }
       },
       "TemplateVariableItemResponse": {
-        "required": [
-          "name",
-          "type",
-          "description"
-        ],
+        "required": ["name", "type", "description"],
         "type": "object",
         "properties": {
           "name": {
@@ -2782,19 +2493,12 @@
             "type": "string"
           },
           "description": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "TemplateVariablesResponse": {
-        "required": [
-          "globalVariables",
-          "modelVariables",
-          "enrichedVariables"
-        ],
+        "required": ["globalVariables", "modelVariables", "enrichedVariables"],
         "type": "object",
         "properties": {
           "globalVariables": {
@@ -2818,12 +2522,7 @@
         }
       },
       "WorkflowLifecycleStatus": {
-        "enum": [
-          "Draft",
-          "PendingReview",
-          "Published",
-          "Archived"
-        ]
+        "enum": ["Draft", "PendingReview", "Published", "Archived"]
       }
     }
   },

--- a/contracts/openapi/webhooks.json
+++ b/contracts/openapi/webhooks.json
@@ -7,9 +7,7 @@
   "paths": {
     "/webhooks/event-types": {
       "get": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Returns all registered webhook event types.",
         "description": "Returns the full list of webhook event types declared by application modules at startup. Each entry includes the event type name, localized display name, description, and category for UI grouping. Labels are resolved based on the Accept-Language header. Use these values when creating webhook subscriptions to ensure the event type is valid. Returns an empty list if no event type providers are registered.",
         "operationId": "GetWebhookEventTypes",
@@ -62,9 +60,7 @@
     },
     "/webhooks/subscriptions/{id}": {
       "get": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Returns a webhook subscription by its unique identifier.",
         "description": "Fetches the full details of a single webhook subscription including its current status, target URL, event type, and delivery statistics. Returns 404 if the subscription does not exist.",
         "operationId": "GetWebhookSubscription",
@@ -134,9 +130,7 @@
         }
       },
       "put": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Updates a webhook subscription's target URL.",
         "description": "Replaces the target URL of an existing subscription. The subscription keeps its current status, secret, and event type. Returns 404 if the subscription does not exist.",
         "operationId": "UpdateWebhookSubscription",
@@ -236,9 +230,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Deletes a webhook subscription.",
         "description": "Permanently removes a webhook subscription and all its associated delivery history. This action is irreversible.",
         "operationId": "DeleteWebhookSubscription",
@@ -293,9 +285,7 @@
     },
     "/webhooks/subscriptions/{id}/keys": {
       "get": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Lists the signing keys associated with a subscription.",
         "description": "Returns all signing keys for the subscription, including Active, Retired (within the rotation grace period), and Revoked entries. The protected secret value is never disclosed; rotate the key to obtain a new plain-text secret.",
         "operationId": "ListWebhookSigningKeys",
@@ -368,9 +358,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Rotates the subscription's signing key with overlap semantics.",
         "description": "Generates a new Active signing key and moves the previous Active key to Retired for a configurable grace period (default 24 hours, controlled by WebhooksOptions.RetiredKeyGracePeriod). Verification accepts both keys until the Retired key expires. The new plain-text secret is returned exactly once.",
         "operationId": "RotateWebhookSigningKey",
@@ -442,9 +430,7 @@
     },
     "/webhooks/subscriptions": {
       "post": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Creates a new webhook subscription.",
         "description": "Registers a new webhook subscription for the specified event type. The response includes the plain-text signing secret which is only returned once. The subscription starts in the Active status.",
         "operationId": "CreateWebhookSubscription",
@@ -522,9 +508,7 @@
         }
       },
       "get": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Returns a filtered, sorted, and paginated list of WebhookSubscription entries.",
         "description": "Executes a dynamic query against WebhookSubscription using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
         "operationId": "QueryWebhookSubscription",
@@ -535,10 +519,7 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": [
-                "null",
-                "integer"
-              ],
+              "type": ["null", "integer"],
               "format": "int32"
             }
           },
@@ -549,10 +530,7 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": [
-                "null",
-                "integer"
-              ],
+              "type": ["null", "integer"],
               "format": "int32"
             }
           },
@@ -561,10 +539,7 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -572,10 +547,7 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -583,10 +555,7 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -594,10 +563,7 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -605,10 +571,7 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -616,10 +579,7 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": [
-                "null",
-                "boolean"
-              ]
+              "type": ["null", "boolean"]
             }
           },
           {
@@ -629,10 +589,7 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": [
-                "null",
-                "object"
-              ],
+              "type": ["null", "object"],
               "additionalProperties": {
                 "type": "string"
               }
@@ -645,10 +602,7 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": [
-                "null",
-                "object"
-              ],
+              "type": ["null", "object"],
               "additionalProperties": {
                 "type": "string"
               }
@@ -719,9 +673,7 @@
     },
     "/webhooks/subscriptions/{id}/activate": {
       "post": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Activates a suspended webhook subscription.",
         "description": "Transitions a subscription from Suspended to Active status. Deliveries will resume for matching events. The consecutive failure counter is reset to zero.",
         "operationId": "ActivateWebhookSubscription",
@@ -793,9 +745,7 @@
     },
     "/webhooks/subscriptions/{id}/suspend": {
       "post": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Suspends an active webhook subscription.",
         "description": "Temporarily pauses event delivery for the subscription. The caller's identity is recorded alongside the suspension reason. Use the activate endpoint to resume deliveries.",
         "operationId": "SuspendWebhookSubscription",
@@ -867,9 +817,7 @@
     },
     "/webhooks/subscriptions/{id}/deactivate": {
       "post": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Permanently deactivates a webhook subscription.",
         "description": "Moves the subscription to the Deactivated terminal status. No further deliveries will be attempted. A deactivation reason must be provided. This action cannot be reversed — create a new subscription instead.",
         "operationId": "DeactivateWebhookSubscription",
@@ -961,9 +909,7 @@
     },
     "/webhooks/subscriptions/{id}/test-ping": {
       "post": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Sends a test ping to the subscription's target URL.",
         "description": "Dispatches a synthetic test event to the subscription endpoint and reports the HTTP status code and round-trip duration. Does not affect delivery statistics or the consecutive failure counter.",
         "operationId": "TestWebhookPing",
@@ -1035,9 +981,7 @@
     },
     "/webhooks/stats": {
       "get": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Returns aggregate webhook delivery statistics.",
         "description": "Provides a summary of all webhook subscriptions: total count by status, number of deliveries in the last 24 hours, success rate, and average response time.",
         "operationId": "GetWebhookStats",
@@ -1087,9 +1031,7 @@
     },
     "/webhooks/subscriptions/{id}/keys/{keyId}": {
       "delete": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Revokes a specific signing key.",
         "description": "Marks the targeted key as Revoked. Verification will reject signatures produced with this key from now on. The last Active key cannot be revoked — rotate first to introduce a new Active key, then revoke the old one.",
         "operationId": "RevokeWebhookSigningKey",
@@ -1174,9 +1116,7 @@
     },
     "/webhooks/subscriptions/meta": {
       "get": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Returns query metadata for WebhookSubscription (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for WebhookSubscription: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetWebhookSubscriptionMeta",
@@ -1226,9 +1166,7 @@
     },
     "/webhooks/deliveries": {
       "get": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Returns a filtered, sorted, and paginated list of WebhookDeliveryAttempt entries.",
         "description": "Executes a dynamic query against WebhookDeliveryAttempt using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
         "operationId": "QueryWebhookDeliveryAttempt",
@@ -1239,10 +1177,7 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": [
-                "null",
-                "integer"
-              ],
+              "type": ["null", "integer"],
               "format": "int32"
             }
           },
@@ -1253,10 +1188,7 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": [
-                "null",
-                "integer"
-              ],
+              "type": ["null", "integer"],
               "format": "int32"
             }
           },
@@ -1265,10 +1197,7 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -1276,10 +1205,7 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -1287,10 +1213,7 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -1298,10 +1221,7 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -1309,10 +1229,7 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -1320,10 +1237,7 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": [
-                "null",
-                "boolean"
-              ]
+              "type": ["null", "boolean"]
             }
           },
           {
@@ -1333,10 +1247,7 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": [
-                "null",
-                "object"
-              ],
+              "type": ["null", "object"],
               "additionalProperties": {
                 "type": "string"
               }
@@ -1349,10 +1260,7 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": [
-                "null",
-                "object"
-              ],
+              "type": ["null", "object"],
               "additionalProperties": {
                 "type": "string"
               }
@@ -1423,9 +1331,7 @@
     },
     "/webhooks/deliveries/meta": {
       "get": {
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "summary": "Returns query metadata for WebhookDeliveryAttempt (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for WebhookDeliveryAttempt: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetWebhookDeliveryAttemptMeta",
@@ -1512,19 +1418,12 @@
             "type": "boolean"
           },
           "format": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "DateFilterMeta": {
-        "required": [
-          "name",
-          "defaultPeriod",
-          "availablePeriods"
-        ],
+        "required": ["name", "defaultPeriod", "availablePeriods"],
         "type": "object",
         "properties": {
           "name": {
@@ -1542,22 +1441,10 @@
         }
       },
       "DatePeriod": {
-        "enum": [
-          "Today",
-          "ThisWeek",
-          "ThisMonth",
-          "LastMonth",
-          "ThisQuarter",
-          "ThisYear",
-          "Custom"
-        ]
+        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
       },
       "FilterableField": {
-        "required": [
-          "name",
-          "type",
-          "operators"
-        ],
+        "required": ["name", "type", "operators"],
         "type": "object",
         "properties": {
           "name": {
@@ -1573,10 +1460,7 @@
             }
           },
           "enumValues": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "type": "string"
             }
@@ -1594,11 +1478,7 @@
         }
       },
       "FilterGroupMeta": {
-        "required": [
-          "name",
-          "label",
-          "presets"
-        ],
+        "required": ["name", "label", "presets"],
         "type": "object",
         "properties": {
           "name": {
@@ -1630,10 +1510,7 @@
         ]
       },
       "GroupByField": {
-        "required": [
-          "name",
-          "type"
-        ],
+        "required": ["name", "type"],
         "type": "object",
         "properties": {
           "name": {
@@ -1645,10 +1522,7 @@
         }
       },
       "GroupedResultOfWebhookDeliveryAttempt": {
-        "required": [
-          "groups",
-          "totalCount"
-        ],
+        "required": ["groups", "totalCount"],
         "type": "object",
         "properties": {
           "groups": {
@@ -1664,10 +1538,7 @@
         }
       },
       "GroupedResultOfWebhookSubscription": {
-        "required": [
-          "groups",
-          "totalCount"
-        ],
+        "required": ["groups", "totalCount"],
         "type": "object",
         "properties": {
           "groups": {
@@ -1683,18 +1554,13 @@
         }
       },
       "GroupEntryOfWebhookDeliveryAttempt": {
-        "required": [
-          "field",
-          "value",
-          "label",
-          "count"
-        ],
+        "required": ["field", "value", "label", "count"],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": { },
+          "value": {},
           "label": {
             "type": "string"
           },
@@ -1703,16 +1569,10 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": [
-              "null",
-              "object"
-            ]
+            "type": ["null", "object"]
           },
           "items": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "$ref": "#/components/schemas/WebhookDeliveryAttempt"
             }
@@ -1720,18 +1580,13 @@
         }
       },
       "GroupEntryOfWebhookSubscription": {
-        "required": [
-          "field",
-          "value",
-          "label",
-          "count"
-        ],
+        "required": ["field", "value", "label", "count"],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": { },
+          "value": {},
           "label": {
             "type": "string"
           },
@@ -1740,16 +1595,10 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": [
-              "null",
-              "object"
-            ]
+            "type": ["null", "object"]
           },
           "items": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "$ref": "#/components/schemas/WebhookSubscription"
             }
@@ -1763,35 +1612,20 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "title": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "status": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "detail": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "instance": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "errors": {
             "type": "object",
@@ -1816,38 +1650,23 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "endpoint": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "kind": {
             "$ref": "#/components/schemas/LookupKind"
           },
           "requiredPermission": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "searchParam": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "default": "search"
           },
           "scopeKeys": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "type": "string"
             }
@@ -1855,20 +1674,11 @@
         }
       },
       "LookupKind": {
-        "enum": [
-          "QueryEngine",
-          "Simple",
-          "ReferenceData",
-          "Enum"
-        ],
+        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
         "default": "QueryEngine"
       },
       "PagedResultOfWebhookDeliveryAttempt": {
-        "required": [
-          "items",
-          "totalCount",
-          "hasMore"
-        ],
+        "required": ["items", "totalCount", "hasMore"],
         "type": "object",
         "properties": {
           "items": {
@@ -1885,10 +1695,7 @@
                   "format": "uuid"
                 },
                 "tenantId": {
-                  "type": [
-                    "null",
-                    "string"
-                  ],
+                  "type": ["null", "string"],
                   "format": "uuid"
                 },
                 "eventType": {
@@ -1898,10 +1705,7 @@
                   "type": "string"
                 },
                 "httpStatusCode": {
-                  "type": [
-                    "null",
-                    "integer"
-                  ],
+                  "type": ["null", "integer"],
                   "format": "int32"
                 },
                 "payloadHash": {
@@ -1913,26 +1717,17 @@
                 },
                 "durationMs": {
                   "pattern": "^-?(?:0|[1-9]\\d*)$",
-                  "type": [
-                    "integer",
-                    "string"
-                  ],
+                  "type": ["integer", "string"],
                   "format": "int64"
                 },
                 "errorMessage": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
+                  "type": ["null", "string"]
                 },
                 "isSuccess": {
                   "type": "boolean"
                 },
                 "payload": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
+                  "type": ["null", "string"]
                 },
                 "id": {
                   "type": "string",
@@ -1943,29 +1738,19 @@
             }
           },
           "totalCount": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "PagedResultOfWebhookSubscription": {
-        "required": [
-          "items",
-          "totalCount",
-          "hasMore"
-        ],
+        "required": ["items", "totalCount", "hasMore"],
         "type": "object",
         "properties": {
           "items": {
@@ -1980,10 +1765,7 @@
                   "type": "string"
                 },
                 "signingKeys": {
-                  "type": [
-                    "null",
-                    "array"
-                  ],
+                  "type": ["null", "array"],
                   "items": {
                     "type": "object",
                     "properties": {
@@ -1999,32 +1781,19 @@
                         "format": "date-time"
                       },
                       "expiresAt": {
-                        "type": [
-                          "null",
-                          "string"
-                        ],
+                        "type": ["null", "string"],
                         "format": "date-time"
                       },
                       "revokedAt": {
-                        "type": [
-                          "null",
-                          "string"
-                        ],
+                        "type": ["null", "string"],
                         "format": "date-time"
                       },
                       "lastRotationNotificationAt": {
-                        "type": [
-                          "null",
-                          "string"
-                        ],
+                        "type": ["null", "string"],
                         "format": "date-time"
                       },
                       "status": {
-                        "enum": [
-                          "Active",
-                          "Retired",
-                          "Revoked"
-                        ]
+                        "enum": ["Active", "Retired", "Revoked"]
                       },
                       "id": {
                         "type": "string",
@@ -2035,85 +1804,51 @@
                   }
                 },
                 "tenantId": {
-                  "type": [
-                    "null",
-                    "string"
-                  ],
+                  "type": ["null", "string"],
                   "format": "uuid"
                 },
                 "status": {
-                  "enum": [
-                    "Active",
-                    "Suspended",
-                    "Deactivated"
-                  ]
+                  "enum": ["Active", "Suspended", "Deactivated"]
                 },
                 "signingSecretHint": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
+                  "type": ["null", "string"]
                 },
                 "deactivationReason": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
+                  "type": ["null", "string"]
                 },
                 "consecutiveFailureCount": {
                   "type": "integer",
                   "format": "int32"
                 },
                 "lastSuccessAt": {
-                  "type": [
-                    "null",
-                    "string"
-                  ],
+                  "type": ["null", "string"],
                   "format": "date-time"
                 },
                 "suspendedAt": {
-                  "type": [
-                    "null",
-                    "string"
-                  ],
+                  "type": ["null", "string"],
                   "format": "date-time"
                 },
                 "suspendedBy": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
+                  "type": ["null", "string"]
                 },
                 "modifiedAt": {
-                  "type": [
-                    "null",
-                    "string"
-                  ],
+                  "type": ["null", "string"],
                   "description": "Last modification timestamp (UTC).",
                   "format": "date-time"
                 },
                 "modifiedBy": {
-                  "type": [
-                    "null",
-                    "string"
-                  ],
+                  "type": ["null", "string"],
                   "description": "Identifier of the user who last modified the entity."
                 },
                 "domainEvents": {
-                  "type": [
-                    "null",
-                    "array"
-                  ],
+                  "type": ["null", "array"],
                   "items": {
                     "type": "object",
                     "description": "Marker interface for domain events."
                   }
                 },
                 "integrationEvents": {
-                  "type": [
-                    "null",
-                    "array"
-                  ],
+                  "type": ["null", "array"],
                   "items": {
                     "type": "object",
                     "description": "Marker interface for integration events (ETO — Event Transfer Object)."
@@ -2137,30 +1872,19 @@
             }
           },
           "totalCount": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "PaginationMeta": {
-        "required": [
-          "defaultPageSize",
-          "maxPageSize",
-          "maxStreamSize",
-          "supportsCursor"
-        ],
+        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
         "type": "object",
         "properties": {
           "defaultPageSize": {
@@ -2181,11 +1905,7 @@
         }
       },
       "PresetMeta": {
-        "required": [
-          "name",
-          "label",
-          "isDefault"
-        ],
+        "required": ["name", "label", "isDefault"],
         "type": "object",
         "properties": {
           "name": {
@@ -2283,19 +2003,12 @@
             "$ref": "#/components/schemas/PaginationMeta"
           },
           "defaultSort": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "QuickFilterMeta": {
-        "required": [
-          "name",
-          "label",
-          "isDefault"
-        ],
+        "required": ["name", "label", "isDefault"],
         "type": "object",
         "properties": {
           "name": {
@@ -2310,9 +2023,7 @@
         }
       },
       "SortableField": {
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "type": "object",
         "properties": {
           "name": {
@@ -2332,10 +2043,7 @@
             "format": "uuid"
           },
           "tenantId": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "uuid"
           },
           "eventType": {
@@ -2345,10 +2053,7 @@
             "type": "string"
           },
           "httpStatusCode": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "payloadHash": {
@@ -2360,26 +2065,17 @@
           },
           "durationMs": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "integer",
-              "string"
-            ],
+            "type": ["integer", "string"],
             "format": "int64"
           },
           "errorMessage": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "isSuccess": {
             "type": "boolean"
           },
           "payload": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "id": {
             "type": "string",
@@ -2389,34 +2085,20 @@
         }
       },
       "WebhookEventTypeResponse": {
-        "required": [
-          "eventType",
-          "displayName",
-          "description",
-          "category"
-        ],
+        "required": ["eventType", "displayName", "description", "category"],
         "type": "object",
         "properties": {
           "eventType": {
             "type": "string"
           },
           "displayName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "description": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "category": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
@@ -2435,24 +2117,15 @@
             "format": "date-time"
           },
           "expiresAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "revokedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "lastRotationNotificationAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "status": {
@@ -2466,12 +2139,7 @@
         }
       },
       "WebhookSigningKeyCreatedResponse": {
-        "required": [
-          "id",
-          "subscriptionId",
-          "createdAt",
-          "plainSecret"
-        ],
+        "required": ["id", "subscriptionId", "createdAt", "plainSecret"],
         "type": "object",
         "properties": {
           "id": {
@@ -2516,24 +2184,15 @@
             "format": "date-time"
           },
           "expiresAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "revokedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "lastRotationNotificationAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "status": {
@@ -2542,11 +2201,7 @@
         }
       },
       "WebhookSigningKeyStatus": {
-        "enum": [
-          "Active",
-          "Retired",
-          "Revoked"
-        ]
+        "enum": ["Active", "Retired", "Revoked"]
       },
       "WebhookSubscription": {
         "type": "object",
@@ -2558,89 +2213,56 @@
             "type": "string"
           },
           "signingKeys": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "$ref": "#/components/schemas/WebhookSigningKey"
             }
           },
           "tenantId": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "uuid"
           },
           "status": {
             "$ref": "#/components/schemas/WebhookSubscriptionStatus"
           },
           "signingSecretHint": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "deactivationReason": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "consecutiveFailureCount": {
             "type": "integer",
             "format": "int32"
           },
           "lastSuccessAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "suspendedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "suspendedBy": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "modifiedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "description": "Last modification timestamp (UTC).",
             "format": "date-time"
           },
           "modifiedBy": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "description": "Identifier of the user who last modified the entity."
           },
           "domainEvents": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "$ref": "#/components/schemas/IDomainEvent"
             }
           },
           "integrationEvents": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "$ref": "#/components/schemas/IIntegrationEvent"
             }
@@ -2662,13 +2284,7 @@
         }
       },
       "WebhookSubscriptionCreatedResponse": {
-        "required": [
-          "id",
-          "targetUrl",
-          "eventType",
-          "status",
-          "signingSecret"
-        ],
+        "required": ["id", "targetUrl", "eventType", "status", "signingSecret"],
         "type": "object",
         "properties": {
           "id": {
@@ -2690,27 +2306,27 @@
         }
       },
       "WebhookSubscriptionCreateRequest": {
-        "required": [
-          "targetUrl",
-          "eventType"
-        ],
+        "required": ["targetUrl", "eventType"],
         "type": "object",
         "properties": {
           "targetUrl": {
-            "type": "string"
+            "maxLength": 2048,
+            "type": "string",
+            "x-granit-validator": "Validation:WebhookUrlBlockedTld"
           },
           "eventType": {
-            "type": "string"
+            "maxLength": 200,
+            "type": "string",
+            "x-granit-validator": "Validation:UnknownWebhookEventType"
           }
         }
       },
       "WebhookSubscriptionDeactivateRequest": {
-        "required": [
-          "reason"
-        ],
+        "required": ["reason"],
         "type": "object",
         "properties": {
           "reason": {
+            "maxLength": 1000,
             "type": "string"
           }
         }
@@ -2747,10 +2363,7 @@
             "format": "int32"
           },
           "lastSuccessAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "createdAt": {
@@ -2758,17 +2371,11 @@
             "format": "date-time"
           },
           "modifiedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "signingSecretHint": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
@@ -2806,35 +2413,21 @@
           },
           "successRateLast24h": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-            "type": [
-              "number",
-              "string"
-            ],
+            "type": ["number", "string"],
             "format": "double"
           },
           "avgResponseTimeMsLast24h": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-            "type": [
-              "number",
-              "string"
-            ],
+            "type": ["number", "string"],
             "format": "double"
           }
         }
       },
       "WebhookSubscriptionStatus": {
-        "enum": [
-          "Active",
-          "Suspended",
-          "Deactivated"
-        ]
+        "enum": ["Active", "Suspended", "Deactivated"]
       },
       "WebhookSubscriptionTestPingResponse": {
-        "required": [
-          "success",
-          "httpStatusCode",
-          "durationMs"
-        ],
+        "required": ["success", "httpStatusCode", "durationMs"],
         "type": "object",
         "properties": {
           "success": {
@@ -2846,22 +2439,19 @@
           },
           "durationMs": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "integer",
-              "string"
-            ],
+            "type": ["integer", "string"],
             "format": "int64"
           }
         }
       },
       "WebhookSubscriptionUpdateRequest": {
-        "required": [
-          "targetUrl"
-        ],
+        "required": ["targetUrl"],
         "type": "object",
         "properties": {
           "targetUrl": {
-            "type": "string"
+            "maxLength": 2048,
+            "type": "string",
+            "x-granit-validator": "Validation:WebhookUrlBlockedTld"
           }
         }
       }

--- a/packages/@granit/contract-tests/src/__tests__/conformance-suite.test.ts
+++ b/packages/@granit/contract-tests/src/__tests__/conformance-suite.test.ts
@@ -22,7 +22,10 @@ function loadSpec(slug: string): OpenApiDocument {
 
 /** Find the source file declaring `interface X` or `type X = …` under a package's src. */
 function findInterfaceFile(srcDir: string, typeName: string): string | undefined {
-  const needle = new RegExp(`\\b(?:interface|type)\\s+${typeName}\\b`);
+  // Match a declaration (`interface X` / `type X =` / `type X<`), not a
+  // re-export specifier (`export { type X }` barrels list `type X,` which would
+  // otherwise resolve to the barrel file instead of the declaration).
+  const needle = new RegExp(`\\binterface\\s+${typeName}\\b|\\btype\\s+${typeName}\\s*[=<]`);
   const stack = [srcDir];
   while (stack.length) {
     const dir = stack.pop();

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -146,6 +146,56 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'AuditPropertyChangeResponse',
     ],
   },
+  // ─── Framework — Tier B module coverage (granit-dotnet) ─────────────────────
+  // Matching request/response DTOs only. Raw query-engine grid entities
+  // (ScheduledAction, WebhookSubscription, WebhookDeliveryAttempt, …) and DTOs
+  // the front names differently / does not model (UserNotificationResponse,
+  // TemplateDetailResponse, …) are not listed here.
+  {
+    slug: 'notifications',
+    package: 'notifications',
+    types: [
+      'NotificationDefinition',
+      'NotificationSubscriptionResponse',
+      'NotificationPreferenceUpdateRequest',
+    ],
+  },
+  {
+    slug: 'localization',
+    package: 'localization',
+    types: ['ApplicationLocalizationResponse', 'LocalizationOverride'],
+  },
+  {
+    slug: 'scheduling',
+    package: 'scheduling',
+    types: ['ScheduledActionResponse', 'RescheduleActionRequest'],
+  },
+  {
+    slug: 'templating',
+    package: 'templating',
+    types: [
+      'SaveTemplateRequest',
+      'SaveTemplateCategoryRequest',
+      'TemplatePreviewRequest',
+      'TemplatePreviewResponse',
+    ],
+  },
+  {
+    slug: 'webhooks',
+    package: 'webhooks',
+    types: [
+      'WebhookSubscriptionResponse',
+      'WebhookSubscriptionCreateRequest',
+      'WebhookSubscriptionCreatedResponse',
+      'WebhookSubscriptionUpdateRequest',
+      'WebhookSubscriptionDeactivateRequest',
+      'WebhookSubscriptionStatsResponse',
+      'WebhookSubscriptionTestPingResponse',
+      'WebhookEventTypeResponse',
+      'WebhookSigningKeyResponse',
+      'WebhookSigningKeyCreatedResponse',
+    ],
+  },
   {
     slug: 'authorization',
     package: 'authorization',


### PR DESCRIPTION
## Context
Coverage campaign for `@granit/contract-tests` — **Tier B (framework)**. Final batch of the A+B coverage push.

## Changes
- **Re-vendor 5 stale framework snapshots** (`notifications`, `localization`, `scheduling`, `templating`, `webhooks`).
- **Register** their matching DTOs (**types-only**): `notifications`, `localization`, `scheduling`, `templating`, `webhooks`. Inserted after `auditing` to avoid manifest merge conflicts with #661/#662/#663.
- **Harness fix** — `findInterfaceFile` in `conformance-suite.test.ts`: its needle matched `export { type X }` re-export specifiers, so a module using that multi-line barrel form (`scheduling`) resolved to the barrel file instead of the declaration → false `type-missing`. The needle now matches a real declaration (`interface X` / `type X =` / `type X<`). Benefits all modules.

Raw query-engine grid entities (`ScheduledAction`, `WebhookSubscription`, `WebhookDeliveryAttempt`…) and DTOs the front names differently / doesn't model (`UserNotificationResponse`, `TemplateDetailResponse`…) are not listed — the latter are Tier C (naming alignment) candidates.

## Verification
- Conformance: **204 passed** — no DTO drift on the registered types.
- `tsc --noEmit`, ESLint clean.

## Campaign status
Tier A (#661, #662) + Tier B (#663, this) cover **32 new modules**. Remaining: Tier C — front DTO renames for `openiddict`, `timeline`, `data-lookup`, `analytics`, `data-exchange` (+ the Tier B deferred drift items).