### PR TITLE
fix(contracts): reconcile 4 field drifts + register their DTOs

### DIFF
--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -107,11 +107,11 @@ export const CONTRACTS: readonly ModuleContract[] = [
   {
     slug: 'openiddict',
     package: 'openiddict-admin',
-    // TODO(contract): AdminOidcApplicationResponse (missing `deviceKind`),
-    // AdminOidcRotateSecretResponse (front newSecret vs backend displayName/
-    // newClientSecret) and AdminOidcAuthorizationResponse (subject/status/type
-    // nullability) deferred — real field drift to reconcile.
+    // TODO(contract): AdminOidcRotateSecretResponse (front newSecret vs backend
+    // displayName/newClientSecret) deferred — structural divergence to reconcile.
     types: [
+      'AdminOidcApplicationResponse',
+      'AdminOidcAuthorizationResponse',
       'AdminOidcCreateApplicationRequest',
       'AdminOidcUpdateApplicationRequest',
       'AdminOidcScopeResponse',
@@ -389,8 +389,9 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'BulkActionFailure',
     ],
     // TODO(contract): EntityFormFieldManifest deferred — front carries a `lookup`
-    // field absent from the backend schema. BulkActionRequest deferred — `payload`
-    // is nullable backend-side but not front-side.
+    // field absent from the backend schema. BulkActionRequest deferred — its
+    // `payload` is `unknown` front-side (which subsumes null) but the oracle
+    // reads a bare `unknown` as non-nullable; an oracle limitation, not a drift.
   },
   {
     slug: 'entities-customization',
@@ -479,9 +480,8 @@ export const CONTRACTS: readonly ModuleContract[] = [
   {
     slug: 'invoicing',
     package: 'invoicing',
-    // TODO(contract): InvoiceResponse deferred — backend `partyId` (required) is
-    // missing from the front type.
     types: [
+      'InvoiceResponse',
       'InvoiceLineItemResponse',
       'InvoiceCreateRequest',
       'FinalizeInvoiceRequest',
@@ -863,8 +863,8 @@ export const CONTRACTS: readonly ModuleContract[] = [
   {
     slug: 'data-exchange',
     package: 'data-exchange',
-    // TODO(contract): ImportReportResponse (`finalStatus` string-vs-object) and
-    // ImportFieldMetadata (`displayName` nullability) deferred — real field drift.
+    // TODO(contract): ImportReportResponse (`finalStatus` string-vs-object)
+    // deferred — real field drift.
     types: [
       'ExportDefinitionResponse',
       'ExportFieldResponse',
@@ -874,6 +874,7 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'SaveExportPresetRequest',
       'ImportJobResponse',
       'ImportPreviewResponse',
+      'ImportFieldMetadata',
       'ImportRowError',
       'ImportColumnMapping',
       'ConfirmMappingsRequest',

--- a/packages/@granit/data-exchange/src/import/types/import-preview.ts
+++ b/packages/@granit/data-exchange/src/import/types/import-preview.ts
@@ -21,7 +21,7 @@ export interface ImportColumnMapping {
 export interface ImportFieldMetadata {
   readonly propertyPath: string;
   readonly clrTypeName: string;
-  readonly displayName: string;
+  readonly displayName: string | null;
   readonly description: string | null;
   readonly isRequired: boolean;
 }

--- a/packages/@granit/invoicing/src/__tests__/invoicing-api.test.ts
+++ b/packages/@granit/invoicing/src/__tests__/invoicing-api.test.ts
@@ -29,6 +29,7 @@ const sampleLineItem = {
 
 const sampleInvoice: InvoiceResponse = {
   id: 'inv-1',
+  partyId: 'party-1',
   documentType: 'Invoice',
   invoiceNumber: 'INV-2026-0001',
   status: 'Paid',

--- a/packages/@granit/invoicing/src/types/index.ts
+++ b/packages/@granit/invoicing/src/types/index.ts
@@ -75,6 +75,7 @@ export interface InvoiceLineItemResponse {
 /** Full invoice response from the API. */
 export interface InvoiceResponse {
   readonly id: string;
+  readonly partyId: string;
   readonly documentType: string;
   readonly invoiceNumber: string | null;
   readonly status: string;

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-application-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-application-api.test.ts
@@ -23,6 +23,7 @@ const mockApplication: AdminOidcApplicationResponse = {
   postLogoutRedirectUris: ['https://example.com/signout-callback'],
   consentType: 'implicit',
   clientSide: 3,
+  deviceKind: null,
   hasSigningKey: false,
 };
 

--- a/packages/@granit/openiddict-admin/src/types/admin-oidc-application.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-oidc-application.ts
@@ -14,6 +14,11 @@ export interface AdminOidcApplicationResponse {
   readonly consentType: string | null;
   /** MultiTenancySides flags: 0=None 1=Host 2=Tenant 3=Both */
   readonly clientSide: number | null;
+  /**
+   * Device-flow client kind (`Browser`, `MobileApp`, …); `null` for
+   * non-device clients. Mirrors the backend `DeviceKind` enum.
+   */
+  readonly deviceKind: string | null;
   readonly hasSigningKey: boolean;
 }
 

--- a/packages/@granit/openiddict-admin/src/types/admin-oidc-authorization.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-oidc-authorization.ts
@@ -12,9 +12,9 @@ export interface AdminOidcAuthorizationListParams {
 export interface AdminOidcAuthorizationResponse {
   readonly id: string;
   readonly clientId: string | null;
-  readonly subject: string;
-  readonly status: string;
-  readonly type: string;
+  readonly subject: string | null;
+  readonly status: string | null;
+  readonly type: string | null;
   readonly scopes: readonly string[];
 }
 

--- a/packages/@granit/react-invoicing/src/__tests__/use-invoicing.test.tsx
+++ b/packages/@granit/react-invoicing/src/__tests__/use-invoicing.test.tsx
@@ -43,6 +43,7 @@ function createWrapper(client: AxiosInstance, basePath?: string) {
 
 const sampleInvoice: InvoiceResponse = {
   id: 'inv-1',
+  partyId: 'party-1',
   documentType: 'Invoice',
   invoiceNumber: 'INV-2026-0001',
   status: 'Paid',

--- a/packages/@granit/react-invoicing/src/testing/data.ts
+++ b/packages/@granit/react-invoicing/src/testing/data.ts
@@ -35,6 +35,7 @@ export const sampleInvoiceLineItems: Mutable<InvoiceLineItemResponse>[] = [
 export const sampleInvoices: Mutable<InvoiceResponse>[] = [
   {
     id: toEntityId<'Invoice'>('inv_001'),
+    partyId: 'party_001',
     invoiceNumber: 'INV-2026-0001',
     status: 'Paid',
     documentType: 'Invoice',
@@ -58,6 +59,7 @@ export const sampleInvoices: Mutable<InvoiceResponse>[] = [
   },
   {
     id: toEntityId<'Invoice'>('inv_002'),
+    partyId: 'party_002',
     invoiceNumber: 'INV-2026-0002',
     status: 'Open',
     documentType: 'Invoice',
@@ -81,6 +83,7 @@ export const sampleInvoices: Mutable<InvoiceResponse>[] = [
   },
   {
     id: toEntityId<'Invoice'>('inv_003'),
+    partyId: 'party_003',
     invoiceNumber: 'INV-2026-0003',
     status: 'Draft',
     documentType: 'Invoice',
@@ -104,6 +107,7 @@ export const sampleInvoices: Mutable<InvoiceResponse>[] = [
   },
   {
     id: toEntityId<'Invoice'>('inv_004'),
+    partyId: 'party_001',
     invoiceNumber: 'CN-2026-0001',
     status: 'Cancelled',
     documentType: 'CreditNote',

--- a/packages/@granit/react-invoicing/src/testing/handlers.ts
+++ b/packages/@granit/react-invoicing/src/testing/handlers.ts
@@ -240,6 +240,7 @@ export function createInvoicingHandlers(baseUrl = DEFAULT_BASE_PATH) {
 
       const newInvoice = {
         id: toEntityId<'Invoice'>(`inv_${String(sampleInvoices.length + 1).padStart(3, '0')}`),
+        partyId: body.partyId,
         invoiceNumber: `INV-2026-${String(sampleInvoices.length + 1).padStart(4, '0')}`,
         status: 'Draft' as const,
         documentType: body.documentType ?? 'Invoice',

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-applications.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-applications.test.tsx
@@ -58,6 +58,7 @@ const mockApp: AdminOidcApplicationResponse = {
   postLogoutRedirectUris: ['https://guava.local/signout-callback'],
   consentType: 'implicit',
   clientSide: 3,
+  deviceKind: null,
   hasSigningKey: false,
 };
 

--- a/packages/@granit/react-openiddict-admin/src/testing/data.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/data.ts
@@ -55,6 +55,7 @@ export const mockOidcApplications: Mutable<AdminOidcApplicationResponse>[] = [
     postLogoutRedirectUris: ['https://showcase.granit-fx.dev/signout-callback'],
     consentType: 'implicit',
     clientSide: 3,
+    deviceKind: null,
     hasSigningKey: false,
   },
   {
@@ -67,6 +68,7 @@ export const mockOidcApplications: Mutable<AdminOidcApplicationResponse>[] = [
     postLogoutRedirectUris: [],
     consentType: null,
     clientSide: 1,
+    deviceKind: null,
     hasSigningKey: false,
   },
 ];

--- a/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
@@ -393,6 +393,7 @@ export function createOpenIddictAdminHandlers(
         postLogoutRedirectUris: body.postLogoutRedirectUris ?? [],
         consentType: body.consentType ?? null,
         clientSide: body.clientSide ?? null,
+        deviceKind: body.deviceKind ?? null,
         hasSigningKey: false,
       };
       mockOidcApplications.push(newApp);
@@ -407,6 +408,7 @@ export function createOpenIddictAdminHandlers(
       const updated: (typeof mockOidcApplications)[number] = {
         clientId: existing.clientId,
         tenantId: existing.tenantId,
+        deviceKind: existing.deviceKind,
         hasSigningKey: existing.hasSigningKey,
         displayName: 'displayName' in body ? (body.displayName ?? null) : existing.displayName,
         type: 'type' in body ? (body.type ?? null) : existing.type,


### PR DESCRIPTION
## Summary

Closes the safe, **no-arbitration** contract drifts the oracle had deferred via `TODO(contract)`. Each front DTO is aligned to the authoritative backend spec, then registered in the conformance manifest.

| Module | DTO | Drift | Fix |
|--------|-----|-------|-----|
| invoicing | `InvoiceResponse` | backend `partyId` required, missing front-side | add `partyId: string` |
| openiddict | `AdminOidcApplicationResponse` | backend `deviceKind` (enum, nullable) missing | add `deviceKind: string \| null` |
| openiddict | `AdminOidcAuthorizationResponse` | backend `subject`/`status`/`type` nullable | widen to `string \| null` |
| data-exchange | `ImportFieldMetadata` | backend `displayName` nullable | widen to `string \| null` |

All four DTOs are now oracle-checked (**480** conformance assertions, was 476). Test fixtures + MSW handlers updated for the new required fields.

## Reclassified (kept deferred, comment corrected)

- **entities `BulkActionRequest`** — front `payload: unknown` already subsumes null; the oracle reads a bare `unknown` as non-nullable. An oracle limitation, **not** a drift (adding `| null` would trip `no-redundant-type-constituents`).
- **taxonomy `CategoryDetailResponse`** — an intentional flattening adapter (`{ category, breadcrumb }` → flat) documented in the type, not drift.

## Verification
- `npx vitest run packages/@granit/contract-tests` — 480 passed
- tsc + tests green: invoicing, openiddict-admin, react-invoicing, react-openiddict-admin, data-exchange
- `granit-showcase-react` tsc green against this branch — **no coordinated MR needed** (changes are backward-compatible for consumers)