### PR TITLE
refactor(remaining)!: brand timestamps as ISODateString (datetime pass complete)

### DIFF
--- a/packages/@granit/activities/package.json
+++ b/packages/@granit/activities/package.json
@@ -15,10 +15,12 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "peerDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/activities/src/__tests__/activities-api.test.ts
+++ b/packages/@granit/activities/src/__tests__/activities-api.test.ts
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -33,12 +34,12 @@ const sampleActivity: ActivityResponse = {
   type: 'FollowUp',
   assignedToUserId: 'user-1',
   createdByUserId: 'user-2',
-  dueAt: '2026-05-10T10:00:00Z',
+  dueAt: toISODateString('2026-05-10T10:00:00Z'),
   description: 'Call back the client',
   status: 'Open',
   completedAt: null,
   completedByUserId: null,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
 };
 
 const sampleListResponse: ActivityListResponse = {
@@ -50,7 +51,7 @@ const sampleListResponse: ActivityListResponse = {
 
 const sampleCalendarItem: ActivityCalendarItemResponse = {
   id: 'act-1',
-  start: '2026-05-10T10:00:00Z',
+  start: toISODateString('2026-05-10T10:00:00Z'),
   end: null,
   title: 'Quote · FollowUp',
   color: 'open',
@@ -126,7 +127,7 @@ describe('createActivity', () => {
       entityId: 'quote-1',
       type: 'FollowUp',
       assignedToUserId: 'user-1',
-      dueAt: '2026-05-10T10:00:00Z',
+      dueAt: toISODateString('2026-05-10T10:00:00Z'),
       description: null,
     };
 
@@ -143,7 +144,7 @@ describe('completeActivity', () => {
     const completed: ActivityResponse = {
       ...sampleActivity,
       status: 'Done',
-      completedAt: '2026-05-09T15:00:00Z',
+      completedAt: toISODateString('2026-05-09T15:00:00Z'),
       completedByUserId: 'user-1',
     };
     vi.mocked(client.post).mockResolvedValue(axiosResponse(completed));
@@ -200,7 +201,9 @@ describe('rescheduleActivity', () => {
   it('PUTs to {id}/due-date', async () => {
     const client = createMockClient();
     vi.mocked(client.put).mockResolvedValue(axiosResponse(sampleActivity));
-    const request: RescheduleActivityRequest = { newDueAt: '2026-05-15T10:00:00Z' };
+    const request: RescheduleActivityRequest = {
+      newDueAt: toISODateString('2026-05-15T10:00:00Z'),
+    };
 
     await rescheduleActivity(client, basePath, 'act-1', request);
 
@@ -213,8 +216,8 @@ describe('getActivitiesCalendar', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleCalendarItem]));
     const filter: ActivityCalendarFilter = {
-      from: '2026-05-01T00:00:00Z',
-      to: '2026-05-31T23:59:59Z',
+      from: toISODateString('2026-05-01T00:00:00Z'),
+      to: toISODateString('2026-05-31T23:59:59Z'),
       assignee: 'me',
       status: 'OpenOrOverdue',
     };
@@ -223,8 +226,8 @@ describe('getActivitiesCalendar', () => {
 
     expect(client.get).toHaveBeenCalledWith(`${basePath}/calendar`, {
       params: {
-        from: '2026-05-01T00:00:00Z',
-        to: '2026-05-31T23:59:59Z',
+        from: toISODateString('2026-05-01T00:00:00Z'),
+        to: toISODateString('2026-05-31T23:59:59Z'),
         assignee: 'me',
         status: 'OpenOrOverdue',
       },
@@ -237,12 +240,15 @@ describe('getActivitiesCalendar', () => {
     vi.mocked(client.get).mockResolvedValue(axiosResponse([]));
 
     await getActivitiesCalendar(client, basePath, {
-      from: '2026-05-01T00:00:00Z',
-      to: '2026-05-31T23:59:59Z',
+      from: toISODateString('2026-05-01T00:00:00Z'),
+      to: toISODateString('2026-05-31T23:59:59Z'),
     });
 
     expect(client.get).toHaveBeenCalledWith(`${basePath}/calendar`, {
-      params: { from: '2026-05-01T00:00:00Z', to: '2026-05-31T23:59:59Z' },
+      params: {
+        from: toISODateString('2026-05-01T00:00:00Z'),
+        to: toISODateString('2026-05-31T23:59:59Z'),
+      },
     });
   });
 
@@ -252,8 +258,8 @@ describe('getActivitiesCalendar', () => {
 
     await expect(
       getActivitiesCalendar(client, basePath, {
-        from: '2026-05-01T00:00:00Z',
-        to: '2026-05-31T23:59:59Z',
+        from: toISODateString('2026-05-01T00:00:00Z'),
+        to: toISODateString('2026-05-31T23:59:59Z'),
       })
     ).rejects.toThrow(/401/);
   });

--- a/packages/@granit/activities/src/types/index.ts
+++ b/packages/@granit/activities/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { ISODateString } from '@granit/types';
+
 /**
  * Lifecycle status of an activity. Mirrors `Granit.Activities.Domain.ActivityStatus`
  * (string-serialized verbatim). Three terminal states only — `Overdue` is a
@@ -22,12 +24,12 @@ export interface ActivityResponse {
   readonly type: string;
   readonly assignedToUserId: string;
   readonly createdByUserId: string | null;
-  readonly dueAt: string;
+  readonly dueAt: ISODateString;
   readonly description: string | null;
   readonly status: ActivityStatus;
-  readonly completedAt: string | null;
+  readonly completedAt: ISODateString | null;
   readonly completedByUserId: string | null;
-  readonly createdAt: string;
+  readonly createdAt: ISODateString;
 }
 
 export interface ActivityListResponse {
@@ -55,7 +57,7 @@ export interface CreateActivityRequest {
   readonly entityId: string;
   readonly type: string;
   readonly assignedToUserId: string;
-  readonly dueAt: string;
+  readonly dueAt: ISODateString;
   readonly description?: string | null;
 }
 
@@ -77,13 +79,13 @@ export interface ReassignActivityRequest {
 }
 
 export interface RescheduleActivityRequest {
-  readonly newDueAt: string;
+  readonly newDueAt: ISODateString;
 }
 
 export interface ActivityCalendarItemResponse {
   readonly id: string;
-  readonly start: string;
-  readonly end: string | null;
+  readonly start: ISODateString;
+  readonly end: ISODateString | null;
   readonly title: string;
   readonly color: ActivityCalendarColor;
   readonly type: string;
@@ -94,8 +96,8 @@ export interface ActivityCalendarItemResponse {
 }
 
 export interface ActivityCalendarFilter {
-  readonly from: string;
-  readonly to: string;
+  readonly from: ISODateString;
+  readonly to: ISODateString;
   /** Either the literal `'me'` or a user GUID. */
   readonly assignee?: string;
   readonly entityType?: string;

--- a/packages/@granit/analytics/package.json
+++ b/packages/@granit/analytics/package.json
@@ -15,7 +15,8 @@
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/dashboards": "workspace:*"
+    "@granit/dashboards": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "@granit/dashboards": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   }
 }

--- a/packages/@granit/analytics/src/__tests__/data-snapshots.test.ts
+++ b/packages/@granit/analytics/src/__tests__/data-snapshots.test.ts
@@ -1,3 +1,4 @@
+import { toISODateString } from '@granit/types';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -38,7 +39,7 @@ const TABLE_FIXTURE: TableSnapshotEnvelope = {
     totalRowCount: 27,
   },
   sequence: 1,
-  emittedAt: '2026-04-29T12:34:56.789Z',
+  emittedAt: toISODateString('2026-04-29T12:34:56.789Z'),
   refreshHint: 'Dynamic',
   reasonLocalizationKey: null,
 };
@@ -60,7 +61,7 @@ const CHART_FIXTURE: ChartSnapshotEnvelope = {
     currency: 'EUR',
   },
   sequence: 1,
-  emittedAt: '2026-04-29T12:34:56.789Z',
+  emittedAt: toISODateString('2026-04-29T12:34:56.789Z'),
   refreshHint: 'Dynamic',
   reasonLocalizationKey: null,
 };
@@ -82,7 +83,7 @@ const PIVOT_FIXTURE: PivotSnapshotEnvelope = {
     currency: 'EUR',
   },
   sequence: 1,
-  emittedAt: '2026-04-29T12:34:56.789Z',
+  emittedAt: toISODateString('2026-04-29T12:34:56.789Z'),
   refreshHint: 'Dynamic',
   reasonLocalizationKey: null,
 };

--- a/packages/@granit/analytics/src/__tests__/kpi-snapshot.test.ts
+++ b/packages/@granit/analytics/src/__tests__/kpi-snapshot.test.ts
@@ -1,3 +1,4 @@
+import { toISODateString } from '@granit/types';
 import { describe, expect, it } from 'vitest';
 
 import { isKpiSnapshotEnvelope } from '../widgets';
@@ -27,7 +28,7 @@ const KPI_SNAPSHOT_FIXTURE: KpiSnapshotEnvelope = {
     },
   },
   sequence: 1,
-  emittedAt: '2026-04-29T12:34:56.789Z',
+  emittedAt: toISODateString('2026-04-29T12:34:56.789Z'),
   refreshHint: 'Dynamic',
   reasonLocalizationKey: null,
 };
@@ -37,7 +38,7 @@ const KPI_UNAVAILABLE_FIXTURE: KpiSnapshotEnvelope = {
   widgetType: 'Kpi',
   snapshot: null,
   sequence: 1,
-  emittedAt: '2026-04-29T12:34:56.789Z',
+  emittedAt: toISODateString('2026-04-29T12:34:56.789Z'),
   refreshHint: 'Static',
   reasonLocalizationKey: 'Widget:Unavailable.QueryAggregateNotImplemented',
 };
@@ -58,7 +59,7 @@ const KPI_QUERY_AGGREGATE_CURRENCY_FIXTURE: KpiSnapshotEnvelope = {
     previous: null,
   },
   sequence: 1,
-  emittedAt: '2026-04-29T12:34:56.789Z',
+  emittedAt: toISODateString('2026-04-29T12:34:56.789Z'),
   refreshHint: 'Dynamic',
   reasonLocalizationKey: null,
 };

--- a/packages/@granit/analytics/src/__tests__/map-snapshot.test.ts
+++ b/packages/@granit/analytics/src/__tests__/map-snapshot.test.ts
@@ -1,3 +1,4 @@
+import { toISODateString } from '@granit/types';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -47,7 +48,7 @@ const MAP_FIXTURE: MapSnapshotEnvelope = {
     defaultLayerKind: 'Satellite',
   },
   sequence: 1,
-  emittedAt: '2026-04-29T12:34:56.789Z',
+  emittedAt: toISODateString('2026-04-29T12:34:56.789Z'),
   refreshHint: 'Dynamic',
   reasonLocalizationKey: null,
 };

--- a/packages/@granit/analytics/src/types/metric.ts
+++ b/packages/@granit/analytics/src/types/metric.ts
@@ -29,6 +29,7 @@ export type Trend = 'up' | 'down' | 'flat';
 // clean. Re-exported here for source-level back-compat.
 export type { RefreshHint } from '@granit/dashboards';
 import type { RefreshHint } from '@granit/dashboards';
+import type { ISODateString } from '@granit/types';
 
 /**
  * Calendar-aware period token. Backend (`Granit.Analytics.Metrics.PeriodSpec`)
@@ -52,7 +53,7 @@ export type CompareToken = 'previous_period' | (string & {});
 
 export type PeriodSpec =
   | { readonly token: PeriodToken }
-  | { readonly from: string; readonly to: string };
+  | { readonly from: ISODateString; readonly to: ISODateString };
 
 export type CompareSpec = { readonly token: CompareToken };
 
@@ -86,6 +87,6 @@ export interface MetricResponse {
   /** Monotonic counter — future-proofs streaming transport (P2.4). */
   readonly sequence: number;
   /** ISO 8601 UTC timestamp the backend emitted the snapshot. */
-  readonly emittedAt: string;
+  readonly emittedAt: ISODateString;
   readonly refreshHint: RefreshHint;
 }

--- a/packages/@granit/cms-hostnames/package.json
+++ b/packages/@granit/cms-hostnames/package.json
@@ -8,10 +8,12 @@
     ".": "./src/index.ts"
   },
   "peerDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   }
 }

--- a/packages/@granit/cms-hostnames/src/__tests__/hostnames.test.ts
+++ b/packages/@granit/cms-hostnames/src/__tests__/hostnames.test.ts
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -21,7 +22,7 @@ const hostname: SiteHostnameResponse = {
   status: 'Active',
   isPrimary: true,
   expectedDnsRecords: [{ recordType: 'Cname', name: 'www', value: 'edge.granit.app' }],
-  lastCheckedAt: '2026-06-01T10:00:00Z',
+  lastCheckedAt: toISODateString('2026-06-01T10:00:00Z'),
   certificateStatus: 'Secured',
 };
 

--- a/packages/@granit/cms-hostnames/src/types/index.ts
+++ b/packages/@granit/cms-hostnames/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { ISODateString } from '@granit/types';
+
 // ---------------------------------------------------------------------------
 // @granit/cms-hostnames — site-scoped hostname DTOs
 //
@@ -46,7 +48,7 @@ export interface SiteHostnameResponse {
   /** DNS records the owner must configure (empty until verification starts). */
   readonly expectedDnsRecords: readonly SiteHostnameDnsRecordResponse[];
   /** When the last DNS check ran; `null` before any check (DateTimeOffset). */
-  readonly lastCheckedAt: string | null;
+  readonly lastCheckedAt: ISODateString | null;
   /** Edge-reported TLS certificate state. */
   readonly certificateStatus: string;
 }

--- a/packages/@granit/cms-redirects/package.json
+++ b/packages/@granit/cms-redirects/package.json
@@ -9,11 +9,13 @@
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/query-engine": "workspace:*"
+    "@granit/query-engine": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   }
 }

--- a/packages/@granit/cms-redirects/src/types/index.ts
+++ b/packages/@granit/cms-redirects/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { ISODateString } from '@granit/types';
+
 /**
  * Redirect wire-contract types for the Granit CMS API.
  * Mirrors `Granit.Cms.Redirects.Endpoints.Dtos.*` and the domain enums under
@@ -45,7 +47,7 @@ export interface RedirectResponse {
   readonly culture: string | null;
   readonly origin: RedirectOrigin;
   readonly hitCount: number;
-  readonly lastHitAt: string | null;
+  readonly lastHitAt: ISODateString | null;
 }
 
 /**

--- a/packages/@granit/cms-seo/package.json
+++ b/packages/@granit/cms-seo/package.json
@@ -9,11 +9,13 @@
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/query-engine": "workspace:*"
+    "@granit/query-engine": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   }
 }

--- a/packages/@granit/cms-seo/src/__tests__/seo-ai.test.ts
+++ b/packages/@granit/cms-seo/src/__tests__/seo-ai.test.ts
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -36,7 +37,7 @@ const suggestion: SeoSuggestionResponse = {
   structuredDataJson: null,
   modelId: 'gpt-4o-mini',
   promptTemplateVersion: 'v1',
-  createdAt: '2026-06-01T10:00:00.000Z',
+  createdAt: toISODateString('2026-06-01T10:00:00.000Z'),
   reviewedBy: null,
   reviewedAt: null,
   failureReason: null,

--- a/packages/@granit/cms-seo/src/types/index.ts
+++ b/packages/@granit/cms-seo/src/types/index.ts
@@ -1,3 +1,6 @@
+import type { PagedResult, QueryRequest } from '@granit/query-engine';
+import type { ISODateString } from '@granit/types';
+
 /**
  * SEO wire-contract types for the Granit CMS API.
  *
@@ -8,8 +11,6 @@
  * value possibly `null`); only parameters with a C# default are genuinely
  * optional (`?`). Guid / DateTimeOffset are serialized as `string`.
  */
-
-import type { PagedResult, QueryRequest } from '@granit/query-engine';
 
 // ─── Shared ──────────────────────────────────────────────────────────────────
 
@@ -183,7 +184,7 @@ export interface SeoMetadataResponse {
   readonly alternateOverrides: readonly Hreflang[];
   readonly xDefaultCulture: string | null;
   readonly statusAtLastReview: SeoReviewStatus;
-  readonly lastReviewedAt: string | null;
+  readonly lastReviewedAt: ISODateString | null;
   readonly concurrencyStamp: string;
 }
 
@@ -311,9 +312,9 @@ export interface SeoSuggestionResponse {
   readonly structuredDataJson: string | null;
   readonly modelId: string;
   readonly promptTemplateVersion: string;
-  readonly createdAt: string;
+  readonly createdAt: ISODateString;
   readonly reviewedBy: string | null;
-  readonly reviewedAt: string | null;
+  readonly reviewedAt: ISODateString | null;
   readonly failureReason: string | null;
   readonly rejectionReason: string | null;
 }

--- a/packages/@granit/cms/package.json
+++ b/packages/@granit/cms/package.json
@@ -10,10 +10,12 @@
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/query-engine": "workspace:*"
+    "@granit/query-engine": "workspace:*",
+    "@granit/types": "workspace:*"
   }
 }

--- a/packages/@granit/cms/src/__tests__/pages.test.ts
+++ b/packages/@granit/cms/src/__tests__/pages.test.ts
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import { getPageByPath, mintPreviewToken, resolvePreview } from '../api/pages';
@@ -81,7 +82,7 @@ describe('mintPreviewToken', () => {
     const req: MintPreviewTokenRequest = { culture: 'fr', lifetimeSeconds: 300 };
     const resp: MintPreviewTokenResponse = {
       token: 'tok_abc',
-      expiresAt: '2026-06-01T12:05:00Z',
+      expiresAt: toISODateString('2026-06-01T12:05:00Z'),
     };
     vi.mocked(client.post).mockResolvedValue(axiosResponse(resp));
 

--- a/packages/@granit/cms/src/types/index.ts
+++ b/packages/@granit/cms/src/types/index.ts
@@ -1,3 +1,6 @@
+import type { QueryRequest } from '@granit/query-engine';
+import type { ISODateString } from '@granit/types';
+
 /**
  * Wire-contract types for the Granit CMS API. Every shape mirrors the
  * corresponding .NET record/enum in `Granit.Cms.*.Endpoints/Dtos/` and the
@@ -6,8 +9,6 @@
  *
  * Source of truth: the running backend's OpenAPI spec.
  */
-
-import type { QueryRequest } from '@granit/query-engine';
 
 // ─── Block Catalog ──────────────────────────────────────────────────────────
 
@@ -130,7 +131,7 @@ export interface MintPreviewTokenRequest {
 export interface MintPreviewTokenResponse {
   readonly token: string;
   /** UTC ISO 8601 expiry instant. */
-  readonly expiresAt: string;
+  readonly expiresAt: ISODateString;
 }
 
 // ─── Menus ──────────────────────────────────────────────────────────────────
@@ -238,7 +239,7 @@ export interface PageVersionSummaryResponse {
   readonly version: number;
   readonly lifecycleStatus: string;
   readonly isPublished: boolean;
-  readonly publishedAt: string | null;
+  readonly publishedAt: ISODateString | null;
 }
 
 /**
@@ -472,7 +473,7 @@ export interface PageSearchParams {
 export interface PageEditingPresenceEntryResponse {
   readonly userId: string;
   /** UTC ISO 8601 instant the participant was last seen. */
-  readonly lastSeenAt: string;
+  readonly lastSeenAt: ISODateString;
 }
 
 /** Active participants for `GET /api/cms/pages/{id}/editing`. */

--- a/packages/@granit/diagnostics/package.json
+++ b/packages/@granit/diagnostics/package.json
@@ -14,11 +14,13 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/diagnostics/src/__tests__/diagnostics-api.test.ts
+++ b/packages/@granit/diagnostics/src/__tests__/diagnostics-api.test.ts
@@ -1,4 +1,5 @@
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import { DEFAULT_DIAGNOSTICS_BASE_PATH, getMonitoringHealth } from '../api/diagnostics-api';
@@ -18,7 +19,7 @@ const mockResponse: MonitoringHealthResponse = {
       tags: ['readiness', 'startup'],
     },
   ],
-  checkedAt: '2026-03-20T12:00:00+00:00',
+  checkedAt: toISODateString('2026-03-20T12:00:00+00:00'),
 };
 
 describe('getMonitoringHealth', () => {
@@ -52,7 +53,7 @@ describe('getMonitoringHealth', () => {
           tags: ['readiness'],
         },
       ],
-      checkedAt: '2026-03-20T12:00:00+00:00',
+      checkedAt: toISODateString('2026-03-20T12:00:00+00:00'),
     };
     vi.mocked(client.get).mockResolvedValueOnce({ data: multiService });
 

--- a/packages/@granit/diagnostics/src/types/index.ts
+++ b/packages/@granit/diagnostics/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { ISODateString } from '@granit/types';
+
 /** Health status of an individual service check. */
 export type ServiceStatus = 'healthy' | 'degraded' | 'down';
 
@@ -15,5 +17,5 @@ export interface ServiceHealthResponse {
 export interface MonitoringHealthResponse {
   readonly services: readonly ServiceHealthResponse[];
   /** ISO 8601 timestamp of when the health check was performed. */
-  readonly checkedAt: string;
+  readonly checkedAt: ISODateString;
 }

--- a/packages/@granit/entities-customization/package.json
+++ b/packages/@granit/entities-customization/package.json
@@ -15,10 +15,12 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "peerDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/entities-customization/src/__tests__/workspace-customization-api.test.ts
+++ b/packages/@granit/entities-customization/src/__tests__/workspace-customization-api.test.ts
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -16,7 +17,7 @@ const apiBase = '/api/v1';
 const sampleResponse: WorkspaceCustomizationResponse = {
   workspaceName: 'sales',
   deltas: [{ $type: 'hide', fieldName: 'pipelineForecast' }],
-  updatedAt: '2026-05-06T10:00:00Z',
+  updatedAt: toISODateString('2026-05-06T10:00:00Z'),
   updatedByUserId: 'user-1',
 };
 

--- a/packages/@granit/entities-customization/src/types/customization.ts
+++ b/packages/@granit/entities-customization/src/types/customization.ts
@@ -1,4 +1,5 @@
 import type { LayoutDelta } from './delta';
+import type { ISODateString } from '@granit/types';
 
 /**
  * Layout kind — the surface of an entity layout being customized. Mirrors
@@ -28,6 +29,6 @@ export interface WorkspaceCustomizationRequest {
 export interface WorkspaceCustomizationResponse {
   readonly workspaceName: string;
   readonly deltas: readonly LayoutDelta[];
-  readonly updatedAt: string | null;
+  readonly updatedAt: ISODateString | null;
   readonly updatedByUserId: string | null;
 }

--- a/packages/@granit/multi-tenancy/src/types/tenant-response.ts
+++ b/packages/@granit/multi-tenancy/src/types/tenant-response.ts
@@ -1,4 +1,4 @@
-import type { TenantId } from '@granit/types';
+import type { TenantId, ISODateString } from '@granit/types';
 
 /**
  * Tenant admin response.
@@ -11,7 +11,7 @@ export interface TenantResponse {
   readonly contactEmail: string | null;
   readonly activated: boolean;
   readonly jurisdiction: string | null;
-  readonly createdAt: string;
+  readonly createdAt: ISODateString;
   /**
    * Opaque optimistic-concurrency token. Echo it back in
    * {@link UpdateTenantRequest} to detect concurrent modifications (HTTP 409).

--- a/packages/@granit/notifications-mobile-push/package.json
+++ b/packages/@granit/notifications-mobile-push/package.json
@@ -14,7 +14,8 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   }
 }

--- a/packages/@granit/notifications-mobile-push/src/__tests__/mobile-push-api.test.ts
+++ b/packages/@granit/notifications-mobile-push/src/__tests__/mobile-push-api.test.ts
@@ -1,4 +1,5 @@
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -45,8 +46,16 @@ describe('mobile-push-api', () => {
   it('should fetch all device tokens', async () => {
     const client = createMockClient();
     const tokens = [
-      { deviceToken: 'token-1', platform: 'android' as const, createdAt: '2026-03-17T10:00:00Z' },
-      { deviceToken: 'token-2', platform: 'ios' as const, createdAt: '2026-03-17T11:00:00Z' },
+      {
+        deviceToken: 'token-1',
+        platform: 'android' as const,
+        createdAt: toISODateString('2026-03-17T10:00:00Z'),
+      },
+      {
+        deviceToken: 'token-2',
+        platform: 'ios' as const,
+        createdAt: toISODateString('2026-03-17T11:00:00Z'),
+      },
     ];
     vi.mocked(client.get).mockResolvedValueOnce({ data: tokens });
 

--- a/packages/@granit/notifications-mobile-push/src/types/index.ts
+++ b/packages/@granit/notifications-mobile-push/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { ISODateString } from '@granit/types';
+
 export type MobilePlatform = 'android' | 'ios';
 
 export interface DeviceTokenDto {
@@ -9,5 +11,5 @@ export interface DeviceTokenDto {
 export interface MobilePushTokenResponse {
   readonly deviceToken: string;
   readonly platform: MobilePlatform;
-  readonly createdAt: string;
+  readonly createdAt: ISODateString;
 }

--- a/packages/@granit/parties/src/__tests__/parties-api.test.ts
+++ b/packages/@granit/parties/src/__tests__/parties-api.test.ts
@@ -1,5 +1,5 @@
 import { createMockClient } from '@granit/testing';
-import { toEntityId } from '@granit/types';
+import { toEntityId, toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -85,7 +85,7 @@ const sampleParty: PartyResponse = {
   taxStatus: { isExempt: false, reverseCharge: false, vatin: null, evidenceBlobId: null },
   metadata: {},
   internalNotes: null,
-  createdAt: '2026-01-01T00:00:00Z',
+  createdAt: toISODateString('2026-01-01T00:00:00Z'),
   modifiedAt: null,
 };
 

--- a/packages/@granit/parties/src/__tests__/parties-duplicates-api.test.ts
+++ b/packages/@granit/parties/src/__tests__/parties-duplicates-api.test.ts
@@ -1,5 +1,5 @@
 import { createMockClient } from '@granit/testing';
-import { toEntityId } from '@granit/types';
+import { toEntityId, toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -29,8 +29,8 @@ const sampleCandidate: PartyDuplicateCandidateResponse = {
   tier: 'Deterministic',
   signals: [{ kind: 'TaxIdEqual', score: 1.0 }],
   dismissedAt: null,
-  createdAt: '2026-04-26T08:00:00Z',
-  updatedAt: '2026-04-27T02:00:00Z',
+  createdAt: toISODateString('2026-04-26T08:00:00Z'),
+  updatedAt: toISODateString('2026-04-27T02:00:00Z'),
 };
 
 describe('parties-duplicates-api', () => {

--- a/packages/@granit/parties/src/types/index.ts
+++ b/packages/@granit/parties/src/types/index.ts
@@ -1,5 +1,5 @@
 import type { FieldConflict, MergeRequest, MergeResult, WinnerSide } from '@granit/entity-merge';
-import type { EntityId, TenantId, UserId } from '@granit/types';
+import type { EntityId, TenantId, UserId, ISODateString } from '@granit/types';
 
 /** Branded identifier for a Party (Tier / Business Partner). */
 export type PartyId = EntityId<'Party'>;
@@ -132,9 +132,9 @@ export interface PartyResponse {
   /** Admin-only free-form notes (max 8 000 chars). NEVER store PII. */
   readonly internalNotes: string | null;
   /** UTC instant the party was created (ISO 8601). Always present. */
-  readonly createdAt: string;
+  readonly createdAt: ISODateString;
   /** Last-modification timestamp; `null` until first modified (coalesce `?? createdAt`). */
-  readonly modifiedAt: string | null;
+  readonly modifiedAt: ISODateString | null;
 }
 
 /** Lightweight summary used by list endpoints. */
@@ -352,11 +352,11 @@ export interface PartyDuplicateCandidateResponse {
   /** Per-signal contributions, sorted by score descending. */
   readonly signals: readonly DuplicateMatchSignalResponse[];
   /** When an admin marked the pair as "not a duplicate"; `null` while pending. */
-  readonly dismissedAt: string | null;
+  readonly dismissedAt: ISODateString | null;
   /** When the pair was first detected. */
-  readonly createdAt: string;
+  readonly createdAt: ISODateString;
   /** When the pair was last refreshed by a re-scan; `null` on initial detection. */
-  readonly updatedAt: string | null;
+  readonly updatedAt: ISODateString | null;
 }
 
 /**

--- a/packages/@granit/react-activities/package.json
+++ b/packages/@granit/react-activities/package.json
@@ -21,6 +21,7 @@
     "@granit/notifications": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-entities": "workspace:*",
+    "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
@@ -61,6 +62,7 @@
     "@granit/react-entities": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*",
     "msw": "^2.12.0"
   }
 }

--- a/packages/@granit/react-activities/src/__tests__/activity-calendar.test.tsx
+++ b/packages/@granit/react-activities/src/__tests__/activity-calendar.test.tsx
@@ -1,5 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import * as React from 'react';
@@ -14,7 +15,7 @@ import type { ReactNode } from 'react';
 
 const monday: ActivityCalendarItemResponse = {
   id: 'a1',
-  start: '2026-05-04T10:00:00Z',
+  start: toISODateString('2026-05-04T10:00:00Z'),
   end: null,
   title: 'Monday item',
   color: 'open',
@@ -27,7 +28,7 @@ const monday: ActivityCalendarItemResponse = {
 
 const overdueWed: ActivityCalendarItemResponse = {
   id: 'a2',
-  start: '2026-05-06T08:00:00Z',
+  start: toISODateString('2026-05-06T08:00:00Z'),
   end: null,
   title: 'Overdue Wed',
   color: 'overdue',
@@ -66,7 +67,10 @@ describe('<ActivityCalendar>', () => {
 
     await waitFor(() => expect(client.get).toHaveBeenCalled());
     expect(client.get).toHaveBeenCalledWith('/api/v1/activities/calendar', {
-      params: { from: '2026-05-04T00:00:00.000Z', to: '2026-05-11T00:00:00.000Z' },
+      params: {
+        from: toISODateString('2026-05-04T00:00:00.000Z'),
+        to: toISODateString('2026-05-11T00:00:00.000Z'),
+      },
     });
   });
 
@@ -81,7 +85,10 @@ describe('<ActivityCalendar>', () => {
 
     await waitFor(() => expect(client.get).toHaveBeenCalled());
     expect(client.get).toHaveBeenCalledWith('/api/v1/activities/calendar', {
-      params: { from: '2026-05-06T00:00:00.000Z', to: '2026-05-07T00:00:00.000Z' },
+      params: {
+        from: toISODateString('2026-05-06T00:00:00.000Z'),
+        to: toISODateString('2026-05-07T00:00:00.000Z'),
+      },
     });
   });
 
@@ -96,7 +103,10 @@ describe('<ActivityCalendar>', () => {
 
     await waitFor(() => expect(client.get).toHaveBeenCalled());
     expect(client.get).toHaveBeenCalledWith('/api/v1/activities/calendar', {
-      params: { from: '2026-05-01T00:00:00.000Z', to: '2026-06-01T00:00:00.000Z' },
+      params: {
+        from: toISODateString('2026-05-01T00:00:00.000Z'),
+        to: toISODateString('2026-06-01T00:00:00.000Z'),
+      },
     });
   });
 
@@ -116,8 +126,8 @@ describe('<ActivityCalendar>', () => {
     await waitFor(() => expect(client.get).toHaveBeenCalled());
     expect(client.get).toHaveBeenCalledWith('/api/v1/activities/calendar', {
       params: {
-        from: '2026-05-06T00:00:00.000Z',
-        to: '2026-05-07T00:00:00.000Z',
+        from: toISODateString('2026-05-06T00:00:00.000Z'),
+        to: toISODateString('2026-05-07T00:00:00.000Z'),
         assignee: 'me',
         status: 'OpenOrOverdue',
         entityType: 'Quote',
@@ -162,7 +172,10 @@ describe('<ActivityCalendar>', () => {
 
     await waitFor(() => {
       expect(client.get).toHaveBeenLastCalledWith('/api/v1/activities/calendar', {
-        params: { from: '2026-05-11T00:00:00.000Z', to: '2026-05-18T00:00:00.000Z' },
+        params: {
+          from: toISODateString('2026-05-11T00:00:00.000Z'),
+          to: toISODateString('2026-05-18T00:00:00.000Z'),
+        },
       });
     });
   });
@@ -182,7 +195,10 @@ describe('<ActivityCalendar>', () => {
 
     await waitFor(() => {
       expect(client.get).toHaveBeenLastCalledWith('/api/v1/activities/calendar', {
-        params: { from: '2026-05-06T00:00:00.000Z', to: '2026-05-07T00:00:00.000Z' },
+        params: {
+          from: toISODateString('2026-05-06T00:00:00.000Z'),
+          to: toISODateString('2026-05-07T00:00:00.000Z'),
+        },
       });
     });
   });

--- a/packages/@granit/react-activities/src/__tests__/activity-detail-panel.test.tsx
+++ b/packages/@granit/react-activities/src/__tests__/activity-detail-panel.test.tsx
@@ -1,5 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -19,19 +20,19 @@ const open: ActivityResponse = {
   type: 'FollowUp',
   assignedToUserId: 'u1',
   createdByUserId: 'u2',
-  dueAt: '2026-05-10T10:00:00Z',
+  dueAt: toISODateString('2026-05-10T10:00:00Z'),
   description: 'Call back the client',
   status: 'Open',
   completedAt: null,
   completedByUserId: null,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
 };
 
 const completed: ActivityResponse = {
   ...open,
   id: 'a2',
   status: 'Done',
-  completedAt: '2026-05-09T15:00:00Z',
+  completedAt: toISODateString('2026-05-09T15:00:00Z'),
   completedByUserId: 'u1',
 };
 

--- a/packages/@granit/react-activities/src/__tests__/activity-list.test.tsx
+++ b/packages/@granit/react-activities/src/__tests__/activity-list.test.tsx
@@ -1,5 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -19,12 +20,12 @@ const open: ActivityResponse = {
   type: 'FollowUp',
   assignedToUserId: 'u1',
   createdByUserId: 'u2',
-  dueAt: '2026-05-10T10:00:00Z',
+  dueAt: toISODateString('2026-05-10T10:00:00Z'),
   description: null,
   status: 'Open',
   completedAt: null,
   completedByUserId: null,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
 };
 
 const completed: ActivityResponse = { ...open, id: 'a2', status: 'Done' };

--- a/packages/@granit/react-activities/src/__tests__/use-activities.test.tsx
+++ b/packages/@granit/react-activities/src/__tests__/use-activities.test.tsx
@@ -1,5 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -23,12 +24,12 @@ const sampleActivity: ActivityResponse = {
   type: 'FollowUp',
   assignedToUserId: 'user-1',
   createdByUserId: 'user-2',
-  dueAt: '2026-05-10T10:00:00Z',
+  dueAt: toISODateString('2026-05-10T10:00:00Z'),
   description: null,
   status: 'Open',
   completedAt: null,
   completedByUserId: null,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
 };
 
 const sampleListResponse: ActivityListResponse = {
@@ -40,7 +41,7 @@ const sampleListResponse: ActivityListResponse = {
 
 const sampleCalendarItem: ActivityCalendarItemResponse = {
   id: 'act-1',
-  start: '2026-05-10T10:00:00Z',
+  start: toISODateString('2026-05-10T10:00:00Z'),
   end: null,
   title: 'Quote · FollowUp',
   color: 'open',
@@ -162,8 +163,8 @@ describe('useActivitiesCalendar', () => {
     const { result } = renderHook(
       () =>
         useActivitiesCalendar({
-          from: '2026-05-01T00:00:00Z',
-          to: '2026-05-31T23:59:59Z',
+          from: toISODateString('2026-05-01T00:00:00Z'),
+          to: toISODateString('2026-05-31T23:59:59Z'),
           assignee: 'me',
           status: 'OpenOrOverdue',
         }),
@@ -173,8 +174,8 @@ describe('useActivitiesCalendar', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(client.get).toHaveBeenCalledWith('/api/v1/activities/calendar', {
       params: {
-        from: '2026-05-01T00:00:00Z',
-        to: '2026-05-31T23:59:59Z',
+        from: toISODateString('2026-05-01T00:00:00Z'),
+        to: toISODateString('2026-05-31T23:59:59Z'),
         assignee: 'me',
         status: 'OpenOrOverdue',
       },

--- a/packages/@granit/react-activities/src/__tests__/use-activity-mutations.test.tsx
+++ b/packages/@granit/react-activities/src/__tests__/use-activity-mutations.test.tsx
@@ -1,5 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -26,12 +27,12 @@ const sampleActivity: ActivityResponse = {
   type: 'FollowUp',
   assignedToUserId: 'user-1',
   createdByUserId: 'user-2',
-  dueAt: '2026-05-10T10:00:00Z',
+  dueAt: toISODateString('2026-05-10T10:00:00Z'),
   description: null,
   status: 'Open',
   completedAt: null,
   completedByUserId: null,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
 };
 
 interface Harness {
@@ -68,7 +69,7 @@ describe('useCreateActivity', () => {
       entityId: 'quote-1',
       type: 'FollowUp',
       assignedToUserId: 'user-1',
-      dueAt: '2026-05-10T10:00:00Z',
+      dueAt: toISODateString('2026-05-10T10:00:00Z'),
       description: null,
     });
 
@@ -92,7 +93,7 @@ describe('useCreateActivity', () => {
         entityId: 'quote-1',
         type: 'FollowUp',
         assignedToUserId: 'user-1',
-        dueAt: '2026-05-10T10:00:00Z',
+        dueAt: toISODateString('2026-05-10T10:00:00Z'),
         description: null,
       })
     ).rejects.toThrow(/boom/);
@@ -201,11 +202,11 @@ describe('useRescheduleActivity', () => {
     const { result } = renderHook(() => useRescheduleActivity(), { wrapper });
     await result.current.mutateAsync({
       id: 'act-1',
-      request: { newDueAt: '2026-05-15T10:00:00Z' },
+      request: { newDueAt: toISODateString('2026-05-15T10:00:00Z') },
     });
 
     expect(client.put).toHaveBeenCalledWith('/api/v1/activities/act-1/due-date', {
-      newDueAt: '2026-05-15T10:00:00Z',
+      newDueAt: toISODateString('2026-05-15T10:00:00Z'),
     });
     const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
     expect(keys).toEqual([

--- a/packages/@granit/react-activities/src/components/activity-calendar.tsx
+++ b/packages/@granit/react-activities/src/components/activity-calendar.tsx
@@ -1,3 +1,4 @@
+import { toISODateString } from '@granit/types';
 import { useMemo, useState, type ReactNode } from 'react';
 
 import { useActivitiesCalendar } from '../hooks/use-activities';
@@ -68,8 +69,8 @@ export function ActivityCalendar({
 
   const query = useActivitiesCalendar({
     ...filter,
-    from: window.from.toISOString(),
-    to: window.to.toISOString(),
+    from: toISODateString(window.from.toISOString()),
+    to: toISODateString(window.to.toISOString()),
   });
 
   const days = useMemo(() => groupByDay(query.data ?? [], window), [query.data, window]);

--- a/packages/@granit/react-activities/src/hooks/use-activities.ts
+++ b/packages/@granit/react-activities/src/hooks/use-activities.ts
@@ -57,8 +57,8 @@ export function useActivity(id: string): UseQueryResult<ActivityResponse> {
  * @example
  * ```tsx
  * const { data } = useActivitiesCalendar({
- *   from: '2026-05-01T00:00:00Z',
- *   to: '2026-05-31T23:59:59Z',
+ *   from: toISODateString('2026-05-01T00:00:00Z'),
+ *   to: toISODateString('2026-05-31T23:59:59Z'),
  *   assignee: 'me',
  *   status: 'OpenOrOverdue',
  * });

--- a/packages/@granit/react-activities/src/hooks/use-activity-mutations.ts
+++ b/packages/@granit/react-activities/src/hooks/use-activity-mutations.ts
@@ -154,7 +154,7 @@ export function useReassignActivity(): UseMutationResult<
  * @example
  * ```tsx
  * const reschedule = useRescheduleActivity();
- * await reschedule.mutateAsync({ id: 'act-1', request: { newDueAt: '...' } });
+ * await reschedule.mutateAsync({ id: 'act-1', request: { newDueAt: toISODateString('...') } });
  * ```
  */
 export function useRescheduleActivity(): UseMutationResult<

--- a/packages/@granit/react-activities/src/testing/data.ts
+++ b/packages/@granit/react-activities/src/testing/data.ts
@@ -1,3 +1,4 @@
+import { toISODateString, type ISODateString } from '@granit/types';
 // ---------------------------------------------------------------------------
 // @granit/react-activities/testing — mock data
 // ---------------------------------------------------------------------------
@@ -10,7 +11,8 @@ const COLLEAGUE = 'b1e22a44-1234-5678-9abc-def012345678';
 const ENTITY_TYPE = 'Granit.Parties.Party';
 
 const now = Date.now();
-const iso = (offsetDays: number): string => new Date(now + offsetDays * DAY).toISOString();
+const iso = (offsetDays: number): ISODateString =>
+  toISODateString(new Date(now + offsetDays * DAY).toISOString());
 
 /**
  * Mock activities spanning the three lifecycle states the backend ships

--- a/packages/@granit/react-activities/src/testing/handlers.ts
+++ b/packages/@granit/react-activities/src/testing/handlers.ts
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------------------
 
 import { created, notFound } from '@granit/testing/msw';
+import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants';
@@ -65,7 +66,7 @@ export function createActivitiesHandlers(baseUrl = DEFAULT_BASE_PATH) {
         status: 'Open',
         completedAt: null,
         completedByUserId: null,
-        createdAt: new Date().toISOString(),
+        createdAt: toISODateString(new Date().toISOString()),
       };
       activities.unshift({ ...newActivity });
       return created(newActivity);
@@ -75,7 +76,7 @@ export function createActivitiesHandlers(baseUrl = DEFAULT_BASE_PATH) {
       const activity = find(params.id);
       if (!activity) return notFound();
       activity.status = 'Done';
-      activity.completedAt = new Date().toISOString();
+      activity.completedAt = toISODateString(new Date().toISOString());
       activity.completedByUserId = MOCK_ACTOR;
       return HttpResponse.json(activity);
     }),
@@ -99,7 +100,7 @@ export function createActivitiesHandlers(baseUrl = DEFAULT_BASE_PATH) {
       const activity = find(params.id);
       if (!activity) return notFound();
       const body = (await request.json()) as { newDueAt: string };
-      activity.dueAt = body.newDueAt;
+      activity.dueAt = toISODateString(body.newDueAt);
       return HttpResponse.json(activity);
     }),
   ];

--- a/packages/@granit/react-analytics/package.json
+++ b/packages/@granit/react-analytics/package.json
@@ -22,6 +22,7 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/react-dashboard-editor": "workspace:*",
     "@granit/react-dashboards": "workspace:*",
+    "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "lucide-react": "^1.0.0",
     "msw": "^2.12.0",
@@ -62,6 +63,7 @@
     "@granit/react-dashboards": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*",
     "msw": "^2.12.0"
   }
 }

--- a/packages/@granit/react-analytics/src/__tests__/kpi-tile-view.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/kpi-tile-view.test.tsx
@@ -1,3 +1,4 @@
+import { toISODateString } from '@granit/types';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -9,7 +10,7 @@ function makeResponse(overrides: Partial<MetricResponse['snapshot']> = {}): Metr
   return {
     name: 'Test.Metric',
     sequence: 1,
-    emittedAt: '2026-04-28T12:00:00Z',
+    emittedAt: toISODateString('2026-04-28T12:00:00Z'),
     refreshHint: 'Dynamic',
     snapshot: {
       value: 12,

--- a/packages/@granit/react-analytics/src/__tests__/pivot-snapshot-widget.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/pivot-snapshot-widget.test.tsx
@@ -1,3 +1,4 @@
+import { toISODateString } from '@granit/types';
 import { render } from '@testing-library/react';
 import i18n from 'i18next';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
@@ -35,7 +36,7 @@ const ENVELOPE_BASE = {
   id: '8c6b1e10-0000-0000-0000-000000000001',
   status: 'Snapshot' as const,
   sequence: 1,
-  emittedAt: '2026-04-29T12:34:56.789Z',
+  emittedAt: toISODateString('2026-04-29T12:34:56.789Z'),
   refreshHint: 'Dynamic' as const,
   reasonLocalizationKey: null,
 };

--- a/packages/@granit/react-analytics/src/__tests__/table-snapshot-widget.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/table-snapshot-widget.test.tsx
@@ -1,3 +1,4 @@
+import { toISODateString } from '@granit/types';
 import { render } from '@testing-library/react';
 import i18n from 'i18next';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
@@ -37,7 +38,7 @@ const ENVELOPE_BASE = {
   id: '8c6b1e10-0000-0000-0000-000000000001',
   status: 'Snapshot' as const,
   sequence: 1,
-  emittedAt: '2026-04-29T12:34:56.789Z',
+  emittedAt: toISODateString('2026-04-29T12:34:56.789Z'),
   refreshHint: 'Dynamic' as const,
   reasonLocalizationKey: null,
 };

--- a/packages/@granit/react-analytics/src/__tests__/use-metric.test.ts
+++ b/packages/@granit/react-analytics/src/__tests__/use-metric.test.ts
@@ -1,3 +1,4 @@
+import { toISODateString } from '@granit/types';
 import { describe, expect, it } from 'vitest';
 
 import { normalizeMetricRequest } from '../hooks/use-metric';
@@ -12,10 +13,16 @@ describe('normalizeMetricRequest', () => {
 
   it('keeps a custom range intact', () => {
     const input: MetricRequest = {
-      period: { from: '2026-04-01T00:00:00Z', to: '2026-04-28T00:00:00Z' },
+      period: {
+        from: toISODateString('2026-04-01T00:00:00Z'),
+        to: toISODateString('2026-04-28T00:00:00Z'),
+      },
     };
     expect(normalizeMetricRequest(input)).toEqual({
-      period: { from: '2026-04-01T00:00:00Z', to: '2026-04-28T00:00:00Z' },
+      period: {
+        from: toISODateString('2026-04-01T00:00:00Z'),
+        to: toISODateString('2026-04-28T00:00:00Z'),
+      },
     });
   });
 

--- a/packages/@granit/react-analytics/src/components/kpi-snapshot-tile.tsx
+++ b/packages/@granit/react-analytics/src/components/kpi-snapshot-tile.tsx
@@ -1,4 +1,5 @@
 import { isKpiSnapshotEnvelope } from '@granit/analytics';
+import { toISODateString } from '@granit/types';
 import { useTranslation } from 'react-i18next';
 
 import { KpiTileView } from './kpi-tile-view';
@@ -31,7 +32,7 @@ export function KpiSnapshotTile({ widget }: { readonly widget: DashboardRendered
         name: widget.id,
         snapshot: widget.snapshot,
         sequence: Number(widget.sequence),
-        emittedAt: widget.emittedAt,
+        emittedAt: toISODateString(widget.emittedAt),
         refreshHint: widget.refreshHint,
       }}
       isLoading={false}

--- a/packages/@granit/react-analytics/src/testing/data.ts
+++ b/packages/@granit/react-analytics/src/testing/data.ts
@@ -1,10 +1,11 @@
+import { toISODateString } from '@granit/types';
 // ---------------------------------------------------------------------------
 // @granit/react-analytics/testing — mock data
 // ---------------------------------------------------------------------------
 
 import type { MetricResponse } from '@granit/analytics';
 
-const emittedAt = new Date().toISOString();
+const emittedAt = toISODateString(new Date().toISOString());
 
 /** Mock metric envelopes keyed by metric name, served by `POST /metrics/{name}`. */
 export const mockMetricResponses: Readonly<Record<string, MetricResponse>> = {

--- a/packages/@granit/react-cms-hostnames/package.json
+++ b/packages/@granit/react-cms-hostnames/package.json
@@ -14,12 +14,14 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/cms-hostnames": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"

--- a/packages/@granit/react-cms-hostnames/src/testing/data.ts
+++ b/packages/@granit/react-cms-hostnames/src/testing/data.ts
@@ -1,3 +1,4 @@
+import { toISODateString } from '@granit/types';
 // ---------------------------------------------------------------------------
 // @granit/react-cms-hostnames/testing — mock fixtures
 // ---------------------------------------------------------------------------
@@ -18,7 +19,7 @@ export const mockHostnames: SiteHostnameResponse[] = [
     status: 'Active',
     isPrimary: true,
     expectedDnsRecords: [{ recordType: 'Cname', name: 'www', value: 'edge.granit.app' }],
-    lastCheckedAt: '2026-06-01T08:00:00Z',
+    lastCheckedAt: toISODateString('2026-06-01T08:00:00Z'),
     certificateStatus: 'Secured',
   },
   {

--- a/packages/@granit/react-cms-hostnames/src/testing/handlers.ts
+++ b/packages/@granit/react-cms-hostnames/src/testing/handlers.ts
@@ -3,6 +3,7 @@
 // ---------------------------------------------------------------------------
 
 import { created } from '@granit/testing/msw';
+import { toISODateString } from '@granit/types';
 import { http, HttpResponse, type RequestHandler } from 'msw';
 
 import { mockHostnames } from './data';
@@ -59,7 +60,7 @@ export function createCmsHostnamesHandlers(baseUrl = '/api/cms'): RequestHandler
       const updated: SiteHostnameResponse = {
         ...existing,
         status: 'Verifying',
-        lastCheckedAt: '2026-06-04T00:00:00Z',
+        lastCheckedAt: toISODateString('2026-06-04T00:00:00Z'),
       };
       hostnames[hostnames.indexOf(existing)] = updated;
       return HttpResponse.json(updated, { status: 202 });

--- a/packages/@granit/react-cms-redirects/package.json
+++ b/packages/@granit/react-cms-redirects/package.json
@@ -15,12 +15,14 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/cms-redirects": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"

--- a/packages/@granit/react-cms-redirects/src/testing/data.ts
+++ b/packages/@granit/react-cms-redirects/src/testing/data.ts
@@ -1,3 +1,4 @@
+import { toISODateString } from '@granit/types';
 // ---------------------------------------------------------------------------
 // @granit/react-cms-redirects/testing — mock fixtures
 // ---------------------------------------------------------------------------
@@ -20,7 +21,7 @@ export const mockRedirects: RedirectResponse[] = [
     culture: null,
     origin: 'Manual',
     hitCount: 12,
-    lastHitAt: '2026-05-01T09:30:00+00:00',
+    lastHitAt: toISODateString('2026-05-01T09:30:00+00:00'),
   },
   {
     id: '50000000-0000-4000-8000-000000000002',

--- a/packages/@granit/react-cms-seo/package.json
+++ b/packages/@granit/react-cms-seo/package.json
@@ -14,12 +14,14 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/cms-seo": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"

--- a/packages/@granit/react-cms-seo/src/__tests__/use-seo-ai.test.ts
+++ b/packages/@granit/react-cms-seo/src/__tests__/use-seo-ai.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@granit/cms-seo';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -58,7 +59,7 @@ const suggestion: SeoSuggestionResponse = {
   structuredDataJson: null,
   modelId: 'gpt-4o-mini',
   promptTemplateVersion: 'v1',
-  createdAt: '2026-06-01T10:00:00.000Z',
+  createdAt: toISODateString('2026-06-01T10:00:00.000Z'),
   reviewedBy: null,
   reviewedAt: null,
   failureReason: null,

--- a/packages/@granit/react-cms-seo/src/testing/data.ts
+++ b/packages/@granit/react-cms-seo/src/testing/data.ts
@@ -1,3 +1,4 @@
+import { toISODateString } from '@granit/types';
 // ---------------------------------------------------------------------------
 // @granit/react-cms-seo/testing — mock fixtures
 // ---------------------------------------------------------------------------
@@ -84,7 +85,7 @@ export const mockSeoSuggestions: SeoSuggestionResponse[] = [
     structuredDataJson: null,
     modelId: 'gpt-4o-mini',
     promptTemplateVersion: 'v1',
-    createdAt: '2026-06-01T10:00:00.000Z',
+    createdAt: toISODateString('2026-06-01T10:00:00.000Z'),
     reviewedBy: null,
     reviewedAt: null,
     failureReason: null,

--- a/packages/@granit/react-cms/package.json
+++ b/packages/@granit/react-cms/package.json
@@ -16,6 +16,7 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*",
     "@granit/utils": "workspace:*",
     "@puckeditor/core": "^0.21.3",
     "@tanstack/react-query": "^5.0.0"
@@ -25,6 +26,7 @@
     "@granit/cms": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/types": "workspace:*",
     "@granit/utils": "workspace:*",
     "@puckeditor/core": "^0.21.0",
     "@tanstack/react-query": "^5.0.0",

--- a/packages/@granit/react-diagnostics/package.json
+++ b/packages/@granit/react-diagnostics/package.json
@@ -17,6 +17,7 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/diagnostics": "workspace:*",
+    "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
@@ -42,6 +43,7 @@
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   }
 }

--- a/packages/@granit/react-diagnostics/src/__tests__/use-monitoring-health.test.tsx
+++ b/packages/@granit/react-diagnostics/src/__tests__/use-monitoring-health.test.tsx
@@ -1,5 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -31,7 +32,7 @@ const mockResponse: MonitoringHealthResponse = {
       tags: ['readiness', 'startup'],
     },
   ],
-  checkedAt: '2026-03-20T12:00:00+00:00',
+  checkedAt: toISODateString('2026-03-20T12:00:00+00:00'),
 };
 
 describe('buildDiagnosticsQueryKey', () => {

--- a/packages/@granit/react-diagnostics/src/testing/data.ts
+++ b/packages/@granit/react-diagnostics/src/testing/data.ts
@@ -1,3 +1,5 @@
+import { toISODateString } from '@granit/types';
+
 import type { MonitoringHealthResponse } from '@granit/diagnostics';
 
 export const mockDiagnosticsHealth: MonitoringHealthResponse = {
@@ -59,5 +61,5 @@ export const mockDiagnosticsHealth: MonitoringHealthResponse = {
       tags: ['readiness'],
     },
   ],
-  checkedAt: '2026-03-12T10:00:00Z',
+  checkedAt: toISODateString('2026-03-12T10:00:00Z'),
 };

--- a/packages/@granit/react-entities-customization/package.json
+++ b/packages/@granit/react-entities-customization/package.json
@@ -17,6 +17,7 @@
     "@granit/api-client": "workspace:*",
     "@granit/entities-customization": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "react": "^19.0.0"
   },
@@ -34,6 +35,7 @@
     "@granit/entities-customization": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   }
 }

--- a/packages/@granit/react-multi-tenancy/package.json
+++ b/packages/@granit/react-multi-tenancy/package.json
@@ -20,6 +20,7 @@
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
+    "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
@@ -51,6 +52,7 @@
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/react-api-client": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   }
 }

--- a/packages/@granit/react-multi-tenancy/src/__tests__/use-tenant-admin.test.tsx
+++ b/packages/@granit/react-multi-tenancy/src/__tests__/use-tenant-admin.test.tsx
@@ -5,6 +5,7 @@ import {
   getTenant,
   updateTenant,
 } from '@granit/multi-tenancy';
+import { toISODateString } from '@granit/types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -57,7 +58,7 @@ const SAMPLE_TENANT: TenantResponse = {
   contactEmail: 'admin@tenant-1.test',
   activated: true,
   jurisdiction: 'BE',
-  createdAt: '2026-01-01T00:00:00.000Z',
+  createdAt: toISODateString('2026-01-01T00:00:00.000Z'),
   concurrencyStamp: 'stamp-1',
 } as unknown as TenantResponse;
 

--- a/packages/@granit/react-multi-tenancy/src/testing/data.ts
+++ b/packages/@granit/react-multi-tenancy/src/testing/data.ts
@@ -1,3 +1,5 @@
+import { toISODateString } from '@granit/types';
+
 import type { TenantResponse } from '@granit/multi-tenancy';
 import type { Mutable } from '@granit/testing';
 
@@ -9,7 +11,7 @@ export const mockTenants: Mutable<TenantResponse>[] = [
     contactEmail: 'admin@acme.example',
     activated: true,
     jurisdiction: 'BE',
-    createdAt: '2025-09-01T00:00:00Z',
+    createdAt: toISODateString('2025-09-01T00:00:00Z'),
     concurrencyStamp: 'stamp-acme-0001',
   },
   {
@@ -19,7 +21,7 @@ export const mockTenants: Mutable<TenantResponse>[] = [
     contactEmail: 'it@globex.example',
     activated: true,
     jurisdiction: 'FR',
-    createdAt: '2025-11-15T00:00:00Z',
+    createdAt: toISODateString('2025-11-15T00:00:00Z'),
     concurrencyStamp: 'stamp-globex-0001',
   },
   {
@@ -29,7 +31,7 @@ export const mockTenants: Mutable<TenantResponse>[] = [
     contactEmail: null,
     activated: false,
     jurisdiction: null,
-    createdAt: '2026-01-20T00:00:00Z',
+    createdAt: toISODateString('2026-01-20T00:00:00Z'),
     concurrencyStamp: 'stamp-initech-0001',
   },
 ];

--- a/packages/@granit/react-multi-tenancy/src/testing/handlers.ts
+++ b/packages/@granit/react-multi-tenancy/src/testing/handlers.ts
@@ -6,6 +6,7 @@ import {
 } from '@granit/query-engine';
 import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { noContent, notFound, pagedResponse } from '@granit/testing/msw';
+import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants';
@@ -146,7 +147,7 @@ export function createTenantHandlers(baseUrl = DEFAULT_BASE_PATH) {
         contactEmail: body.contactEmail ?? null,
         activated: true,
         jurisdiction: body.jurisdiction ?? null,
-        createdAt: new Date().toISOString(),
+        createdAt: toISODateString(new Date().toISOString()),
         concurrencyStamp: `stamp-${Date.now()}`,
       };
       mockTenants.push(newTenant);

--- a/packages/@granit/react-notifications-mobile-push/package.json
+++ b/packages/@granit/react-notifications-mobile-push/package.json
@@ -18,6 +18,7 @@
     "@granit/api-client": "workspace:*",
     "@granit/notifications-mobile-push": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "react": "^19.0.0"
   },
@@ -26,7 +27,8 @@
     "@granit/api-client": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-notifications-mobile-push/src/__tests__/use-device-tokens.test.tsx
+++ b/packages/@granit/react-notifications-mobile-push/src/__tests__/use-device-tokens.test.tsx
@@ -1,6 +1,7 @@
 import { listDeviceTokens } from '@granit/notifications-mobile-push';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -20,12 +21,12 @@ const mockTokens: readonly MobilePushTokenResponse[] = [
   {
     deviceToken: 'token-abc-123',
     platform: 'android',
-    createdAt: '2026-03-17T10:00:00Z',
+    createdAt: toISODateString('2026-03-17T10:00:00Z'),
   },
   {
     deviceToken: 'token-def-456',
     platform: 'ios',
-    createdAt: '2026-03-17T09:00:00Z',
+    createdAt: toISODateString('2026-03-17T09:00:00Z'),
   },
 ];
 

--- a/packages/@granit/react-parties/src/__tests__/duplicates-inbox.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/duplicates-inbox.test.tsx
@@ -1,6 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { axiosResponse, createMockClient } from '@granit/testing';
-import { toEntityId } from '@granit/types';
+import { toEntityId, toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import i18next from 'i18next';
@@ -35,8 +35,8 @@ const rows: PartyDuplicateCandidateResponse[] = [
     tier: 'Deterministic',
     signals: [],
     dismissedAt: null,
-    createdAt: '2026-04-25T08:00:00Z',
-    updatedAt: '2026-04-26T02:00:00Z',
+    createdAt: toISODateString('2026-04-25T08:00:00Z'),
+    updatedAt: toISODateString('2026-04-26T02:00:00Z'),
   },
   {
     id: dupId2,
@@ -46,7 +46,7 @@ const rows: PartyDuplicateCandidateResponse[] = [
     tier: 'Fuzzy',
     signals: [],
     dismissedAt: null,
-    createdAt: '2026-04-26T14:00:00Z',
+    createdAt: toISODateString('2026-04-26T14:00:00Z'),
     updatedAt: null,
   },
 ];

--- a/packages/@granit/react-parties/src/__tests__/merge-wizard.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/merge-wizard.test.tsx
@@ -1,6 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { axiosResponse, createMockClient } from '@granit/testing';
-import { toEntityId } from '@granit/types';
+import { toEntityId, toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import i18next from 'i18next';
@@ -375,7 +375,7 @@ function makeParty(
     },
     metadata: {},
     internalNotes: null,
-    createdAt: '2026-01-01T00:00:00Z',
+    createdAt: toISODateString('2026-01-01T00:00:00Z'),
     modifiedAt: null,
   };
 }

--- a/packages/@granit/react-parties/src/__tests__/party-duplicates-badge.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/party-duplicates-badge.test.tsx
@@ -1,6 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { axiosResponse, createMockClient } from '@granit/testing';
-import { toEntityId } from '@granit/types';
+import { toEntityId, toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
 import i18next from 'i18next';
@@ -33,7 +33,7 @@ const candidateBuilder = (
   tier: 'Blocking',
   signals: [],
   dismissedAt: null,
-  createdAt: '2026-04-26T08:00:00Z',
+  createdAt: toISODateString('2026-04-26T08:00:00Z'),
   updatedAt: null,
   ...overrides,
 });
@@ -131,7 +131,7 @@ describe('PartyDuplicatesBadge', () => {
   it('hides dismissed-only rows', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue(
-      axiosResponse([candidateBuilder({ dismissedAt: '2026-04-26T10:00:00Z' })])
+      axiosResponse([candidateBuilder({ dismissedAt: toISODateString('2026-04-26T10:00:00Z') })])
     );
 
     const { container } = renderBadge(client);

--- a/packages/@granit/react-parties/src/__tests__/use-parties.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/use-parties.test.tsx
@@ -1,6 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toEntityId } from '@granit/types';
+import { toEntityId, toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -87,7 +87,7 @@ const sampleParty: PartyResponse = {
   taxStatus: { isExempt: false, reverseCharge: false, vatin: null, evidenceBlobId: null },
   metadata: {},
   internalNotes: null,
-  createdAt: '2026-01-01T00:00:00Z',
+  createdAt: toISODateString('2026-01-01T00:00:00Z'),
   modifiedAt: null,
 };
 

--- a/packages/@granit/react-parties/src/__tests__/use-party-duplicates.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/use-party-duplicates.test.tsx
@@ -1,6 +1,6 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { axiosResponse, createMockClient } from '@granit/testing';
-import { toEntityId } from '@granit/types';
+import { toEntityId, toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -36,7 +36,7 @@ const candidate: PartyDuplicateCandidateResponse = {
   tier: 'Deterministic',
   signals: [{ kind: 'TaxIdEqual', score: 1.0 }],
   dismissedAt: null,
-  createdAt: '2026-04-26T08:00:00Z',
+  createdAt: toISODateString('2026-04-26T08:00:00Z'),
   updatedAt: null,
 };
 

--- a/packages/@granit/react-parties/src/testing/data.ts
+++ b/packages/@granit/react-parties/src/testing/data.ts
@@ -1,4 +1,4 @@
-import { toEntityId } from '@granit/types';
+import { toEntityId, toISODateString } from '@granit/types';
 
 import type {
   PartyAddressId,
@@ -106,7 +106,7 @@ export const sampleParty: Mutable<PartyResponse> = {
   },
   metadata: { segment: 'enterprise', region: 'EU', tier: 'gold' },
   internalNotes: 'Strategic account — escalate billing issues to AM team.',
-  createdAt: '2026-01-01T00:00:00Z',
+  createdAt: toISODateString('2026-01-01T00:00:00Z'),
   modifiedAt: null,
 };
 
@@ -141,7 +141,7 @@ const aliceMartin: Mutable<PartyResponse> = {
   taxStatus: { isExempt: false, reverseCharge: false, vatin: null, evidenceBlobId: null },
   metadata: { source: 'website-form' },
   internalNotes: null,
-  createdAt: '2026-01-01T00:00:00Z',
+  createdAt: toISODateString('2026-01-01T00:00:00Z'),
   modifiedAt: null,
 };
 
@@ -198,7 +198,7 @@ const globex: Mutable<PartyResponse> = {
   taxStatus: { isExempt: false, reverseCharge: false, vatin: null, evidenceBlobId: null },
   metadata: { segment: 'mid-market' },
   internalNotes: 'Suspended 2026-03-12 — 90+ days overdue on INV-2026-0042.',
-  createdAt: '2026-01-01T00:00:00Z',
+  createdAt: toISODateString('2026-01-01T00:00:00Z'),
   modifiedAt: null,
 };
 
@@ -252,7 +252,7 @@ const initech: Mutable<PartyResponse> = {
   },
   metadata: {},
   internalNotes: null,
-  createdAt: '2026-01-01T00:00:00Z',
+  createdAt: toISODateString('2026-01-01T00:00:00Z'),
   modifiedAt: null,
 };
 
@@ -287,7 +287,7 @@ const starkRD: Mutable<PartyResponse> = {
   taxStatus: { isExempt: false, reverseCharge: false, vatin: null, evidenceBlobId: null },
   metadata: { 'cost-center': 'RD-401' },
   internalNotes: null,
-  createdAt: '2026-01-01T00:00:00Z',
+  createdAt: toISODateString('2026-01-01T00:00:00Z'),
   modifiedAt: null,
 };
 
@@ -322,7 +322,7 @@ const bobDupont: Mutable<PartyResponse> = {
   taxStatus: { isExempt: false, reverseCharge: false, vatin: null, evidenceBlobId: null },
   metadata: {},
   internalNotes: 'Left the company 2025-09-30. Kept for legal retention.',
-  createdAt: '2026-01-01T00:00:00Z',
+  createdAt: toISODateString('2026-01-01T00:00:00Z'),
   modifiedAt: null,
 };
 
@@ -371,7 +371,7 @@ const ngoHelpers: Mutable<PartyResponse> = {
   taxStatus: { isExempt: true, reverseCharge: false, vatin: null, evidenceBlobId: null },
   metadata: { segment: 'non-profit' },
   internalNotes: 'VAT exemption certificate on file (BE-NGO-2024-1142).',
-  createdAt: '2026-01-01T00:00:00Z',
+  createdAt: toISODateString('2026-01-01T00:00:00Z'),
   modifiedAt: null,
 };
 
@@ -417,8 +417,8 @@ export const sampleDuplicates: Mutable<PartyDuplicateCandidateResponse>[] = [
       { kind: 'NameTrigram', score: 0.74 },
     ],
     dismissedAt: null,
-    createdAt: '2026-04-25T08:30:00Z',
-    updatedAt: '2026-04-27T02:00:00Z',
+    createdAt: toISODateString('2026-04-25T08:30:00Z'),
+    updatedAt: toISODateString('2026-04-27T02:00:00Z'),
   },
   {
     id: duplicateId('002'),
@@ -431,7 +431,7 @@ export const sampleDuplicates: Mutable<PartyDuplicateCandidateResponse>[] = [
       { kind: 'NameTrigram', score: 0.78 },
     ],
     dismissedAt: null,
-    createdAt: '2026-04-26T14:15:00Z',
+    createdAt: toISODateString('2026-04-26T14:15:00Z'),
     updatedAt: null,
   },
   {
@@ -445,7 +445,7 @@ export const sampleDuplicates: Mutable<PartyDuplicateCandidateResponse>[] = [
       { kind: 'CountryEqual', score: 1.0 },
     ],
     dismissedAt: null,
-    createdAt: '2026-04-27T03:00:00Z',
+    createdAt: toISODateString('2026-04-27T03:00:00Z'),
     updatedAt: null,
   },
 ];

--- a/packages/@granit/react-parties/src/testing/handlers.ts
+++ b/packages/@granit/react-parties/src/testing/handlers.ts
@@ -1,7 +1,7 @@
 import { ENUM_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
 import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { created, pagedResponse } from '@granit/testing/msw';
-import { toEntityId } from '@granit/types';
+import { toEntityId, toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants';
@@ -228,7 +228,7 @@ export function createPartiesHandlers(baseUrl = DEFAULT_BASE_PATH) {
     http.post(`${baseUrl}/duplicates/:id/dismiss`, ({ params }) => {
       const row = sampleDuplicates.find((d) => d.id === params.id);
       if (!row) return notFound();
-      row.dismissedAt = new Date().toISOString();
+      row.dismissedAt = toISODateString(new Date().toISOString());
       return new HttpResponse(null, { status: 204 });
     }),
 
@@ -257,7 +257,7 @@ export function createPartiesHandlers(baseUrl = DEFAULT_BASE_PATH) {
       // Reuse the same merge response shape — apply minimal demo mutations
       // so the inbox refresh + party detail refresh both observe the change.
       loser.status = 'Archived';
-      row.dismissedAt = new Date().toISOString();
+      row.dismissedAt = toISODateString(new Date().toISOString());
 
       const response: PartyMergeResponse = {
         survivorId: survivor.id,
@@ -332,7 +332,7 @@ export function createPartiesHandlers(baseUrl = DEFAULT_BASE_PATH) {
         taxStatus: { isExempt: false, reverseCharge: false, vatin: null, evidenceBlobId: null },
         metadata: {},
         internalNotes: body.internalNotes ?? null,
-        createdAt: '2026-01-01T00:00:00Z',
+        createdAt: toISODateString('2026-01-01T00:00:00Z'),
         modifiedAt: null,
       };
       sampleParties.push(newParty);

--- a/packages/@granit/react-taxonomy/package.json
+++ b/packages/@granit/react-taxonomy/package.json
@@ -18,6 +18,7 @@
     "@granit/api-client": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/taxonomy": "workspace:*",
+    "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
@@ -46,6 +47,7 @@
     "@granit/react-testing": "workspace:*",
     "@granit/taxonomy": "workspace:*",
     "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*",
     "msw": "^2.12.0"
   }
 }

--- a/packages/@granit/react-taxonomy/src/__tests__/branch-coverage-extra.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/branch-coverage-extra.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -20,8 +21,8 @@ const tag: TagResponse = {
   name: 'Urgent',
   color: '#FF0000',
   hideOnEntityCard: false,
-  createdAt: '2026-05-01T08:00:00Z',
-  modifiedAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
+  modifiedAt: toISODateString('2026-05-01T08:00:00Z'),
   concurrencyStamp: 'stamp-1',
 };
 
@@ -36,7 +37,7 @@ const root: CategoryResponse = {
   iconName: null,
   hideOnEntityCard: false,
   hasChildren: false,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
   modifiedAt: null,
   concurrencyStamp: 'stamp-1',
 };

--- a/packages/@granit/react-taxonomy/src/__tests__/branch-coverage.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/branch-coverage.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -22,8 +23,8 @@ const tag: TagResponse = {
   name: 'Urgent',
   color: '#FF0000',
   hideOnEntityCard: false,
-  createdAt: '2026-05-01T08:00:00Z',
-  modifiedAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
+  modifiedAt: toISODateString('2026-05-01T08:00:00Z'),
   concurrencyStamp: 'stamp-1',
 };
 
@@ -38,7 +39,7 @@ const root: CategoryResponse = {
   iconName: null,
   hideOnEntityCard: false,
   hasChildren: false,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
   modifiedAt: null,
   concurrencyStamp: 'stamp-1',
 };

--- a/packages/@granit/react-taxonomy/src/__tests__/category-breadcrumb.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/category-breadcrumb.test.tsx
@@ -1,3 +1,4 @@
+import { toISODateString } from '@granit/types';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
@@ -17,7 +18,7 @@ const root: CategoryResponse = {
   iconName: null,
   hideOnEntityCard: false,
   hasChildren: true,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
   modifiedAt: null,
   concurrencyStamp: 'stamp-1',
 };
@@ -33,7 +34,7 @@ const leaf: CategoryResponse = {
   iconName: null,
   hideOnEntityCard: false,
   hasChildren: false,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
   modifiedAt: null,
   concurrencyStamp: 'stamp-1',
 };

--- a/packages/@granit/react-taxonomy/src/__tests__/category-selector.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/category-selector.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -22,7 +23,7 @@ const detail: CategoryDetailResponse = {
   iconName: null,
   hideOnEntityCard: false,
   hasChildren: false,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
   modifiedAt: null,
   concurrencyStamp: 'stamp-1',
   breadcrumb: [
@@ -37,7 +38,7 @@ const detail: CategoryDetailResponse = {
       iconName: null,
       hideOnEntityCard: false,
       hasChildren: true,
-      createdAt: '2026-05-01T08:00:00Z',
+      createdAt: toISODateString('2026-05-01T08:00:00Z'),
       modifiedAt: null,
       concurrencyStamp: 'stamp-1',
     },
@@ -52,7 +53,7 @@ const detail: CategoryDetailResponse = {
       iconName: null,
       hideOnEntityCard: false,
       hasChildren: false,
-      createdAt: '2026-05-01T08:00:00Z',
+      createdAt: toISODateString('2026-05-01T08:00:00Z'),
       modifiedAt: null,
       concurrencyStamp: 'stamp-1',
     },

--- a/packages/@granit/react-taxonomy/src/__tests__/category-tree-actions.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/category-tree-actions.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -22,7 +23,7 @@ const root: CategoryResponse = {
   iconName: null,
   hideOnEntityCard: false,
   hasChildren: false,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
   modifiedAt: null,
   concurrencyStamp: 'stamp-1',
 };

--- a/packages/@granit/react-taxonomy/src/__tests__/category-tree.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/category-tree.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -22,7 +23,7 @@ const root: CategoryResponse = {
   iconName: null,
   hideOnEntityCard: false,
   hasChildren: true,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
   modifiedAt: null,
   concurrencyStamp: 'stamp-1',
 };
@@ -38,7 +39,7 @@ const child: CategoryResponse = {
   iconName: null,
   hideOnEntityCard: false,
   hasChildren: false,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
   modifiedAt: null,
   concurrencyStamp: 'stamp-1',
 };

--- a/packages/@granit/react-taxonomy/src/__tests__/document-tag-chip-strip.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/document-tag-chip-strip.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -17,8 +18,8 @@ const tag: TagResponse = {
   name: 'Urgent',
   color: '#FF0000',
   hideOnEntityCard: false,
-  createdAt: '2026-05-01T08:00:00Z',
-  modifiedAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
+  modifiedAt: toISODateString('2026-05-01T08:00:00Z'),
   concurrencyStamp: 'stamp-1',
 };
 

--- a/packages/@granit/react-taxonomy/src/__tests__/entity-taxonomy.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/entity-taxonomy.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -72,7 +73,7 @@ describe('entityTaxonomy', () => {
             name: 'legal',
             depth: 0,
             hasChildren: false,
-            createdAt: '2026-05-01T08:00:00Z',
+            createdAt: toISODateString('2026-05-01T08:00:00Z'),
             modifiedAt: null,
             concurrencyStamp: 'stamp-1',
             breadcrumb: [
@@ -84,7 +85,7 @@ describe('entityTaxonomy', () => {
                 name: 'legal',
                 depth: 0,
                 hasChildren: false,
-                createdAt: '2026-05-01T08:00:00Z',
+                createdAt: toISODateString('2026-05-01T08:00:00Z'),
                 modifiedAt: null,
                 concurrencyStamp: 'stamp-1',
               },

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-autocomplete-create.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-autocomplete-create.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -18,8 +19,8 @@ const createdTag: TagResponse = {
   name: 'Brand new',
   color: '#94a3b8',
   hideOnEntityCard: false,
-  createdAt: '2026-05-01T08:00:00Z',
-  modifiedAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
+  modifiedAt: toISODateString('2026-05-01T08:00:00Z'),
   concurrencyStamp: 'stamp-1',
 };
 

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-autocomplete.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-autocomplete.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -18,8 +19,8 @@ const sampleTag: TagResponse = {
   name: 'Urgent',
   color: '#FF0000',
   hideOnEntityCard: false,
-  createdAt: '2026-05-01T08:00:00Z',
-  modifiedAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
+  modifiedAt: toISODateString('2026-05-01T08:00:00Z'),
   concurrencyStamp: 'stamp-1',
 };
 
@@ -30,8 +31,8 @@ const otherTag: TagResponse = {
   name: 'Internal',
   color: '#00FF00',
   hideOnEntityCard: false,
-  createdAt: '2026-05-01T08:00:00Z',
-  modifiedAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
+  modifiedAt: toISODateString('2026-05-01T08:00:00Z'),
   concurrencyStamp: 'stamp-1',
 };
 

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-chip-strip.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-chip-strip.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -18,8 +19,8 @@ const visibleTag: TagResponse = {
   name: 'Urgent',
   color: '#FF0000',
   hideOnEntityCard: false,
-  createdAt: '2026-05-01T08:00:00Z',
-  modifiedAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
+  modifiedAt: toISODateString('2026-05-01T08:00:00Z'),
   concurrencyStamp: 'stamp-1',
 };
 
@@ -30,8 +31,8 @@ const hiddenTag: TagResponse = {
   name: 'Internal',
   color: '#00FF00',
   hideOnEntityCard: true,
-  createdAt: '2026-05-01T08:00:00Z',
-  modifiedAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
+  modifiedAt: toISODateString('2026-05-01T08:00:00Z'),
   concurrencyStamp: 'stamp-1',
 };
 

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-chip.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-chip.test.tsx
@@ -1,3 +1,4 @@
+import { toISODateString } from '@granit/types';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
@@ -13,8 +14,8 @@ const sampleTag: TagResponse = {
   name: 'Urgent',
   color: '#FF0000',
   hideOnEntityCard: false,
-  createdAt: '2026-05-01T08:00:00Z',
-  modifiedAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
+  modifiedAt: toISODateString('2026-05-01T08:00:00Z'),
   concurrencyStamp: 'stamp-1',
 };
 

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-manager-actions.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-manager-actions.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -18,8 +19,8 @@ const tag: TagResponse = {
   name: 'Urgent',
   color: '#FF0000',
   hideOnEntityCard: false,
-  createdAt: '2026-05-01T08:00:00Z',
-  modifiedAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
+  modifiedAt: toISODateString('2026-05-01T08:00:00Z'),
   concurrencyStamp: 'stamp-1',
 };
 

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-manager.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-manager.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -18,8 +19,8 @@ const tag: TagResponse = {
   name: 'Urgent',
   color: '#FF0000',
   hideOnEntityCard: false,
-  createdAt: '2026-05-01T08:00:00Z',
-  modifiedAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
+  modifiedAt: toISODateString('2026-05-01T08:00:00Z'),
   concurrencyStamp: 'stamp-1',
 };
 

--- a/packages/@granit/react-taxonomy/src/__tests__/use-categories.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/use-categories.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -21,7 +22,7 @@ const sampleRoot: CategoryResponse = {
   iconName: null,
   hideOnEntityCard: false,
   hasChildren: true,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
   modifiedAt: null,
   concurrencyStamp: 'stamp-1',
 };
@@ -37,7 +38,7 @@ const sampleChild: CategoryResponse = {
   iconName: null,
   hideOnEntityCard: false,
   hasChildren: false,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
   modifiedAt: null,
   concurrencyStamp: 'stamp-1',
 };

--- a/packages/@granit/react-taxonomy/src/__tests__/use-category-mutations.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/use-category-mutations.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook } from '@testing-library/react';
 import * as React from 'react';
@@ -30,7 +31,7 @@ const sampleCategory: CategoryResponse = {
   iconName: null,
   hideOnEntityCard: false,
   hasChildren: true,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
   modifiedAt: null,
   concurrencyStamp: 'stamp-1',
 };
@@ -41,7 +42,7 @@ const sampleAssignment: CategoryAssignmentResponse = {
   categoryId: 'cat-1',
   targetType: 'Granit.Documents.Domain.Document',
   targetId: 'doc-1',
-  assignedAt: '2026-05-02T12:00:00Z',
+  assignedAt: toISODateString('2026-05-02T12:00:00Z'),
   assignedByUserId: 'user-1',
 };
 

--- a/packages/@granit/react-taxonomy/src/__tests__/use-document-tags.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/use-document-tags.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -22,8 +23,8 @@ const sampleTag: TagResponse = {
   name: 'Urgent',
   color: '#FF0000',
   hideOnEntityCard: false,
-  createdAt: '2026-05-01T08:00:00Z',
-  modifiedAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
+  modifiedAt: toISODateString('2026-05-01T08:00:00Z'),
   concurrencyStamp: 'stamp-1',
 };
 

--- a/packages/@granit/react-taxonomy/src/__tests__/use-tag-mutations.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/use-tag-mutations.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook } from '@testing-library/react';
 import * as React from 'react';
@@ -25,8 +26,8 @@ const sampleTag: TagResponse = {
   name: 'Urgent',
   color: '#FF0000',
   hideOnEntityCard: false,
-  createdAt: '2026-05-01T08:00:00Z',
-  modifiedAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
+  modifiedAt: toISODateString('2026-05-01T08:00:00Z'),
   concurrencyStamp: 'stamp-1',
 };
 
@@ -36,7 +37,7 @@ const sampleAssignment: TagAssignmentResponse = {
   tagId: 'tag-1',
   targetType: 'Granit.Documents.Domain.Document',
   targetId: 'doc-1',
-  assignedAt: '2026-05-02T12:00:00Z',
+  assignedAt: toISODateString('2026-05-02T12:00:00Z'),
   assignedByUserId: 'user-1',
 };
 

--- a/packages/@granit/react-taxonomy/src/__tests__/use-tags.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/use-tags.test.tsx
@@ -1,4 +1,5 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -17,8 +18,8 @@ const sampleTag: TagResponse = {
   name: 'Urgent',
   color: '#FF0000',
   hideOnEntityCard: false,
-  createdAt: '2026-05-01T08:00:00Z',
-  modifiedAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
+  modifiedAt: toISODateString('2026-05-01T08:00:00Z'),
   concurrencyStamp: 'stamp-1',
 };
 

--- a/packages/@granit/react-taxonomy/src/testing/data.ts
+++ b/packages/@granit/react-taxonomy/src/testing/data.ts
@@ -1,3 +1,5 @@
+import { toISODateString } from '@granit/types';
+
 import type {
   CategoryAssignmentResponse,
   CategoryResponse,
@@ -17,7 +19,7 @@ export interface TaxonomyStore {
   categoryAssignments: CategoryAssignmentResponse[];
 }
 
-const now = () => new Date().toISOString();
+const now = () => toISODateString(new Date().toISOString());
 
 export function createTaxonomyStore(): TaxonomyStore {
   return {
@@ -90,7 +92,7 @@ export function createTaxonomyStore(): TaxonomyStore {
         iconName: null,
         hideOnEntityCard: false,
         hasChildren: true,
-        createdAt: '2026-05-01T08:00:00Z',
+        createdAt: toISODateString('2026-05-01T08:00:00Z'),
         modifiedAt: null,
         concurrencyStamp: 'stamp-1',
       },
@@ -105,7 +107,7 @@ export function createTaxonomyStore(): TaxonomyStore {
         iconName: null,
         hideOnEntityCard: false,
         hasChildren: false,
-        createdAt: '2026-05-01T08:00:00Z',
+        createdAt: toISODateString('2026-05-01T08:00:00Z'),
         modifiedAt: null,
         concurrencyStamp: 'stamp-1',
       },
@@ -120,7 +122,7 @@ export function createTaxonomyStore(): TaxonomyStore {
         iconName: null,
         hideOnEntityCard: false,
         hasChildren: false,
-        createdAt: '2026-05-01T08:00:00Z',
+        createdAt: toISODateString('2026-05-01T08:00:00Z'),
         modifiedAt: null,
         concurrencyStamp: 'stamp-1',
       },

--- a/packages/@granit/react-taxonomy/src/testing/handlers.ts
+++ b/packages/@granit/react-taxonomy/src/testing/handlers.ts
@@ -1,4 +1,5 @@
 import { created } from '@granit/testing/msw';
+import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants';
@@ -20,7 +21,7 @@ import type {
 
 const store: TaxonomyStore = createTaxonomyStore();
 
-const now = () => new Date().toISOString();
+const now = () => toISODateString(new Date().toISOString());
 const newId = (prefix: string) => `${prefix}-${crypto.randomUUID().slice(0, 8)}`;
 
 function wouldCreateCategoryCycle(nodeId: string, newParentId: string): boolean {
@@ -201,7 +202,7 @@ export function createTaxonomyHandlers(baseUrl = DEFAULT_BASE_PATH) {
         iconName: body.iconName,
         hideOnEntityCard: body.hideOnEntityCard ?? false,
         hasChildren: false,
-        createdAt: '2026-05-01T08:00:00Z',
+        createdAt: toISODateString('2026-05-01T08:00:00Z'),
         modifiedAt: null,
         concurrencyStamp: 'stamp-1',
       };

--- a/packages/@granit/taxonomy/package.json
+++ b/packages/@granit/taxonomy/package.json
@@ -15,10 +15,12 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "peerDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/taxonomy/src/__tests__/categories-api.test.ts
+++ b/packages/@granit/taxonomy/src/__tests__/categories-api.test.ts
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -34,7 +35,7 @@ const sampleRoot: CategoryResponse = {
   iconName: null,
   hideOnEntityCard: false,
   hasChildren: true,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
   modifiedAt: null,
   concurrencyStamp: 'stamp-1',
 };
@@ -50,7 +51,7 @@ const sampleChild: CategoryResponse = {
   iconName: null,
   hideOnEntityCard: false,
   hasChildren: false,
-  createdAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
   modifiedAt: null,
   concurrencyStamp: 'stamp-1',
 };
@@ -66,7 +67,7 @@ const sampleAssignment: CategoryAssignmentResponse = {
   categoryId: 'cat-2',
   targetType: 'Granit.Documents.Domain.Document',
   targetId: 'doc-1',
-  assignedAt: '2026-05-02T12:00:00Z',
+  assignedAt: toISODateString('2026-05-02T12:00:00Z'),
   assignedByUserId: 'user-1',
 };
 

--- a/packages/@granit/taxonomy/src/__tests__/documents-proxy-api.test.ts
+++ b/packages/@granit/taxonomy/src/__tests__/documents-proxy-api.test.ts
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -18,8 +19,8 @@ const sampleTag: TagResponse = {
   name: 'Urgent',
   color: '#FF0000',
   hideOnEntityCard: false,
-  createdAt: '2026-05-01T08:00:00Z',
-  modifiedAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
+  modifiedAt: toISODateString('2026-05-01T08:00:00Z'),
   concurrencyStamp: 'stamp-1',
 };
 

--- a/packages/@granit/taxonomy/src/__tests__/tags-api.test.ts
+++ b/packages/@granit/taxonomy/src/__tests__/tags-api.test.ts
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -29,8 +30,8 @@ const sampleTag: TagResponse = {
   name: 'Urgent',
   color: '#FF0000',
   hideOnEntityCard: false,
-  createdAt: '2026-05-01T08:00:00Z',
-  modifiedAt: '2026-05-01T08:00:00Z',
+  createdAt: toISODateString('2026-05-01T08:00:00Z'),
+  modifiedAt: toISODateString('2026-05-01T08:00:00Z'),
   concurrencyStamp: 'stamp-1',
 };
 
@@ -40,7 +41,7 @@ const sampleAssignment: TagAssignmentResponse = {
   tagId: 'tag-1',
   targetType: 'Granit.Documents.Domain.Document',
   targetId: 'doc-1',
-  assignedAt: '2026-05-02T12:00:00Z',
+  assignedAt: toISODateString('2026-05-02T12:00:00Z'),
   assignedByUserId: 'user-1',
 };
 

--- a/packages/@granit/taxonomy/src/types/index.ts
+++ b/packages/@granit/taxonomy/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { ISODateString } from '@granit/types';
+
 /**
  * 7-character hexadecimal color in `#RRGGBB` form. The backend rejects any
  * other shape, so the front carries the same constraint at the type level.
@@ -31,13 +33,13 @@ export interface TagResponse {
   readonly name: string;
   readonly color: HexColor;
   readonly hideOnEntityCard: boolean;
-  readonly createdAt: string;
+  readonly createdAt: ISODateString;
   /**
    * Last-modification timestamp; `null` until the tag is first modified
    * (framework audit convention). For a non-null "updated at", coalesce
    * `modifiedAt ?? createdAt` at the call site.
    */
-  readonly modifiedAt: string | null;
+  readonly modifiedAt: ISODateString | null;
   /** Optimistic-concurrency token; echo back on edit to detect conflicts (409). */
   readonly concurrencyStamp: string;
 }
@@ -75,7 +77,7 @@ export interface TagAssignmentResponse {
   readonly tagId: string;
   readonly targetType: string;
   readonly targetId: string;
-  readonly assignedAt: string;
+  readonly assignedAt: ISODateString;
   readonly assignedByUserId: string;
 }
 
@@ -98,9 +100,9 @@ export interface CategoryResponse {
   readonly hideOnEntityCard: boolean;
   /** `true` when at least one child exists — drives tree lazy-load. */
   readonly hasChildren: boolean;
-  readonly createdAt: string;
+  readonly createdAt: ISODateString;
   /** Last-modification timestamp; `null` until first modified (coalesce `?? createdAt`). */
-  readonly modifiedAt: string | null;
+  readonly modifiedAt: ISODateString | null;
   /** Optimistic-concurrency token; echo back on edit to detect conflicts (409). */
   readonly concurrencyStamp: string;
 }
@@ -158,7 +160,7 @@ export interface CategoryAssignmentResponse {
   readonly categoryId: string;
   readonly targetType: string;
   readonly targetId: string;
-  readonly assignedAt: string;
+  readonly assignedAt: ISODateString;
   readonly assignedByUserId: string;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/ai:
     dependencies:
@@ -243,6 +246,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/api-client:
     dependencies:
@@ -463,6 +469,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/cms-hostnames:
     devDependencies:
@@ -472,6 +481,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/cms-redirects:
     devDependencies:
@@ -484,6 +496,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/cms-seo:
     devDependencies:
@@ -496,6 +511,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/contract-tests:
     devDependencies:
@@ -600,6 +618,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/documents:
     devDependencies:
@@ -634,6 +655,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/entities-views:
     devDependencies:
@@ -816,6 +840,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/notifications-signalr:
     devDependencies:
@@ -1022,6 +1049,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.9.3)(typescript@6.0.3)
@@ -1176,6 +1206,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.9.3)(typescript@6.0.3)
@@ -1660,6 +1693,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
       '@granit/utils':
         specifier: workspace:*
         version: link:../utils
@@ -1694,6 +1730,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
       '@tanstack/react-query':
         specifier: 5.101.0
         version: 5.101.0(react@19.2.7)
@@ -1725,6 +1764,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
       '@tanstack/react-query':
         specifier: 5.101.0
         version: 5.101.0(react@19.2.7)
@@ -1753,6 +1795,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
       '@tanstack/react-query':
         specifier: 5.101.0
         version: 5.101.0(react@19.2.7)
@@ -1967,6 +2012,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/react-documents:
     dependencies:
@@ -2081,6 +2129,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/react-entities-views:
     dependencies:
@@ -2451,6 +2502,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/react-notifications:
     dependencies:
@@ -2513,6 +2567,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/react-notifications-web-push:
     dependencies:
@@ -3023,6 +3080,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.9.3)(typescript@6.0.3)
@@ -3362,6 +3422,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/templating:
     devDependencies:


### PR DESCRIPTION
## Summary

**Final slice (4/4)** of the datetime uniformization. Brands plain-string date-time fields as `ISODateString` across all remaining packages: `taxonomy`, `parties`, `activities`, `cms`/`cms-seo`/`cms-redirects`/`cms-hostnames`, `multi-tenancy`, `entities-customization`, `diagnostics`, `analytics`, `notifications-mobile-push`.

Covers `*At` fields plus calendar `start`/`end`, date-range `from`/`to`, and `PeriodSpec` bounds.

- Fixtures / handlers / components wrap literals + dynamic dates in `toISODateString()`; shared date helpers (`now()`/`iso()`) now return `ISODateString`.
- Adds `@granit/types` where missing (lockfile updated).
- **No plain-string date-time DTO field remains repo-wide** — the `ISODateString` convention is now uniform (closes the campaign).
- Reads unaffected; no wire/oracle change (495 ✓).

## Verification
- `pnpm tsc` (full workspace) clean · lint clean · 770 tests green · oracle 495 ✓

## Showcase
Checking consumers; coordinated MR to follow if any fixtures construct these DTOs.