### PR TITLE
refactor(documents,blob-storage)!: brand timestamps as ISODateString

### DIFF
--- a/packages/@granit/blob-storage/package.json
+++ b/packages/@granit/blob-storage/package.json
@@ -14,11 +14,13 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/blob-storage/src/__tests__/blob-storage-api.test.ts
+++ b/packages/@granit/blob-storage/src/__tests__/blob-storage-api.test.ts
@@ -1,4 +1,5 @@
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -30,7 +31,7 @@ describe('blob-storage-api', () => {
         blobId: 'abc-123',
         uploadUrl: 'https://s3.example.com/presigned',
         httpMethod: 'PUT',
-        expiresAt: '2026-03-20T12:00:00Z',
+        expiresAt: toISODateString('2026-03-20T12:00:00Z'),
         requiredHeaders: { 'Content-Type': 'image/png' },
       };
       vi.mocked(client.post).mockResolvedValueOnce({ data: response });
@@ -94,7 +95,7 @@ describe('blob-storage-api', () => {
       const client = createMockClient();
       const response: BlobDownloadUrlResponse = {
         downloadUrl: 'https://s3.example.com/download',
-        expiresAt: '2026-03-20T12:05:00Z',
+        expiresAt: toISODateString('2026-03-20T12:05:00Z'),
       };
       vi.mocked(client.post).mockResolvedValueOnce({ data: response });
 
@@ -157,8 +158,8 @@ describe('blob-storage-api', () => {
         status: BlobStatus.Valid,
         rejectionReason: null,
         deletionReason: null,
-        createdAt: '2026-03-20T10:00:00Z',
-        validatedAt: '2026-03-20T10:00:05Z',
+        createdAt: toISODateString('2026-03-20T10:00:00Z'),
+        validatedAt: toISODateString('2026-03-20T10:00:05Z'),
         deletedAt: null,
       };
       vi.mocked(client.get).mockResolvedValueOnce({ data: descriptor });

--- a/packages/@granit/blob-storage/src/types/index.ts
+++ b/packages/@granit/blob-storage/src/types/index.ts
@@ -2,6 +2,8 @@
 // Blob storage types — mirrors Granit.BlobStorage .NET contract
 // ---------------------------------------------------------------------------
 
+import type { ISODateString } from '@granit/types';
+
 /**
  * Blob lifecycle status.
  *
@@ -33,7 +35,7 @@ export interface BlobUploadInitiateResponse {
   readonly blobId: string;
   readonly uploadUrl: string;
   readonly httpMethod: string;
-  readonly expiresAt: string;
+  readonly expiresAt: ISODateString;
   readonly requiredHeaders: Readonly<Record<string, string>>;
 }
 
@@ -65,7 +67,7 @@ export interface BlobDownloadUrlRequest {
 /** Response from `POST /{id}/download-url`. */
 export interface BlobDownloadUrlResponse {
   readonly downloadUrl: string;
-  readonly expiresAt: string;
+  readonly expiresAt: ISODateString;
 }
 
 // ── Delete ───────────────────────────────────────────────────────────────────
@@ -105,9 +107,9 @@ export interface BlobDescriptorResponse {
   readonly status: BlobStatus;
   readonly rejectionReason: string | null;
   readonly deletionReason: string | null;
-  readonly createdAt: string;
-  readonly validatedAt: string | null;
-  readonly deletedAt: string | null;
+  readonly createdAt: ISODateString;
+  readonly validatedAt: ISODateString | null;
+  readonly deletedAt: ISODateString | null;
 }
 
 // ── Query / list row ──────────────────────────────────────────────────────────
@@ -135,10 +137,10 @@ export interface BlobDescriptorListItem {
   readonly status: BlobStatus;
   readonly rejectionReason: string | null;
   readonly deletionReason: string | null;
-  readonly createdAt: string;
+  readonly createdAt: ISODateString;
   readonly createdBy: string;
-  readonly validatedAt: string | null;
-  readonly deletedAt: string | null;
+  readonly validatedAt: ISODateString | null;
+  readonly deletedAt: ISODateString | null;
 }
 
 // ── Cleanup orphans ─────────────────────────────────────────────────────────

--- a/packages/@granit/documents/package.json
+++ b/packages/@granit/documents/package.json
@@ -15,10 +15,12 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "peerDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/documents/src/__tests__/documents-api.test.ts
+++ b/packages/@granit/documents/src/__tests__/documents-api.test.ts
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -41,7 +42,7 @@ const sampleDocument: DocumentResponse = {
   sizeBytes: 1024,
   contentType: 'application/pdf',
   status: 'Active',
-  createdAt: '2026-05-01T10:00:00Z',
+  createdAt: toISODateString('2026-05-01T10:00:00Z'),
   modifiedAt: null,
   concurrencyStamp: 'stamp-1',
   trashedAt: null,
@@ -57,7 +58,7 @@ const sampleVersion: DocumentVersionResponse = {
   contentType: 'application/pdf',
   contentHash: null,
   uploadedByUserId: 'user-1',
-  uploadedAt: '2026-05-01T10:00:00Z',
+  uploadedAt: toISODateString('2026-05-01T10:00:00Z'),
   commitMessage: null,
   isCurrent: true,
 };
@@ -74,7 +75,7 @@ describe('requestUploadTicket', () => {
       blobId: 'blob-1',
       uploadUrl: 'https://example.com/upload',
       httpMethod: 'PUT',
-      expiresAt: '2026-05-01T10:15:00Z',
+      expiresAt: toISODateString('2026-05-01T10:15:00Z'),
       requiredHeaders: { 'Content-Type': 'application/pdf' },
     };
     vi.mocked(client.post).mockResolvedValue(axiosResponse(ticket));
@@ -223,7 +224,7 @@ describe('permanentlyDeleteDocument', () => {
 describe('requestDocumentDownloadUrl', () => {
   const url: DownloadUrlResponse = {
     url: 'https://example.com/download',
-    expiresAt: '2026-05-01T10:15:00Z',
+    expiresAt: toISODateString('2026-05-01T10:15:00Z'),
   };
 
   it('GETs /documents/{id}/download with no query when versionId is omitted', async () => {

--- a/packages/@granit/documents/src/__tests__/folders-api.test.ts
+++ b/packages/@granit/documents/src/__tests__/folders-api.test.ts
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -31,7 +32,7 @@ const sampleFolder: FolderResponse = {
   depth: 1,
   ownerId: 'user-1',
   status: 'Active',
-  createdAt: '2026-05-01T10:00:00Z',
+  createdAt: toISODateString('2026-05-01T10:00:00Z'),
   modifiedAt: null,
   trashedAt: null,
   permission: null,

--- a/packages/@granit/documents/src/__tests__/quota-api.test.ts
+++ b/packages/@granit/documents/src/__tests__/quota-api.test.ts
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import { getTenantStorageQuota } from '../api/quota-api';
@@ -14,7 +15,7 @@ describe('getTenantStorageQuota', () => {
       limitBytes: 10_000_000,
       usageBytes: 2_500_000,
       percentUsed: 25,
-      updatedAt: '2026-05-01T10:00:00Z',
+      updatedAt: toISODateString('2026-05-01T10:00:00Z'),
     };
     vi.mocked(client.get).mockResolvedValue(axiosResponse(quota));
 

--- a/packages/@granit/documents/src/__tests__/shares-api.test.ts
+++ b/packages/@granit/documents/src/__tests__/shares-api.test.ts
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -23,7 +24,7 @@ const sampleFolderShare: ShareResponse = {
   permission: 'Read',
   isDefault: true,
   expiresAt: null,
-  createdAt: '2026-05-01T10:00:00Z',
+  createdAt: toISODateString('2026-05-01T10:00:00Z'),
   createdBy: 'user-1',
 };
 

--- a/packages/@granit/documents/src/__tests__/tags-api.test.ts
+++ b/packages/@granit/documents/src/__tests__/tags-api.test.ts
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import { assignDocumentTag, listDocumentTags, unassignDocumentTag } from '../api/tags-api';
@@ -12,7 +13,7 @@ const sampleAssignment: DocumentTagAssignmentResponse = {
   tenantId: 'tenant-1',
   tagId: 'tag-1',
   documentId: 'doc-1',
-  assignedAt: '2026-05-01T10:00:00Z',
+  assignedAt: toISODateString('2026-05-01T10:00:00Z'),
   assignedByUserId: 'user-1',
 };
 

--- a/packages/@granit/documents/src/types/index.ts
+++ b/packages/@granit/documents/src/types/index.ts
@@ -5,6 +5,8 @@
  * are ISO 8601 UTC strings (round-tripped from .NET `DateTimeOffset`).
  */
 
+import type { ISODateString } from '@granit/types';
+
 // ─── Enums (string unions) ──────────────────────────────────────────────────
 
 /** Lifecycle status of a {@link FolderResponse}. */
@@ -47,11 +49,11 @@ export interface FolderResponse {
   readonly ownerId: string;
   readonly status: FolderStatus;
   /** UTC instant the folder was created (ISO 8601). Always present. */
-  readonly createdAt: string;
+  readonly createdAt: ISODateString;
   /** UTC instant of the last change; `null` if never modified since creation. */
-  readonly modifiedAt: string | null;
+  readonly modifiedAt: ISODateString | null;
   /** UTC instant the folder was trashed; `null` while active. */
-  readonly trashedAt: string | null;
+  readonly trashedAt: ISODateString | null;
   /** Effective permission resolved via F6.5b; `null` when not requested. */
   readonly permission: EffectivePermissionLevel | null;
 }
@@ -112,12 +114,12 @@ export interface DocumentResponse {
   readonly contentType: string | null;
   readonly status: DocumentStatus;
   /** UTC instant the document was created (ISO 8601). Always present. */
-  readonly createdAt: string;
+  readonly createdAt: ISODateString;
   /** UTC instant of the last content/metadata change; `null` if never modified since creation. */
-  readonly modifiedAt: string | null;
+  readonly modifiedAt: ISODateString | null;
   /** Optimistic-concurrency token; echo back on edit to detect conflicts (409). */
   readonly concurrencyStamp: string;
-  readonly trashedAt: string | null;
+  readonly trashedAt: ISODateString | null;
   /** Effective permission resolved via F6.5; `null` when not requested. */
   readonly permission: EffectivePermissionLevel | null;
 }
@@ -140,7 +142,7 @@ export interface UploadTicketResponse {
   readonly uploadUrl: string;
   /** Always `"PUT"` for S3-compatible providers. */
   readonly httpMethod: string;
-  readonly expiresAt: string;
+  readonly expiresAt: ISODateString;
   readonly requiredHeaders: Readonly<Record<string, string>>;
 }
 
@@ -191,7 +193,7 @@ export interface TransferOwnerRequest {
 /** Response payload for `GET /documents/{id}/download`. */
 export interface DownloadUrlResponse {
   readonly url: string;
-  readonly expiresAt: string;
+  readonly expiresAt: ISODateString;
 }
 
 export interface DocumentVersionResponse {
@@ -207,7 +209,7 @@ export interface DocumentVersionResponse {
   readonly contentType: string;
   readonly contentHash: string | null;
   readonly uploadedByUserId: string;
-  readonly uploadedAt: string;
+  readonly uploadedAt: ISODateString;
   readonly commitMessage: string | null;
   /** `true` when this version matches the parent document's `currentVersionId`. */
   readonly isCurrent: boolean;
@@ -226,7 +228,7 @@ export interface TrashedDocumentResponse {
   readonly folderId: string;
   readonly name: string;
   readonly ownerId: string;
-  readonly trashedAt: string;
+  readonly trashedAt: ISODateString;
   /**
    * Days remaining before the empty-trash background job permanently deletes
    * the row. Clamped at zero for past-due rows awaiting the next cleanup run.
@@ -269,7 +271,7 @@ export interface DocumentTagAssignmentResponse {
   readonly tenantId: string | null;
   readonly tagId: string;
   readonly documentId: string;
-  readonly assignedAt: string;
+  readonly assignedAt: ISODateString;
   readonly assignedByUserId: string;
 }
 
@@ -290,8 +292,8 @@ export interface ShareResponse {
   readonly permission: SharePermissionLevel;
   /** Folder-share inheritance flag; ignored for document shares. */
   readonly isDefault: boolean;
-  readonly expiresAt: string | null;
-  readonly createdAt: string;
+  readonly expiresAt: ISODateString | null;
+  readonly createdAt: ISODateString;
   readonly createdBy: string;
 }
 
@@ -324,7 +326,7 @@ export interface TenantStorageQuotaResponse {
   readonly usageBytes: number;
   /** `usageBytes / limitBytes * 100`, clamped at 100 and rounded to two decimals. */
   readonly percentUsed: number;
-  readonly updatedAt: string;
+  readonly updatedAt: ISODateString;
 }
 
 // ─── Document properties (extracted metadata) ───────────────────────────────
@@ -343,8 +345,8 @@ export interface DocumentPropertiesResponse {
   readonly documentVersionId: string;
   readonly sourceContentType: string;
   readonly status: DocumentPropertiesStatus;
-  readonly createdAt: string;
-  readonly completedAt: string | null;
+  readonly createdAt: ISODateString;
+  readonly completedAt: ISODateString | null;
   readonly failureReason: string | null;
   readonly extractorCount: number;
   // Image / photo
@@ -356,7 +358,7 @@ export interface DocumentPropertiesResponse {
   readonly iso: number | null;
   readonly fNumber: number | null;
   readonly exposureTimeMs: number | null;
-  readonly takenAt: string | null;
+  readonly takenAt: ISODateString | null;
   readonly gpsLatitude: number | null;
   readonly gpsLongitude: number | null;
   readonly gpsAltitude: number | null;
@@ -402,7 +404,7 @@ export interface CreatePublicLinkResponse {
   readonly token: string;
   readonly url: string;
   readonly scope: PublicLinkScope;
-  readonly expiresAt: string;
+  readonly expiresAt: ISODateString;
   readonly maxUses: number | null;
 }
 
@@ -411,12 +413,12 @@ export interface PublicLinkResponse {
   readonly id: string;
   readonly documentId: string;
   readonly scope: PublicLinkScope;
-  readonly expiresAt: string;
+  readonly expiresAt: ISODateString;
   readonly maxUses: number | null;
   readonly currentUses: number;
-  readonly revokedAt: string | null;
+  readonly revokedAt: ISODateString | null;
   readonly revocationReason: string | null;
-  readonly createdAt: string;
+  readonly createdAt: ISODateString;
   /** Optimistic-concurrency token; echo back on edit to detect conflicts (409). */
   readonly concurrencyStamp: string;
 }
@@ -446,8 +448,8 @@ export interface RenditionResponse {
   readonly sizeBytes: number | null;
   readonly width: number | null;
   readonly height: number | null;
-  readonly createdAt: string;
-  readonly completedAt: string | null;
+  readonly createdAt: ISODateString;
+  readonly completedAt: ISODateString | null;
   readonly failureReason: string | null;
 }
 
@@ -461,7 +463,7 @@ export interface ListRenditionsResponse {
 /** Response for `GET /documents/{id}/renditions/{type}/download`. */
 export interface RenditionDownloadUrlResponse {
   readonly url: string;
-  readonly expiresAt: string;
+  readonly expiresAt: ISODateString;
 }
 
 // ─── Document resolution ─────────────────────────────────────────────────────

--- a/packages/@granit/react-blob-storage/package.json
+++ b/packages/@granit/react-blob-storage/package.json
@@ -20,6 +20,7 @@
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
+    "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
@@ -37,7 +38,8 @@
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-blob-storage/src/__tests__/blob-upload-field.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/blob-upload-field.test.tsx
@@ -1,5 +1,6 @@
 import { GranitClientProvider } from '@granit/react-api-client';
 import { createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import axios from 'axios';
@@ -62,7 +63,7 @@ function makeWrapper() {
           blobId: 'blob-uploaded-123',
           uploadUrl: 'https://s3.example.com/presigned',
           httpMethod: 'PUT',
-          expiresAt: '2026-12-31T00:00:00Z',
+          expiresAt: toISODateString('2026-12-31T00:00:00Z'),
           requiredHeaders: {},
         },
       } as unknown as Awaited<ReturnType<typeof apiClient.post>>;

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob-download.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob-download.test.tsx
@@ -1,5 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -28,7 +29,7 @@ describe('useDownloadUrl', () => {
     const client = createMockClient();
     const response: BlobDownloadUrlResponse = {
       downloadUrl: 'https://s3.example.com/download',
-      expiresAt: '2026-03-20T12:05:00Z',
+      expiresAt: toISODateString('2026-03-20T12:05:00Z'),
     };
     vi.mocked(client.post).mockResolvedValueOnce({ data: response });
 

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob-mutations.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob-mutations.test.tsx
@@ -1,6 +1,7 @@
 import { BlobStatus } from '@granit/blob-storage';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -37,7 +38,7 @@ describe('useInitiateUpload', () => {
       blobId: 'abc-123',
       uploadUrl: 'https://s3.example.com/presigned',
       httpMethod: 'PUT',
-      expiresAt: '2026-03-20T12:00:00Z',
+      expiresAt: toISODateString('2026-03-20T12:00:00Z'),
       requiredHeaders: { 'Content-Type': 'image/png' },
     };
     vi.mocked(client.post).mockResolvedValueOnce({ data: response });

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob-upload.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob-upload.test.tsx
@@ -1,6 +1,7 @@
 import { BlobStatus } from '@granit/blob-storage';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -28,7 +29,7 @@ const mockTicket: BlobUploadInitiateResponse = {
   blobId: 'blob-456',
   uploadUrl: 'https://s3.example.com/presigned',
   httpMethod: 'PUT',
-  expiresAt: '2026-03-20T12:00:00Z',
+  expiresAt: toISODateString('2026-03-20T12:00:00Z'),
   requiredHeaders: { 'Content-Type': 'image/png', 'x-amz-meta-tenant': 'tenant-1' },
 };
 

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob.test.tsx
@@ -1,6 +1,7 @@
 import { BlobStatus } from '@granit/blob-storage';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -35,8 +36,8 @@ const mockDescriptor: BlobDescriptorResponse = {
   status: BlobStatus.Valid,
   rejectionReason: null,
   deletionReason: null,
-  createdAt: '2026-03-20T10:00:00Z',
-  validatedAt: '2026-03-20T10:00:05Z',
+  createdAt: toISODateString('2026-03-20T10:00:00Z'),
+  validatedAt: toISODateString('2026-03-20T10:00:05Z'),
   deletedAt: null,
 };
 

--- a/packages/@granit/react-blob-storage/src/testing/data.ts
+++ b/packages/@granit/react-blob-storage/src/testing/data.ts
@@ -1,4 +1,5 @@
 import { BlobStatus } from '@granit/blob-storage';
+import { toISODateString } from '@granit/types';
 
 import type { BlobDescriptorResponse } from '@granit/blob-storage';
 
@@ -17,8 +18,8 @@ export const mockBlobs: BlobDescriptorResponse[] = [
     status: S.Valid,
     rejectionReason: null,
     deletionReason: null,
-    createdAt: '2026-03-01T08:12:00Z',
-    validatedAt: '2026-03-01T08:12:05Z',
+    createdAt: toISODateString('2026-03-01T08:12:00Z'),
+    validatedAt: toISODateString('2026-03-01T08:12:05Z'),
     deletedAt: null,
   },
   {
@@ -32,8 +33,8 @@ export const mockBlobs: BlobDescriptorResponse[] = [
     status: S.Valid,
     rejectionReason: null,
     deletionReason: null,
-    createdAt: '2026-03-02T14:30:00Z',
-    validatedAt: '2026-03-02T14:30:03Z',
+    createdAt: toISODateString('2026-03-02T14:30:00Z'),
+    validatedAt: toISODateString('2026-03-02T14:30:03Z'),
     deletedAt: null,
   },
   {
@@ -47,8 +48,8 @@ export const mockBlobs: BlobDescriptorResponse[] = [
     status: S.Valid,
     rejectionReason: null,
     deletionReason: null,
-    createdAt: '2026-03-03T09:45:00Z',
-    validatedAt: '2026-03-03T09:45:02Z',
+    createdAt: toISODateString('2026-03-03T09:45:00Z'),
+    validatedAt: toISODateString('2026-03-03T09:45:02Z'),
     deletedAt: null,
   },
   {
@@ -62,8 +63,8 @@ export const mockBlobs: BlobDescriptorResponse[] = [
     status: S.Valid,
     rejectionReason: null,
     deletionReason: null,
-    createdAt: '2026-03-05T06:00:00Z',
-    validatedAt: '2026-03-05T06:00:12Z',
+    createdAt: toISODateString('2026-03-05T06:00:00Z'),
+    validatedAt: toISODateString('2026-03-05T06:00:12Z'),
     deletedAt: null,
   },
   {
@@ -77,8 +78,8 @@ export const mockBlobs: BlobDescriptorResponse[] = [
     status: S.Valid,
     rejectionReason: null,
     deletionReason: null,
-    createdAt: '2026-03-06T11:20:00Z',
-    validatedAt: '2026-03-06T11:20:18Z',
+    createdAt: toISODateString('2026-03-06T11:20:00Z'),
+    validatedAt: toISODateString('2026-03-06T11:20:18Z'),
     deletedAt: null,
   },
   {
@@ -92,8 +93,8 @@ export const mockBlobs: BlobDescriptorResponse[] = [
     status: S.Valid,
     rejectionReason: null,
     deletionReason: null,
-    createdAt: '2026-03-07T15:00:00Z',
-    validatedAt: '2026-03-07T15:00:04Z',
+    createdAt: toISODateString('2026-03-07T15:00:00Z'),
+    validatedAt: toISODateString('2026-03-07T15:00:04Z'),
     deletedAt: null,
   },
   {
@@ -107,7 +108,7 @@ export const mockBlobs: BlobDescriptorResponse[] = [
     status: S.Pending,
     rejectionReason: null,
     deletionReason: null,
-    createdAt: '2026-03-18T16:42:00Z',
+    createdAt: toISODateString('2026-03-18T16:42:00Z'),
     validatedAt: null,
     deletedAt: null,
   },
@@ -122,7 +123,7 @@ export const mockBlobs: BlobDescriptorResponse[] = [
     status: S.Uploading,
     rejectionReason: null,
     deletionReason: null,
-    createdAt: '2026-03-19T10:05:00Z',
+    createdAt: toISODateString('2026-03-19T10:05:00Z'),
     validatedAt: null,
     deletedAt: null,
   },
@@ -138,7 +139,7 @@ export const mockBlobs: BlobDescriptorResponse[] = [
     rejectionReason:
       'Content-type mismatch: declared application/pdf, detected application/x-dosexec',
     deletionReason: null,
-    createdAt: '2026-03-10T22:15:00Z',
+    createdAt: toISODateString('2026-03-10T22:15:00Z'),
     validatedAt: null,
     deletedAt: null,
   },
@@ -153,9 +154,9 @@ export const mockBlobs: BlobDescriptorResponse[] = [
     status: S.Deleted,
     rejectionReason: null,
     deletionReason: 'Retention policy — older than 60 days',
-    createdAt: '2026-01-15T07:00:00Z',
-    validatedAt: '2026-01-15T07:00:08Z',
-    deletedAt: '2026-03-16T02:00:00Z',
+    createdAt: toISODateString('2026-01-15T07:00:00Z'),
+    validatedAt: toISODateString('2026-01-15T07:00:08Z'),
+    deletedAt: toISODateString('2026-03-16T02:00:00Z'),
   },
   {
     id: '9a1b2c3d-0011-4000-a000-000000000011',
@@ -168,8 +169,8 @@ export const mockBlobs: BlobDescriptorResponse[] = [
     status: S.Valid,
     rejectionReason: null,
     deletionReason: null,
-    createdAt: '2026-03-12T13:10:00Z',
-    validatedAt: '2026-03-12T13:10:06Z',
+    createdAt: toISODateString('2026-03-12T13:10:00Z'),
+    validatedAt: toISODateString('2026-03-12T13:10:06Z'),
     deletedAt: null,
   },
   {
@@ -183,8 +184,8 @@ export const mockBlobs: BlobDescriptorResponse[] = [
     status: S.Valid,
     rejectionReason: null,
     deletionReason: null,
-    createdAt: '2026-03-14T17:30:00Z',
-    validatedAt: '2026-03-14T17:30:01Z',
+    createdAt: toISODateString('2026-03-14T17:30:00Z'),
+    validatedAt: toISODateString('2026-03-14T17:30:01Z'),
     deletedAt: null,
   },
   {
@@ -198,8 +199,8 @@ export const mockBlobs: BlobDescriptorResponse[] = [
     status: S.Valid,
     rejectionReason: null,
     deletionReason: null,
-    createdAt: '2026-03-08T10:00:00Z',
-    validatedAt: '2026-03-08T10:00:02Z',
+    createdAt: toISODateString('2026-03-08T10:00:00Z'),
+    validatedAt: toISODateString('2026-03-08T10:00:02Z'),
     deletedAt: null,
   },
   {
@@ -213,8 +214,8 @@ export const mockBlobs: BlobDescriptorResponse[] = [
     status: S.Valid,
     rejectionReason: null,
     deletionReason: null,
-    createdAt: '2026-03-17T09:30:00Z',
-    validatedAt: '2026-03-17T09:30:04Z',
+    createdAt: toISODateString('2026-03-17T09:30:00Z'),
+    validatedAt: toISODateString('2026-03-17T09:30:04Z'),
     deletedAt: null,
   },
   {
@@ -228,8 +229,8 @@ export const mockBlobs: BlobDescriptorResponse[] = [
     status: S.Valid,
     rejectionReason: null,
     deletionReason: null,
-    createdAt: '2026-03-19T18:00:00Z',
-    validatedAt: '2026-03-19T18:00:10Z',
+    createdAt: toISODateString('2026-03-19T18:00:00Z'),
+    validatedAt: toISODateString('2026-03-19T18:00:10Z'),
     deletedAt: null,
   },
 ];

--- a/packages/@granit/react-blob-storage/src/testing/handlers.ts
+++ b/packages/@granit/react-blob-storage/src/testing/handlers.ts
@@ -6,6 +6,7 @@ import {
   parseSort,
   sortItems,
 } from '@granit/testing/msw';
+import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants';
@@ -265,7 +266,7 @@ export function createBlobStorageHandlers(baseUrl = DEFAULT_BASE_PATH) {
         blobId,
         uploadUrl: `${baseUrl}/blobs/${encodeURIComponent(blobId)}/_mock-upload-target`,
         httpMethod: 'PUT',
-        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        expiresAt: toISODateString(new Date(Date.now() + 60 * 60 * 1000).toISOString()),
         requiredHeaders: {},
       };
       return HttpResponse.json(response);
@@ -296,7 +297,7 @@ export function createBlobStorageHandlers(baseUrl = DEFAULT_BASE_PATH) {
         // Stash the descriptor so subsequent `GET /blobs/:id` requests
         // (typically issued by `<BlobImage>` or the blob list page)
         // find the freshly-uploaded record.
-        const now = new Date().toISOString();
+        const now = toISODateString(new Date().toISOString());
         const descriptor: BlobDescriptorResponse = {
           id: blobId,
           containerName: tracked.containerName,

--- a/packages/@granit/react-documents/package.json
+++ b/packages/@granit/react-documents/package.json
@@ -20,6 +20,7 @@
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
+    "@granit/types": "workspace:*",
     "@granit/utils": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.14.6",
@@ -51,6 +52,7 @@
     "@granit/react-query-engine": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*",
     "@granit/utils": "workspace:*",
     "msw": "^2.14.6"
   }

--- a/packages/@granit/react-documents/src/__tests__/document-detail.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/document-detail.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -22,7 +23,7 @@ const sampleDocument: DocumentResponse = {
   sizeBytes: 1024,
   contentType: 'application/pdf',
   status: 'Active',
-  createdAt: '2026-05-01T10:00:00Z',
+  createdAt: toISODateString('2026-05-01T10:00:00Z'),
   modifiedAt: null,
   trashedAt: null,
   permission: null,
@@ -48,7 +49,9 @@ function mockGet(client: AxiosInstance, document: DocumentResponse | null): void
       return Promise.resolve({ data: { versions: [], totalCount: 0, skip: 0, take: 1 } });
     }
     if (url.includes('/download')) {
-      return Promise.resolve({ data: { url: 'https://blob/x', expiresAt: '2026-05-12' } });
+      return Promise.resolve({
+        data: { url: 'https://blob/x', expiresAt: toISODateString('2026-05-12') },
+      });
     }
     return Promise.resolve({ data: document });
   }) as AxiosInstance['get']);

--- a/packages/@granit/react-documents/src/__tests__/document-quick-look.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/document-quick-look.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -32,7 +33,7 @@ function makeDocument(id: string, name: string): DocumentResponse {
     concurrencyStamp: 'stamp-1',
     sizeBytes: 1024,
     contentType: 'application/pdf',
-    createdAt: '2026-05-01T10:00:00Z',
+    createdAt: toISODateString('2026-05-01T10:00:00Z'),
     modifiedAt: null,
     description: null,
     trashedAt: null,

--- a/packages/@granit/react-documents/src/__tests__/documents-explorer.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/documents-explorer.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -17,7 +18,7 @@ const activeFolder: FolderResponse = {
   name: 'Contracts',
   path: '/Contracts',
   depth: 1,
-  createdAt: '2026-05-01T10:00:00Z',
+  createdAt: toISODateString('2026-05-01T10:00:00Z'),
   modifiedAt: null,
   ownerId: 'user-1',
   status: 'Active',

--- a/packages/@granit/react-documents/src/__tests__/folder-breadcrumb.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/folder-breadcrumb.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -17,7 +18,7 @@ const a: FolderResponse = {
   name: 'Contracts',
   path: '/Contracts',
   depth: 1,
-  createdAt: '2026-05-01T10:00:00Z',
+  createdAt: toISODateString('2026-05-01T10:00:00Z'),
   modifiedAt: null,
   ownerId: 'user-1',
   status: 'Active',
@@ -32,7 +33,7 @@ const b: FolderResponse = {
   name: '2026',
   path: '/Contracts/2026',
   depth: 2,
-  createdAt: '2026-05-01T10:00:00Z',
+  createdAt: toISODateString('2026-05-01T10:00:00Z'),
   modifiedAt: null,
 };
 

--- a/packages/@granit/react-documents/src/__tests__/folder-tree.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/folder-tree.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -18,7 +19,7 @@ const root: FolderResponse = {
   name: 'Contracts',
   path: '/Contracts',
   depth: 1,
-  createdAt: '2026-05-01T10:00:00Z',
+  createdAt: toISODateString('2026-05-01T10:00:00Z'),
   modifiedAt: null,
   ownerId: 'user-1',
   status: 'Active',
@@ -32,7 +33,7 @@ const child: FolderResponse = {
   name: '2026',
   path: '/Contracts/2026',
   depth: 2,
-  createdAt: '2026-05-01T10:00:00Z',
+  createdAt: toISODateString('2026-05-01T10:00:00Z'),
   modifiedAt: null,
   ownerId: 'user-1',
   status: 'Active',

--- a/packages/@granit/react-documents/src/__tests__/quota-badge.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/quota-badge.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -41,7 +42,7 @@ describe('QuotaBadge', () => {
       limitBytes: 10 * 1024 * 1024 * 1024,
       usageBytes: 5 * 1024 * 1024 * 1024 + Math.round(0.2 * 1024 * 1024 * 1024),
       percentUsed: 52,
-      updatedAt: '2026-05-01T08:00:00Z',
+      updatedAt: toISODateString('2026-05-01T08:00:00Z'),
     };
     vi.mocked(client.get).mockResolvedValue({ data: quota });
 

--- a/packages/@granit/react-documents/src/__tests__/quota-panel.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/quota-panel.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -14,7 +15,7 @@ const quota: TenantStorageQuotaResponse = {
   limitBytes: 10 * 1024 * 1024 * 1024,
   usageBytes: 5 * 1024 * 1024 * 1024,
   percentUsed: 50,
-  updatedAt: '2026-05-01T08:00:00Z',
+  updatedAt: toISODateString('2026-05-01T08:00:00Z'),
 };
 
 function createWrapper(client: AxiosInstance) {

--- a/packages/@granit/react-documents/src/__tests__/share-dialog.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/share-dialog.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -21,7 +22,7 @@ const folderShare: ShareResponse = {
   permission: 'Read',
   isDefault: true,
   expiresAt: null,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
   createdBy: 'admin',
 };
 

--- a/packages/@granit/react-documents/src/__tests__/transfer-ownership-dialog.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/transfer-ownership-dialog.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -53,7 +54,7 @@ const SAMPLE_DOCUMENT: DocumentResponse = {
   sizeBytes: 1024,
   contentType: 'application/pdf',
   status: 'Active',
-  createdAt: '2026-05-01T10:00:00Z',
+  createdAt: toISODateString('2026-05-01T10:00:00Z'),
   modifiedAt: null,
   trashedAt: null,
   permission: 'Manage',
@@ -65,7 +66,7 @@ const SAMPLE_FOLDER: FolderResponse = {
   name: 'Contracts',
   path: '/Contracts',
   depth: 1,
-  createdAt: '2026-05-01T10:00:00Z',
+  createdAt: toISODateString('2026-05-01T10:00:00Z'),
   modifiedAt: null,
   ownerId: '00000000-0000-4000-8000-000000000001',
   status: 'Active',

--- a/packages/@granit/react-documents/src/__tests__/trash-bin.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/trash-bin.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -16,7 +17,7 @@ const trashed: TrashedDocumentResponse = {
   folderId: 'fld-1',
   name: 'Old.pdf',
   ownerId: 'user-1',
-  trashedAt: '2026-05-01T08:00:00Z',
+  trashedAt: toISODateString('2026-05-01T08:00:00Z'),
   daysUntilPermanentDeletion: 5,
 };
 

--- a/packages/@granit/react-documents/src/__tests__/upload-button.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/upload-button.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -76,7 +77,7 @@ describe('UploadButton', () => {
       blobId: 'blob-1',
       uploadUrl: 'https://blob.example/put',
       httpMethod: 'PUT',
-      expiresAt: '2026-05-12T00:00:00Z',
+      expiresAt: toISODateString('2026-05-12T00:00:00Z'),
       requiredHeaders: { 'x-ms-blob-type': 'BlockBlob' },
     };
     const documentResponse = {
@@ -132,7 +133,7 @@ describe('UploadButton', () => {
       blobId: 'blob-1',
       uploadUrl: 'https://blob.example/put',
       httpMethod: 'PUT',
-      expiresAt: '2026-05-12T00:00:00Z',
+      expiresAt: toISODateString('2026-05-12T00:00:00Z'),
       requiredHeaders: {},
     };
     vi.mocked(client.post).mockImplementation(((url: string) => {
@@ -196,7 +197,7 @@ describe('UploadButton', () => {
       blobId: 'blob-1',
       uploadUrl: 'https://blob.example/put',
       httpMethod: 'PUT',
-      expiresAt: '2026-05-12T00:00:00Z',
+      expiresAt: toISODateString('2026-05-12T00:00:00Z'),
       requiredHeaders: {},
     };
     vi.mocked(client.post).mockResolvedValue({ data: ticket });
@@ -230,7 +231,7 @@ describe('UploadButton', () => {
       blobId: 'blob-1',
       uploadUrl: 'https://blob.example/put',
       httpMethod: 'PUT',
-      expiresAt: '2026-05-12T00:00:00Z',
+      expiresAt: toISODateString('2026-05-12T00:00:00Z'),
       requiredHeaders: { 'x-h': 'v' },
     };
     vi.mocked(client.post).mockResolvedValue({ data: ticket });
@@ -273,7 +274,7 @@ describe('UploadButton', () => {
       blobId: 'blob-1',
       uploadUrl: 'https://blob.example/put',
       httpMethod: 'PUT',
-      expiresAt: '2026-05-12T00:00:00Z',
+      expiresAt: toISODateString('2026-05-12T00:00:00Z'),
       requiredHeaders: {},
     };
     const documentResponse = {

--- a/packages/@granit/react-documents/src/__tests__/upload-drop-zone.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/upload-drop-zone.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -157,7 +158,7 @@ describe('UploadDropZone', () => {
       blobId: 'blob-1',
       uploadUrl: 'https://blob.example/put',
       httpMethod: 'PUT',
-      expiresAt: '2026-05-12T00:00:00Z',
+      expiresAt: toISODateString('2026-05-12T00:00:00Z'),
       requiredHeaders: {},
     };
     const finalized = {

--- a/packages/@granit/react-documents/src/__tests__/use-document-mutations.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-document-mutations.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook } from '@testing-library/react';
 import * as React from 'react';
@@ -37,7 +38,7 @@ const sampleDoc: DocumentResponse = {
   sizeBytes: 1024,
   contentType: 'application/pdf',
   status: 'Active',
-  createdAt: '2026-05-01T00:00:00Z',
+  createdAt: toISODateString('2026-05-01T00:00:00Z'),
   modifiedAt: null,
   trashedAt: null,
   permission: null,
@@ -52,7 +53,7 @@ const sampleVersion: DocumentVersionResponse = {
   contentType: 'application/pdf',
   contentHash: null,
   uploadedByUserId: 'user-1',
-  uploadedAt: '2026-05-01T00:00:00Z',
+  uploadedAt: toISODateString('2026-05-01T00:00:00Z'),
   commitMessage: null,
   isCurrent: true,
 };
@@ -61,7 +62,7 @@ const sampleTicket: UploadTicketResponse = {
   blobId: 'blob-1',
   uploadUrl: 'https://blob.example/upload',
   httpMethod: 'PUT',
-  expiresAt: '2026-05-01T01:00:00Z',
+  expiresAt: toISODateString('2026-05-01T01:00:00Z'),
   requiredHeaders: {},
 };
 

--- a/packages/@granit/react-documents/src/__tests__/use-document-properties.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-document-properties.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -19,8 +20,8 @@ const sampleProperties: DocumentPropertiesResponse = {
   documentVersionId: 'ver-1',
   sourceContentType: 'application/pdf',
   status: 'Ready',
-  createdAt: '2026-06-01T00:00:00Z',
-  completedAt: '2026-06-01T00:01:00Z',
+  createdAt: toISODateString('2026-06-01T00:00:00Z'),
+  completedAt: toISODateString('2026-06-01T00:01:00Z'),
   failureReason: null,
   extractorCount: 2,
   width: null,

--- a/packages/@granit/react-documents/src/__tests__/use-document-tags.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-document-tags.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -34,7 +35,7 @@ const sampleAssignment: DocumentTagAssignmentResponse = {
   tenantId: null,
   tagId: 'tag-1',
   documentId: 'doc-1',
-  assignedAt: '2026-05-02T00:00:00Z',
+  assignedAt: toISODateString('2026-05-02T00:00:00Z'),
   assignedByUserId: 'user-1',
 };
 

--- a/packages/@granit/react-documents/src/__tests__/use-documents.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-documents.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -33,7 +34,7 @@ const sampleDoc: DocumentResponse = {
   sizeBytes: 1024,
   contentType: 'application/pdf',
   status: 'Active',
-  createdAt: '2026-05-01T00:00:00Z',
+  createdAt: toISODateString('2026-05-01T00:00:00Z'),
   modifiedAt: null,
   trashedAt: null,
   permission: null,
@@ -48,7 +49,7 @@ const sampleVersion: DocumentVersionResponse = {
   contentType: 'application/pdf',
   contentHash: null,
   uploadedByUserId: 'user-1',
-  uploadedAt: '2026-05-01T00:00:00Z',
+  uploadedAt: toISODateString('2026-05-01T00:00:00Z'),
   commitMessage: null,
   isCurrent: true,
 };
@@ -65,7 +66,7 @@ const sampleTrashed: TrashedDocumentResponse = {
   folderId: 'fld-1',
   name: 'contract.pdf',
   ownerId: 'user-1',
-  trashedAt: '2026-05-01T00:00:00Z',
+  trashedAt: toISODateString('2026-05-01T00:00:00Z'),
   daysUntilPermanentDeletion: 29,
 };
 
@@ -78,7 +79,7 @@ const sampleTrashList: ListTrashedDocumentsResponse = {
 
 const sampleDownload: DownloadUrlResponse = {
   url: 'https://blob.example/signed',
-  expiresAt: '2026-05-01T01:00:00Z',
+  expiresAt: toISODateString('2026-05-01T01:00:00Z'),
 };
 
 function createWrapper(client: AxiosInstance) {

--- a/packages/@granit/react-documents/src/__tests__/use-folder-mutations.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-folder-mutations.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook } from '@testing-library/react';
 import * as React from 'react';
@@ -25,7 +26,7 @@ const sampleFolder: FolderResponse = {
   name: 'Contracts',
   path: '/Contracts',
   depth: 1,
-  createdAt: '2026-05-01T10:00:00Z',
+  createdAt: toISODateString('2026-05-01T10:00:00Z'),
   modifiedAt: null,
   ownerId: 'user-1',
   status: 'Active',

--- a/packages/@granit/react-documents/src/__tests__/use-folders.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-folders.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -20,7 +21,7 @@ const sampleFolder: FolderResponse = {
   name: 'Contracts',
   path: '/Contracts',
   depth: 1,
-  createdAt: '2026-05-01T10:00:00Z',
+  createdAt: toISODateString('2026-05-01T10:00:00Z'),
   modifiedAt: null,
   ownerId: 'user-1',
   status: 'Active',

--- a/packages/@granit/react-documents/src/__tests__/use-public-links.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-public-links.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -18,13 +19,13 @@ const sampleLink: PublicLinkResponse = {
   id: 'lnk-1',
   documentId: 'doc-1',
   scope: 'Download',
-  expiresAt: '2026-07-01T00:00:00Z',
+  expiresAt: toISODateString('2026-07-01T00:00:00Z'),
   maxUses: null,
   concurrencyStamp: 'stamp-1',
   currentUses: 0,
   revokedAt: null,
   revocationReason: null,
-  createdAt: '2026-06-01T00:00:00Z',
+  createdAt: toISODateString('2026-06-01T00:00:00Z'),
 };
 
 const createResponse: CreatePublicLinkResponse = {
@@ -33,7 +34,7 @@ const createResponse: CreatePublicLinkResponse = {
   token: 'tok-abc',
   url: 'https://example.com/dl/tok-abc',
   scope: 'Download',
-  expiresAt: '2026-07-01T00:00:00Z',
+  expiresAt: toISODateString('2026-07-01T00:00:00Z'),
   maxUses: null,
 };
 

--- a/packages/@granit/react-documents/src/__tests__/use-quota.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-quota.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -14,7 +15,7 @@ const sampleQuota: TenantStorageQuotaResponse = {
   limitBytes: 10_000_000,
   usageBytes: 1_024,
   percentUsed: 0.01,
-  updatedAt: '2026-05-01T00:00:00Z',
+  updatedAt: toISODateString('2026-05-01T00:00:00Z'),
 };
 
 function createWrapper(client: AxiosInstance) {

--- a/packages/@granit/react-documents/src/__tests__/use-renditions.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-renditions.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -18,7 +19,7 @@ const sampleRenditions: ListRenditionsResponse = {
 
 const sampleDownloadUrl: RenditionDownloadUrlResponse = {
   url: 'https://cdn.example.com/rendition.webp',
-  expiresAt: '2026-06-06T01:00:00Z',
+  expiresAt: toISODateString('2026-06-06T01:00:00Z'),
 };
 
 function createWrapper(client: AxiosInstance) {

--- a/packages/@granit/react-documents/src/__tests__/use-share-mutations.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-share-mutations.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook } from '@testing-library/react';
 import * as React from 'react';
@@ -26,7 +27,7 @@ const sampleShare: ShareResponse = {
   permission: 'Read',
   isDefault: true,
   expiresAt: null,
-  createdAt: '2026-05-01T00:00:00Z',
+  createdAt: toISODateString('2026-05-01T00:00:00Z'),
   createdBy: 'user-1',
 };
 

--- a/packages/@granit/react-documents/src/__tests__/use-shares.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-shares.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -20,7 +21,7 @@ const sampleShare: ShareResponse = {
   permission: 'Read',
   isDefault: true,
   expiresAt: null,
-  createdAt: '2026-05-01T00:00:00Z',
+  createdAt: toISODateString('2026-05-01T00:00:00Z'),
   createdBy: 'user-1',
 };
 const sampleResponse: ListSharesResponse = { items: [sampleShare] };

--- a/packages/@granit/react-documents/src/__tests__/versions-timeline.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/versions-timeline.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -20,7 +21,7 @@ const version: DocumentVersionResponse = {
   contentType: 'application/pdf',
   contentHash: null,
   uploadedByUserId: 'user-1',
-  uploadedAt: '2026-05-01T08:00:00Z',
+  uploadedAt: toISODateString('2026-05-01T08:00:00Z'),
   commitMessage: 'Initial upload',
   isCurrent: true,
 };
@@ -115,7 +116,9 @@ describe('VersionsTimeline', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockImplementation(((url: string) => {
       if (url.includes('/download')) {
-        return Promise.resolve({ data: { url: 'https://blob.example/get', expiresAt: 'x' } });
+        return Promise.resolve({
+          data: { url: 'https://blob.example/get', expiresAt: toISODateString('x') },
+        });
       }
       return Promise.resolve({
         data: { versions: [version], totalCount: 1, skip: 0, take: 20 },

--- a/packages/@granit/react-documents/src/components/quota-panel.tsx
+++ b/packages/@granit/react-documents/src/components/quota-panel.tsx
@@ -1,3 +1,5 @@
+import { toISODateString } from '@granit/types';
+
 import { useTenantStorageQuota } from '../hooks/use-quota';
 
 import { formatBytes } from './format-bytes';
@@ -23,7 +25,7 @@ const DEFAULT_LABELS: Required<QuotaPanelLabels> = {
   used: 'Used',
   limit: 'Limit',
   percentUsed: '% used',
-  updatedAt: 'Updated',
+  updatedAt: toISODateString('Updated'),
   loading: 'Loading quota…',
 };
 

--- a/packages/@granit/react-documents/src/components/share-dialog.tsx
+++ b/packages/@granit/react-documents/src/components/share-dialog.tsx
@@ -1,3 +1,4 @@
+import { toISODateString } from '@granit/types';
 import { useState } from 'react';
 
 import {
@@ -81,7 +82,7 @@ const EMPTY_DRAFT: DraftShare = {
   granteeId: '',
   permission: 'Read',
   isDefault: true,
-  expiresAt: '',
+  expiresAt: toISODateString(''),
 };
 
 /**

--- a/packages/@granit/react-documents/src/testing/data.ts
+++ b/packages/@granit/react-documents/src/testing/data.ts
@@ -1,3 +1,5 @@
+import { toISODateString, type ISODateString } from '@granit/types';
+
 import type {
   DocumentResponse,
   DocumentVersionResponse,
@@ -20,12 +22,12 @@ const OWNER_USER_ID = '00000000-0000-4000-8000-0000000000a1';
 const OTHER_USER_ID = '00000000-0000-4000-8000-0000000000a2';
 
 // Anchor every relative timestamp to the project's currentDate.
-const T0 = '2026-05-11T10:00:00Z';
-const T1 = '2026-05-11T09:00:00Z';
-const T2 = '2026-05-10T16:30:00Z';
-const T3 = '2026-05-09T11:00:00Z';
-const T4 = '2026-05-05T08:00:00Z';
-const T5 = '2026-04-28T12:00:00Z';
+const T0 = toISODateString('2026-05-11T10:00:00Z');
+const T1 = toISODateString('2026-05-11T09:00:00Z');
+const T2 = toISODateString('2026-05-10T16:30:00Z');
+const T3 = toISODateString('2026-05-09T11:00:00Z');
+const T4 = toISODateString('2026-05-05T08:00:00Z');
+const T5 = toISODateString('2026-04-28T12:00:00Z');
 
 // ---------------------------------------------------------------------------
 // Folders
@@ -43,7 +45,7 @@ export const mockFoldersData: Mutable<FolderResponse>[] = [
     name: 'Contracts',
     path: '/Contracts',
     depth: 1,
-    createdAt: '2026-05-01T10:00:00Z',
+    createdAt: toISODateString('2026-05-01T10:00:00Z'),
     modifiedAt: null,
     ownerId: OWNER_USER_ID,
     status: 'Active',
@@ -56,7 +58,7 @@ export const mockFoldersData: Mutable<FolderResponse>[] = [
     name: 'Invoices',
     path: '/Invoices',
     depth: 1,
-    createdAt: '2026-05-01T10:00:00Z',
+    createdAt: toISODateString('2026-05-01T10:00:00Z'),
     modifiedAt: null,
     ownerId: OWNER_USER_ID,
     status: 'Active',
@@ -69,7 +71,7 @@ export const mockFoldersData: Mutable<FolderResponse>[] = [
     name: '2025',
     path: '/Contracts/2025',
     depth: 2,
-    createdAt: '2026-05-01T10:00:00Z',
+    createdAt: toISODateString('2026-05-01T10:00:00Z'),
     modifiedAt: null,
     ownerId: OWNER_USER_ID,
     status: 'Active',
@@ -82,7 +84,7 @@ export const mockFoldersData: Mutable<FolderResponse>[] = [
     name: '2026',
     path: '/Contracts/2026',
     depth: 2,
-    createdAt: '2026-05-01T10:00:00Z',
+    createdAt: toISODateString('2026-05-01T10:00:00Z'),
     modifiedAt: null,
     ownerId: OWNER_USER_ID,
     status: 'Active',
@@ -225,7 +227,7 @@ export const mockDocumentsData: Mutable<DocumentResponse>[] = [
 function makeVersions(
   documentId: string,
   count: number,
-  baseTimes: readonly string[]
+  baseTimes: readonly ISODateString[]
 ): Mutable<DocumentVersionResponse>[] {
   const versions: Mutable<DocumentVersionResponse>[] = [];
   for (let n = 1; n <= count; n++) {

--- a/packages/@granit/react-documents/src/testing/handlers.ts
+++ b/packages/@granit/react-documents/src/testing/handlers.ts
@@ -10,6 +10,7 @@
 
 import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { noContent, notFound, pagedResponse, parseFilters, parseSort } from '@granit/testing/msw';
+import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants';
@@ -202,7 +203,7 @@ export function createDocumentsHandlers(
         name: body.name,
         path: parent ? `${parent.path}/${body.name}` : `/${body.name}`,
         depth: (parent?.depth ?? 0) + 1,
-        createdAt: '2026-05-01T10:00:00Z',
+        createdAt: toISODateString('2026-05-01T10:00:00Z'),
         modifiedAt: null,
         ownerId: MOCK_OWNER_USER_ID,
         status: 'Active',
@@ -289,7 +290,7 @@ export function createDocumentsHandlers(
       const trashedFolder: FolderResponse = {
         ...folder,
         status: 'Trashed',
-        trashedAt: new Date().toISOString(),
+        trashedAt: toISODateString(new Date().toISOString()),
       };
       Object.assign(folder, trashedFolder);
       return HttpResponse.json(folder);
@@ -316,8 +317,8 @@ export function createDocumentsHandlers(
         granteeId: body.granteeId,
         permission: body.permission,
         isDefault: body.isDefault ?? true,
-        expiresAt: body.expiresAt ?? null,
-        createdAt: new Date().toISOString(),
+        expiresAt: body.expiresAt != null ? toISODateString(body.expiresAt) : null,
+        createdAt: toISODateString(new Date().toISOString()),
         createdBy: MOCK_OWNER_USER_ID,
       };
       shares.push(share);
@@ -332,7 +333,7 @@ export function createDocumentsHandlers(
         blobId,
         uploadUrl: `mock://upload/${blobId}?name=${encodeURIComponent(body.fileName)}`,
         httpMethod: 'PUT',
-        expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+        expiresAt: toISODateString(new Date(Date.now() + 15 * 60_000).toISOString()),
         requiredHeaders: {},
       };
       return HttpResponse.json(payload);
@@ -350,12 +351,12 @@ export function createDocumentsHandlers(
         contentType: 'application/octet-stream',
         contentHash: `sha256:${docId.slice(-6)}1`,
         uploadedByUserId: MOCK_OWNER_USER_ID,
-        uploadedAt: new Date().toISOString(),
+        uploadedAt: toISODateString(new Date().toISOString()),
         commitMessage: body.commitMessage ?? 'Initial upload',
         isCurrent: true,
       };
       versions.push(initialVersion);
-      const now = new Date().toISOString();
+      const now = toISODateString(new Date().toISOString());
       const created: DocumentResponse = {
         id: docId,
         folderId: body.folderId ?? '',
@@ -430,7 +431,7 @@ export function createDocumentsHandlers(
         contentType: 'application/octet-stream',
         contentHash: `sha256:${id.slice(-6)}${versionNumber}`,
         uploadedByUserId: MOCK_OWNER_USER_ID,
-        uploadedAt: new Date().toISOString(),
+        uploadedAt: toISODateString(new Date().toISOString()),
         commitMessage: body.commitMessage ?? null,
         isCurrent: true,
       };
@@ -453,7 +454,7 @@ export function createDocumentsHandlers(
       const versionId = url.searchParams.get('versionId');
       const body: DownloadUrlResponse = {
         url: `mock://download/${id}${versionId ? `?versionId=${versionId}` : ''}`,
-        expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+        expiresAt: toISODateString(new Date(Date.now() + 15 * 60_000).toISOString()),
       };
       return HttpResponse.json(body);
     }),
@@ -475,7 +476,7 @@ export function createDocumentsHandlers(
         tenantId: null,
         tagId,
         documentId,
-        assignedAt: new Date().toISOString(),
+        assignedAt: toISODateString(new Date().toISOString()),
         assignedByUserId: MOCK_OWNER_USER_ID,
       };
       return HttpResponse.json(assignment, { status: 201 });
@@ -508,8 +509,8 @@ export function createDocumentsHandlers(
         granteeId: body.granteeId,
         permission: body.permission,
         isDefault: false,
-        expiresAt: body.expiresAt ?? null,
-        createdAt: new Date().toISOString(),
+        expiresAt: body.expiresAt != null ? toISODateString(body.expiresAt) : null,
+        createdAt: toISODateString(new Date().toISOString()),
         createdBy: MOCK_OWNER_USER_ID,
       };
       shares.push(share);
@@ -597,7 +598,7 @@ export function createDocumentsHandlers(
       const id = params.id as string;
       const doc = findDocument(id);
       if (!doc) return notFound();
-      const trashedAt = new Date().toISOString();
+      const trashedAt = toISODateString(new Date().toISOString());
       Object.assign(doc, { ...doc, status: 'Trashed', trashedAt });
       trashed.push({
         id: doc.id,
@@ -727,7 +728,9 @@ export function createDocumentsHandlers(
       const body = (await request.json()) as CreatePublicLinkRequest;
       const id = newId('lk', shareCounter++);
       const token = `mock-token-${id.slice(-8)}`;
-      const expiresAt = new Date(Date.now() + body.ttlDays * 24 * 60 * 60 * 1000).toISOString();
+      const expiresAt = toISODateString(
+        new Date(Date.now() + body.ttlDays * 24 * 60 * 60 * 1000).toISOString()
+      );
       const created: CreatePublicLinkResponse = {
         id,
         documentId,
@@ -747,7 +750,7 @@ export function createDocumentsHandlers(
         currentUses: 0,
         revokedAt: null,
         revocationReason: null,
-        createdAt: new Date().toISOString(),
+        createdAt: toISODateString(new Date().toISOString()),
       });
       return HttpResponse.json(created, { status: 201 });
     }),
@@ -768,7 +771,7 @@ export function createDocumentsHandlers(
       if (link) {
         Object.assign(link, {
           ...link,
-          revokedAt: new Date().toISOString(),
+          revokedAt: toISODateString(new Date().toISOString()),
           revocationReason: body.reason,
         });
       }
@@ -798,7 +801,7 @@ export function createDocumentsHandlers(
       if (!findDocument(id)) return notFound();
       const body = {
         url: `mock://renditions/${id}/${type}`,
-        expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+        expiresAt: toISODateString(new Date(Date.now() + 15 * 60_000).toISOString()),
       };
       return HttpResponse.json(body);
     }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,6 +424,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/catalog:
     devDependencies:
@@ -600,6 +603,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/entities:
     dependencies:
@@ -1534,6 +1540,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/react-catalog:
     dependencies:
@@ -1968,6 +1977,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
       '@granit/utils':
         specifier: workspace:*
         version: link:../utils


### PR DESCRIPTION
## Summary

First slice of the **datetime uniformization** (decided 2026-06-16: branded `ISODateString` everywhere, incremental by domain). Converts plain-string date-time fields to `ISODateString` in **@granit/documents** + **@granit/blob-storage** (33 fields).

- Reads are unaffected (`ISODateString` ≡ `string` family) — only DTO *construction* is type-checked.
- Fixtures / MSW handlers wrap literals in `toISODateString()`; shared timestamp consts typed as `ISODateString`.
- Adds `@granit/types` to these packages' (+ `react-*`) peer/dev deps (lockfile updated).
- **No wire/oracle change** (495 oracle checks still green).

## ⚠️ Coordinated showcase MR
`granit-showcase-react` document fixtures construct these DTOs → MR follows (merge this first).

## Verification
- `pnpm tsc` (full workspace) clean · lint clean · documents/blob tests green (374)
- oracle 495 ✓