### PR TITLE
feat(api-client): add ConcurrencyConflictError + isConcurrencyConflict

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -260,21 +260,6 @@
           "members": []
         },
         {
-          "name": "HttpError",
-          "kind": "class",
-          "signature": "class HttpError extends Error"
-        },
-        {
-          "name": "TimeoutError",
-          "kind": "class",
-          "signature": "class TimeoutError extends Error"
-        },
-        {
-          "name": "ValidationError",
-          "kind": "class",
-          "signature": "class ValidationError extends Error"
-        },
-        {
           "name": "ProblemDetailsPayload",
           "kind": "interface",
           "signature": "interface ProblemDetailsPayload",
@@ -285,21 +270,6 @@
           "kind": "interface",
           "signature": "interface ValidationDetails",
           "members": []
-        },
-        {
-          "name": "isIdempotencyTombstoned",
-          "kind": "function",
-          "signature": "function isIdempotencyTombstoned(error: unknown): boolean"
-        },
-        {
-          "name": "readIdempotencyTombstone",
-          "kind": "function",
-          "signature": "function readIdempotencyTombstone(error: unknown): IdempotencyTombstoneInfo | undefined"
-        },
-        {
-          "name": "isIdempotentReplay",
-          "kind": "function",
-          "signature": "function isIdempotentReplay(responseOrError: unknown): boolean"
         },
         {
           "name": "IdempotencyTombstoneInfo",

--- a/packages/@granit/api-client/src/__tests__/errors.test.ts
+++ b/packages/@granit/api-client/src/__tests__/errors.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { HttpError, TimeoutError, ValidationError } from '../errors';
+import {
+  ConcurrencyConflictError,
+  HttpError,
+  isConcurrencyConflict,
+  TimeoutError,
+  ValidationError,
+} from '../errors';
 
 describe('HttpError', () => {
   it('should set name, message, and status', () => {
@@ -41,6 +47,40 @@ describe('ValidationError', () => {
     const error = new ValidationError('Validation failed', details);
 
     expect(error.details).toEqual(details);
+  });
+});
+
+describe('ConcurrencyConflictError', () => {
+  it('is an HttpError fixed to status 409', () => {
+    const details = { title: 'Conflict', status: 409, detail: 'Stale stamp' };
+    const error = new ConcurrencyConflictError('Resource changed', details);
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect(error.name).toBe('ConcurrencyConflictError');
+    expect(error.status).toBe(409);
+    expect(error.problemDetails).toEqual(details);
+  });
+});
+
+describe('isConcurrencyConflict', () => {
+  it('matches a ConcurrencyConflictError', () => {
+    expect(isConcurrencyConflict(new ConcurrencyConflictError('x'))).toBe(true);
+  });
+
+  it('matches an HttpError with status 409', () => {
+    expect(isConcurrencyConflict(new HttpError('Conflict', 409))).toBe(true);
+    expect(isConcurrencyConflict(new HttpError('Not Found', 404))).toBe(false);
+  });
+
+  it('matches a raw Axios-shaped error with response status 409', () => {
+    expect(isConcurrencyConflict({ response: { status: 409 } })).toBe(true);
+    expect(isConcurrencyConflict({ response: { status: 400 } })).toBe(false);
+  });
+
+  it('is false for unrelated values', () => {
+    expect(isConcurrencyConflict(null)).toBe(false);
+    expect(isConcurrencyConflict(new Error('boom'))).toBe(false);
+    expect(isConcurrencyConflict('409')).toBe(false);
   });
 });
 

--- a/packages/@granit/api-client/src/errors.ts
+++ b/packages/@granit/api-client/src/errors.ts
@@ -19,7 +19,7 @@
  * ```
  */
 export class HttpError extends Error {
-  override readonly name = 'HttpError';
+  override readonly name: string = 'HttpError';
 
   /** HTTP status code (e.g. 400, 404, 500). */
   readonly status: number;
@@ -31,6 +31,48 @@ export class HttpError extends Error {
     this.status = status;
     this.problemDetails = problemDetails;
   }
+}
+
+/**
+ * Optimistic-concurrency conflict (HTTP 409).
+ *
+ * Thrown when a write is rejected because the resource changed since the client
+ * read it. Granit's framework convention is a body-field concurrency stamp
+ * (`IConcurrencyStampRequest`): the `*Response` carries `concurrencyStamp`, the
+ * `Update*Request` echoes it back, and a stale stamp surfaces as a `409`
+ * (`DbUpdateConcurrencyException` → `EfCoreExceptionStatusCodeMapper`). There is
+ * no `If-Match`/`412` mechanism.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await updateTag(client, basePath, id, { ...form, concurrencyStamp });
+ * } catch (err) {
+ *   if (isConcurrencyConflict(err)) {
+ *     // refetch the resource, re-apply the user's edits onto the fresh stamp,
+ *     // then resubmit — or surface a "someone else changed this" prompt.
+ *   }
+ * }
+ * ```
+ */
+export class ConcurrencyConflictError extends HttpError {
+  override readonly name = 'ConcurrencyConflictError';
+
+  constructor(message: string, problemDetails?: ProblemDetailsPayload) {
+    super(message, 409, problemDetails);
+  }
+}
+
+/**
+ * Type guard: did this error come from an optimistic-concurrency conflict (409)?
+ * Matches a {@link ConcurrencyConflictError}, an {@link HttpError} with status
+ * 409, or a raw Axios error whose response status is 409 — so it works whether
+ * the caller mapped the error or let the bare Axios error propagate.
+ */
+export function isConcurrencyConflict(error: unknown): boolean {
+  if (error instanceof HttpError) return error.status === 409;
+  const response = (error as { response?: { status?: number } } | null)?.response;
+  return response?.status === 409;
 }
 
 /**

--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -283,11 +283,21 @@ export function buildApiUrl(basePath: string, ...segments: string[]): string {
 // Domain error classes
 // ---------------------------------------------------------------------------
 
-export { HttpError, TimeoutError, ValidationError } from './errors';
+export {
+  ConcurrencyConflictError,
+  HttpError,
+  isConcurrencyConflict,
+  TimeoutError,
+  ValidationError,
+} from './errors';
 export type { ProblemDetailsPayload, ValidationDetails } from './errors';
 
 // Idempotency tombstone + replay helpers — see ./idempotency.ts.
-export { isIdempotencyTombstoned, readIdempotencyTombstone, isIdempotentReplay } from './idempotency';
+export {
+  isIdempotencyTombstoned,
+  readIdempotencyTombstone,
+  isIdempotentReplay,
+} from './idempotency';
 export type { IdempotencyTombstoneInfo } from './idempotency';
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Generic front-side piece for Granit's optimistic-concurrency convention — **body-field concurrency stamp → HTTP 409** (no `If-Match`/`412`; confirmed by the granit-business team, ref `IConcurrencyStampRequest` + `EfCoreExceptionStatusCodeMapper`).

- `ConcurrencyConflictError extends HttpError` (status fixed to 409).
- `isConcurrencyConflict(error)` predicate — matches the typed error, a 409 `HttpError`, or a raw Axios 409, so callers detect a stale-stamp conflict whether or not the error was mapped.
- Widens `HttpError.name` to `string` so subclasses carry their own name.

## Scope / follow-up

This is the **generic, endpoint-agnostic** piece. The per-endpoint write round-trip — echoing the read `concurrencyStamp` in the `Update*Request` body + handling the 409 — lands **with the coordinated granit-business write-MR** that makes Tag/Category/Document endpoints accept + override the stamp (`SetConcurrencyStampOriginalValue`). Until then the front receives the stamp (via !145) but can't yet return it.

## Verification
- `pnpm tsc` (full workspace) clean
- `@granit/api-client` tests green (69), incl. new error + predicate cases
- lint clean