### PR TITLE
fix(cms,cms-seo)!: sync with granit-website rework

### DIFF
--- a/contracts/openapi/cms-seo.json
+++ b/contracts/openapi/cms-seo.json
@@ -319,6 +319,16 @@
               }
             }
           },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -586,6 +596,16 @@
               "application/problem+json": {
                 "schema": {
                   "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -3151,6 +3171,10 @@
           "xDefaultCulture": {
             "maxLength": 20,
             "type": ["null", "string"]
+          },
+          "concurrencyStamp": {
+            "type": "string",
+            "default": ""
           }
         }
       },
@@ -3273,7 +3297,7 @@
         "type": "object",
         "properties": {
           "fields": {
-            "$ref": "#/components/schemas/SuggestionScope"
+            "$ref": "#/components/schemas/SuggestionScopes"
           }
         }
       },
@@ -3286,7 +3310,7 @@
             "format": "uuid"
           },
           "scope": {
-            "$ref": "#/components/schemas/SuggestionScope"
+            "$ref": "#/components/schemas/SuggestionScopes"
           },
           "fields": {
             "type": "array",
@@ -3331,7 +3355,6 @@
         }
       },
       "SeoSuggestionRejectRequest": {
-        "required": ["reason"],
         "type": "object",
         "properties": {
           "reason": {
@@ -3387,10 +3410,10 @@
             "$ref": "#/components/schemas/SuggestionStatus"
           },
           "scope": {
-            "$ref": "#/components/schemas/SuggestionScope"
+            "$ref": "#/components/schemas/SuggestionScopes"
           },
           "appliedFields": {
-            "$ref": "#/components/schemas/SuggestionScope"
+            "$ref": "#/components/schemas/SuggestionScopes"
           },
           "title": {
             "type": ["null", "string"]
@@ -3437,15 +3460,7 @@
         }
       },
       "SeoSuggestRequest": {
-        "required": [
-          "siteId",
-          "contentType",
-          "contentId",
-          "culture",
-          "contentTitle",
-          "contentBody",
-          "scope"
-        ],
+        "required": ["siteId", "contentType", "contentId", "contentTitle", "scope"],
         "type": "object",
         "properties": {
           "siteId": {
@@ -3460,20 +3475,20 @@
             "type": "string",
             "format": "uuid"
           },
-          "culture": {
-            "maxLength": 20,
-            "type": ["null", "string"]
-          },
           "contentTitle": {
             "maxLength": 300,
             "type": "string"
           },
+          "scope": {
+            "$ref": "#/components/schemas/SuggestionScopes"
+          },
+          "culture": {
+            "maxLength": 20,
+            "type": ["null", "string"]
+          },
           "contentBody": {
             "maxLength": 50000,
             "type": ["null", "string"]
-          },
-          "scope": {
-            "$ref": "#/components/schemas/SuggestionScope"
           }
         }
       },
@@ -3605,6 +3620,10 @@
           "enableAutomaticSeoGeneration": {
             "type": "boolean",
             "default": false
+          },
+          "concurrencyStamp": {
+            "type": "string",
+            "default": ""
           }
         }
       },
@@ -3726,7 +3745,7 @@
           }
         }
       },
-      "SuggestionScope": {
+      "SuggestionScopes": {
         "type": "string"
       },
       "SuggestionStatus": {

--- a/contracts/openapi/cms.json
+++ b/contracts/openapi/cms.json
@@ -1249,6 +1249,16 @@
               }
             }
           },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
@@ -1406,6 +1416,16 @@
           },
           "400": {
             "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4263,7 +4283,7 @@
   "components": {
     "schemas": {
       "AddReleaseActionRequest": {
-        "required": ["contentType", "contentId", "culture", "type"],
+        "required": ["contentType", "contentId", "culture", "type", "concurrencyStamp"],
         "type": "object",
         "properties": {
           "contentType": {
@@ -4280,6 +4300,9 @@
           },
           "type": {
             "$ref": "#/components/schemas/ReleaseActionType"
+          },
+          "concurrencyStamp": {
+            "type": "string"
           }
         }
       },
@@ -5208,12 +5231,15 @@
         }
       },
       "MovePageRequest": {
-        "required": ["newParentId"],
+        "required": ["newParentId", "concurrencyStamp"],
         "type": "object",
         "properties": {
           "newParentId": {
             "type": "string",
             "format": "uuid"
+          },
+          "concurrencyStamp": {
+            "type": "string"
           }
         }
       },
@@ -6438,7 +6464,8 @@
           "kind",
           "isSiteRoot",
           "layoutKey",
-          "translations"
+          "translations",
+          "concurrencyStamp"
         ],
         "type": "object",
         "properties": {
@@ -6478,6 +6505,9 @@
             "items": {
               "$ref": "#/components/schemas/PageTranslationResponse"
             }
+          },
+          "concurrencyStamp": {
+            "type": "string"
           }
         }
       },
@@ -7072,22 +7102,28 @@
         "enum": ["Draft", "Ready", "Running", "Done", "Failed"]
       },
       "RenamePageRequest": {
-        "required": ["slugSegment"],
+        "required": ["slugSegment", "concurrencyStamp"],
         "type": "object",
         "properties": {
           "slugSegment": {
             "maxLength": 200,
             "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
             "type": "string"
+          },
+          "concurrencyStamp": {
+            "type": "string"
           }
         }
       },
       "RenameReleaseRequest": {
-        "required": ["name"],
+        "required": ["name", "concurrencyStamp"],
         "type": "object",
         "properties": {
           "name": {
             "maxLength": 200,
+            "type": "string"
+          },
+          "concurrencyStamp": {
             "type": "string"
           }
         }
@@ -7155,7 +7191,7 @@
         }
       },
       "ScheduleReleaseRequest": {
-        "required": ["localDateTime", "timeZoneId"],
+        "required": ["localDateTime", "timeZoneId", "concurrencyStamp"],
         "type": "object",
         "properties": {
           "localDateTime": {
@@ -7164,6 +7200,9 @@
           },
           "timeZoneId": {
             "maxLength": 64,
+            "type": "string"
+          },
+          "concurrencyStamp": {
             "type": "string"
           }
         }

--- a/packages/@granit/cms-seo/src/types/index.ts
+++ b/packages/@granit/cms-seo/src/types/index.ts
@@ -158,6 +158,7 @@ export interface SeoMetadataRequest {
   readonly disableAutoJsonLd?: boolean;
   readonly alternateOverrides?: readonly Hreflang[] | null;
   readonly xDefaultCulture?: string | null;
+  readonly concurrencyStamp?: string;
 }
 
 /**
@@ -227,6 +228,7 @@ export interface SiteSeoDefaultsRequest {
   readonly robotsTxtExtra?: string | null;
   readonly manifest?: WebManifest | null;
   readonly enableAutomaticSeoGeneration?: boolean;
+  readonly concurrencyStamp?: string;
 }
 
 /** A site's SEO defaults. Maps `SiteSeoDefaultsResponse`. */
@@ -336,9 +338,9 @@ export interface SeoSuggestRequest {
   readonly siteId: string;
   readonly contentType: string;
   readonly contentId: string;
-  readonly culture: string | null;
+  readonly culture?: string | null;
   readonly contentTitle: string;
-  readonly contentBody: string | null;
+  readonly contentBody?: string | null;
   readonly scope: SuggestionScope;
 }
 

--- a/packages/@granit/cms-seo/src/types/index.ts
+++ b/packages/@granit/cms-seo/src/types/index.ts
@@ -338,10 +338,10 @@ export interface SeoSuggestRequest {
   readonly siteId: string;
   readonly contentType: string;
   readonly contentId: string;
-  readonly culture?: string | null;
   readonly contentTitle: string;
-  readonly contentBody?: string | null;
   readonly scope: SuggestionScope;
+  readonly culture?: string | null;
+  readonly contentBody?: string | null;
 }
 
 /**

--- a/packages/@granit/cms/src/__tests__/pages-admin.test.ts
+++ b/packages/@granit/cms/src/__tests__/pages-admin.test.ts
@@ -46,6 +46,7 @@ const page: PageResponse = {
   isSiteRoot: true,
   layoutKey: null,
   translations: [{ culture: 'fr', urlSlug: 'accueil', title: 'Accueil', path: '/accueil' }],
+  concurrencyStamp: 'mock-stamp',
 };
 
 const version: PageVersionSummaryResponse = {
@@ -113,10 +114,14 @@ describe('updatePage', () => {
     const client = createMockClient();
     vi.mocked(client.put).mockResolvedValue(axiosResponse(page));
 
-    await updatePage(client, BASE, 'page-1', { slugSegment: 'new-home' });
+    await updatePage(client, BASE, 'page-1', {
+      slugSegment: 'new-home',
+      concurrencyStamp: 'stamp-1',
+    });
 
     expect(client.put).toHaveBeenCalledWith(`${BASE}/api/cms/pages/page-1`, {
       slugSegment: 'new-home',
+      concurrencyStamp: 'stamp-1',
     });
   });
 });
@@ -143,10 +148,14 @@ describe('movePage', () => {
     const client = createMockClient();
     vi.mocked(client.post).mockResolvedValue({ status: 204, data: undefined });
 
-    await movePage(client, BASE, 'page-1', { newParentId: 'parent-1' });
+    await movePage(client, BASE, 'page-1', {
+      newParentId: 'parent-1',
+      concurrencyStamp: 'stamp-1',
+    });
 
     expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/pages/page-1/move`, {
       newParentId: 'parent-1',
+      concurrencyStamp: 'stamp-1',
     });
   });
 });

--- a/packages/@granit/cms/src/__tests__/releases.test.ts
+++ b/packages/@granit/cms/src/__tests__/releases.test.ts
@@ -92,10 +92,14 @@ describe('updateRelease', () => {
     const updated = { ...release, name: 'Sprint 42 rev2' };
     vi.mocked(client.put).mockResolvedValue(axiosResponse(updated));
 
-    await updateRelease(client, BASE, 'rel-1', { name: 'Sprint 42 rev2' });
+    await updateRelease(client, BASE, 'rel-1', {
+      name: 'Sprint 42 rev2',
+      concurrencyStamp: 'stamp-1',
+    });
 
     expect(client.put).toHaveBeenCalledWith(`${BASE}/api/cms/releases/rel-1`, {
       name: 'Sprint 42 rev2',
+      concurrencyStamp: 'stamp-1',
     });
   });
 });
@@ -110,6 +114,7 @@ describe('addReleaseAction', () => {
       contentId: 'page-1',
       culture: 'fr',
       type: 'Publish' as const,
+      concurrencyStamp: 'stamp-1',
     };
     const result = await addReleaseAction(client, BASE, 'rel-1', request);
 
@@ -136,7 +141,11 @@ describe('scheduleRelease', () => {
     const scheduled = { ...release, status: 'Ready' as const };
     vi.mocked(client.post).mockResolvedValue(axiosResponse(scheduled));
 
-    const request = { localDateTime: '2026-07-01T09:00:00', timeZoneId: 'Europe/Brussels' };
+    const request = {
+      localDateTime: '2026-07-01T09:00:00',
+      timeZoneId: 'Europe/Brussels',
+      concurrencyStamp: 'stamp-1',
+    };
     const result = await scheduleRelease(client, BASE, 'rel-1', request);
 
     expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/releases/rel-1/schedule`, request);

--- a/packages/@granit/cms/src/types/index.ts
+++ b/packages/@granit/cms/src/types/index.ts
@@ -231,6 +231,7 @@ export interface PageResponse {
   readonly isSiteRoot: boolean;
   readonly layoutKey: string | null;
   readonly translations: readonly PageTranslation[];
+  readonly concurrencyStamp: string;
 }
 
 /** Summary of one page version. Returned by `GET /api/cms/pages/{id}/versions`. */
@@ -257,6 +258,7 @@ export interface CreatePageRequest {
 /** Request body for `PUT /api/cms/pages/{id}`. */
 export interface UpdatePageRequest {
   readonly slugSegment: string;
+  readonly concurrencyStamp: string;
 }
 
 /** Request body for `PUT /api/cms/pages/{id}/translations/{culture}`. */
@@ -268,6 +270,7 @@ export interface UpdatePageTranslationRequest {
 /** Request body for `POST /api/cms/pages/{id}/move` — reparents the page. */
 export interface MovePageRequest {
   readonly newParentId: string;
+  readonly concurrencyStamp: string;
 }
 
 /** Request body for `PUT /api/cms/pages/{id}/draft/{culture}`. */
@@ -383,6 +386,7 @@ export interface CreateReleaseRequest {
 /** Request body for `PUT /api/cms/releases/{id}`. */
 export interface UpdateReleaseRequest {
   readonly name: string;
+  readonly concurrencyStamp: string;
 }
 
 /** Request body for `POST /api/cms/releases/{id}/actions` (add action). */
@@ -391,6 +395,7 @@ export interface AddReleaseActionRequest {
   readonly contentId: string;
   readonly culture: string | null;
   readonly type: ReleaseActionType;
+  readonly concurrencyStamp: string;
 }
 
 /** Request body for `POST /api/cms/releases/{id}/schedule`. */
@@ -398,6 +403,7 @@ export interface ScheduleReleaseRequest {
   readonly localDateTime: string;
   /** IANA time-zone identifier (e.g. `"Europe/Brussels"`). */
   readonly timeZoneId: string;
+  readonly concurrencyStamp: string;
 }
 
 // ─── List params (admin) ─────────────────────────────────────────────────────

--- a/packages/@granit/react-cms/src/__tests__/use-page-mutations.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-page-mutations.test.ts
@@ -56,6 +56,7 @@ const page: PageResponse = {
   isSiteRoot: true,
   layoutKey: null,
   translations: [],
+  concurrencyStamp: 'mock-stamp',
 };
 const version: PageVersionSummaryResponse = {
   versionId: 'v-1',
@@ -107,10 +108,16 @@ describe('useUpdatePage', () => {
     vi.mocked(updatePage).mockResolvedValue(page);
 
     const { result } = renderHook(() => useUpdatePage(), { wrapper: createWrapper(client) });
-    result.current.mutate({ id: 'page-1', request: { slugSegment: 'new-home' } });
+    result.current.mutate({
+      id: 'page-1',
+      request: { slugSegment: 'new-home', concurrencyStamp: 'stamp-1' },
+    });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(updatePage).toHaveBeenCalledWith(client, '', 'page-1', { slugSegment: 'new-home' });
+    expect(updatePage).toHaveBeenCalledWith(client, '', 'page-1', {
+      slugSegment: 'new-home',
+      concurrencyStamp: 'stamp-1',
+    });
   });
 });
 
@@ -150,10 +157,17 @@ describe('useMovePage', () => {
     vi.mocked(movePage).mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useMovePage(), { wrapper: createWrapper(client) });
-    result.current.mutate({ id: 'page-1', request: { newParentId: 'parent-1' }, siteId: 'site-1' });
+    result.current.mutate({
+      id: 'page-1',
+      request: { newParentId: 'parent-1', concurrencyStamp: 'stamp-1' },
+      siteId: 'site-1',
+    });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(movePage).toHaveBeenCalledWith(client, '', 'page-1', { newParentId: 'parent-1' });
+    expect(movePage).toHaveBeenCalledWith(client, '', 'page-1', {
+      newParentId: 'parent-1',
+      concurrencyStamp: 'stamp-1',
+    });
   });
 });
 

--- a/packages/@granit/react-cms/src/__tests__/use-pages.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-pages.test.ts
@@ -40,6 +40,7 @@ const page: PageResponse = {
   isSiteRoot: true,
   layoutKey: null,
   translations: [],
+  concurrencyStamp: 'mock-stamp',
 };
 const version: PageVersionSummaryResponse = {
   versionId: 'v-1',

--- a/packages/@granit/react-cms/src/__tests__/use-release-mutations.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-release-mutations.test.ts
@@ -88,10 +88,16 @@ describe('useUpdateRelease', () => {
     vi.mocked(updateRelease).mockResolvedValue(release);
 
     const { result } = renderHook(() => useUpdateRelease(), { wrapper: createWrapper(client) });
-    result.current.mutate({ id: 'rel-1', request: { name: 'Sprint 1 v2' } });
+    result.current.mutate({
+      id: 'rel-1',
+      request: { name: 'Sprint 1 v2', concurrencyStamp: 'stamp-1' },
+    });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(updateRelease).toHaveBeenCalledWith(client, '', 'rel-1', { name: 'Sprint 1 v2' });
+    expect(updateRelease).toHaveBeenCalledWith(client, '', 'rel-1', {
+      name: 'Sprint 1 v2',
+      concurrencyStamp: 'stamp-1',
+    });
   });
 });
 
@@ -109,6 +115,7 @@ describe('useAddReleaseAction', () => {
       contentId: 'page-1',
       culture: 'fr',
       type: 'Publish' as const,
+      concurrencyStamp: 'stamp-1',
     };
     const { result } = renderHook(() => useAddReleaseAction(), { wrapper: createWrapper(client) });
     result.current.mutate({ id: 'rel-1', request: req });
@@ -146,7 +153,11 @@ describe('useScheduleRelease', () => {
     const client = createMockClient();
     vi.mocked(scheduleRelease).mockResolvedValue({ ...release, status: 'Ready' });
 
-    const req = { localDateTime: '2026-07-01T09:00:00', timeZoneId: 'Europe/Brussels' };
+    const req = {
+      localDateTime: '2026-07-01T09:00:00',
+      timeZoneId: 'Europe/Brussels',
+      concurrencyStamp: 'stamp-1',
+    };
     const { result } = renderHook(() => useScheduleRelease(), { wrapper: createWrapper(client) });
     result.current.mutate({ id: 'rel-1', request: req });
 

--- a/packages/@granit/react-cms/src/testing/handlers.ts
+++ b/packages/@granit/react-cms/src/testing/handlers.ts
@@ -126,6 +126,7 @@ export function createPagesHandlers(baseUrl = '/api/cms/pages'): RequestHandler[
     isSiteRoot: node.isSiteRoot,
     layoutKey: null,
     translations: [],
+    concurrencyStamp: 'mock-stamp',
   });
 
   return [


### PR DESCRIPTION
## Summary

- `cms.json`: 6 DTOs gain `concurrencyStamp: string` (required) — `PageResponse`, `MovePageRequest`, `UpdatePageRequest`, `AddReleaseActionRequest`, `UpdateReleaseRequest`, `ScheduleReleaseRequest`
- `cms-seo.json`: `SeoMetadataRequest` + `SiteSeoDefaultsRequest` gain `concurrencyStamp?: string` (optional, C# `default=""`); `SeoSuggestRequest.culture`/`.contentBody` become optional (C# `default=null`, removed from `required`)
- Re-sync `contracts/openapi/{cms,cms-seo}.json` from granit-website generator output
- Contract oracle: 496 ✓

## Test plan

- [ ] `pnpm tsc` clean (0 errors)
- [ ] `pnpm lint` clean (0 warnings)
- [ ] `npx vitest run packages/@granit/contract-tests` — 496 tests ✓
- [ ] `npx vitest run packages/@granit/cms packages/@granit/react-cms packages/@granit/cms-seo packages/@granit/react-cms-seo` — all passing