### PR TITLE
fix(api-keys,scheduling,data-exchange,openiddict): consume backend DTO enrichment

### DIFF
--- a/contracts/openapi/api-keys.json
+++ b/contracts/openapi/api-keys.json
@@ -7,64 +7,104 @@
   "paths": {
     "/authentication/api-keys": {
       "get": {
-        "tags": [
-          "API Keys"
-        ],
-        "summary": "Returns a paginated list of API keys.",
-        "description": "Lists all API keys for the current tenant with optional filters on type, environment, search term, and revocation status. The raw secret is never returned — only the prefix and last four characters for identification.",
-        "operationId": "ListApiKeys",
+        "tags": ["API Keys"],
+        "summary": "Returns a paged, filterable list of ApiKeyListItemResponse from ApiKeyEntry.",
+        "description": "Executes a dynamic query against ApiKeyEntry using the Granit query engine and projects each row to ApiKeyListItemResponse. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult<ApiKeyListItemResponse> by default. When the groupBy query parameter is specified, returns a GroupedResult<ApiKeyListItemResponse> with the same projection applied to the items inside each group.",
+        "operationId": "QueryApiKeyEntry",
         "parameters": [
           {
-            "name": "Search",
+            "name": "page",
             "in": "query",
-            "description": "Free-text search query.",
+            "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
-              "type": "string"
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
             }
           },
           {
-            "name": "Type",
+            "name": "pageSize",
             "in": "query",
-            "description": "Filter by type discriminator value.",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
             "schema": {
-              "$ref": "#/components/schemas/ApiKeyType"
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
             }
           },
           {
-            "name": "Environment",
+            "name": "cursor",
             "in": "query",
-            "description": "Filter by environment (e.g. 'production', 'staging', 'sandbox').",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": "string"
+              "type": ["null", "string"]
             }
           },
           {
-            "name": "IncludeRevoked",
+            "name": "search",
             "in": "query",
-            "description": "When true, include revoked items in the response.",
+            "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": "boolean",
-              "default": false
+              "type": ["null", "string"]
             }
           },
           {
-            "name": "Page",
+            "name": "sort",
             "in": "query",
-            "description": "1-based page index.",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 1
+              "type": ["null", "string"]
             }
           },
           {
-            "name": "PageSize",
+            "name": "groupBy",
             "in": "query",
-            "description": "Number of items per page.",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 20
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -74,7 +114,25 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedResultOfApiKeyResponse"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfApiKeyListItemResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfApiKeyListItemResponse"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
                 }
               }
             }
@@ -112,11 +170,9 @@
         }
       },
       "post": {
-        "tags": [
-          "API Keys"
-        ],
+        "tags": ["API Keys"],
         "summary": "Creates a new API key. The raw secret is returned once.",
-        "description": "Generates a new API key with the specified type, environment, permissions, and optional CIDR restrictions. The caller must possess every permission being assigned (privilege escalation prevention). The response includes the full raw secret — this is the only time the secret is available. Store it securely; it cannot be retrieved later. The key is immediately active.",
+        "description": "Generates a new API key with the specified type, environment, permissions, and optional CIDR restrictions. The caller must possess every permission being assigned (privilege escalation prevention). The response includes the full raw secret \u2014 this is the only time the secret is available. Store it securely; it cannot be retrieved later. The key is immediately active.",
         "operationId": "CreateApiKey",
         "requestBody": {
           "content": {
@@ -182,11 +238,59 @@
         }
       }
     },
+    "/authentication/api-keys/meta": {
+      "get": {
+        "tags": ["API Keys"],
+        "summary": "Returns query metadata for ApiKeyEntry (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for ApiKeyEntry: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetApiKeyEntryMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/authentication/api-keys/{id}": {
       "get": {
-        "tags": [
-          "API Keys"
-        ],
+        "tags": ["API Keys"],
         "summary": "Returns a single API key by ID.",
         "description": "Returns the metadata of a single API key. The raw secret is never exposed after creation. Returns 404 if the key does not exist.",
         "operationId": "GetApiKeyById",
@@ -258,11 +362,9 @@
     },
     "/authentication/api-keys/{id}/revoke": {
       "post": {
-        "tags": [
-          "API Keys"
-        ],
+        "tags": ["API Keys"],
         "summary": "Revokes an API key. The key will no longer be accepted for authentication.",
-        "description": "Permanently revokes the API key. Any subsequent authentication attempt using this key will be rejected. This operation is irreversible — use rotate instead if you need a replacement key. Returns 404 if the key does not exist.",
+        "description": "Permanently revokes the API key. Any subsequent authentication attempt using this key will be rejected. This operation is irreversible \u2014 use rotate instead if you need a replacement key. Returns 404 if the key does not exist.",
         "operationId": "RevokeApiKey",
         "parameters": [
           {
@@ -325,9 +427,7 @@
     },
     "/authentication/api-keys/{id}/rotate": {
       "post": {
-        "tags": [
-          "API Keys"
-        ],
+        "tags": ["API Keys"],
         "summary": "Rotates an API key: revokes the current key and creates a replacement with the same settings.",
         "description": "Atomically revokes the existing key and creates a new one inheriting the same name, type, environment, permissions, CIDR restrictions, and expiration. The response contains the new raw secret (shown once) and both the old and new key IDs. Returns 404 if the key does not exist or is already revoked.",
         "operationId": "RotateApiKey",
@@ -399,9 +499,7 @@
     },
     "/authentication/api-keys/{id}/scopes": {
       "put": {
-        "tags": [
-          "API Keys"
-        ],
+        "tags": ["API Keys"],
         "summary": "Updates the permissions and allowed CIDR ranges for an API key.",
         "description": "Replaces the full list of permissions and allowed CIDR ranges for the specified key. The caller must possess every permission being assigned (privilege escalation prevention). Both fields are replaced entirely (not merged). Returns 404 if the key does not exist.",
         "operationId": "UpdateApiKeyScopes",
@@ -488,46 +586,38 @@
   "components": {
     "schemas": {
       "ApiKeyCreateRequest": {
-        "required": [
-          "name",
-          "type",
-          "environment"
-        ],
+        "required": ["name", "type", "environment"],
         "type": "object",
         "properties": {
           "name": {
+            "maxLength": 200,
             "type": "string"
           },
           "type": {
             "$ref": "#/components/schemas/ApiKeyType"
           },
           "environment": {
-            "type": "string"
+            "type": "string",
+            "x-granit-validator": "Validation:InvalidEnvironment"
           },
           "permissions": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "type": "string"
-            }
+            },
+            "x-granit-validator": "Validation:MaxPermissions"
           },
           "allowedCidrs": {
-            "type": [
-              "null",
-              "array"
-            ],
+            "type": ["null", "array"],
             "items": {
               "type": "string"
-            }
+            },
+            "x-granit-validator": "Validation:InvalidCidrNotation"
           },
           "expiresAt": {
-            "type": [
-              "null",
-              "string"
-            ],
-            "format": "date-time"
+            "type": ["null", "string"],
+            "format": "date-time",
+            "x-granit-validator": "Validation:ExpirationMustBeFuture"
           },
           "cacheBehavior": {
             "$ref": "#/components/schemas/CacheBehavior"
@@ -570,10 +660,63 @@
             "type": "string"
           },
           "expiresAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "ApiKeyListItemResponse": {
+        "required": [
+          "id",
+          "name",
+          "type",
+          "environment",
+          "prefix",
+          "lastFourChars",
+          "expiresAt",
+          "lastUsedAt",
+          "revokedAt",
+          "cacheBehavior",
+          "createdAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/ApiKeyType"
+          },
+          "environment": {
+            "type": "string"
+          },
+          "prefix": {
+            "type": "string"
+          },
+          "lastFourChars": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "lastUsedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "revokedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "cacheBehavior": {
+            "$ref": "#/components/schemas/CacheBehavior"
+          },
+          "createdAt": {
+            "type": "string",
             "format": "date-time"
           }
         }
@@ -628,24 +771,15 @@
             }
           },
           "expiresAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "lastUsedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "revokedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "cacheBehavior": {
@@ -654,17 +788,15 @@
           "createdAt": {
             "type": "string",
             "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": ["string", "null"],
+            "format": "date-time"
           }
         }
       },
       "ApiKeyRotateResponse": {
-        "required": [
-          "newKeyId",
-          "rawSecret",
-          "prefix",
-          "lastFourChars",
-          "oldKeyId"
-        ],
+        "required": ["newKeyId", "rawSecret", "prefix", "lastFourChars", "oldKeyId"],
         "type": "object",
         "properties": {
           "newKeyId": {
@@ -687,69 +819,381 @@
         }
       },
       "ApiKeyType": {
-        "enum": [
-          "Secret",
-          "Publishable",
-          "Webhook",
-          "Ephemeral"
-        ]
+        "enum": ["Secret", "Publishable", "Webhook", "Ephemeral"]
       },
       "ApiKeyUpdateScopesRequest": {
-        "required": [
-          "permissions",
-          "allowedCidrs"
-        ],
+        "required": ["permissions", "allowedCidrs"],
         "type": "object",
         "properties": {
           "permissions": {
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "x-granit-validator": "Validation:MaxPermissions"
           },
           "allowedCidrs": {
             "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "x-granit-validator": "Validation:InvalidCidrNotation"
+          }
+        }
+      },
+      "CacheBehavior": {
+        "enum": ["Normal", "NoCache"]
+      },
+      "ColumnDefinition": {
+        "required": [
+          "name",
+          "label",
+          "type",
+          "order",
+          "isSortable",
+          "isFilterable",
+          "isVisible",
+          "format"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isSortable": {
+            "type": "boolean"
+          },
+          "isFilterable": {
+            "type": "boolean"
+          },
+          "isVisible": {
+            "type": "boolean"
+          },
+          "format": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "DateFilterMeta": {
+        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "defaultPeriod": {
+            "$ref": "#/components/schemas/DatePeriod"
+          },
+          "availablePeriods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DatePeriod"
+            }
+          }
+        }
+      },
+      "DatePeriod": {
+        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+      },
+      "FilterableField": {
+        "required": ["name", "type", "operators"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "operators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterOperator"
+            }
+          },
+          "enumValues": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          },
+          "lookup": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LookupDescriptor"
+              }
+            ]
+          }
+        }
+      },
+      "FilterGroupMeta": {
+        "required": ["name", "label", "presets"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PresetMeta"
+            }
+          }
+        }
+      },
+      "FilterOperator": {
+        "enum": [
+          "Eq",
+          "Contains",
+          "StartsWith",
+          "EndsWith",
+          "Gt",
+          "Gte",
+          "Lt",
+          "Lte",
+          "In",
+          "Between"
+        ]
+      },
+      "GroupByField": {
+        "required": ["name", "type"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "GroupedResultOfApiKeyListItemResponse": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfApiKeyListItemResponse"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupEntryOfApiKeyListItemResponse": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/ApiKeyListItemResponse"
+            }
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "LookupDescriptor": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["null", "string"]
+          },
+          "endpoint": {
+            "type": ["null", "string"]
+          },
+          "kind": {
+            "$ref": "#/components/schemas/LookupKind"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "searchParam": {
+            "type": ["null", "string"],
+            "default": "search"
+          },
+          "scopeKeys": {
+            "type": ["null", "array"],
             "items": {
               "type": "string"
             }
           }
         }
       },
-      "CacheBehavior": {
-        "enum": [
-          "Normal",
-          "NoCache"
-        ]
+      "LookupKind": {
+        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "default": "QueryEngine"
       },
-      "PagedResultOfApiKeyResponse": {
-        "required": [
-          "items",
-          "totalCount",
-          "hasMore"
-        ],
+      "PagedResultOfApiKeyListItemResponse": {
+        "required": ["items", "totalCount", "hasMore"],
         "type": "object",
         "properties": {
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ApiKeyResponse"
+              "required": [
+                "id",
+                "name",
+                "type",
+                "environment",
+                "prefix",
+                "lastFourChars",
+                "expiresAt",
+                "lastUsedAt",
+                "revokedAt",
+                "cacheBehavior",
+                "createdAt"
+              ],
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": ["Secret", "Publishable", "Webhook", "Ephemeral"]
+                },
+                "environment": {
+                  "type": "string"
+                },
+                "prefix": {
+                  "type": "string"
+                },
+                "lastFourChars": {
+                  "type": "string"
+                },
+                "expiresAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "lastUsedAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "revokedAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "cacheBehavior": {
+                  "enum": ["Normal", "NoCache"]
+                },
+                "createdAt": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
             }
           },
           "totalCount": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PaginationMeta": {
+        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "type": "object",
+        "properties": {
+          "defaultPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxStreamSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "supportsCursor": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PresetMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
           }
         }
       },
@@ -775,6 +1219,93 @@
           "instance": {
             "type": "string",
             "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "QueryMetadata": {
+        "required": [
+          "columns",
+          "filterableFields",
+          "sortableFields",
+          "presetFilterGroups",
+          "quickFilters",
+          "dateFilters",
+          "groupByFields",
+          "pagination"
+        ],
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ColumnDefinition"
+            }
+          },
+          "filterableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterableField"
+            }
+          },
+          "sortableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortableField"
+            }
+          },
+          "presetFilterGroups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterGroupMeta"
+            }
+          },
+          "quickFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuickFilterMeta"
+            }
+          },
+          "dateFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DateFilterMeta"
+            }
+          },
+          "groupByFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupByField"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          },
+          "defaultSort": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "QuickFilterMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SortableField": {
+        "required": ["name"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
           }
         }
       }

--- a/contracts/openapi/data-exchange.json
+++ b/contracts/openapi/data-exchange.json
@@ -363,7 +363,7 @@
       "post": {
         "tags": ["Data Exchange"],
         "summary": "Dispatches the import job for asynchronous background execution.",
-        "description": "Enqueues the import job for background processing. Returns 202 Accepted — poll the status endpoint to track progress. The job must be in 'Mapped' status (mappings confirmed). Returns 400 if the job is in an invalid state, or 404 if not found.",
+        "description": "Enqueues the import job for background processing. Returns 202 Accepted \u2014 poll the status endpoint to track progress. The job must be in 'Mapped' status (mappings confirmed). Returns 400 if the job is in an invalid state, or 404 if not found.",
         "operationId": "ExecuteImportJob",
         "parameters": [
           {
@@ -1179,7 +1179,7 @@
       "get": {
         "tags": ["Data Exchange"],
         "summary": "Returns the available fields for a given export definition.",
-        "description": "Returns the list of selectable fields for the named export definition — each with its property name, display label, and data type. Use this to populate a field picker UI before creating an export job. Returns 404 if the definition name is not registered.",
+        "description": "Returns the list of selectable fields for the named export definition \u2014 each with its property name, display label, and data type. Use this to populate a field picker UI before creating an export job. Returns 404 if the definition name is not registered.",
         "operationId": "GetExportDefinitionFields",
         "parameters": [
           {
@@ -1580,7 +1580,8 @@
           "createdAt",
           "completedAt",
           "modifiedAt",
-          "modifiedBy"
+          "modifiedBy",
+          "concurrencyStamp"
         ],
         "type": "object",
         "properties": {
@@ -1621,6 +1622,9 @@
           },
           "modifiedBy": {
             "type": ["null", "string"]
+          },
+          "concurrencyStamp": {
+            "type": "string"
           }
         }
       },

--- a/contracts/openapi/scheduling.json
+++ b/contracts/openapi/scheduling.json
@@ -690,7 +690,7 @@
       },
       "IIntegrationEvent": {
         "type": "object",
-        "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+        "description": "Marker interface for integration events (ETO \u2014 Event Transfer Object)."
       },
       "LookupDescriptor": {
         "type": "object",
@@ -782,7 +782,7 @@
                   "type": ["null", "array"],
                   "items": {
                     "type": "object",
-                    "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+                    "description": "Marker interface for integration events (ETO \u2014 Event Transfer Object)."
                   }
                 },
                 "createdAt": {
@@ -1077,6 +1077,10 @@
           },
           "createdAt": {
             "type": "string",
+            "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": ["string", "null"],
             "format": "date-time"
           }
         }

--- a/packages/@granit/authentication-api-keys/src/types/index.ts
+++ b/packages/@granit/authentication-api-keys/src/types/index.ts
@@ -31,6 +31,7 @@ export interface ApiKeyResponse {
   readonly revokedAt: ISODateString | null;
   readonly cacheBehavior: CacheBehavior;
   readonly createdAt: ISODateString;
+  readonly modifiedAt: ISODateString | null;
 }
 
 /**

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -109,13 +109,12 @@ export const CONTRACTS: readonly ModuleContract[] = [
   {
     slug: 'openiddict',
     package: 'openiddict-admin',
-    // TODO(contract): AdminOidcRotateSecretResponse (front newSecret vs backend
-    // displayName/newClientSecret) deferred — structural divergence to reconcile.
     types: [
       'AdminOidcApplicationResponse',
       'AdminOidcAuthorizationResponse',
       'AdminOidcCreateApplicationRequest',
       'AdminOidcUpdateApplicationRequest',
+      'AdminOidcRotateSecretResponse',
       'AdminOidcScopeResponse',
       'AdminOidcCreateScopeRequest',
       'AdminOidcUpdateScopeRequest',

--- a/packages/@granit/data-exchange/src/export/types/export-job.ts
+++ b/packages/@granit/data-exchange/src/export/types/export-job.ts
@@ -20,6 +20,7 @@ export interface ExportJobResponse {
   readonly completedAt: string | null;
   readonly modifiedAt: string | null;
   readonly modifiedBy: string | null;
+  readonly concurrencyStamp: string;
 }
 
 /**

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-application-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-application-api.test.ts
@@ -124,7 +124,8 @@ describe('admin-oidc-application-api', () => {
       const client = createMockClient();
       const response: AdminOidcRotateSecretResponse = {
         clientId: 'my-spa',
-        newSecret: 'new-secret-value',
+        displayName: 'My SPA',
+        newClientSecret: 'new-secret-value',
       };
       vi.mocked(client.post).mockResolvedValueOnce({ data: response });
 
@@ -137,7 +138,7 @@ describe('admin-oidc-application-api', () => {
     it('encodes client ID with special characters', async () => {
       const client = createMockClient();
       vi.mocked(client.post).mockResolvedValueOnce({
-        data: { newSecret: 'secret' },
+        data: { clientId: null, displayName: null, newClientSecret: 'secret' },
       });
 
       await rotateApplicationSecret(client, BASE, 'id/slash');

--- a/packages/@granit/openiddict-admin/src/types/admin-oidc-application.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-oidc-application.ts
@@ -54,6 +54,7 @@ export interface AdminOidcUpdateApplicationRequest {
 
 /** Response from `POST /oidc/applications/{clientId}/rotate-secret`. */
 export interface AdminOidcRotateSecretResponse {
-  readonly clientId: string;
-  readonly newSecret: string;
+  readonly clientId: string | null;
+  readonly displayName: string | null;
+  readonly newClientSecret: string;
 }

--- a/packages/@granit/react-authentication-api-keys/src/testing/data.ts
+++ b/packages/@granit/react-authentication-api-keys/src/testing/data.ts
@@ -17,6 +17,7 @@ export const mockApiKeys: ApiKeyResponse[] = [
     revokedAt: null,
     cacheBehavior: 'Normal',
     createdAt: toISODateString('2025-11-15T10:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'ApiKey'>('ak-2'),
@@ -32,6 +33,7 @@ export const mockApiKeys: ApiKeyResponse[] = [
     revokedAt: null,
     cacheBehavior: 'Normal',
     createdAt: toISODateString('2025-12-01T09:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'ApiKey'>('ak-3'),
@@ -47,6 +49,7 @@ export const mockApiKeys: ApiKeyResponse[] = [
     revokedAt: toISODateString('2026-01-15T09:00:00Z'),
     cacheBehavior: 'Normal',
     createdAt: toISODateString('2025-06-01T08:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'ApiKey'>('ak-4'),
@@ -62,6 +65,7 @@ export const mockApiKeys: ApiKeyResponse[] = [
     revokedAt: null,
     cacheBehavior: 'NoCache',
     createdAt: toISODateString('2026-01-10T11:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'ApiKey'>('ak-5'),
@@ -77,5 +81,6 @@ export const mockApiKeys: ApiKeyResponse[] = [
     revokedAt: null,
     cacheBehavior: 'NoCache',
     createdAt: toISODateString('2026-03-09T08:00:00Z'),
+    modifiedAt: null,
   },
 ];

--- a/packages/@granit/react-authentication-api-keys/src/testing/handlers.ts
+++ b/packages/@granit/react-authentication-api-keys/src/testing/handlers.ts
@@ -346,6 +346,7 @@ export function createApiKeyHandlers(baseUrl = `${DEFAULT_BASE_PATH}/api-keys`) 
         revokedAt: null,
         cacheBehavior: body.cacheBehavior ?? 'Normal',
         createdAt: toISODateString(now),
+        modifiedAt: null,
       };
       apiKeys.push(newKey);
 
@@ -388,6 +389,7 @@ export function createApiKeyHandlers(baseUrl = `${DEFAULT_BASE_PATH}/api-keys`) 
         revokedAt: null,
         lastUsedAt: null,
         createdAt: toISODateString(new Date().toISOString()),
+        modifiedAt: null,
       };
       apiKeys.push(newKey);
 

--- a/packages/@granit/react-data-exchange/src/testing/data.ts
+++ b/packages/@granit/react-data-exchange/src/testing/data.ts
@@ -114,6 +114,7 @@ export const mockExportHistory: ExportJobResponse[] = [
     errorMessage: null,
     modifiedAt: null,
     modifiedBy: null,
+    concurrencyStamp: 'stamp-exp-001',
   },
   {
     id: 'exp-002',
@@ -127,6 +128,7 @@ export const mockExportHistory: ExportJobResponse[] = [
     errorMessage: null,
     modifiedAt: null,
     modifiedBy: null,
+    concurrencyStamp: 'stamp-exp-002',
   },
   {
     id: 'exp-003',
@@ -140,6 +142,7 @@ export const mockExportHistory: ExportJobResponse[] = [
     errorMessage: null,
     modifiedAt: null,
     modifiedBy: null,
+    concurrencyStamp: 'stamp-exp-003',
   },
   {
     id: 'exp-004',
@@ -153,6 +156,7 @@ export const mockExportHistory: ExportJobResponse[] = [
     errorMessage: 'Export definition "users" has no data source configured',
     modifiedAt: null,
     modifiedBy: null,
+    concurrencyStamp: 'stamp-exp-004',
   },
   {
     id: 'exp-005',
@@ -166,6 +170,7 @@ export const mockExportHistory: ExportJobResponse[] = [
     errorMessage: null,
     modifiedAt: null,
     modifiedBy: null,
+    concurrencyStamp: 'stamp-exp-005',
   },
   {
     id: 'exp-006',
@@ -179,5 +184,6 @@ export const mockExportHistory: ExportJobResponse[] = [
     errorMessage: null,
     modifiedAt: null,
     modifiedBy: null,
+    concurrencyStamp: 'stamp-exp-006',
   },
 ];

--- a/packages/@granit/react-data-exchange/src/testing/handlers.ts
+++ b/packages/@granit/react-data-exchange/src/testing/handlers.ts
@@ -668,6 +668,9 @@ export function createDataExchangeHandlers(
         errorMessage: null,
         createdAt: new Date().toISOString(),
         completedAt: new Date().toISOString(),
+        modifiedAt: null,
+        modifiedBy: null,
+        concurrencyStamp: crypto.randomUUID(),
       };
       return HttpResponse.json(job);
     }),
@@ -684,6 +687,9 @@ export function createDataExchangeHandlers(
         errorMessage: null,
         createdAt: new Date().toISOString(),
         completedAt: new Date().toISOString(),
+        modifiedAt: null,
+        modifiedBy: null,
+        concurrencyStamp: 'mock-stamp',
       });
     }),
 

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-applications.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-applications.test.tsx
@@ -214,7 +214,8 @@ describe('useUpdateOidcApplication', () => {
 describe('useRotateApplicationSecret', () => {
   const mockSecretResponse: AdminOidcRotateSecretResponse = {
     clientId: 'guava-front',
-    newSecret: 'generated-secret-value',
+    displayName: 'Guava Frontend',
+    newClientSecret: 'generated-secret-value',
   };
 
   it('should rotate application secret', async () => {

--- a/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
@@ -434,7 +434,8 @@ export function createOpenIddictAdminHandlers(
       if (!app) return notFound();
       return HttpResponse.json({
         clientId: String(params.clientId),
-        newSecret: `mock-secret-rotated`,
+        displayName: app.displayName,
+        newClientSecret: 'mock-secret-rotated',
       });
     }),
 

--- a/packages/@granit/react-scheduling/src/testing/data.ts
+++ b/packages/@granit/react-scheduling/src/testing/data.ts
@@ -15,6 +15,7 @@ export const mockScheduledActions: Mutable<ScheduledActionResponse>[] = [
     cancelledBy: null,
     failureReason: null,
     createdAt: toISODateString('2026-04-02T14:30:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'ScheduledAction'>('a1b2c3d4-0002-4000-8000-000000000002'),
@@ -26,6 +27,7 @@ export const mockScheduledActions: Mutable<ScheduledActionResponse>[] = [
     cancelledBy: null,
     failureReason: null,
     createdAt: toISODateString('2026-03-25T10:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'ScheduledAction'>('a1b2c3d4-0003-4000-8000-000000000003'),
@@ -37,6 +39,7 @@ export const mockScheduledActions: Mutable<ScheduledActionResponse>[] = [
     cancelledBy: 'admin@example.com',
     failureReason: null,
     createdAt: toISODateString('2026-03-20T16:45:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'ScheduledAction'>('a1b2c3d4-0004-4000-8000-000000000004'),
@@ -48,6 +51,7 @@ export const mockScheduledActions: Mutable<ScheduledActionResponse>[] = [
     cancelledBy: null,
     failureReason: 'Connection timeout after 30s',
     createdAt: toISODateString('2026-03-28T08:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'ScheduledAction'>('a1b2c3d4-0005-4000-8000-000000000005'),
@@ -59,6 +63,7 @@ export const mockScheduledActions: Mutable<ScheduledActionResponse>[] = [
     cancelledBy: null,
     failureReason: null,
     createdAt: toISODateString('2026-04-01T18:00:00Z'),
+    modifiedAt: null,
   },
   {
     id: toEntityId<'ScheduledAction'>('a1b2c3d4-0006-4000-8000-000000000006'),
@@ -70,5 +75,6 @@ export const mockScheduledActions: Mutable<ScheduledActionResponse>[] = [
     cancelledBy: null,
     failureReason: null,
     createdAt: toISODateString('2026-04-03T09:15:00Z'),
+    modifiedAt: null,
   },
 ];

--- a/packages/@granit/react-scheduling/src/testing/handlers.ts
+++ b/packages/@granit/react-scheduling/src/testing/handlers.ts
@@ -294,6 +294,7 @@ export function createSchedulingHandlers(baseUrl = DEFAULT_BASE_PATH) {
       }
       const body = (await request.json()) as { newExecuteAt: string };
       action.executeAt = toISODateString(body.newExecuteAt);
+      action.modifiedAt = toISODateString(new Date().toISOString());
       return new HttpResponse(null, { status: 200 });
     }),
   ];

--- a/packages/@granit/scheduling/src/__tests__/scheduling-api.test.ts
+++ b/packages/@granit/scheduling/src/__tests__/scheduling-api.test.ts
@@ -41,6 +41,7 @@ const sampleAction: ScheduledActionResponse = {
   cancelledBy: null,
   failureReason: null,
   createdAt: toISODateString('2026-06-01T10:00:00Z'),
+  modifiedAt: null,
 };
 
 const pagedResult: PagedResult<ScheduledActionResponse> = {

--- a/packages/@granit/scheduling/src/types/index.ts
+++ b/packages/@granit/scheduling/src/types/index.ts
@@ -28,6 +28,7 @@ export interface ScheduledActionResponse {
   readonly cancelledBy: string | null;
   readonly failureReason: string | null;
   readonly createdAt: ISODateString;
+  readonly modifiedAt: ISODateString | null;
 }
 
 /** Request body for rescheduling a pending action. */


### PR DESCRIPTION
## Summary

Applies the front-end side of `test/openiddict-endpoints-coverage` (granit-dotnet), which enriched 4 DTOs:

| Package | Type | Change |
|---------|------|--------|
| `@granit/authentication-api-keys` | `ApiKeyResponse` | Add `modifiedAt: ISODateString \| null` |
| `@granit/scheduling` | `ScheduledActionResponse` | Add `modifiedAt: ISODateString \| null` |
| `@granit/data-exchange` | `ExportJobResponse` | Add `concurrencyStamp: string` |
| `@granit/openiddict-admin` | `AdminOidcRotateSecretResponse` | Rename `newSecret` → `newClientSecret`, add `displayName: string \| null`, widen `clientId` to `string \| null` |

> `RoleResponse.concurrencyStamp` — no front package uses `RoleResponse` yet (role management UI not implemented). Skipped per handover notes.

Also re-syncs `contracts/openapi/{api-keys,scheduling,data-exchange}.json` (backend generator output was stale — the new fields appear in the C# DTOs but had not been re-generated to JSON yet). Snapshots patched manually to unblock the oracle until the generator runs in CI.

Undefers `AdminOidcRotateSecretResponse` from the contract-tests manifest. Oracle now covers it fully.

## Test plan

- [ ] `pnpm tsc` — 0 errors ✓
- [ ] `pnpm lint` — 0 warnings ✓
- [ ] `npx vitest run packages/@granit/contract-tests` — 496 ✓ (was 493)
- [ ] Affected package tests (35 files, 252 tests) — all pass ✓