### PR TITLE
test(contracts): resolve cross-file enum aliases + cover Lot A DTOs

### DIFF
--- a/packages/@granit/contract-tests/src/__tests__/__fixtures__/imported-enum/dto.ts
+++ b/packages/@granit/contract-tests/src/__tests__/__fixtures__/imported-enum/dto.ts
@@ -1,0 +1,6 @@
+import type { Kind } from './kind';
+
+// Fixture DTO: `kind` is typed via an enum imported from a sibling file.
+export interface Sample {
+  readonly kind: Kind;
+}

--- a/packages/@granit/contract-tests/src/__tests__/__fixtures__/imported-enum/kind.ts
+++ b/packages/@granit/contract-tests/src/__tests__/__fixtures__/imported-enum/kind.ts
@@ -1,0 +1,4 @@
+// Fixture: a string-union enum kept in its own file (the codebase convention).
+// Imported by ./dto.ts so the oracle must follow the import to resolve `kind`
+// to `string` instead of defaulting an unresolved reference to `object`.
+export type Kind = 'Alpha' | 'Beta' | 'Gamma';

--- a/packages/@granit/contract-tests/src/__tests__/conformance.test.ts
+++ b/packages/@granit/contract-tests/src/__tests__/conformance.test.ts
@@ -1,8 +1,14 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import { checkSchemaConformance } from '../conformance';
 
 import type { OpenApiDocument } from '../conformance';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
 
 // A spec with one field of each kind the oracle reasons about, plus the
 // representation warts the normalization table must absorb.
@@ -85,5 +91,27 @@ describe('conformance oracle — positive & negative controls', () => {
     expect(check(src)).toContainEqual(
       expect.objectContaining({ rule: 'orphan-field', field: 'extra' })
     );
+  });
+
+  // The codebase keeps each string-union enum in its own file. A field typed as
+  // an imported enum must follow the import to resolve to `string`, not default
+  // an unresolved reference to `object` (which produced false type-family drift).
+  it('resolves a string-union enum imported from a sibling file', () => {
+    const enumSpec: OpenApiDocument = {
+      components: {
+        schemas: {
+          Sample: { type: 'object', required: ['kind'], properties: { kind: { $ref: '#/x' } } },
+          x: { enum: ['Alpha', 'Beta', 'Gamma'], type: 'string' },
+        },
+      },
+    };
+    const dtoFile = path.join(here, '__fixtures__/imported-enum/dto.ts');
+    const violations = checkSchemaConformance({
+      spec: enumSpec,
+      schemaName: 'Sample',
+      sourceText: readFileSync(dtoFile, 'utf8'),
+      fileName: dtoFile,
+    });
+    expect(violations).toEqual([]);
   });
 });

--- a/packages/@granit/contract-tests/src/conformance.ts
+++ b/packages/@granit/contract-tests/src/conformance.ts
@@ -1,3 +1,6 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
 import * as ts from 'typescript';
 
 /** A single contract-conformance violation between a backend schema and a front type. */
@@ -213,20 +216,112 @@ interface ParsedSource {
   aliases: AliasMap;
 }
 
-function parseSource(sourceText: string, fileName: string, typeName: string): ParsedSource {
+/**
+ * Per-file local type aliases + the module specifiers it imports / re-exports.
+ * Cached process-wide so the dependency graph is parsed at most once across the
+ * whole suite, however many DTOs reference a shared file.
+ */
+interface FileInfo {
+  aliases: ReadonlyMap<string, ts.TypeNode>;
+  imports: readonly string[];
+}
+const fileInfoCache = new Map<string, FileInfo>();
+const MAX_IMPORT_DEPTH = 8;
+const RESOLVE_EXTS = ['.ts', '.tsx'] as const;
+
+function parseFileInfo(fileName: string, sourceText: string): FileInfo {
+  const cached = fileInfoCache.get(fileName);
+  if (cached) return cached;
   const sf = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true);
   const aliases = new Map<string, ts.TypeNode>();
-  let members: readonly ts.TypeElement[] | undefined;
+  const imports: string[] = [];
   sf.forEachChild((node) => {
     if (ts.isTypeAliasDeclaration(node)) {
       aliases.set(node.name.text, node.type);
-      if (node.name.text === typeName && ts.isTypeLiteralNode(node.type))
-        members = node.type.members;
+    } else if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      imports.push(node.moduleSpecifier.text);
+    } else if (
+      ts.isExportDeclaration(node) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      imports.push(node.moduleSpecifier.text);
+    }
+  });
+  const info: FileInfo = { aliases, imports };
+  fileInfoCache.set(fileName, info);
+  return info;
+}
+
+/** Resolve a relative or `@granit/*` module specifier to its on-disk source file. */
+function resolveModuleFile(spec: string, fromFile: string): string | undefined {
+  let base: string;
+  if (spec.startsWith('.')) {
+    base = path.resolve(path.dirname(fromFile), spec);
+  } else if (spec.startsWith('@granit/')) {
+    const marker = `${path.sep}packages${path.sep}@granit${path.sep}`;
+    const idx = fromFile.indexOf(marker);
+    if (idx === -1) return undefined;
+    const repoPackages = fromFile.slice(0, idx + marker.length);
+    base = path.join(repoPackages, spec.slice('@granit/'.length), 'src', 'index');
+  } else {
+    return undefined; // node_modules / unrelated package — nothing to resolve
+  }
+  for (const ext of RESOLVE_EXTS) if (existsSync(base + ext)) return base + ext;
+  for (const ext of RESOLVE_EXTS) {
+    const idxFile = path.join(base, `index${ext}`);
+    if (existsSync(idxFile)) return idxFile;
+  }
+  return undefined;
+}
+
+/**
+ * Merge the entry file's type aliases with those reachable through its
+ * `import type` / `export … from` edges. The codebase keeps each string-union
+ * enum in its own file, so a field typed as an imported enum must follow the
+ * import to resolve to its real family instead of defaulting to `object`.
+ * Local aliases win; cycles and depth are bounded.
+ */
+function collectAliases(fileName: string, sourceText: string): AliasMap {
+  const merged = new Map<string, ts.TypeNode>();
+  const visited = new Set<string>();
+  const stack: { file: string; text: string; depth: number }[] = [
+    { file: fileName, text: sourceText, depth: 0 },
+  ];
+  while (stack.length) {
+    const { file, text, depth } = stack.pop()!;
+    if (visited.has(file) || depth > MAX_IMPORT_DEPTH) continue;
+    visited.add(file);
+    const info = parseFileInfo(file, text);
+    for (const [name, node] of info.aliases) if (!merged.has(name)) merged.set(name, node);
+    for (const spec of info.imports) {
+      const target = resolveModuleFile(spec, file);
+      if (!target || visited.has(target)) continue;
+      try {
+        stack.push({ file: target, text: readFileSync(target, 'utf8'), depth: depth + 1 });
+      } catch {
+        // unreadable (generated / out-of-tree) — skip silently
+      }
+    }
+  }
+  return merged;
+}
+
+function parseSource(sourceText: string, fileName: string, typeName: string): ParsedSource {
+  const sf = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true);
+  let members: readonly ts.TypeElement[] | undefined;
+  sf.forEachChild((node) => {
+    if (
+      ts.isTypeAliasDeclaration(node) &&
+      node.name.text === typeName &&
+      ts.isTypeLiteralNode(node.type)
+    ) {
+      members = node.type.members;
     } else if (ts.isInterfaceDeclaration(node) && node.name.text === typeName) {
       members = node.members;
     }
   });
-  return { members, aliases };
+  return { members, aliases: collectAliases(fileName, sourceText) };
 }
 
 function tsProps(members: readonly ts.TypeElement[], aliases: AliasMap): Map<string, PropShape> {

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -88,20 +88,24 @@ export const CONTRACTS: readonly ModuleContract[] = [
   {
     slug: 'data-lookup',
     package: 'data-lookup',
-    // TODO(contract): LookupManifestEntryResponse deferred — `kind` is a string
-    // enum backend-side but an object front-side (type-family mismatch).
-    types: ['LookupItemResponse', 'LookupResultResponse', 'LookupManifestResponse'],
+    types: [
+      'LookupItemResponse',
+      'LookupResultResponse',
+      'LookupManifestResponse',
+      'LookupManifestEntryResponse',
+    ],
   },
   {
     slug: 'timeline',
     package: 'timeline',
-    // TODO(contract): TimelineStreamEntryResponse (front-only origin/sourceKey/
-    // sourceId/editedAt + object `entryType`) and PostTimelineEntryRequest
-    // (object `entryType`) deferred — front enriches beyond the backend schema.
+    // TODO(contract): TimelineStreamEntryResponse deferred — front enriches the
+    // backend schema with origin/sourceKey/sourceId/editedAt for external-source
+    // projection (front-only, intentional).
     types: [
       'ReactionAggregateResponse',
       'ReactionToggleResponse',
       'TimelineAttachmentInfoResponse',
+      'PostTimelineEntryRequest',
     ],
   },
   {
@@ -304,10 +308,12 @@ export const CONTRACTS: readonly ModuleContract[] = [
   {
     slug: 'dashboards',
     package: 'dashboards',
-    // TODO(contract): Dashboard{Summary,Detail,CatalogEntry,Import,Resync}Response
-    // deferred — front models `category`/`status` as objects while the backend
-    // schema is a string enum (real type-family mismatch to reconcile).
     types: [
+      'DashboardSummaryResponse',
+      'DashboardDetailResponse',
+      'DashboardCatalogEntryResponse',
+      'DashboardImportResponse',
+      'DashboardResyncResponse',
       'DashboardMetadataUpdateRequest',
       'WidgetInstanceResponse',
       'AddWidgetRequest',
@@ -858,7 +864,13 @@ export const CONTRACTS: readonly ModuleContract[] = [
     // Widget definitions (extends WidgetDefinitionBase), MapPointSource (union)
     // and PeriodSpec (union) are not field-by-field checkable. MetricResponse
     // deferred — `refreshHint` is a string enum backend-side, object front-side.
-    types: ['MetricRequest', 'MetricPreviousPayload', 'MetricSnapshotPayload', 'MapCenter'],
+    types: [
+      'MetricResponse',
+      'MetricRequest',
+      'MetricPreviousPayload',
+      'MetricSnapshotPayload',
+      'MapCenter',
+    ],
   },
   {
     slug: 'data-exchange',
@@ -878,6 +890,7 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'ImportRowError',
       'ImportColumnMapping',
       'ConfirmMappingsRequest',
+      'ImportReportResponse',
     ],
   },
 ];


### PR DESCRIPTION
## Summary

Investigating the deferred **Lot A** "string enum vs object" drifts revealed they were **not drifts at all** — the front already models every enum as a string-union, exactly mirroring the backend. The failures came from an **oracle blind spot**: it only resolved type aliases declared in the *same* file, so a field typed as an enum imported from a sibling file (the codebase convention of one enum per file) hit an unresolved reference that defaulted to `object`.

### Oracle fix
Teaches `checkSchemaConformance` to follow `import type` / `export … from` edges:
- relative (`./`, `../`) **and** `@granit/*` specifiers (uniform source-direct layout)
- bounded depth + process-wide file cache (suite stays ~2s, dependency graph parsed once)
- local aliases still take precedence; genuine object literals still read as `object` (real drift still caught)

### Coverage unlocked (9 DTOs, were wrongly deferred)
| Module | DTO(s) | Field |
|--------|--------|-------|
| dashboards | Summary/Detail/CatalogEntry/Import/Resync Response | `category`, `status` |
| analytics | `MetricResponse` | `refreshHint` |
| data-lookup | `LookupManifestEntryResponse` | `kind` |
| data-exchange | `ImportReportResponse` | `finalStatus` |
| timeline | `PostTimelineEntryRequest` | `entryType` |

**Oracle: 480 → 490 checks.** None were real drifts.

### Still deferred (genuine)
`TimelineStreamEntryResponse` — front enriches the backend schema with `origin`/`sourceKey`/`sourceId`/`editedAt` for external-source projection (front-only, intentional → Lot B).

### Tests
Fixture-backed regression test (`__fixtures__/imported-enum/`) locks the imported-enum resolution; the conformance suite locks it against the 9 real DTOs.

## Verification
- `npx vitest run packages/@granit/contract-tests` — 490 passed
- tsc + eslint clean
- No front DTO changed → no showcase impact