### PR TITLE
test(contracts): re-sync taxonomy/entities + cover 3 reconciled DTOs

### DIFF
--- a/contracts/openapi/entities.json
+++ b/contracts/openapi/entities.json
@@ -850,7 +850,8 @@
           "helpKey",
           "order",
           "readOnly",
-          "visibleIf"
+          "visibleIf",
+          "lookup"
         ],
         "type": "object",
         "properties": {
@@ -886,6 +887,16 @@
               },
               {
                 "$ref": "#/components/schemas/VisibilityCondition"
+              }
+            ]
+          },
+          "lookup": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LookupDescriptor"
               }
             ]
           },
@@ -1527,6 +1538,37 @@
       },
       "KanbanColumnState": {
         "enum": ["Open", "Collapsed", "Hidden"]
+      },
+      "LookupDescriptor": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["null", "string"]
+          },
+          "endpoint": {
+            "type": ["null", "string"]
+          },
+          "kind": {
+            "$ref": "#/components/schemas/LookupKind"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "searchParam": {
+            "type": ["null", "string"],
+            "default": "search"
+          },
+          "scopeKeys": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "LookupKind": {
+        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "default": "QueryEngine"
       },
       "ProblemDetails": {
         "type": "object",

--- a/contracts/openapi/taxonomy.json
+++ b/contracts/openapi/taxonomy.json
@@ -1531,7 +1531,8 @@
           "path",
           "depth",
           "iconName",
-          "hideOnEntityCard"
+          "hideOnEntityCard",
+          "hasChildren"
         ],
         "type": "object",
         "properties": {
@@ -1564,6 +1565,9 @@
             "type": ["null", "string"]
           },
           "hideOnEntityCard": {
+            "type": "boolean"
+          },
+          "hasChildren": {
             "type": "boolean"
           }
         }
@@ -1814,7 +1818,16 @@
         }
       },
       "TagResponse": {
-        "required": ["id", "tenantId", "scope", "name", "color", "hideOnEntityCard"],
+        "required": [
+          "id",
+          "tenantId",
+          "scope",
+          "name",
+          "color",
+          "hideOnEntityCard",
+          "createdAt",
+          "modifiedAt"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -1836,6 +1849,14 @@
           },
           "hideOnEntityCard": {
             "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
           }
         }
       },

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -392,11 +392,11 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'CalendarItemResponse',
       'BulkActionResponse',
       'BulkActionFailure',
+      'EntityFormFieldManifest',
     ],
-    // TODO(contract): EntityFormFieldManifest deferred — front carries a `lookup`
-    // field absent from the backend schema. BulkActionRequest deferred — its
-    // `payload` is `unknown` front-side (which subsumes null) but the oracle
-    // reads a bare `unknown` as non-nullable; an oracle limitation, not a drift.
+    // TODO(contract): BulkActionRequest deferred — its `payload` is `unknown`
+    // front-side (which subsumes null) but the oracle reads a bare `unknown` as
+    // non-nullable; an oracle limitation, not a drift.
   },
   {
     slug: 'entities-customization',
@@ -419,10 +419,12 @@ export const CONTRACTS: readonly ModuleContract[] = [
   {
     slug: 'taxonomy',
     package: 'taxonomy',
-    // TODO(contract): CategoryResponse (orphan `hasChildren`), CategoryDetailResponse
-    // (missing `category`) and TagResponse (orphan `createdAt`/`updatedAt`) deferred —
-    // front fields diverge from the current backend schema.
+    // CategoryDetailResponse stays unregistered — the front intentionally
+    // flattens the wire shape ({ category: CategoryResponse, breadcrumb })
+    // into `extends CategoryResponse`, which the oracle cannot mirror.
     types: [
+      'CategoryResponse',
+      'TagResponse',
       'CategoryAssignmentResponse',
       'CreateCategoryRequest',
       'UpdateCategoryRequest',

--- a/packages/@granit/react-taxonomy/src/__tests__/branch-coverage-extra.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/branch-coverage-extra.test.tsx
@@ -21,7 +21,7 @@ const tag: TagResponse = {
   color: '#FF0000',
   hideOnEntityCard: false,
   createdAt: '2026-05-01T08:00:00Z',
-  updatedAt: '2026-05-01T08:00:00Z',
+  modifiedAt: '2026-05-01T08:00:00Z',
 };
 
 const root: CategoryResponse = {

--- a/packages/@granit/react-taxonomy/src/__tests__/branch-coverage.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/branch-coverage.test.tsx
@@ -23,7 +23,7 @@ const tag: TagResponse = {
   color: '#FF0000',
   hideOnEntityCard: false,
   createdAt: '2026-05-01T08:00:00Z',
-  updatedAt: '2026-05-01T08:00:00Z',
+  modifiedAt: '2026-05-01T08:00:00Z',
 };
 
 const root: CategoryResponse = {

--- a/packages/@granit/react-taxonomy/src/__tests__/document-tag-chip-strip.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/document-tag-chip-strip.test.tsx
@@ -18,7 +18,7 @@ const tag: TagResponse = {
   color: '#FF0000',
   hideOnEntityCard: false,
   createdAt: '2026-05-01T08:00:00Z',
-  updatedAt: '2026-05-01T08:00:00Z',
+  modifiedAt: '2026-05-01T08:00:00Z',
 };
 
 function createWrapper(client: AxiosInstance) {

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-autocomplete-create.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-autocomplete-create.test.tsx
@@ -19,7 +19,7 @@ const createdTag: TagResponse = {
   color: '#94a3b8',
   hideOnEntityCard: false,
   createdAt: '2026-05-01T08:00:00Z',
-  updatedAt: '2026-05-01T08:00:00Z',
+  modifiedAt: '2026-05-01T08:00:00Z',
 };
 
 function createWrapper(client: AxiosInstance) {

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-autocomplete.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-autocomplete.test.tsx
@@ -19,7 +19,7 @@ const sampleTag: TagResponse = {
   color: '#FF0000',
   hideOnEntityCard: false,
   createdAt: '2026-05-01T08:00:00Z',
-  updatedAt: '2026-05-01T08:00:00Z',
+  modifiedAt: '2026-05-01T08:00:00Z',
 };
 
 const otherTag: TagResponse = {
@@ -30,7 +30,7 @@ const otherTag: TagResponse = {
   color: '#00FF00',
   hideOnEntityCard: false,
   createdAt: '2026-05-01T08:00:00Z',
-  updatedAt: '2026-05-01T08:00:00Z',
+  modifiedAt: '2026-05-01T08:00:00Z',
 };
 
 function createWrapper(client: AxiosInstance) {

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-chip-strip.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-chip-strip.test.tsx
@@ -19,7 +19,7 @@ const visibleTag: TagResponse = {
   color: '#FF0000',
   hideOnEntityCard: false,
   createdAt: '2026-05-01T08:00:00Z',
-  updatedAt: '2026-05-01T08:00:00Z',
+  modifiedAt: '2026-05-01T08:00:00Z',
 };
 
 const hiddenTag: TagResponse = {
@@ -30,7 +30,7 @@ const hiddenTag: TagResponse = {
   color: '#00FF00',
   hideOnEntityCard: true,
   createdAt: '2026-05-01T08:00:00Z',
-  updatedAt: '2026-05-01T08:00:00Z',
+  modifiedAt: '2026-05-01T08:00:00Z',
 };
 
 function createWrapperFromClient(client: AxiosInstance) {

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-chip.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-chip.test.tsx
@@ -14,7 +14,7 @@ const sampleTag: TagResponse = {
   color: '#FF0000',
   hideOnEntityCard: false,
   createdAt: '2026-05-01T08:00:00Z',
-  updatedAt: '2026-05-01T08:00:00Z',
+  modifiedAt: '2026-05-01T08:00:00Z',
 };
 
 describe('TagChip', () => {

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-manager-actions.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-manager-actions.test.tsx
@@ -19,7 +19,7 @@ const tag: TagResponse = {
   color: '#FF0000',
   hideOnEntityCard: false,
   createdAt: '2026-05-01T08:00:00Z',
-  updatedAt: '2026-05-01T08:00:00Z',
+  modifiedAt: '2026-05-01T08:00:00Z',
 };
 
 function createWrapper(client: AxiosInstance) {

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-manager.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-manager.test.tsx
@@ -19,7 +19,7 @@ const tag: TagResponse = {
   color: '#FF0000',
   hideOnEntityCard: false,
   createdAt: '2026-05-01T08:00:00Z',
-  updatedAt: '2026-05-01T08:00:00Z',
+  modifiedAt: '2026-05-01T08:00:00Z',
 };
 
 function createWrapper(client: AxiosInstance) {

--- a/packages/@granit/react-taxonomy/src/__tests__/use-document-tags.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/use-document-tags.test.tsx
@@ -23,7 +23,7 @@ const sampleTag: TagResponse = {
   color: '#FF0000',
   hideOnEntityCard: false,
   createdAt: '2026-05-01T08:00:00Z',
-  updatedAt: '2026-05-01T08:00:00Z',
+  modifiedAt: '2026-05-01T08:00:00Z',
 };
 
 interface Harness {

--- a/packages/@granit/react-taxonomy/src/__tests__/use-tag-mutations.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/use-tag-mutations.test.tsx
@@ -26,7 +26,7 @@ const sampleTag: TagResponse = {
   color: '#FF0000',
   hideOnEntityCard: false,
   createdAt: '2026-05-01T08:00:00Z',
-  updatedAt: '2026-05-01T08:00:00Z',
+  modifiedAt: '2026-05-01T08:00:00Z',
 };
 
 const sampleAssignment: TagAssignmentResponse = {

--- a/packages/@granit/react-taxonomy/src/__tests__/use-tags.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/use-tags.test.tsx
@@ -18,7 +18,7 @@ const sampleTag: TagResponse = {
   color: '#FF0000',
   hideOnEntityCard: false,
   createdAt: '2026-05-01T08:00:00Z',
-  updatedAt: '2026-05-01T08:00:00Z',
+  modifiedAt: '2026-05-01T08:00:00Z',
 };
 
 function createWrapper(client: AxiosInstance, basePath?: string) {

--- a/packages/@granit/react-taxonomy/src/testing/data.ts
+++ b/packages/@granit/react-taxonomy/src/testing/data.ts
@@ -30,7 +30,7 @@ export function createTaxonomyStore(): TaxonomyStore {
         color: '#3B82F6',
         hideOnEntityCard: false,
         createdAt: now(),
-        updatedAt: now(),
+        modifiedAt: now(),
       },
       {
         id: 'tag-doc-invoice',
@@ -40,7 +40,7 @@ export function createTaxonomyStore(): TaxonomyStore {
         color: '#10B981',
         hideOnEntityCard: false,
         createdAt: now(),
-        updatedAt: now(),
+        modifiedAt: now(),
       },
       {
         id: 'tag-doc-internal',
@@ -50,7 +50,7 @@ export function createTaxonomyStore(): TaxonomyStore {
         color: '#A855F7',
         hideOnEntityCard: true,
         createdAt: now(),
-        updatedAt: now(),
+        modifiedAt: now(),
       },
       {
         id: 'tag-party-vip',
@@ -60,7 +60,7 @@ export function createTaxonomyStore(): TaxonomyStore {
         color: '#F59E0B',
         hideOnEntityCard: false,
         createdAt: now(),
-        updatedAt: now(),
+        modifiedAt: now(),
       },
       {
         id: 'tag-party-prospect',
@@ -70,7 +70,7 @@ export function createTaxonomyStore(): TaxonomyStore {
         color: '#EF4444',
         hideOnEntityCard: false,
         createdAt: now(),
-        updatedAt: now(),
+        modifiedAt: now(),
       },
     ],
     categories: [

--- a/packages/@granit/react-taxonomy/src/testing/handlers.ts
+++ b/packages/@granit/react-taxonomy/src/testing/handlers.ts
@@ -92,7 +92,7 @@ export function createTaxonomyHandlers(baseUrl = DEFAULT_BASE_PATH) {
         color: body.color,
         hideOnEntityCard: body.hideOnEntityCard ?? false,
         createdAt: now(),
-        updatedAt: now(),
+        modifiedAt: now(),
       };
       store.tags.push(tag);
       return created(tag);
@@ -107,7 +107,7 @@ export function createTaxonomyHandlers(baseUrl = DEFAULT_BASE_PATH) {
         name: body.name ?? existing.name,
         color: (body.color ?? existing.color) as HexColor,
         hideOnEntityCard: body.hideOnEntityCard ?? existing.hideOnEntityCard,
-        updatedAt: now(),
+        modifiedAt: now(),
       };
       store.tags[idx] = next;
       return HttpResponse.json(next);

--- a/packages/@granit/taxonomy/src/__tests__/documents-proxy-api.test.ts
+++ b/packages/@granit/taxonomy/src/__tests__/documents-proxy-api.test.ts
@@ -19,7 +19,7 @@ const sampleTag: TagResponse = {
   color: '#FF0000',
   hideOnEntityCard: false,
   createdAt: '2026-05-01T08:00:00Z',
-  updatedAt: '2026-05-01T08:00:00Z',
+  modifiedAt: '2026-05-01T08:00:00Z',
 };
 
 describe('listDocumentTags', () => {

--- a/packages/@granit/taxonomy/src/__tests__/tags-api.test.ts
+++ b/packages/@granit/taxonomy/src/__tests__/tags-api.test.ts
@@ -30,7 +30,7 @@ const sampleTag: TagResponse = {
   color: '#FF0000',
   hideOnEntityCard: false,
   createdAt: '2026-05-01T08:00:00Z',
-  updatedAt: '2026-05-01T08:00:00Z',
+  modifiedAt: '2026-05-01T08:00:00Z',
 };
 
 const sampleAssignment: TagAssignmentResponse = {

--- a/packages/@granit/taxonomy/src/__tests__/types.test.ts
+++ b/packages/@granit/taxonomy/src/__tests__/types.test.ts
@@ -24,7 +24,7 @@ describe('Taxonomy types', () => {
       readonly color: HexColor;
       readonly hideOnEntityCard: boolean;
       readonly createdAt: string;
-      readonly updatedAt: string;
+      readonly modifiedAt: string | null;
     }>();
   });
 

--- a/packages/@granit/taxonomy/src/types/index.ts
+++ b/packages/@granit/taxonomy/src/types/index.ts
@@ -31,9 +31,13 @@ export interface TagResponse {
   readonly name: string;
   readonly color: HexColor;
   readonly hideOnEntityCard: boolean;
-  /** Audit field — may be absent when the spec is extended; treat as informational. */
   readonly createdAt: string;
-  readonly updatedAt: string;
+  /**
+   * Last-modification timestamp; `null` until the tag is first modified
+   * (framework audit convention). For a non-null "updated at", coalesce
+   * `modifiedAt ?? createdAt` at the call site.
+   */
+  readonly modifiedAt: string | null;
 }
 
 export interface TagListFilter {
@@ -90,10 +94,7 @@ export interface CategoryResponse {
   /** `null` when no icon is assigned. */
   readonly iconName: string | null;
   readonly hideOnEntityCard: boolean;
-  /**
-   * Derived field for tree-lazy-load: true when at least one child exists.
-   * Not in the published OpenAPI spec but sent by the backend implementation.
-   */
+  /** `true` when at least one child exists — drives tree lazy-load. */
   readonly hasChildren: boolean;
 }
 


### PR DESCRIPTION
## Summary

Consumes **granit-business !144** (merged) — the backend now exposes 3 DTO fields the front already modelled. Re-vendors `taxonomy.json` + `entities.json` and registers the reconciled DTOs.

| Contract | DTO | Change |
|----------|-----|--------|
| entities | `EntityFormFieldManifest` | backend promoted `lookup` to a first-level field → registered |
| taxonomy | `CategoryResponse` | backend now emits `hasChildren` → registered (dropped "not in spec" caveat) |
| taxonomy | `TagResponse` | backend exposes `createdAt` + **`modifiedAt`** (nullable), **not** `updatedAt` |

### TagResponse: `updatedAt` → `modifiedAt`
Per the backend handoff, the wire carries `modifiedAt` (nullable, `null` until first modified), not `updatedAt` (framework audit convention). The front type now mirrors the wire: `modifiedAt: string | null`. For a non-null "updated at", consumers coalesce `modifiedAt ?? createdAt` (no current consumer reads it). Fixtures updated.

## Still deferred
- `CategoryDetailResponse` — intentional front flattening of the wire `{ category, breadcrumb }` shape (oracle can't mirror `extends`).
- `BulkActionRequest` — oracle `unknown`-nullability limitation, not a drift.

## ⚠️ Coordinated showcase MR
The `TagResponse` field change is breaking — `granit-showcase-react` tag fixtures set `updatedAt`. MR follows (merge this first).

## Verification
- `npx vitest run packages/@granit/contract-tests` — **495 passed**
- `pnpm tsc` (full workspace) clean; lint clean; taxonomy/entities tests green (990)