### PR TITLE
test(contracts): re-sync 6 dotnet-enriched contracts + reconcile front

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -6197,7 +6197,7 @@
             {
               "name": "preferences",
               "kind": "property",
-              "signature": "preferences: readonly NotificationPreference[]"
+              "signature": "preferences: readonly NotificationPreferenceResponse[]"
             },
             {
               "name": "loading",

--- a/contracts/openapi/auditing.json
+++ b/contracts/openapi/auditing.json
@@ -7,10 +7,8 @@
   "paths": {
     "/auditing/audit-entries": {
       "get": {
-        "tags": [
-          "Audit Log"
-        ],
-        "summary": "Returns a filtered, sorted, and paginated list of AuditEntryResponse entries projected from AuditEntry.",
+        "tags": ["Audit Log"],
+        "summary": "Returns a paged, filterable list of AuditEntryResponse from AuditEntry.",
         "description": "Executes a dynamic query against AuditEntry using the Granit query engine and projects each row to AuditEntryResponse. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult<AuditEntryResponse> by default. When the groupBy query parameter is specified, returns a GroupedResult<AuditEntryResponse> with the same projection applied to the items inside each group.",
         "operationId": "QueryAuditEntry",
         "parameters": [
@@ -20,10 +18,7 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": [
-                "null",
-                "integer"
-              ],
+              "type": ["null", "integer"],
               "format": "int32"
             }
           },
@@ -34,10 +29,7 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": [
-                "null",
-                "integer"
-              ],
+              "type": ["null", "integer"],
               "format": "int32"
             }
           },
@@ -46,10 +38,7 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -57,10 +46,7 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -68,10 +54,7 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -79,10 +62,7 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -90,10 +70,7 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -101,10 +78,7 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": [
-                "null",
-                "boolean"
-              ]
+              "type": ["null", "boolean"]
             }
           },
           {
@@ -114,10 +88,7 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": [
-                "null",
-                "object"
-              ],
+              "type": ["null", "object"],
               "additionalProperties": {
                 "type": "string"
               }
@@ -130,10 +101,7 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": [
-                "null",
-                "object"
-              ],
+              "type": ["null", "object"],
               "additionalProperties": {
                 "type": "string"
               }
@@ -204,9 +172,7 @@
     },
     "/auditing/audit-entries/meta": {
       "get": {
-        "tags": [
-          "Audit Log"
-        ],
+        "tags": ["Audit Log"],
         "summary": "Returns query metadata for AuditEntry (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for AuditEntry: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetAuditEntryMeta",
@@ -256,9 +222,7 @@
     },
     "/auditing/audit-entries/{id}": {
       "get": {
-        "tags": [
-          "Audit Log"
-        ],
+        "tags": ["Audit Log"],
         "summary": "Returns a single audit log entry with full change details.",
         "description": "Returns the complete audit log entry including all entity changes and property-level diffs (original → new value). Sensitive properties are masked with '***'. Returns 404 if the entry does not exist.",
         "operationId": "GetAuditEntryById",
@@ -330,9 +294,7 @@
     },
     "/auditing/audit-entries/entity/{entityType}/{entityId}": {
       "get": {
-        "tags": [
-          "Audit Log"
-        ],
+        "tags": ["Audit Log"],
         "summary": "Returns the audit trail for a specific entity instance.",
         "description": "Returns all audit log entries associated with a specific entity, identified by its CLR type name and primary key. Results are paginated and ordered by timestamp descending. Useful for displaying the full change history of a single record. Path parameters are limited to 256 characters.",
         "operationId": "GetAuditEntriesByEntity",
@@ -430,9 +392,7 @@
     },
     "/auditing/audit-entries/correlation/{correlationId}": {
       "get": {
-        "tags": [
-          "Audit Log"
-        ],
+        "tags": ["Audit Log"],
         "summary": "Returns audit entries matching a distributed tracing correlation ID.",
         "description": "Returns all audit log entries that share the given correlation ID, ordered by timestamp descending. This is essential for distributed tracing investigation — correlating audit events across multiple services or operations that belong to the same logical transaction. The correlation ID is limited to 256 characters.",
         "operationId": "GetAuditEntriesByCorrelationId",
@@ -506,9 +466,7 @@
     },
     "/auditing/audit-entries/pseudonymize/{userId}": {
       "post": {
-        "tags": [
-          "Audit Log"
-        ],
+        "tags": ["Audit Log"],
         "summary": "Pseudonymize all audit entries for a specific user.",
         "description": "Replaces personal data (UserId, UserName, IpAddress, UserAgent) in all audit entries belonging to the specified user with pseudonymized values (GDPR Art. 17). The UserId is replaced with a SHA-256 hash to preserve audit trail correlation without re-identification. Audit entry integrity is maintained per ISO 27001 A.12.4. Returns 204 No Content on success.",
         "operationId": "PseudonymizeAuditEntries",
@@ -572,10 +530,8 @@
     },
     "/auditing/audit-entity-changes": {
       "get": {
-        "tags": [
-          "Audit Log"
-        ],
-        "summary": "Returns a filtered, sorted, and paginated list of AuditEntityChangeSummaryResponse entries projected from AuditEntityChange.",
+        "tags": ["Audit Log"],
+        "summary": "Returns a paged, filterable list of AuditEntityChangeSummaryResponse from AuditEntityChange.",
         "description": "Executes a dynamic query against AuditEntityChange using the Granit query engine and projects each row to AuditEntityChangeSummaryResponse. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult<AuditEntityChangeSummaryResponse> by default. When the groupBy query parameter is specified, returns a GroupedResult<AuditEntityChangeSummaryResponse> with the same projection applied to the items inside each group.",
         "operationId": "QueryAuditEntityChange",
         "parameters": [
@@ -585,10 +541,7 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": [
-                "null",
-                "integer"
-              ],
+              "type": ["null", "integer"],
               "format": "int32"
             }
           },
@@ -599,10 +552,7 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": [
-                "null",
-                "integer"
-              ],
+              "type": ["null", "integer"],
               "format": "int32"
             }
           },
@@ -611,10 +561,7 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -622,10 +569,7 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -633,10 +577,7 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -644,10 +585,7 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -655,10 +593,7 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": [
-                "null",
-                "string"
-              ]
+              "type": ["null", "string"]
             }
           },
           {
@@ -666,10 +601,7 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": [
-                "null",
-                "boolean"
-              ]
+              "type": ["null", "boolean"]
             }
           },
           {
@@ -679,10 +611,7 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": [
-                "null",
-                "object"
-              ],
+              "type": ["null", "object"],
               "additionalProperties": {
                 "type": "string"
               }
@@ -695,10 +624,7 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": [
-                "null",
-                "object"
-              ],
+              "type": ["null", "object"],
               "additionalProperties": {
                 "type": "string"
               }
@@ -769,9 +695,7 @@
     },
     "/auditing/audit-entity-changes/meta": {
       "get": {
-        "tags": [
-          "Audit Log"
-        ],
+        "tags": ["Audit Log"],
         "summary": "Returns query metadata for AuditEntityChange (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for AuditEntityChange: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetAuditEntityChangeMeta",
@@ -832,20 +756,10 @@
         ]
       },
       "AuditChangeType": {
-        "enum": [
-          "Created",
-          "Modified",
-          "Deleted",
-          "SoftDeleted"
-        ]
+        "enum": ["Created", "Modified", "Deleted", "SoftDeleted"]
       },
       "AuditEntityChangeResponse": {
-        "required": [
-          "entityType",
-          "entityId",
-          "changeType",
-          "propertyChanges"
-        ],
+        "required": ["entityType", "entityId", "changeType", "propertyChanges"],
         "type": "object",
         "properties": {
           "entityType": {
@@ -907,6 +821,7 @@
           "userName",
           "category",
           "ipAddress",
+          "userAgent",
           "tenantId",
           "correlationId",
           "entityChanges"
@@ -925,32 +840,23 @@
             "type": "string"
           },
           "userName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "category": {
             "type": "string"
           },
           "ipAddress": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
+          },
+          "userAgent": {
+            "type": ["null", "string"]
           },
           "tenantId": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "uuid"
           },
           "correlationId": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "entityChanges": {
             "type": "array",
@@ -986,32 +892,20 @@
             "type": "string"
           },
           "userName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "category": {
             "$ref": "#/components/schemas/AuditCategory"
           },
           "ipAddress": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "tenantId": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "uuid"
           },
           "correlationId": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "entityChangeCount": {
             "type": "integer",
@@ -1020,27 +914,17 @@
         }
       },
       "AuditPropertyChangeResponse": {
-        "required": [
-          "propertyName",
-          "originalValue",
-          "newValue"
-        ],
+        "required": ["propertyName", "originalValue", "newValue"],
         "type": "object",
         "properties": {
           "propertyName": {
             "type": "string"
           },
           "originalValue": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "newValue": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
@@ -1080,19 +964,12 @@
             "type": "boolean"
           },
           "format": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "DateFilterMeta": {
-        "required": [
-          "name",
-          "defaultPeriod",
-          "availablePeriods"
-        ],
+        "required": ["name", "defaultPeriod", "availablePeriods"],
         "type": "object",
         "properties": {
           "name": {
@@ -1110,22 +987,10 @@
         }
       },
       "DatePeriod": {
-        "enum": [
-          "Today",
-          "ThisWeek",
-          "ThisMonth",
-          "LastMonth",
-          "ThisQuarter",
-          "ThisYear",
-          "Custom"
-        ]
+        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
       },
       "FilterableField": {
-        "required": [
-          "name",
-          "type",
-          "operators"
-        ],
+        "required": ["name", "type", "operators"],
         "type": "object",
         "properties": {
           "name": {
@@ -1141,10 +1006,7 @@
             }
           },
           "enumValues": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "type": "string"
             }
@@ -1162,11 +1024,7 @@
         }
       },
       "FilterGroupMeta": {
-        "required": [
-          "name",
-          "label",
-          "presets"
-        ],
+        "required": ["name", "label", "presets"],
         "type": "object",
         "properties": {
           "name": {
@@ -1198,10 +1056,7 @@
         ]
       },
       "GroupByField": {
-        "required": [
-          "name",
-          "type"
-        ],
+        "required": ["name", "type"],
         "type": "object",
         "properties": {
           "name": {
@@ -1213,10 +1068,7 @@
         }
       },
       "GroupedResultOfAuditEntityChangeSummaryResponse": {
-        "required": [
-          "groups",
-          "totalCount"
-        ],
+        "required": ["groups", "totalCount"],
         "type": "object",
         "properties": {
           "groups": {
@@ -1232,10 +1084,7 @@
         }
       },
       "GroupedResultOfAuditEntryResponse": {
-        "required": [
-          "groups",
-          "totalCount"
-        ],
+        "required": ["groups", "totalCount"],
         "type": "object",
         "properties": {
           "groups": {
@@ -1251,18 +1100,13 @@
         }
       },
       "GroupEntryOfAuditEntityChangeSummaryResponse": {
-        "required": [
-          "field",
-          "value",
-          "label",
-          "count"
-        ],
+        "required": ["field", "value", "label", "count"],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": { },
+          "value": {},
           "label": {
             "type": "string"
           },
@@ -1271,16 +1115,10 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": [
-              "null",
-              "object"
-            ]
+            "type": ["null", "object"]
           },
           "items": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "$ref": "#/components/schemas/AuditEntityChangeSummaryResponse"
             }
@@ -1288,18 +1126,13 @@
         }
       },
       "GroupEntryOfAuditEntryResponse": {
-        "required": [
-          "field",
-          "value",
-          "label",
-          "count"
-        ],
+        "required": ["field", "value", "label", "count"],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": { },
+          "value": {},
           "label": {
             "type": "string"
           },
@@ -1308,16 +1141,10 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": [
-              "null",
-              "object"
-            ]
+            "type": ["null", "object"]
           },
           "items": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "$ref": "#/components/schemas/AuditEntryResponse"
             }
@@ -1328,35 +1155,20 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "title": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "status": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "detail": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "instance": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "errors": {
             "type": "object",
@@ -1373,38 +1185,23 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "endpoint": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "kind": {
             "$ref": "#/components/schemas/LookupKind"
           },
           "requiredPermission": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "searchParam": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "default": "search"
           },
           "scopeKeys": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "type": "string"
             }
@@ -1412,20 +1209,11 @@
         }
       },
       "LookupKind": {
-        "enum": [
-          "QueryEngine",
-          "Simple",
-          "ReferenceData",
-          "Enum"
-        ],
+        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
         "default": "QueryEngine"
       },
       "PagedResultOfAuditEntityChangeSummaryResponse": {
-        "required": [
-          "items",
-          "totalCount",
-          "hasMore"
-        ],
+        "required": ["items", "totalCount", "hasMore"],
         "type": "object",
         "properties": {
           "items": {
@@ -1456,12 +1244,7 @@
                   "type": "string"
                 },
                 "changeType": {
-                  "enum": [
-                    "Created",
-                    "Modified",
-                    "Deleted",
-                    "SoftDeleted"
-                  ]
+                  "enum": ["Created", "Modified", "Deleted", "SoftDeleted"]
                 },
                 "propertyChangeCount": {
                   "type": "integer",
@@ -1471,29 +1254,19 @@
             }
           },
           "totalCount": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "PagedResultOfAuditEntryResponse": {
-        "required": [
-          "items",
-          "totalCount",
-          "hasMore"
-        ],
+        "required": ["items", "totalCount", "hasMore"],
         "type": "object",
         "properties": {
           "items": {
@@ -1524,10 +1297,7 @@
                   "type": "string"
                 },
                 "userName": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
+                  "type": ["null", "string"]
                 },
                 "category": {
                   "enum": [
@@ -1539,23 +1309,14 @@
                   ]
                 },
                 "ipAddress": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
+                  "type": ["null", "string"]
                 },
                 "tenantId": {
-                  "type": [
-                    "null",
-                    "string"
-                  ],
+                  "type": ["null", "string"],
                   "format": "uuid"
                 },
                 "correlationId": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
+                  "type": ["null", "string"]
                 },
                 "entityChangeCount": {
                   "type": "integer",
@@ -1565,30 +1326,19 @@
             }
           },
           "totalCount": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "PaginationMeta": {
-        "required": [
-          "defaultPageSize",
-          "maxPageSize",
-          "maxStreamSize",
-          "supportsCursor"
-        ],
+        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
         "type": "object",
         "properties": {
           "defaultPageSize": {
@@ -1609,11 +1359,7 @@
         }
       },
       "PresetMeta": {
-        "required": [
-          "name",
-          "label",
-          "isDefault"
-        ],
+        "required": ["name", "label", "isDefault"],
         "type": "object",
         "properties": {
           "name": {
@@ -1711,19 +1457,12 @@
             "$ref": "#/components/schemas/PaginationMeta"
           },
           "defaultSort": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "QuickFilterMeta": {
-        "required": [
-          "name",
-          "label",
-          "isDefault"
-        ],
+        "required": ["name", "label", "isDefault"],
         "type": "object",
         "properties": {
           "name": {
@@ -1738,9 +1477,7 @@
         }
       },
       "SortableField": {
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "type": "object",
         "properties": {
           "name": {

--- a/contracts/openapi/data-exchange.json
+++ b/contracts/openapi/data-exchange.json
@@ -1578,7 +1578,9 @@
           "fileName",
           "errorMessage",
           "createdAt",
-          "completedAt"
+          "completedAt",
+          "modifiedAt",
+          "modifiedBy"
         ],
         "type": "object",
         "properties": {
@@ -1612,6 +1614,13 @@
           "completedAt": {
             "type": ["null", "string"],
             "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": ["null", "string"]
           }
         }
       },
@@ -1692,12 +1701,15 @@
         "required": [
           "id",
           "definitionName",
+          "entityTypeName",
           "originalFileName",
           "mimeType",
           "fileSizeBytes",
           "status",
           "createdAt",
           "completedAt",
+          "modifiedAt",
+          "modifiedBy",
           "concurrencyStamp"
         ],
         "type": "object",
@@ -1707,6 +1719,9 @@
             "format": "uuid"
           },
           "definitionName": {
+            "type": "string"
+          },
+          "entityTypeName": {
             "type": "string"
           },
           "originalFileName": {
@@ -1730,6 +1745,13 @@
           "completedAt": {
             "type": ["null", "string"],
             "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": ["null", "string"]
           },
           "concurrencyStamp": {
             "type": "string"

--- a/contracts/openapi/notifications.json
+++ b/contracts/openapi/notifications.json
@@ -921,7 +921,15 @@
         }
       },
       "NotificationPreferenceResponse": {
-        "required": ["id", "userId", "notificationTypeName", "channelName", "isEnabled"],
+        "required": [
+          "id",
+          "userId",
+          "notificationTypeName",
+          "channelName",
+          "isEnabled",
+          "createdAt",
+          "modifiedAt"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -939,6 +947,14 @@
           },
           "isEnabled": {
             "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
           }
         }
       },
@@ -963,7 +979,7 @@
         "enum": ["Info", "Success", "Warning", "Error", "Fatal"]
       },
       "NotificationSubscriptionResponse": {
-        "required": ["id", "userId", "notificationTypeName", "entityType", "entityId"],
+        "required": ["id", "userId", "notificationTypeName", "entityType", "entityId", "createdAt"],
         "type": "object",
         "properties": {
           "id": {
@@ -981,6 +997,10 @@
           },
           "entityId": {
             "type": ["null", "string"]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       },

--- a/contracts/openapi/privacy.json
+++ b/contracts/openapi/privacy.json
@@ -2037,6 +2037,8 @@
       "PrivacyExportStatusResponse": {
         "required": [
           "requestId",
+          "subjectUserId",
+          "callerUserId",
           "state",
           "requestedAt",
           "completedAt",
@@ -2046,6 +2048,14 @@
         "type": "object",
         "properties": {
           "requestId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "subjectUserId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "callerUserId": {
             "type": "string",
             "format": "uuid"
           },

--- a/contracts/openapi/templating.json
+++ b/contracts/openapi/templating.json
@@ -2352,6 +2352,7 @@
           "content",
           "mimeType",
           "status",
+          "version",
           "createdAt",
           "createdBy",
           "publishedAt",
@@ -2373,6 +2374,10 @@
           },
           "status": {
             "$ref": "#/components/schemas/WorkflowLifecycleStatus"
+          },
+          "version": {
+            "type": "integer",
+            "format": "int32"
           },
           "createdAt": {
             "type": "string",

--- a/contracts/openapi/timeline.json
+++ b/contracts/openapi/timeline.json
@@ -956,6 +956,9 @@
           }
         }
       },
+      "TimelineEntryOrigin": {
+        "enum": ["Native", "External"]
+      },
       "TimelineEntryType": {
         "enum": ["Comment", "SystemLog", "InternalNote"]
       },
@@ -968,7 +971,11 @@
           "authorName",
           "body",
           "attachments",
-          "parentEntryId"
+          "parentEntryId",
+          "origin",
+          "sourceKey",
+          "sourceId",
+          "editedAt"
         ],
         "type": "object",
         "properties": {
@@ -1001,6 +1008,19 @@
           "parentEntryId": {
             "type": ["null", "string"],
             "format": "uuid"
+          },
+          "origin": {
+            "$ref": "#/components/schemas/TimelineEntryOrigin"
+          },
+          "sourceKey": {
+            "type": "string"
+          },
+          "sourceId": {
+            "type": ["null", "string"]
+          },
+          "editedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
           },
           "reactions": {
             "type": ["null", "object"],

--- a/packages/@granit/auditing/src/__tests__/audit-log-api.test.ts
+++ b/packages/@granit/auditing/src/__tests__/audit-log-api.test.ts
@@ -24,6 +24,7 @@ describe('audit-log-api', () => {
         userName: 'admin',
         category: AuditCategory.DataMutation,
         ipAddress: '127.0.0.1',
+        userAgent: 'Mozilla/5.0',
         tenantId: null,
         correlationId: null,
         entityChanges: [],

--- a/packages/@granit/auditing/src/types/index.ts
+++ b/packages/@granit/auditing/src/types/index.ts
@@ -68,6 +68,8 @@ export type AuditEntryDetailResponse = {
   readonly userName: string | null;
   readonly category: AuditCategoryValue;
   readonly ipAddress: string | null;
+  /** Client user-agent captured with the entry; `null` when unavailable (parity with {@link ipAddress}). */
+  readonly userAgent: string | null;
   readonly tenantId: TenantId | null;
   readonly correlationId: CorrelationId | null;
   readonly entityChanges: readonly AuditEntityChangeResponse[];

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -98,13 +98,11 @@ export const CONTRACTS: readonly ModuleContract[] = [
   {
     slug: 'timeline',
     package: 'timeline',
-    // TODO(contract): TimelineStreamEntryResponse deferred — front enriches the
-    // backend schema with origin/sourceKey/sourceId/editedAt for external-source
-    // projection (front-only, intentional).
     types: [
       'ReactionAggregateResponse',
       'ReactionToggleResponse',
       'TimelineAttachmentInfoResponse',
+      'TimelineStreamEntryResponse',
       'PostTimelineEntryRequest',
     ],
   },
@@ -237,6 +235,7 @@ export const CONTRACTS: readonly ModuleContract[] = [
     types: [
       'NotificationDefinition',
       'NotificationSubscriptionResponse',
+      'NotificationPreferenceResponse',
       'NotificationPreferenceUpdateRequest',
     ],
   },

--- a/packages/@granit/data-exchange/src/export/types/export-job.ts
+++ b/packages/@granit/data-exchange/src/export/types/export-job.ts
@@ -18,6 +18,8 @@ export interface ExportJobResponse {
   readonly errorMessage: string | null;
   readonly createdAt: string;
   readonly completedAt: string | null;
+  readonly modifiedAt: string | null;
+  readonly modifiedBy: string | null;
 }
 
 /**

--- a/packages/@granit/data-exchange/src/import/types/import-job.ts
+++ b/packages/@granit/data-exchange/src/import/types/import-job.ts
@@ -19,12 +19,16 @@ export type ImportJobStatus =
 export interface ImportJobResponse {
   readonly id: string;
   readonly definitionName: string;
+  /** Target entity type being imported. */
+  readonly entityTypeName: string;
   readonly originalFileName: string;
   readonly mimeType: string;
   readonly fileSizeBytes: number;
   readonly status: ImportJobStatus;
   readonly createdAt: string;
   readonly completedAt: string | null;
+  readonly modifiedAt: string | null;
+  readonly modifiedBy: string | null;
   /** Opaque optimistic-concurrency token. Echo back in update requests to detect concurrent modifications (HTTP 409). */
   readonly concurrencyStamp: string;
 }

--- a/packages/@granit/notifications/src/__tests__/notification-api.test.ts
+++ b/packages/@granit/notifications/src/__tests__/notification-api.test.ts
@@ -13,7 +13,7 @@ import {
 
 import type {
   UserNotificationPage,
-  NotificationPreference,
+  NotificationPreferenceResponse,
   NotificationPreferenceUpdateRequest,
 } from '../types/index';
 
@@ -98,7 +98,7 @@ describe('notification-api', () => {
   // getPreferences
   // -----------------------------------------------------------------------
   it('should send GET for preferences (getPreferences)', async () => {
-    const prefs: NotificationPreference[] = [];
+    const prefs: NotificationPreferenceResponse[] = [];
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue(axiosResponse(prefs));
 

--- a/packages/@granit/notifications/src/api/notification-api.ts
+++ b/packages/@granit/notifications/src/api/notification-api.ts
@@ -2,7 +2,7 @@ import { buildApiUrl } from '@granit/api-client';
 
 import type {
   NotificationDefinition,
-  NotificationPreference,
+  NotificationPreferenceResponse,
   NotificationPreferenceUpdateRequest,
   NotificationSubscriptionResponse,
   UserNotificationPage,
@@ -73,8 +73,8 @@ export async function getEntityActivityFeed(
 export async function getPreferences(
   client: AxiosInstance,
   basePath: string
-): Promise<NotificationPreference[]> {
-  const { data } = await client.get<NotificationPreference[]>(
+): Promise<NotificationPreferenceResponse[]> {
+  const { data } = await client.get<NotificationPreferenceResponse[]>(
     buildApiUrl(basePath, 'notifications', 'preferences')
   );
   return data;

--- a/packages/@granit/notifications/src/index.ts
+++ b/packages/@granit/notifications/src/index.ts
@@ -5,7 +5,7 @@ export type {
   NotificationConfig,
   NotificationDefinition,
   NotificationId,
-  NotificationPreference,
+  NotificationPreferenceResponse,
   NotificationPreferenceId,
   NotificationPreferenceUpdateRequest,
   NotificationSeverity,

--- a/packages/@granit/notifications/src/types/index.ts
+++ b/packages/@granit/notifications/src/types/index.ts
@@ -93,12 +93,16 @@ export const NotificationChannels = {
 /** Branded notification preference identifier. */
 export type NotificationPreferenceId = EntityId<'NotificationPreference'>;
 
-export interface NotificationPreference {
+export interface NotificationPreferenceResponse {
   readonly id: NotificationPreferenceId;
   readonly userId: UserId;
   readonly notificationTypeName: string;
   readonly channelName: string;
   readonly isEnabled: boolean;
+  /** When the preference was created. */
+  readonly createdAt: ISODateString;
+  /** When the preference was last changed; `null` if never modified. */
+  readonly modifiedAt: ISODateString | null;
 }
 
 /** Write DTO for upsert. Mirrors `NotificationPreferenceUpdateRequest` from .NET. */
@@ -152,6 +156,8 @@ export interface NotificationSubscriptionResponse {
   readonly entityType: string | null;
   /** Entity id for follower subscriptions (null for type-level subscriptions). */
   readonly entityId: string | null;
+  /** When the subscription was created. */
+  readonly createdAt: ISODateString;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/@granit/privacy/src/__tests__/privacy-api.test.ts
+++ b/packages/@granit/privacy/src/__tests__/privacy-api.test.ts
@@ -74,6 +74,8 @@ describe('privacy-api', () => {
       const client = createMockClient();
       const response: PrivacyExportStatusResponse = {
         requestId: 'req-1',
+        subjectUserId: '11111111-1111-1111-1111-111111111111',
+        callerUserId: '11111111-1111-1111-1111-111111111111',
         requestedAt: '2026-03-21T10:00:00Z',
         state: 'Completed',
         archiveBlobReferenceId: 'blob-123',

--- a/packages/@granit/privacy/src/types/index.ts
+++ b/packages/@granit/privacy/src/types/index.ts
@@ -9,6 +9,10 @@ export type PrivacyExportRequestResponse = {
 
 export type PrivacyExportStatusResponse = {
   readonly requestId: string;
+  /** Whose data is exported. Differs from {@link callerUserId} in the on-behalf-of flow. */
+  readonly subjectUserId: string;
+  /** Who requested the export. Differs from {@link subjectUserId} in the on-behalf-of flow. */
+  readonly callerUserId: string;
   readonly requestedAt: string;
   readonly state: PrivacyExportStatus;
   readonly archiveBlobReferenceId: string | null;

--- a/packages/@granit/react-auditing/src/__tests__/use-audit-log.test.tsx
+++ b/packages/@granit/react-auditing/src/__tests__/use-audit-log.test.tsx
@@ -43,6 +43,7 @@ describe('useAuditLogEntry', () => {
       userName: 'admin',
       category: AuditCategory.DataMutation,
       ipAddress: null,
+      userAgent: null,
       tenantId: null,
       correlationId: null,
       entityChanges: [],

--- a/packages/@granit/react-auditing/src/testing/handlers.ts
+++ b/packages/@granit/react-auditing/src/testing/handlers.ts
@@ -202,6 +202,7 @@ function toDetail(entry: AuditEntryResponse): AuditEntryDetailResponse {
     userName: entry.userName,
     category: entry.category,
     ipAddress: entry.ipAddress,
+    userAgent: 'Mozilla/5.0',
     tenantId: entry.tenantId,
     correlationId: entry.correlationId,
     entityChanges: [

--- a/packages/@granit/react-data-exchange/src/testing/data.ts
+++ b/packages/@granit/react-data-exchange/src/testing/data.ts
@@ -10,6 +10,9 @@ export const mockImportHistory: ImportJobResponse[] = [
     status: 'Completed',
     createdAt: '2026-03-07T09:15:00Z',
     completedAt: '2026-03-07T09:15:12Z',
+    entityTypeName: 'Country',
+    modifiedAt: null,
+    modifiedBy: null,
     concurrencyStamp: 'stamp-imp-001',
   },
   {
@@ -21,6 +24,9 @@ export const mockImportHistory: ImportJobResponse[] = [
     status: 'PartiallyCompleted',
     createdAt: '2026-03-06T14:30:00Z',
     completedAt: '2026-03-06T14:30:08Z',
+    entityTypeName: 'Country',
+    modifiedAt: null,
+    modifiedBy: null,
     concurrencyStamp: 'stamp-imp-002',
   },
   {
@@ -32,6 +38,9 @@ export const mockImportHistory: ImportJobResponse[] = [
     status: 'Failed',
     createdAt: '2026-03-05T11:00:00Z',
     completedAt: '2026-03-05T11:00:03Z',
+    entityTypeName: 'Country',
+    modifiedAt: null,
+    modifiedBy: null,
     concurrencyStamp: 'stamp-imp-003',
   },
   {
@@ -43,6 +52,9 @@ export const mockImportHistory: ImportJobResponse[] = [
     status: 'Completed',
     createdAt: '2026-03-04T16:45:00Z',
     completedAt: '2026-03-04T16:45:06Z',
+    entityTypeName: 'Country',
+    modifiedAt: null,
+    modifiedBy: null,
     concurrencyStamp: 'stamp-imp-004',
   },
   {
@@ -54,6 +66,9 @@ export const mockImportHistory: ImportJobResponse[] = [
     status: 'Cancelled',
     createdAt: '2026-03-03T08:20:00Z',
     completedAt: null,
+    entityTypeName: 'Country',
+    modifiedAt: null,
+    modifiedBy: null,
     concurrencyStamp: 'stamp-imp-005',
   },
   {
@@ -65,6 +80,9 @@ export const mockImportHistory: ImportJobResponse[] = [
     status: 'Completed',
     createdAt: '2026-02-28T10:00:00Z',
     completedAt: '2026-02-28T10:00:22Z',
+    entityTypeName: 'Country',
+    modifiedAt: null,
+    modifiedBy: null,
     concurrencyStamp: 'stamp-imp-006',
   },
   {
@@ -76,6 +94,9 @@ export const mockImportHistory: ImportJobResponse[] = [
     status: 'PartiallyCompleted',
     createdAt: '2026-02-25T13:15:00Z',
     completedAt: '2026-02-25T13:15:14Z',
+    entityTypeName: 'Country',
+    modifiedAt: null,
+    modifiedBy: null,
     concurrencyStamp: 'stamp-imp-007',
   },
 ];
@@ -91,6 +112,8 @@ export const mockExportHistory: ExportJobResponse[] = [
     createdAt: '2026-03-07T10:00:00Z',
     completedAt: '2026-03-07T10:00:05Z',
     errorMessage: null,
+    modifiedAt: null,
+    modifiedBy: null,
   },
   {
     id: 'exp-002',
@@ -102,6 +125,8 @@ export const mockExportHistory: ExportJobResponse[] = [
     createdAt: '2026-03-06T16:00:00Z',
     completedAt: '2026-03-06T16:00:18Z',
     errorMessage: null,
+    modifiedAt: null,
+    modifiedBy: null,
   },
   {
     id: 'exp-003',
@@ -113,6 +138,8 @@ export const mockExportHistory: ExportJobResponse[] = [
     createdAt: '2026-03-05T09:30:00Z',
     completedAt: '2026-03-05T09:30:08Z',
     errorMessage: null,
+    modifiedAt: null,
+    modifiedBy: null,
   },
   {
     id: 'exp-004',
@@ -124,6 +151,8 @@ export const mockExportHistory: ExportJobResponse[] = [
     createdAt: '2026-03-04T14:00:00Z',
     completedAt: '2026-03-04T14:00:02Z',
     errorMessage: 'Export definition "users" has no data source configured',
+    modifiedAt: null,
+    modifiedBy: null,
   },
   {
     id: 'exp-005',
@@ -135,6 +164,8 @@ export const mockExportHistory: ExportJobResponse[] = [
     createdAt: '2026-02-28T11:45:00Z',
     completedAt: '2026-02-28T11:45:12Z',
     errorMessage: null,
+    modifiedAt: null,
+    modifiedBy: null,
   },
   {
     id: 'exp-006',
@@ -146,5 +177,7 @@ export const mockExportHistory: ExportJobResponse[] = [
     createdAt: '2026-02-20T08:00:00Z',
     completedAt: '2026-02-20T08:00:04Z',
     errorMessage: null,
+    modifiedAt: null,
+    modifiedBy: null,
   },
 ];

--- a/packages/@granit/react-notifications/src/__tests__/use-notification-preferences.test.tsx
+++ b/packages/@granit/react-notifications/src/__tests__/use-notification-preferences.test.tsx
@@ -7,7 +7,7 @@ import { NotificationProvider } from '../providers/notification-provider';
 
 import { axiosResponse, createMockClient } from './test-utils';
 
-import type { NotificationConfig, NotificationPreference } from '@granit/notifications';
+import type { NotificationConfig, NotificationPreferenceResponse } from '@granit/notifications';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -39,7 +39,7 @@ function createWrapperWithoutBasePath(client: AxiosInstance) {
   };
 }
 
-const MOCK_PREFS: NotificationPreference[] = [
+const MOCK_PREFS: NotificationPreferenceResponse[] = [
   {
     id: 'pref-1',
     userId: 'u-1',
@@ -61,7 +61,7 @@ const MOCK_PREFS: NotificationPreference[] = [
     channelName: 'InApp',
     isEnabled: true,
   },
-] as unknown as NotificationPreference[];
+] as unknown as NotificationPreferenceResponse[];
 
 describe('useNotificationPreferences', () => {
   it('should fetch preferences on mount', async () => {
@@ -195,9 +195,9 @@ describe('useNotificationPreferences', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    const updatedPrefs: NotificationPreference[] = [
+    const updatedPrefs: NotificationPreferenceResponse[] = [
       { ...MOCK_PREFS[0]!, isEnabled: false },
-    ] as unknown as NotificationPreference[];
+    ] as unknown as NotificationPreferenceResponse[];
     vi.mocked(client.get).mockResolvedValue(axiosResponse(updatedPrefs));
 
     act(() => {

--- a/packages/@granit/react-notifications/src/hooks/use-notification-preferences.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-notification-preferences.ts
@@ -6,12 +6,12 @@ import { API_BASE_PATH } from '../constants';
 import { useNotificationConfig } from '../providers/notification-provider';
 
 import type {
-  NotificationPreference,
+  NotificationPreferenceResponse,
   NotificationPreferenceUpdateRequest,
 } from '@granit/notifications';
 
 export interface UseNotificationPreferencesReturn {
-  preferences: readonly NotificationPreference[];
+  preferences: readonly NotificationPreferenceResponse[];
   loading: boolean;
   error: Error | null;
   saving: boolean;
@@ -60,9 +60,11 @@ export function useNotificationPreferences(): UseNotificationPreferencesReturn {
     },
     onMutate: async ({ preferenceId, enabled }) => {
       await queryClient.cancelQueries({ queryKey: PREFERENCES_KEY });
-      const previous = queryClient.getQueryData<readonly NotificationPreference[]>(PREFERENCES_KEY);
-      queryClient.setQueryData<readonly NotificationPreference[]>(PREFERENCES_KEY, (old = []) =>
-        old.map((p) => (p.id === preferenceId ? { ...p, isEnabled: enabled } : p))
+      const previous =
+        queryClient.getQueryData<readonly NotificationPreferenceResponse[]>(PREFERENCES_KEY);
+      queryClient.setQueryData<readonly NotificationPreferenceResponse[]>(
+        PREFERENCES_KEY,
+        (old = []) => old.map((p) => (p.id === preferenceId ? { ...p, isEnabled: enabled } : p))
       );
       return { previous };
     },
@@ -79,7 +81,7 @@ export function useNotificationPreferences(): UseNotificationPreferencesReturn {
   const togglePreference = useCallback(
     (preferenceId: string, enabled: boolean) => {
       const pref = (
-        queryClient.getQueryData<readonly NotificationPreference[]>(PREFERENCES_KEY) ?? []
+        queryClient.getQueryData<readonly NotificationPreferenceResponse[]>(PREFERENCES_KEY) ?? []
       ).find((p) => p.id === preferenceId);
       if (!pref) return;
       mutation.mutate({

--- a/packages/@granit/react-notifications/src/testing/data.ts
+++ b/packages/@granit/react-notifications/src/testing/data.ts
@@ -2,7 +2,7 @@ import { toEntityId, toISODateString } from '@granit/types';
 
 import type {
   NotificationDefinition,
-  NotificationPreference,
+  NotificationPreferenceResponse,
   NotificationSubscriptionResponse,
   UserNotification,
 } from '@granit/notifications';
@@ -361,13 +361,15 @@ export const mockNotificationDefinitions: NotificationDefinition[] = [
   },
 ];
 
-export const mockNotificationPreferences: NotificationPreference[] = [
+export const mockNotificationPreferences: NotificationPreferenceResponse[] = [
   {
     id: toEntityId<'NotificationPreference'>('pref-001'),
     userId: adminUserId,
     notificationTypeName: 'user_registered',
     channelName: 'InApp',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-002'),
@@ -375,6 +377,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'user_registered',
     channelName: 'Email',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-003'),
@@ -382,6 +386,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'user_registered',
     channelName: 'Push',
     isEnabled: false,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-004'),
@@ -389,6 +395,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'user_role_changed',
     channelName: 'InApp',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-005'),
@@ -396,6 +404,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'user_role_changed',
     channelName: 'Email',
     isEnabled: false,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-006'),
@@ -403,6 +413,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'user_role_changed',
     channelName: 'Push',
     isEnabled: false,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-007'),
@@ -410,6 +422,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'country_updated',
     channelName: 'InApp',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-008'),
@@ -417,6 +431,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'country_updated',
     channelName: 'Email',
     isEnabled: false,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-009'),
@@ -424,6 +440,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'country_updated',
     channelName: 'Push',
     isEnabled: false,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-010'),
@@ -431,6 +449,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'config_changed',
     channelName: 'InApp',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-011'),
@@ -438,6 +458,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'config_changed',
     channelName: 'Email',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-012'),
@@ -445,6 +467,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'config_changed',
     channelName: 'Push',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-013'),
@@ -452,6 +476,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'security_alert',
     channelName: 'InApp',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-014'),
@@ -459,6 +485,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'security_alert',
     channelName: 'Email',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-015'),
@@ -466,6 +494,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'security_alert',
     channelName: 'Push',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-016'),
@@ -473,6 +503,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'service_health',
     channelName: 'InApp',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-017'),
@@ -480,6 +512,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'service_health',
     channelName: 'Email',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-018'),
@@ -487,6 +521,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'service_health',
     channelName: 'Push',
     isEnabled: false,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-019'),
@@ -494,6 +530,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'audit_export',
     channelName: 'InApp',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-020'),
@@ -501,6 +539,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'audit_export',
     channelName: 'Email',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-021'),
@@ -508,6 +548,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'audit_export',
     channelName: 'Push',
     isEnabled: false,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-022'),
@@ -515,6 +557,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'rgpd_request',
     channelName: 'InApp',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-023'),
@@ -522,6 +566,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'rgpd_request',
     channelName: 'Email',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'NotificationPreference'>('pref-024'),
@@ -529,6 +575,8 @@ export const mockNotificationPreferences: NotificationPreference[] = [
     notificationTypeName: 'rgpd_request',
     channelName: 'Push',
     isEnabled: true,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
+    modifiedAt: null,
   },
 ];
 
@@ -540,6 +588,7 @@ export const mockSubscriptions: NotificationSubscriptionResponse[] = [
     notificationTypeName: 'user_registered',
     entityType: null,
     entityId: null,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
   },
   {
     id: toEntityId<'NotificationSubscription'>('sub-002'),
@@ -547,6 +596,7 @@ export const mockSubscriptions: NotificationSubscriptionResponse[] = [
     notificationTypeName: 'security_alert',
     entityType: null,
     entityId: null,
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
   },
 ];
 
@@ -558,5 +608,6 @@ export const mockEntityFollowers: NotificationSubscriptionResponse[] = [
     notificationTypeName: 'country_updated',
     entityType: 'Country',
     entityId: 'BE',
+    createdAt: toISODateString('2026-03-12T09:00:00Z'),
   },
 ];

--- a/packages/@granit/react-notifications/src/testing/handlers.ts
+++ b/packages/@granit/react-notifications/src/testing/handlers.ts
@@ -15,7 +15,7 @@ import {
 } from './data';
 
 import type {
-  NotificationPreference,
+  NotificationPreferenceResponse,
   NotificationPreferenceUpdateRequest,
   NotificationSubscriptionResponse,
   UserNotification,
@@ -169,7 +169,7 @@ export const notificationQueryMetadata: QueryMetadata = {
  */
 export function createNotificationsHandlers(baseUrl = API_BASE_PATH) {
   let notifications: Mutable<UserNotification>[] = [...mockNotifications];
-  let preferences: Mutable<NotificationPreference>[] = [...mockNotificationPreferences];
+  let preferences: Mutable<NotificationPreferenceResponse>[] = [...mockNotificationPreferences];
   let subscriptions: Mutable<NotificationSubscriptionResponse>[] = [...mockSubscriptions];
   let entityFollowers: Mutable<NotificationSubscriptionResponse>[] = [...mockEntityFollowers];
 
@@ -283,6 +283,7 @@ export function createNotificationsHandlers(baseUrl = API_BASE_PATH) {
             notificationTypeName: '',
             entityType,
             entityId,
+            createdAt: toISODateString('2026-03-12T09:00:00Z'),
           },
         ];
       }
@@ -336,6 +337,8 @@ export function createNotificationsHandlers(baseUrl = API_BASE_PATH) {
             notificationTypeName: body.notificationTypeName,
             channelName: body.channelName,
             isEnabled: body.isEnabled,
+            createdAt: toISODateString('2026-03-12T09:00:00Z'),
+            modifiedAt: null,
           },
         ];
       } else {
@@ -367,6 +370,7 @@ export function createNotificationsHandlers(baseUrl = API_BASE_PATH) {
             notificationTypeName: typeName,
             entityType: null,
             entityId: null,
+            createdAt: toISODateString('2026-03-12T09:00:00Z'),
           },
         ];
       }

--- a/packages/@granit/react-privacy/src/testing/data.ts
+++ b/packages/@granit/react-privacy/src/testing/data.ts
@@ -14,6 +14,8 @@ import type {
 export const mockExports: PrivacyExportStatusResponse[] = [
   {
     requestId: 'exp-001',
+    subjectUserId: '11111111-1111-1111-1111-111111111111',
+    callerUserId: '11111111-1111-1111-1111-111111111111',
     requestedAt: '2026-03-10T08:00:00Z',
     state: 'Completed',
     archiveBlobReferenceId: 'blob-archive-001',
@@ -22,6 +24,8 @@ export const mockExports: PrivacyExportStatusResponse[] = [
   },
   {
     requestId: 'exp-002',
+    subjectUserId: '11111111-1111-1111-1111-111111111111',
+    callerUserId: '11111111-1111-1111-1111-111111111111',
     requestedAt: '2026-03-15T14:30:00Z',
     state: 'Pending',
     archiveBlobReferenceId: null,
@@ -30,6 +34,8 @@ export const mockExports: PrivacyExportStatusResponse[] = [
   },
   {
     requestId: 'exp-003',
+    subjectUserId: '11111111-1111-1111-1111-111111111111',
+    callerUserId: '11111111-1111-1111-1111-111111111111',
     requestedAt: '2026-02-20T09:00:00Z',
     state: 'TimedOut',
     archiveBlobReferenceId: null,

--- a/packages/@granit/react-privacy/src/testing/handlers.ts
+++ b/packages/@granit/react-privacy/src/testing/handlers.ts
@@ -400,6 +400,8 @@ export function createPrivacyHandlers(baseUrl = DEFAULT_BASE_PATH) {
       const requestedAt = new Date().toISOString();
       const newExport: Mutable<PrivacyExportStatusResponse> = {
         requestId,
+        subjectUserId: '11111111-1111-1111-1111-111111111111',
+        callerUserId: '11111111-1111-1111-1111-111111111111',
         requestedAt,
         state: 'Pending',
         archiveBlobReferenceId: null,


### PR DESCRIPTION
## Summary

Consumes the granit-dotnet handoff (PRs **#2776** + **#2777**, both merged) that enriched 7 `*Response` schemas which were dropping fields their source already carried. Re-vendors the 6 affected snapshots and mirrors every addition front-side.

| Contract | DTO | Added fields |
|----------|-----|--------------|
| timeline | `TimelineStreamEntryResponse` | origin, sourceKey, sourceId, editedAt *(already modelled → now registered)* |
| auditing | `AuditEntryDetailResponse` | `userAgent: string \| null` |
| data-exchange | `ImportJobResponse` | `entityTypeName`, `modifiedAt \| null`, `modifiedBy \| null` |
| data-exchange | `ExportJobResponse` | `modifiedAt \| null`, `modifiedBy \| null` |
| privacy | `PrivacyExportStatusResponse` | `subjectUserId`, `callerUserId` |
| notifications | `NotificationSubscriptionResponse` | `createdAt` |
| notifications | `NotificationPreferenceResponse` | `createdAt`, `modifiedAt \| null` |

## Rename (breaking)

Front `NotificationPreference` → **`NotificationPreferenceResponse`** to mirror the .NET schema name (hard rename, no alias). Brand tag `EntityId<'NotificationPreference'>` deliberately preserved. Now registered in the oracle.

⚠️ **Coordinated showcase MR** follows (merge this PR first) — `notification-preferences.tsx` imports the old name.

## Notes
- templating `TemplateRevisionResponse` (+`version`) re-synced but **unregistered** — front doesn't model it.
- All fixtures / MSW handlers updated for the new required fields.

## Verification
- `npx vitest run packages/@granit/contract-tests` — **492 passed** (was 490)
- `pnpm tsc` (full workspace) clean; lint clean; touched-package tests green