### PR TITLE
refactor(billing)!: brand timestamps as ISODateString

### DIFF
--- a/packages/@granit/customer-balance/package.json
+++ b/packages/@granit/customer-balance/package.json
@@ -16,11 +16,13 @@
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/query-engine": "workspace:*"
+    "@granit/query-engine": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/customer-balance/src/__tests__/customer-balance-api.test.ts
+++ b/packages/@granit/customer-balance/src/__tests__/customer-balance-api.test.ts
@@ -1,4 +1,5 @@
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -20,7 +21,7 @@ const sampleBalance: CustomerBalanceResponse = {
   currency: 'EUR',
   balance: 150.0,
   concurrencyStamp: 'stamp-1',
-  updatedAt: '2026-04-01T10:00:00Z',
+  updatedAt: toISODateString('2026-04-01T10:00:00Z'),
 };
 
 const sampleTransaction: BalanceTransactionResponse = {
@@ -31,8 +32,8 @@ const sampleTransaction: BalanceTransactionResponse = {
   reason: 'Welcome bonus',
   referenceId: null,
   referenceType: null,
-  expiresAt: '2026-12-31T23:59:59Z',
-  createdAt: '2026-04-01T10:00:00Z',
+  expiresAt: toISODateString('2026-12-31T23:59:59Z'),
+  createdAt: toISODateString('2026-04-01T10:00:00Z'),
 };
 
 const basePath = '/customer-balance';
@@ -126,7 +127,7 @@ describe('customer-balance-api', () => {
         currency: 'EUR',
         source: 'Promotional',
         reason: 'Welcome bonus',
-        expiresAt: '2026-12-31T23:59:59Z',
+        expiresAt: toISODateString('2026-12-31T23:59:59Z'),
       };
 
       const result = await addAdminCredit(client, basePath, request);

--- a/packages/@granit/customer-balance/src/types/index.ts
+++ b/packages/@granit/customer-balance/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { ISODateString } from '@granit/types';
+
 /** Request payload for adding an administrative credit to a customer balance. */
 export interface AdminCreditRequest {
   readonly partyId: string;
@@ -5,7 +7,7 @@ export interface AdminCreditRequest {
   readonly currency: string;
   readonly source: 'Promotional' | 'ManualAdjustment';
   readonly reason: string;
-  readonly expiresAt: string | null;
+  readonly expiresAt: ISODateString | null;
 }
 
 /** Request payload for applying a manual debit to a customer balance (admin tooling). */
@@ -32,7 +34,7 @@ export interface CustomerBalanceResponse {
   readonly balance: number;
   /** Optimistic-concurrency token; echo back on edit to detect conflicts (409). */
   readonly concurrencyStamp: string;
-  readonly updatedAt: string | null;
+  readonly updatedAt: ISODateString | null;
 }
 
 /** A single transaction entry on a customer's balance. */
@@ -44,6 +46,6 @@ export interface BalanceTransactionResponse {
   readonly reason: string;
   readonly referenceId: string | null;
   readonly referenceType: string | null;
-  readonly expiresAt: string | null;
-  readonly createdAt: string;
+  readonly expiresAt: ISODateString | null;
+  readonly createdAt: ISODateString;
 }

--- a/packages/@granit/invoicing/src/__tests__/invoicing-api.test.ts
+++ b/packages/@granit/invoicing/src/__tests__/invoicing-api.test.ts
@@ -1,4 +1,5 @@
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -23,8 +24,8 @@ const sampleLineItem = {
   taxAmount: 1029,
   sourceType: 'Subscription',
   sourceId: 'sub-1',
-  periodStart: '2026-03-01T00:00:00Z',
-  periodEnd: '2026-04-01T00:00:00Z',
+  periodStart: toISODateString('2026-03-01T00:00:00Z'),
+  periodEnd: toISODateString('2026-04-01T00:00:00Z'),
 } as const;
 
 const sampleInvoice: InvoiceResponse = {
@@ -44,11 +45,11 @@ const sampleInvoice: InvoiceResponse = {
   amountRemaining: 0,
   parentInvoiceId: null,
   creditNoteReason: null,
-  issuedAt: '2026-03-01T00:00:00Z',
-  dueAt: '2026-03-15T00:00:00Z',
-  paidAt: '2026-03-02T10:00:00Z',
-  periodStart: '2026-03-01T00:00:00Z',
-  periodEnd: '2026-04-01T00:00:00Z',
+  issuedAt: toISODateString('2026-03-01T00:00:00Z'),
+  dueAt: toISODateString('2026-03-15T00:00:00Z'),
+  paidAt: toISODateString('2026-03-02T10:00:00Z'),
+  periodStart: toISODateString('2026-03-01T00:00:00Z'),
+  periodEnd: toISODateString('2026-04-01T00:00:00Z'),
   lineItems: [sampleLineItem],
 };
 
@@ -139,8 +140,8 @@ describe('invoicing-api', () => {
         billingReason: 'SubscriptionCycle',
         parentInvoiceId: null,
         creditNoteReason: null,
-        periodStart: '2026-03-01T00:00:00Z',
-        periodEnd: '2026-04-01T00:00:00Z',
+        periodStart: toISODateString('2026-03-01T00:00:00Z'),
+        periodEnd: toISODateString('2026-04-01T00:00:00Z'),
       };
 
       const result = await createInvoice(client, '/invoicing', request);
@@ -186,8 +187,8 @@ describe('invoicing-api', () => {
       vi.mocked(client.post).mockResolvedValue({ data: sampleInvoice });
 
       const request: FinalizeInvoiceRequest = {
-        issuedAt: '2026-03-01T00:00:00Z',
-        dueAt: '2026-03-15T00:00:00Z',
+        issuedAt: toISODateString('2026-03-01T00:00:00Z'),
+        dueAt: toISODateString('2026-03-15T00:00:00Z'),
         comment: 'Issued by ops',
       };
 
@@ -202,13 +203,13 @@ describe('invoicing-api', () => {
       vi.mocked(client.post).mockResolvedValue({ data: sampleInvoice });
 
       await finalizeInvoice(client, '/invoicing', 'inv/special&id', {
-        issuedAt: '2026-03-01T00:00:00Z',
+        issuedAt: toISODateString('2026-03-01T00:00:00Z'),
         dueAt: null,
       });
 
       expect(client.post).toHaveBeenCalledWith(
         `/invoicing/invoices/${encodeURIComponent('inv/special&id')}/finalize`,
-        expect.objectContaining({ issuedAt: '2026-03-01T00:00:00Z', dueAt: null })
+        expect.objectContaining({ issuedAt: toISODateString('2026-03-01T00:00:00Z'), dueAt: null })
       );
     });
   });

--- a/packages/@granit/invoicing/src/types/index.ts
+++ b/packages/@granit/invoicing/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { EntityId } from '@granit/types';
+import type { EntityId, ISODateString } from '@granit/types';
 
 /** Branded identifier for an invoice. */
 export type InvoiceId = EntityId<'Invoice'>;
@@ -25,9 +25,9 @@ export type BillingReason =
 /** Payload for finalizing a Draft invoice (Draft → Open). */
 export interface FinalizeInvoiceRequest {
   /** Timestamp at which the document is issued (ISO 8601). */
-  readonly issuedAt: string;
+  readonly issuedAt: ISODateString;
   /** Payment deadline — ignored for credit notes (ISO 8601). */
-  readonly dueAt: string | null;
+  readonly dueAt: ISODateString | null;
   /** Optional comment persisted on the workflow transition record (ISO 27001). */
   readonly comment?: string | null;
 }
@@ -53,8 +53,8 @@ export interface InvoiceCreateRequest {
   readonly billingReason: BillingReason;
   readonly parentInvoiceId: string | null;
   readonly creditNoteReason: string | null;
-  readonly periodStart: string | null;
-  readonly periodEnd: string | null;
+  readonly periodStart: ISODateString | null;
+  readonly periodEnd: ISODateString | null;
 }
 
 /** A single line item within an invoice. */
@@ -68,8 +68,8 @@ export interface InvoiceLineItemResponse {
   readonly taxAmount: number;
   readonly sourceType: string;
   readonly sourceId: string | null;
-  readonly periodStart: string | null;
-  readonly periodEnd: string | null;
+  readonly periodStart: ISODateString | null;
+  readonly periodEnd: ISODateString | null;
 }
 
 /** Full invoice response from the API. */
@@ -90,10 +90,10 @@ export interface InvoiceResponse {
   readonly amountRemaining: number;
   readonly parentInvoiceId: string | null;
   readonly creditNoteReason: string | null;
-  readonly issuedAt: string | null;
-  readonly dueAt: string | null;
-  readonly paidAt: string | null;
-  readonly periodStart: string | null;
-  readonly periodEnd: string | null;
+  readonly issuedAt: ISODateString | null;
+  readonly dueAt: ISODateString | null;
+  readonly paidAt: ISODateString | null;
+  readonly periodStart: ISODateString | null;
+  readonly periodEnd: ISODateString | null;
   readonly lineItems: readonly InvoiceLineItemResponse[];
 }

--- a/packages/@granit/metering/src/__tests__/metering-api.test.ts
+++ b/packages/@granit/metering/src/__tests__/metering-api.test.ts
@@ -1,4 +1,5 @@
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -50,8 +51,8 @@ const sampleUsage: UsageAggregateResponse = {
   id: 'agg-1',
   meterDefinitionId: 'meter-1',
   period: 'Daily',
-  periodStart: '2026-04-01T00:00:00Z',
-  periodEnd: '2026-04-02T00:00:00Z',
+  periodStart: toISODateString('2026-04-01T00:00:00Z'),
+  periodEnd: toISODateString('2026-04-02T00:00:00Z'),
   aggregatedValue: 150,
   eventCount: 30,
 };
@@ -214,8 +215,8 @@ describe('metering-api', () => {
       const client = createMockClient();
       const response = {
         meterDefinitionId: 'meter-1',
-        windowStart: '2026-04-01T00:00:00Z',
-        windowEnd: '2026-04-30T00:00:00Z',
+        windowStart: toISODateString('2026-04-01T00:00:00Z'),
+        windowEnd: toISODateString('2026-04-30T00:00:00Z'),
         eventsScanned: 1200,
         aggregatesRebuilt: 30,
         durationMilliseconds: 84,
@@ -246,8 +247,8 @@ describe('metering-api', () => {
       expect(client.get).toHaveBeenCalledWith('/metering/usage', {
         params: {
           meterId: 'meter-1',
-          periodStart: '2026-04-01T00:00:00Z',
-          periodEnd: '2026-05-01T00:00:00Z',
+          periodStart: toISODateString('2026-04-01T00:00:00Z'),
+          periodEnd: toISODateString('2026-05-01T00:00:00Z'),
         },
       });
       expect(result).toEqual(sampleUsage);
@@ -340,7 +341,7 @@ describe('metering-api', () => {
       const response = {
         eventId: 'evt-1',
         meterDefinitionId: 'meter-1',
-        deprecatedAt: '2026-04-04T12:00:00Z',
+        deprecatedAt: toISODateString('2026-04-04T12:00:00Z'),
         aggregatesRebuilt: 1,
       };
       vi.mocked(client.post).mockResolvedValue({ data: response });
@@ -377,7 +378,7 @@ const sampleMeterDefinition: MeterDefinition = {
   distinctProperty: null,
   lifecycleStatus: 'Published',
   productId: null,
-  createdAt: '2026-04-01T00:00:00Z' as ISODateString,
+  createdAt: toISODateString('2026-04-01T00:00:00Z') as ISODateString,
   createdBy: 'user-1',
   modifiedAt: null,
   modifiedBy: null,
@@ -388,8 +389,8 @@ const sampleUsageAggregate: UsageAggregate = {
   tenantId: 'tenant-1' as TenantId,
   meterDefinitionId: 'md-1',
   period: 'Daily',
-  periodStart: '2026-04-01T00:00:00Z' as ISODateString,
-  periodEnd: '2026-04-02T00:00:00Z' as ISODateString,
+  periodStart: toISODateString('2026-04-01T00:00:00Z') as ISODateString,
+  periodEnd: toISODateString('2026-04-02T00:00:00Z') as ISODateString,
   aggregatedValue: 150,
   eventCount: 30,
 };

--- a/packages/@granit/metering/src/types/index.ts
+++ b/packages/@granit/metering/src/types/index.ts
@@ -76,8 +76,8 @@ export interface UsageAggregateResponse {
   readonly id: string;
   readonly meterDefinitionId: string;
   readonly period: AggregationPeriod;
-  readonly periodStart: string;
-  readonly periodEnd: string;
+  readonly periodStart: ISODateString;
+  readonly periodEnd: ISODateString;
   readonly aggregatedValue: number;
   readonly eventCount: number;
 }
@@ -102,8 +102,8 @@ export interface RecomputeUsageRequest {
 
 export interface RecomputeUsageResponse {
   readonly meterDefinitionId: string;
-  readonly windowStart: string;
-  readonly windowEnd: string;
+  readonly windowStart: ISODateString;
+  readonly windowEnd: ISODateString;
   readonly eventsScanned: number;
   readonly aggregatesRebuilt: number;
   readonly durationMilliseconds: number;
@@ -123,7 +123,7 @@ export interface DeprecateEventRequest {
 export interface DeprecateEventResponse {
   readonly eventId: string;
   readonly meterDefinitionId: string;
-  readonly deprecatedAt: string;
+  readonly deprecatedAt: ISODateString;
   readonly aggregatesRebuilt: number;
 }
 

--- a/packages/@granit/payments-sepa-direct-debit/package.json
+++ b/packages/@granit/payments-sepa-direct-debit/package.json
@@ -15,10 +15,12 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "peerDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/payments-sepa-direct-debit/src/__tests__/sepa-direct-debit-api.test.ts
+++ b/packages/@granit/payments-sepa-direct-debit/src/__tests__/sepa-direct-debit-api.test.ts
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -31,8 +32,8 @@ const sampleMandate: MandateResponse = {
   creditorId: 'BE68ZZZ0123456789',
   providerName: 'GoCardless',
   providerMandateId: 'MD0001',
-  signedAt: '2026-05-01T10:00:00Z',
-  activatedAt: '2026-05-01T10:05:00Z',
+  signedAt: toISODateString('2026-05-01T10:00:00Z'),
+  activatedAt: toISODateString('2026-05-01T10:05:00Z'),
   cancelledAt: null,
   tenantId: null,
   concurrencyStamp: 'stamp-1',
@@ -103,7 +104,7 @@ describe('sepa-direct-debit-api', () => {
     it('should POST {basePath}/mandates/{id}/confirm with the signature payload', async () => {
       const client = createMockClient();
       vi.mocked(client.post).mockResolvedValue(axiosResponse(sampleMandate));
-      const request: ConfirmMandateRequest = { signedAt: '2026-05-01T10:00:00Z' };
+      const request: ConfirmMandateRequest = { signedAt: toISODateString('2026-05-01T10:00:00Z') };
 
       const result = await confirmMandate(client, basePath, 'mdt-1', request);
 
@@ -119,7 +120,7 @@ describe('sepa-direct-debit-api', () => {
         axiosResponse({
           ...sampleMandate,
           status: 'Cancelled',
-          cancelledAt: '2026-06-01T00:00:00Z',
+          cancelledAt: toISODateString('2026-06-01T00:00:00Z'),
         })
       );
 

--- a/packages/@granit/payments-sepa-direct-debit/src/types/index.ts
+++ b/packages/@granit/payments-sepa-direct-debit/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { ISODateString } from '@granit/types';
+
 /** Lifecycle status of a SEPA Direct Debit mandate. */
 export type MandateStatus = 'Pending' | 'Active' | 'Suspended' | 'Cancelled' | 'Failed' | 'Expired';
 
@@ -36,7 +38,7 @@ export interface CreateMandateRequest {
 /** Confirm (activate) a pending mandate after the debtor's signature. */
 export interface ConfirmMandateRequest {
   /** When the debtor signed (ISO 8601). */
-  readonly signedAt: string;
+  readonly signedAt: ISODateString;
   /** Reference to the stored signed document, when activation is overridden. */
   readonly documentReference?: string | null;
 }
@@ -63,9 +65,9 @@ export interface MandateResponse {
   readonly creditorId: string;
   readonly providerName: string | null;
   readonly providerMandateId: string | null;
-  readonly signedAt: string | null;
-  readonly activatedAt: string | null;
-  readonly cancelledAt: string | null;
+  readonly signedAt: ISODateString | null;
+  readonly activatedAt: ISODateString | null;
+  readonly cancelledAt: ISODateString | null;
   readonly tenantId: string | null;
   readonly concurrencyStamp: string;
 }

--- a/packages/@granit/payments/package.json
+++ b/packages/@granit/payments/package.json
@@ -16,11 +16,13 @@
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/query-engine": "workspace:*"
+    "@granit/query-engine": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/payments/src/__tests__/payments-api.test.ts
+++ b/packages/@granit/payments/src/__tests__/payments-api.test.ts
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -47,7 +48,7 @@ const sampleTransaction: PaymentTransactionResponse = {
   actionUrl: null,
   idempotencyKey: 'key-1',
   failureCode: null,
-  succeededAt: '2026-04-01T10:00:00Z',
+  succeededAt: toISODateString('2026-04-01T10:00:00Z'),
   canceledAt: null,
   refunds: [],
   disputes: [],
@@ -57,7 +58,7 @@ const sampleTransaction: PaymentTransactionResponse = {
 const sampleCheckoutSession: PaymentCheckoutSessionResponse = {
   url: 'https://checkout.stripe.com/session/abc123',
   sessionId: 'cs_abc123',
-  expiresAt: '2026-04-01T11:00:00Z',
+  expiresAt: toISODateString('2026-04-01T11:00:00Z'),
 };
 
 const sampleMethod: PaymentMethodResponse = {
@@ -67,7 +68,7 @@ const sampleMethod: PaymentMethodResponse = {
   providerMethodId: 'pm_abc123',
   displayLabel: 'Visa •••• 4242',
   isDefault: true,
-  expiresAt: '2028-12-01T00:00:00Z',
+  expiresAt: toISODateString('2028-12-01T00:00:00Z'),
   tenantId: null,
 };
 

--- a/packages/@granit/payments/src/types/index.ts
+++ b/packages/@granit/payments/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { ISODateString } from '@granit/types';
+
 export type PaymentStatus =
   | 'Created'
   | 'RequiresAction'
@@ -62,8 +64,8 @@ export interface PaymentTransactionResponse {
   readonly actionUrl: string | null;
   readonly idempotencyKey: string;
   readonly failureCode: string | null;
-  readonly succeededAt: string | null;
-  readonly canceledAt: string | null;
+  readonly succeededAt: ISODateString | null;
+  readonly canceledAt: ISODateString | null;
   readonly refunds: readonly PaymentRefundResponse[];
   readonly disputes: readonly PaymentDisputeResponse[];
   readonly tenantId: string | null;
@@ -76,8 +78,8 @@ export interface PaymentRefundResponse {
   readonly status: RefundStatus;
   readonly providerRefundId: string | null;
   readonly reason: string | null;
-  readonly createdAt: string;
-  readonly completedAt: string | null;
+  readonly createdAt: ISODateString;
+  readonly completedAt: ISODateString | null;
 }
 
 export interface PaymentDisputeResponse {
@@ -87,14 +89,14 @@ export interface PaymentDisputeResponse {
   readonly reason: string;
   readonly amount: number;
   readonly currency: string;
-  readonly createdAt: string;
-  readonly resolvedAt: string | null;
+  readonly createdAt: ISODateString;
+  readonly resolvedAt: ISODateString | null;
 }
 
 export interface PaymentCheckoutSessionResponse {
   readonly url: string;
   readonly sessionId: string;
-  readonly expiresAt: string;
+  readonly expiresAt: ISODateString;
 }
 
 export interface PaymentMethodResponse {
@@ -104,7 +106,7 @@ export interface PaymentMethodResponse {
   readonly providerMethodId: string;
   readonly displayLabel: string;
   readonly isDefault: boolean;
-  readonly expiresAt: string | null;
+  readonly expiresAt: ISODateString | null;
   readonly tenantId: string | null;
 }
 

--- a/packages/@granit/react-customer-balance/src/__tests__/use-customer-balance.test.tsx
+++ b/packages/@granit/react-customer-balance/src/__tests__/use-customer-balance.test.tsx
@@ -1,5 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -28,7 +29,7 @@ const sampleBalance: CustomerBalanceResponse = {
   currency: 'EUR',
   balance: 150.0,
   concurrencyStamp: 'stamp-1',
-  updatedAt: '2026-04-01T10:00:00Z',
+  updatedAt: toISODateString('2026-04-01T10:00:00Z'),
 };
 
 const sampleTransaction: BalanceTransactionResponse = {
@@ -39,8 +40,8 @@ const sampleTransaction: BalanceTransactionResponse = {
   reason: 'Welcome bonus',
   referenceId: null,
   referenceType: null,
-  expiresAt: '2026-12-31T23:59:59Z',
-  createdAt: '2026-04-01T10:00:00Z',
+  expiresAt: toISODateString('2026-12-31T23:59:59Z'),
+  createdAt: toISODateString('2026-04-01T10:00:00Z'),
 };
 
 function createWrapper(client: AxiosInstance, basePath?: string) {
@@ -157,7 +158,7 @@ describe('use-customer-balance', () => {
         currency: 'USD',
         source: 'ManualAdjustment',
         reason: 'Compensation',
-        expiresAt: '2026-12-31T23:59:59Z',
+        expiresAt: toISODateString('2026-12-31T23:59:59Z'),
       };
 
       const { result } = renderHook(() => useAddAdminCredit(), {

--- a/packages/@granit/react-invoicing/src/__tests__/use-invoicing.test.tsx
+++ b/packages/@granit/react-invoicing/src/__tests__/use-invoicing.test.tsx
@@ -1,5 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -58,11 +59,11 @@ const sampleInvoice: InvoiceResponse = {
   amountRemaining: 0,
   parentInvoiceId: null,
   creditNoteReason: null,
-  issuedAt: '2026-03-01T00:00:00Z',
-  dueAt: '2026-03-15T00:00:00Z',
-  paidAt: '2026-03-02T10:00:00Z',
-  periodStart: '2026-03-01T00:00:00Z',
-  periodEnd: '2026-04-01T00:00:00Z',
+  issuedAt: toISODateString('2026-03-01T00:00:00Z'),
+  dueAt: toISODateString('2026-03-15T00:00:00Z'),
+  paidAt: toISODateString('2026-03-02T10:00:00Z'),
+  periodStart: toISODateString('2026-03-01T00:00:00Z'),
+  periodEnd: toISODateString('2026-04-01T00:00:00Z'),
   lineItems: [],
 };
 
@@ -205,8 +206,8 @@ describe('useCreateInvoice', () => {
       billingReason: 'SubscriptionCycle',
       parentInvoiceId: null,
       creditNoteReason: null,
-      periodStart: '2026-03-01T00:00:00Z',
-      periodEnd: '2026-04-01T00:00:00Z',
+      periodStart: toISODateString('2026-03-01T00:00:00Z'),
+      periodEnd: toISODateString('2026-04-01T00:00:00Z'),
     };
 
     result.current.mutate(request);
@@ -256,8 +257,8 @@ describe('useFinalizeInvoice', () => {
     });
 
     const request: FinalizeInvoiceRequest = {
-      issuedAt: '2026-03-01T00:00:00Z',
-      dueAt: '2026-03-15T00:00:00Z',
+      issuedAt: toISODateString('2026-03-01T00:00:00Z'),
+      dueAt: toISODateString('2026-03-15T00:00:00Z'),
     };
 
     result.current.mutate({ id: 'inv-1', request });

--- a/packages/@granit/react-metering/src/__tests__/use-metering.test.tsx
+++ b/packages/@granit/react-metering/src/__tests__/use-metering.test.tsx
@@ -1,5 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -58,8 +59,8 @@ const sampleUsage: UsageAggregateResponse = {
   id: 'agg-1',
   meterDefinitionId: 'meter-1',
   period: 'Daily',
-  periodStart: '2026-04-01T00:00:00Z',
-  periodEnd: '2026-04-02T00:00:00Z',
+  periodStart: toISODateString('2026-04-01T00:00:00Z'),
+  periodEnd: toISODateString('2026-04-02T00:00:00Z'),
   aggregatedValue: 150,
   eventCount: 30,
 };
@@ -142,8 +143,8 @@ describe('use-metering', () => {
         () =>
           useUsageForPeriod({
             meterId: 'meter-1',
-            periodStart: '2026-04-01T00:00:00Z',
-            periodEnd: '2026-05-01T00:00:00Z',
+            periodStart: toISODateString('2026-04-01T00:00:00Z'),
+            periodEnd: toISODateString('2026-05-01T00:00:00Z'),
           }),
         { wrapper: createWrapper(client) }
       );
@@ -152,8 +153,8 @@ describe('use-metering', () => {
       expect(client.get).toHaveBeenCalledWith('/api/v1/metering/usage', {
         params: {
           meterId: 'meter-1',
-          periodStart: '2026-04-01T00:00:00Z',
-          periodEnd: '2026-05-01T00:00:00Z',
+          periodStart: toISODateString('2026-04-01T00:00:00Z'),
+          periodEnd: toISODateString('2026-05-01T00:00:00Z'),
         },
       });
       expect(result.current.data).toEqual(sampleUsage);

--- a/packages/@granit/react-payments-sepa-direct-debit/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-payments-sepa-direct-debit/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,5 @@
 import { createMswServer } from '@granit/testing/msw-server';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it } from 'vitest';
 
 import { createSepaDirectDebitHandlers, mandateQueryMetadata } from '../testing/index';
@@ -45,7 +46,7 @@ describe('createSepaDirectDebitHandlers', () => {
     const response = await fetch(`${BASE}/mandates/mdt_01/confirm`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ signedAt: '2026-06-01T00:00:00Z' }),
+      body: JSON.stringify({ signedAt: toISODateString('2026-06-01T00:00:00Z') }),
     });
     expect(response.status).toBe(200);
     const body = (await response.json()) as { status: string };

--- a/packages/@granit/react-payments-sepa-direct-debit/src/__tests__/use-sepa-direct-debit.test.tsx
+++ b/packages/@granit/react-payments-sepa-direct-debit/src/__tests__/use-sepa-direct-debit.test.tsx
@@ -1,5 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -34,8 +35,8 @@ const sampleMandate: MandateResponse = {
   creditorId: 'BE68ZZZ0123456789',
   providerName: 'GoCardless',
   providerMandateId: 'MD0001',
-  signedAt: '2026-05-01T10:00:00Z',
-  activatedAt: '2026-05-01T10:05:00Z',
+  signedAt: toISODateString('2026-05-01T10:00:00Z'),
+  activatedAt: toISODateString('2026-05-01T10:05:00Z'),
   cancelledAt: null,
   tenantId: null,
   concurrencyStamp: 'stamp-1',
@@ -153,11 +154,11 @@ describe('use-sepa-direct-debit', () => {
 
       await result.current.mutateAsync({
         id: 'mdt-1',
-        request: { signedAt: '2026-05-01T10:00:00Z' },
+        request: { signedAt: toISODateString('2026-05-01T10:00:00Z') },
       });
 
       expect(client.post).toHaveBeenCalledWith('/api/v1/sepa-direct-debit/mandates/mdt-1/confirm', {
-        signedAt: '2026-05-01T10:00:00Z',
+        signedAt: toISODateString('2026-05-01T10:00:00Z'),
       });
     });
   });

--- a/packages/@granit/react-payments-sepa-direct-debit/src/testing/data.ts
+++ b/packages/@granit/react-payments-sepa-direct-debit/src/testing/data.ts
@@ -1,3 +1,5 @@
+import { toISODateString } from '@granit/types';
+
 import type {
   MandateResponse,
   SepaConfigurationResponse,
@@ -14,8 +16,8 @@ export const sampleMandates: MandateResponse[] = [
     creditorId: 'BE68ZZZ0123456789',
     providerName: 'GoCardless',
     providerMandateId: 'MD0000001',
-    signedAt: '2026-05-01T10:00:00Z',
-    activatedAt: '2026-05-01T10:05:00Z',
+    signedAt: toISODateString('2026-05-01T10:00:00Z'),
+    activatedAt: toISODateString('2026-05-01T10:05:00Z'),
     cancelledAt: null,
     tenantId: 'tenant_01',
     concurrencyStamp: 'stamp_01',

--- a/packages/@granit/react-payments-sepa-direct-debit/src/testing/handlers.ts
+++ b/packages/@granit/react-payments-sepa-direct-debit/src/testing/handlers.ts
@@ -1,6 +1,7 @@
 import { DATE_OPERATORS, ENUM_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
 import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { created, notFound } from '@granit/testing/msw';
+import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants';
@@ -194,7 +195,7 @@ export function createSepaDirectDebitHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return HttpResponse.json({
         ...mandate,
         status: 'Cancelled',
-        cancelledAt: '2026-06-15T00:00:00Z',
+        cancelledAt: toISODateString('2026-06-15T00:00:00Z'),
       });
     }),
 

--- a/packages/@granit/react-payments/src/__tests__/use-payments.test.tsx
+++ b/packages/@granit/react-payments/src/__tests__/use-payments.test.tsx
@@ -1,5 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -54,7 +55,7 @@ const sampleTransaction: PaymentTransactionResponse = {
   actionUrl: null,
   idempotencyKey: 'key-1',
   failureCode: null,
-  succeededAt: '2026-04-01T10:00:00Z',
+  succeededAt: toISODateString('2026-04-01T10:00:00Z'),
   canceledAt: null,
   refunds: [],
   disputes: [],
@@ -68,14 +69,14 @@ const sampleRefund: PaymentRefundResponse = {
   status: 'Succeeded',
   providerRefundId: 're_abc123',
   reason: 'Customer request',
-  createdAt: '2026-04-02T10:00:00Z',
-  completedAt: '2026-04-02T10:05:00Z',
+  createdAt: toISODateString('2026-04-02T10:00:00Z'),
+  completedAt: toISODateString('2026-04-02T10:05:00Z'),
 };
 
 const sampleCheckoutSession: PaymentCheckoutSessionResponse = {
   url: 'https://checkout.stripe.com/session/abc123',
   sessionId: 'cs_abc123',
-  expiresAt: '2026-04-01T11:00:00Z',
+  expiresAt: toISODateString('2026-04-01T11:00:00Z'),
 };
 
 const sampleMethod: PaymentMethodResponse = {
@@ -85,7 +86,7 @@ const sampleMethod: PaymentMethodResponse = {
   providerMethodId: 'pm_abc123',
   displayLabel: 'Visa •••• 4242',
   isDefault: true,
-  expiresAt: '2028-12-01T00:00:00Z',
+  expiresAt: toISODateString('2028-12-01T00:00:00Z'),
   tenantId: null,
 };
 

--- a/packages/@granit/react-payments/src/testing/handlers.ts
+++ b/packages/@granit/react-payments/src/testing/handlers.ts
@@ -6,7 +6,7 @@ import {
 } from '@granit/query-engine';
 import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { created, noContent, notFound } from '@granit/testing/msw';
-import { toEntityId } from '@granit/types';
+import { toEntityId, toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants';
@@ -259,7 +259,7 @@ export function createPaymentsHandlers(baseUrl = DEFAULT_BASE_PATH) {
         {
           sessionId: 'cs_mock_checkout',
           url: `https://checkout.example.com/pay?amount=${body.amount}`,
-          expiresAt: '2099-01-01T00:00:00Z',
+          expiresAt: toISODateString('2099-01-01T00:00:00Z'),
         },
         { status: 201 }
       );

--- a/packages/@granit/react-subscriptions/src/__tests__/use-plans.test.tsx
+++ b/packages/@granit/react-subscriptions/src/__tests__/use-plans.test.tsx
@@ -1,5 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -40,7 +41,7 @@ const samplePrice: PlanPriceResponse = {
   amount: 29.99,
   currency: 'EUR',
   interval: 'Monthly',
-  effectiveFrom: '2026-01-01T00:00:00Z',
+  effectiveFrom: toISODateString('2026-01-01T00:00:00Z'),
   isCurrent: true,
   replacedByPriceId: null,
   replacedAt: null,

--- a/packages/@granit/react-subscriptions/src/__tests__/use-seats.test.tsx
+++ b/packages/@granit/react-subscriptions/src/__tests__/use-seats.test.tsx
@@ -1,5 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -16,7 +17,7 @@ import type { ReactNode } from 'react';
 const sampleSeat: SeatResponse = {
   id: 'seat-1',
   userId: 'user-1',
-  assignedAt: '2026-01-15T10:00:00Z',
+  assignedAt: toISODateString('2026-01-15T10:00:00Z'),
 };
 
 function createWrapper(client: AxiosInstance, basePath?: string) {

--- a/packages/@granit/react-subscriptions/src/__tests__/use-subscriptions.test.tsx
+++ b/packages/@granit/react-subscriptions/src/__tests__/use-subscriptions.test.tsx
@@ -1,5 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -29,14 +30,14 @@ const sampleSubscription: SubscriptionResponse = {
   planId: 'plan-1',
   status: 'Active',
   currency: 'EUR',
-  currentPeriodStart: '2026-01-01T00:00:00Z',
-  currentPeriodEnd: '2026-02-01T00:00:00Z',
+  currentPeriodStart: toISODateString('2026-01-01T00:00:00Z'),
+  currentPeriodEnd: toISODateString('2026-02-01T00:00:00Z'),
   trialEndsAt: null,
   cancelAtPeriodEnd: false,
   cancelledAt: null,
   cancellationReason: null,
   seatCount: 5,
-  createdAt: '2026-03-01T00:00:00Z',
+  createdAt: toISODateString('2026-03-01T00:00:00Z'),
   modifiedAt: null,
   planPriceId: 'price-1',
 };

--- a/packages/@granit/react-tax/package.json
+++ b/packages/@granit/react-tax/package.json
@@ -19,6 +19,7 @@
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/tax": "workspace:*",
+    "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"

--- a/packages/@granit/react-tax/src/__tests__/use-tax.test.tsx
+++ b/packages/@granit/react-tax/src/__tests__/use-tax.test.tsx
@@ -1,5 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -40,7 +41,7 @@ const mockValidateResponse: TaxValidateResponse = {
   companyName: 'Digital Dynamics SRL',
   companyAddress: 'Rue de la Loi 1, 1000 Bruxelles',
   requestIdentifier: 'req-abc-123',
-  validatedAt: '2026-04-04T10:00:00Z',
+  validatedAt: toISODateString('2026-04-04T10:00:00Z'),
   source: 'VIES',
 };
 
@@ -50,7 +51,7 @@ const mockBelgiumEntry: TaxRateEntry = {
   reducedRate: 6,
   superReducedRate: null,
   parkingRate: 12,
-  effectiveFrom: '2024-01-01',
+  effectiveFrom: toISODateString('2024-01-01'),
   effectiveTo: null,
 };
 
@@ -60,7 +61,7 @@ const mockLuxembourgEntry: TaxRateEntry = {
   reducedRate: 8,
   superReducedRate: 3,
   parkingRate: 14,
-  effectiveFrom: '2024-01-01',
+  effectiveFrom: toISODateString('2024-01-01'),
   effectiveTo: null,
 };
 
@@ -70,7 +71,7 @@ const mockBelgiumRate: TaxRateResponse = {
   reducedRate: 6,
   superReducedRate: null,
   parkingRate: 12,
-  effectiveFrom: '2024-01-01',
+  effectiveFrom: toISODateString('2024-01-01'),
   effectiveTo: null,
 };
 
@@ -80,7 +81,7 @@ const mockLuxembourgRate: TaxRateResponse = {
   reducedRate: 8,
   superReducedRate: 3,
   parkingRate: 14,
-  effectiveFrom: '2024-01-01',
+  effectiveFrom: toISODateString('2024-01-01'),
   effectiveTo: null,
 };
 

--- a/packages/@granit/react-tax/src/testing/data.ts
+++ b/packages/@granit/react-tax/src/testing/data.ts
@@ -1,3 +1,5 @@
+import { toISODateString } from '@granit/types';
+
 import type { TaxRateEntry, TaxValidateResponse } from '@granit/tax';
 import type { ISODateString } from '@granit/types';
 
@@ -8,7 +10,7 @@ export const sampleTaxRates: TaxRateEntry[] = [
     reducedRate: 6,
     superReducedRate: null,
     parkingRate: 12,
-    effectiveFrom: '2024-01-01T00:00:00Z' as ISODateString,
+    effectiveFrom: toISODateString('2024-01-01T00:00:00Z') as ISODateString,
     effectiveTo: null,
   },
   {
@@ -17,7 +19,7 @@ export const sampleTaxRates: TaxRateEntry[] = [
     reducedRate: 5.5,
     superReducedRate: 2.1,
     parkingRate: null,
-    effectiveFrom: '2024-01-01T00:00:00Z' as ISODateString,
+    effectiveFrom: toISODateString('2024-01-01T00:00:00Z') as ISODateString,
     effectiveTo: null,
   },
   {
@@ -26,7 +28,7 @@ export const sampleTaxRates: TaxRateEntry[] = [
     reducedRate: 7,
     superReducedRate: null,
     parkingRate: null,
-    effectiveFrom: '2024-01-01T00:00:00Z' as ISODateString,
+    effectiveFrom: toISODateString('2024-01-01T00:00:00Z') as ISODateString,
     effectiveTo: null,
   },
   {
@@ -35,7 +37,7 @@ export const sampleTaxRates: TaxRateEntry[] = [
     reducedRate: 9,
     superReducedRate: null,
     parkingRate: null,
-    effectiveFrom: '2024-01-01T00:00:00Z' as ISODateString,
+    effectiveFrom: toISODateString('2024-01-01T00:00:00Z') as ISODateString,
     effectiveTo: null,
   },
   {
@@ -44,7 +46,7 @@ export const sampleTaxRates: TaxRateEntry[] = [
     reducedRate: 5,
     superReducedRate: null,
     parkingRate: null,
-    effectiveFrom: '2024-01-01T00:00:00Z' as ISODateString,
+    effectiveFrom: toISODateString('2024-01-01T00:00:00Z') as ISODateString,
     effectiveTo: null,
   },
 ];
@@ -54,6 +56,6 @@ export const sampleValidation: TaxValidateResponse = {
   companyName: 'Digital Dynamics SRL',
   companyAddress: 'Rue de la Loi 42, 1000 Brussels',
   requestIdentifier: 'BE0123456789',
-  validatedAt: '2026-04-04T10:00:00Z' as ISODateString,
+  validatedAt: toISODateString('2026-04-04T10:00:00Z') as ISODateString,
   source: 'VIES',
 };

--- a/packages/@granit/subscriptions/src/__tests__/subscriptions-api.test.ts
+++ b/packages/@granit/subscriptions/src/__tests__/subscriptions-api.test.ts
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -52,7 +53,7 @@ const samplePrice: PlanPriceResponse = {
   amount: 29.99,
   currency: 'EUR',
   interval: 'Monthly',
-  effectiveFrom: '2026-01-01T00:00:00Z',
+  effectiveFrom: toISODateString('2026-01-01T00:00:00Z'),
   isCurrent: true,
   replacedByPriceId: null,
   replacedAt: null,
@@ -64,14 +65,14 @@ const sampleSubscription: SubscriptionResponse = {
   planId: 'plan-1',
   status: 'Active',
   currency: 'EUR',
-  currentPeriodStart: '2026-01-01T00:00:00Z',
-  currentPeriodEnd: '2026-02-01T00:00:00Z',
+  currentPeriodStart: toISODateString('2026-01-01T00:00:00Z'),
+  currentPeriodEnd: toISODateString('2026-02-01T00:00:00Z'),
   trialEndsAt: null,
   cancelAtPeriodEnd: false,
   cancelledAt: null,
   cancellationReason: null,
   seatCount: 5,
-  createdAt: '2026-03-01T00:00:00Z',
+  createdAt: toISODateString('2026-03-01T00:00:00Z'),
   modifiedAt: null,
   planPriceId: 'price-1',
 };
@@ -79,7 +80,7 @@ const sampleSubscription: SubscriptionResponse = {
 const sampleSeat: SeatResponse = {
   id: 'seat-1',
   userId: 'user-1',
-  assignedAt: '2026-01-15T10:00:00Z',
+  assignedAt: toISODateString('2026-01-15T10:00:00Z'),
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/@granit/subscriptions/src/types/index.ts
+++ b/packages/@granit/subscriptions/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { EntityId } from '@granit/types';
+import type { EntityId, ISODateString } from '@granit/types';
 
 /** Branded identifier for a plan. */
 export type PlanId = EntityId<'Plan'>;
@@ -46,7 +46,7 @@ export interface SubscriptionCreateRequest {
   readonly partyId: string;
   readonly planId: string;
   readonly currency: string;
-  readonly trialEndsAt: string | null;
+  readonly trialEndsAt: ISODateString | null;
 }
 
 export interface SubscriptionCancelRequest {
@@ -90,10 +90,10 @@ export interface PlanPriceResponse {
   readonly amount: number;
   readonly currency: string;
   readonly interval: string;
-  readonly effectiveFrom: string;
+  readonly effectiveFrom: ISODateString;
   readonly isCurrent: boolean;
   readonly replacedByPriceId: string | null;
-  readonly replacedAt: string | null;
+  readonly replacedAt: ISODateString | null;
   readonly productId?: string | null;
 }
 
@@ -103,24 +103,24 @@ export interface SubscriptionResponse {
   readonly planId: string;
   readonly status: SubscriptionStatus;
   readonly currency: string;
-  readonly currentPeriodStart: string;
-  readonly currentPeriodEnd: string;
-  readonly trialEndsAt: string | null;
+  readonly currentPeriodStart: ISODateString;
+  readonly currentPeriodEnd: ISODateString;
+  readonly trialEndsAt: ISODateString | null;
   readonly cancelAtPeriodEnd: boolean;
-  readonly cancelledAt: string | null;
+  readonly cancelledAt: ISODateString | null;
   readonly cancellationReason: string | null;
   readonly seatCount: number;
   /** UTC instant the subscription was created (ISO 8601). Always present. */
-  readonly createdAt: string;
+  readonly createdAt: ISODateString;
   /** Last-modification timestamp; `null` until first modified (coalesce `?? createdAt`). */
-  readonly modifiedAt: string | null;
+  readonly modifiedAt: ISODateString | null;
   readonly planPriceId: string | null;
 }
 
 export interface SeatResponse {
   readonly id: string;
   readonly userId: string;
-  readonly assignedAt: string;
+  readonly assignedAt: ISODateString;
 }
 
 export interface BulkMigratePriceResponse {

--- a/packages/@granit/tax/package.json
+++ b/packages/@granit/tax/package.json
@@ -16,11 +16,13 @@
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/query-engine": "workspace:*"
+    "@granit/query-engine": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/tax/src/__tests__/tax-api.test.ts
+++ b/packages/@granit/tax/src/__tests__/tax-api.test.ts
@@ -1,4 +1,5 @@
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import { getTaxRateByCountry, getTaxRatesMeta, queryTaxRates, validateTaxId } from '../api/tax-api';
@@ -25,7 +26,7 @@ const mockValidateResponse: TaxValidateResponse = {
   companyName: 'Digital Dynamics SRL',
   companyAddress: 'Rue de la Loi 1, 1000 Bruxelles',
   requestIdentifier: 'req-abc-123',
-  validatedAt: '2026-04-04T10:00:00Z',
+  validatedAt: toISODateString('2026-04-04T10:00:00Z'),
   source: 'VIES',
 };
 
@@ -35,7 +36,7 @@ const mockBelgiumEntry: TaxRateEntry = {
   reducedRate: 6,
   superReducedRate: null,
   parkingRate: 12,
-  effectiveFrom: '2024-01-01T00:00:00Z',
+  effectiveFrom: toISODateString('2024-01-01T00:00:00Z'),
   effectiveTo: null,
 };
 
@@ -45,7 +46,7 @@ const mockLuxembourgEntry: TaxRateEntry = {
   reducedRate: 8,
   superReducedRate: 3,
   parkingRate: 14,
-  effectiveFrom: '2024-01-01T00:00:00Z',
+  effectiveFrom: toISODateString('2024-01-01T00:00:00Z'),
   effectiveTo: null,
 };
 
@@ -55,7 +56,7 @@ const mockBelgiumRate: TaxRateResponse = {
   reducedRate: 6,
   superReducedRate: null,
   parkingRate: 12,
-  effectiveFrom: '2024-01-01',
+  effectiveFrom: toISODateString('2024-01-01'),
   effectiveTo: null,
 };
 
@@ -65,7 +66,7 @@ const mockLuxembourgRate: TaxRateResponse = {
   reducedRate: 8,
   superReducedRate: 3,
   parkingRate: 14,
-  effectiveFrom: '2024-01-01',
+  effectiveFrom: toISODateString('2024-01-01'),
   effectiveTo: null,
 };
 
@@ -116,7 +117,7 @@ describe('validateTaxId', () => {
       companyName: null,
       companyAddress: null,
       requestIdentifier: 'req-def-456',
-      validatedAt: '2026-04-04T10:00:00Z',
+      validatedAt: toISODateString('2026-04-04T10:00:00Z'),
       source: 'VIES',
     };
     const client = createMockClient();

--- a/packages/@granit/tax/src/types/index.ts
+++ b/packages/@granit/tax/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { ISODateString } from '@granit/types';
+
 /** Request payload for tax ID validation. */
 export interface TaxValidateRequest {
   readonly taxId: string;
@@ -10,7 +12,7 @@ export interface TaxValidateResponse {
   readonly companyName: string | null;
   readonly companyAddress: string | null;
   readonly requestIdentifier: string | null;
-  readonly validatedAt: string | null;
+  readonly validatedAt: ISODateString | null;
   readonly source: string;
 }
 
@@ -32,6 +34,6 @@ export interface TaxRateResponse {
   readonly reducedRate: number | null;
   readonly superReducedRate: number | null;
   readonly parkingRate: number | null;
-  readonly effectiveFrom: string | null;
-  readonly effectiveTo: string | null;
+  readonly effectiveFrom: ISODateString | null;
+  readonly effectiveTo: ISODateString | null;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -555,6 +555,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/dashboards:
     devDependencies:
@@ -891,6 +894,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/payments-sepa-direct-debit:
     devDependencies:
@@ -900,6 +906,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/payments-sepa-transfer:
     devDependencies:
@@ -3341,6 +3350,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/taxonomy:
     devDependencies:


### PR DESCRIPTION
## Summary

Datetime uniformization **slice 3/4**. Brands plain-string date-time fields as `ISODateString` across the billing domain: `@granit/{payments,subscriptions,invoicing,customer-balance,tax,metering,payments-sepa-direct-debit}`.

Covers `*At` fields **plus** period/window/effective ranges (`periodStart/End`, `currentPeriodStart/End`, `windowStart/End`, `effectiveFrom/To`).

- Reads unaffected (`ISODateString` ≡ `string`); only DTO construction is type-checked.
- Fixtures / MSW handlers wrap literals in `toISODateString()`.
- Adds `@granit/types` to packages (+ `react-*`) that lacked it (lockfile updated).
- **No wire/oracle change** (495 ✓).

## Verification
- `pnpm tsc` (full workspace) clean · lint clean · 425 tests green · oracle 495 ✓

## Showcase
Checking consumers; coordinated MR to follow if any billing fixtures construct these DTOs.