### PR TITLE
test(contracts): cover analytics + data-exchange in the oracle

### DIFF
--- a/contracts/openapi/data-exchange.json
+++ b/contracts/openapi/data-exchange.json
@@ -756,7 +756,15 @@
             "description": "No Content"
           },
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
@@ -1051,7 +1059,15 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
@@ -1169,7 +1185,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1454,7 +1470,8 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ImportColumnMapping"
-            }
+            },
+            "x-granit-validator": "Validation:AtLeastOneMappingTarget"
           },
           "concurrencyStamp": {
             "type": "string"
@@ -1466,9 +1483,11 @@
         "type": "object",
         "properties": {
           "definitionName": {
+            "maxLength": 500,
             "type": "string"
           },
           "format": {
+            "maxLength": 10,
             "type": "string"
           },
           "selectedFields": {
@@ -1482,6 +1501,7 @@
             "default": false
           },
           "sort": {
+            "maxLength": 2000,
             "type": ["null", "string"]
           },
           "filter": {
@@ -1497,6 +1517,7 @@
             }
           },
           "search": {
+            "maxLength": 1000,
             "type": ["null", "string"]
           }
         }

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -814,4 +814,32 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'SetPinnedLandingRouteRequest',
     ],
   },
+  // ─── Analytics + data-exchange (granit-business / granit-dotnet) ────────────
+  {
+    slug: 'analytics',
+    package: 'analytics',
+    // Widget definitions (extends WidgetDefinitionBase), MapPointSource (union)
+    // and PeriodSpec (union) are not field-by-field checkable. MetricResponse
+    // deferred — `refreshHint` is a string enum backend-side, object front-side.
+    types: ['MetricRequest', 'MetricPreviousPayload', 'MetricSnapshotPayload', 'MapCenter'],
+  },
+  {
+    slug: 'data-exchange',
+    package: 'data-exchange',
+    // TODO(contract): ImportReportResponse (`finalStatus` string-vs-object) and
+    // ImportFieldMetadata (`displayName` nullability) deferred — real field drift.
+    types: [
+      'ExportDefinitionResponse',
+      'ExportFieldResponse',
+      'ExportJobResponse',
+      'ExportPresetResponse',
+      'CreateExportJobRequest',
+      'SaveExportPresetRequest',
+      'ImportJobResponse',
+      'ImportPreviewResponse',
+      'ImportRowError',
+      'ImportColumnMapping',
+      'ConfirmMappingsRequest',
+    ],
+  },
 ];


### PR DESCRIPTION
## Context
Final module of the `@granit/contract-tests` coverage campaign. With `analytics` DTOs now under `src/types/` (#665), both remaining domain modules can be registered.

## Changes
- **Re-sync** the stale `data-exchange` snapshot.
- **analytics**: register `MetricRequest`, `MetricPreviousPayload`, `MetricSnapshotPayload`, `MapCenter`. Widget definitions (`extends WidgetDefinitionBase`) and the `MapPointSource` / `PeriodSpec` unions are not field-by-field checkable by the oracle; `MetricResponse` deferred (`refreshHint` string-vs-object).
- **data-exchange**: register 11 export/import DTOs. `ImportReportResponse` (`finalStatus` family) and `ImportFieldMetadata` (`displayName` nullability) deferred with `TODO(contract)`.

## Verification
Conformance **455 passed**; `tsc --noEmit`, ESLint clean.

## Campaign wrap-up
This closes the coverage push: **19 → 54 modules** registered. Remaining work is the tracked `TODO(contract)` field-drift items (front-vs-backend reconciliation) scattered across the registered entries.