### PR TITLE
feat(contract-tests): add field-order conformance rule + fix 21 existing drifts

### DIFF
--- a/packages/@granit/bank-accounts/src/types/index.ts
+++ b/packages/@granit/bank-accounts/src/types/index.ts
@@ -83,8 +83,6 @@ export interface BankAccountResponse {
  * is effectively never populated through this surface.
  */
 export interface BankAccount {
-  readonly id: string;
-  readonly tenantId: TenantId | null;
   readonly partyId: string;
   readonly scheme: BankAccountScheme;
   readonly accountIdentifier: string;
@@ -100,10 +98,12 @@ export interface BankAccount {
   readonly status: BankAccountStatus;
   readonly verified: boolean;
   readonly trusted: boolean;
-  readonly createdAt: ISODateString;
-  readonly createdBy: string;
+  readonly tenantId: TenantId | null;
   readonly modifiedAt: ISODateString | null;
   readonly modifiedBy: string | null;
+  readonly createdAt: ISODateString;
+  readonly createdBy: string;
+  readonly id: string;
 }
 
 /** Paginated page of {@link BankAccount} entities (QueryEngine admin grid). */

--- a/packages/@granit/catalog/src/types/index.ts
+++ b/packages/@granit/catalog/src/types/index.ts
@@ -55,8 +55,8 @@ export interface ProductCreateRequest {
 /** Request to update editable fields of a Draft product. */
 export interface ProductUpdateRequest {
   readonly name: string;
-  readonly description: string | null;
   readonly unit: string;
+  readonly description: string | null;
 }
 
 /**

--- a/packages/@granit/cms/src/types/index.ts
+++ b/packages/@granit/cms/src/types/index.ts
@@ -213,10 +213,10 @@ export interface PageTreeNodeResponse {
 
 /** Per-culture translation of a page. */
 export interface PageTranslation {
-  readonly culture: string;
   readonly urlSlug: string;
   readonly title: string;
   readonly path: string;
+  readonly culture: string;
 }
 
 /** Full page record. Returned by `GET /api/cms/pages/{id}`. */

--- a/packages/@granit/contract-tests/src/__tests__/conformance.test.ts
+++ b/packages/@granit/contract-tests/src/__tests__/conformance.test.ts
@@ -93,6 +93,65 @@ describe('conformance oracle — positive & negative controls', () => {
     );
   });
 
+  it('passes when optional spec fields are absent from the front (no order false-positive)', () => {
+    // spec: id, count, when, flag, note — front omits optional `note`
+    const specWithOptional: OpenApiDocument = {
+      components: {
+        schemas: {
+          Sample: {
+            type: 'object',
+            required: ['id', 'count', 'when', 'flag'],
+            properties: {
+              id: { type: 'string' },
+              count: { type: 'integer' },
+              when: { type: 'string' },
+              flag: { type: 'boolean' },
+              note: { type: 'string' }, // optional — front may omit it
+            },
+          },
+        },
+      },
+    };
+    const src = `export interface Sample {
+      readonly id: string;
+      readonly count: number;
+      readonly when: string;
+      readonly flag: boolean;
+    }`;
+    const violations = checkSchemaConformance({
+      spec: specWithOptional,
+      schemaName: 'Sample',
+      sourceText: src,
+      fileName: file,
+    });
+    expect(violations.some((v) => v.rule === 'field-order')).toBe(false);
+  });
+
+  it('flags field-order drift', () => {
+    const src = `export interface Sample {
+      readonly id: string;
+      readonly count: number;
+      readonly flag: boolean;   // swapped with when
+      readonly when: string | null;
+      readonly note: string | null;
+    }`;
+    expect(check(src)).toContainEqual(expect.objectContaining({ rule: 'field-order', field: '*' }));
+  });
+
+  it('field-order message shows spec order vs front order', () => {
+    const src = `export interface Sample {
+      readonly count: number;
+      readonly id: string;
+      readonly when: string | null;
+      readonly flag: boolean;
+      readonly note: string | null;
+    }`;
+    const violations = check(src);
+    const v = violations.find((x) => x.rule === 'field-order');
+    expect(v?.message).toContain('spec: [id, count');
+    expect(v?.message).toContain('front: [count, id');
+  });
+
   // The codebase keeps each string-union enum in its own file. A field typed as
   // an imported enum must follow the import to resolve to `string`, not default
   // an unresolved reference to `object` (which produced false type-family drift).

--- a/packages/@granit/contract-tests/src/conformance.ts
+++ b/packages/@granit/contract-tests/src/conformance.ts
@@ -443,5 +443,20 @@ export function checkSchemaConformance(opts: CheckSchemaOptions): ConformanceVio
     }
   }
 
+  // Field order — compare the relative order of shared fields only (missing /
+  // orphan fields are already reported above; they must not skew the position
+  // check). A mismatch here means a C# record parameter was reordered without
+  // updating the TS interface, or a field was inserted in the wrong place.
+  const sharedInSpec = [...backend.keys()].filter((k) => front.has(k));
+  const sharedInFront = [...front.keys()].filter((k) => backend.has(k));
+  if (sharedInSpec.join('\0') !== sharedInFront.join('\0')) {
+    out.push({
+      rule: 'field-order',
+      schema: opts.schemaName,
+      field: '*',
+      message: `field order differs — spec: [${sharedInSpec.join(', ')}], front: [${sharedInFront.join(', ')}]`,
+    });
+  }
+
   return out;
 }

--- a/packages/@granit/documents/src/types/index.ts
+++ b/packages/@granit/documents/src/types/index.ts
@@ -48,12 +48,12 @@ export interface FolderResponse {
   readonly depth: number;
   readonly ownerId: string;
   readonly status: FolderStatus;
+  /** UTC instant the folder was trashed; `null` while active. */
+  readonly trashedAt: ISODateString | null;
   /** UTC instant the folder was created (ISO 8601). Always present. */
   readonly createdAt: ISODateString;
   /** UTC instant of the last change; `null` if never modified since creation. */
   readonly modifiedAt: ISODateString | null;
-  /** UTC instant the folder was trashed; `null` while active. */
-  readonly trashedAt: ISODateString | null;
   /** Effective permission resolved via F6.5b; `null` when not requested. */
   readonly permission: EffectivePermissionLevel | null;
 }
@@ -70,9 +70,9 @@ export interface FolderBreadcrumbResponse {
 
 /** PUT-like create payload for `POST /folders`. */
 export interface CreateFolderRequest {
+  readonly name: string;
   /** `null` creates the folder directly under the invisible tenant root. */
   readonly parentFolderId: string | null;
-  readonly name: string;
 }
 
 /** PATCH payload for `PATCH /folders/{id}`. */
@@ -104,6 +104,8 @@ export interface DocumentResponse {
   readonly ownerId: string;
   /** Identifier of the active version; `null` until the first version is uploaded. */
   readonly currentVersionId: string | null;
+  readonly status: DocumentStatus;
+  readonly trashedAt: ISODateString | null;
   /**
    * Size in bytes of the current version (.NET `long`; see
    * {@link DocumentVersionResponse.sizeBytes}). `null` until the first version
@@ -112,14 +114,12 @@ export interface DocumentResponse {
   readonly sizeBytes: number | null;
   /** Content type of the current version; `null` until the first version is uploaded. */
   readonly contentType: string | null;
-  readonly status: DocumentStatus;
   /** UTC instant the document was created (ISO 8601). Always present. */
   readonly createdAt: ISODateString;
   /** UTC instant of the last content/metadata change; `null` if never modified since creation. */
   readonly modifiedAt: ISODateString | null;
   /** Optimistic-concurrency token; echo back on edit to detect conflicts (409). */
   readonly concurrencyStamp: string;
-  readonly trashedAt: ISODateString | null;
   /** Effective permission resolved via F6.5; `null` when not requested. */
   readonly permission: EffectivePermissionLevel | null;
 }
@@ -149,9 +149,9 @@ export interface UploadTicketResponse {
 /** Request payload for `POST /documents/finalize`. */
 export interface FinalizeUploadRequest {
   readonly blobId: string;
+  readonly name: string;
   /** `null` drops the document directly under the tenant root. */
   readonly folderId: string | null;
-  readonly name: string;
   readonly description: string | null;
   readonly commitMessage: string | null;
 }

--- a/packages/@granit/entities-views/src/types/requests.ts
+++ b/packages/@granit/entities-views/src/types/requests.ts
@@ -8,10 +8,10 @@ export interface EntityViewCreateBodyRequest {
   /** View kind inherited from `basedOn`. */
   readonly kind: string;
   readonly name: string;
-  readonly description: string | null;
-  readonly icon: string | null;
   /** JSON delta payload. */
   readonly state: Readonly<Record<string, unknown>>;
+  readonly description: string | null;
+  readonly icon: string | null;
 }
 
 /**
@@ -23,9 +23,10 @@ export interface EntityViewCreateBodyRequest {
  */
 export interface EntityViewUpdateBodyRequest {
   readonly name: string;
+  /** JSON delta payload. */
+  readonly state: Readonly<Record<string, unknown>>;
   readonly description: string | null;
   readonly icon: string | null;
-  readonly state: Readonly<Record<string, unknown>>;
 }
 
 /**

--- a/packages/@granit/localization/src/types/index.ts
+++ b/packages/@granit/localization/src/types/index.ts
@@ -36,17 +36,17 @@ export type LocalizationOverrideId = EntityId<'LocalizationOverride'>;
  * `AuditedEntity`), not `lastModified*`.
  */
 export interface LocalizationOverride {
-  readonly id: LocalizationOverrideId;
   /** Tenant scope. `null` = host-level override (applies to all tenants). */
   readonly tenantId: string | null;
   readonly resourceName: string;
   readonly cultureName: string;
   readonly key: string;
   readonly value: string;
-  readonly createdAt: ISODateString;
-  readonly createdBy: string;
   readonly modifiedAt: ISODateString | null;
   readonly modifiedBy: string | null;
+  readonly createdAt: ISODateString;
+  readonly createdBy: string;
+  readonly id: LocalizationOverrideId;
 }
 
 export interface LocalizationConfig {

--- a/packages/@granit/metering/src/types/index.ts
+++ b/packages/@granit/metering/src/types/index.ts
@@ -140,8 +140,6 @@ export interface DeprecateEventResponse {
  * projection applied by the CRUD endpoints.
  */
 export interface MeterDefinition {
-  readonly id: string;
-  readonly tenantId: TenantId | null;
   readonly name: string;
   readonly unit: string;
   readonly description: string | null;
@@ -149,10 +147,12 @@ export interface MeterDefinition {
   readonly distinctProperty: string | null;
   readonly lifecycleStatus: MeterLifecycleStatus;
   readonly productId: string | null;
-  readonly createdAt: ISODateString;
-  readonly createdBy: string;
+  readonly tenantId: TenantId | null;
   readonly modifiedAt: ISODateString | null;
   readonly modifiedBy: string | null;
+  readonly createdAt: ISODateString;
+  readonly createdBy: string;
+  readonly id: string;
 }
 
 /**
@@ -163,14 +163,14 @@ export interface MeterDefinition {
  * audited entity — no `createdAt` / `modifiedAt`.
  */
 export interface UsageAggregate {
-  readonly id: string;
-  readonly tenantId: TenantId | null;
   readonly meterDefinitionId: string;
   readonly period: AggregationPeriod;
   readonly periodStart: ISODateString;
   readonly periodEnd: ISODateString;
   readonly aggregatedValue: number;
   readonly eventCount: number;
+  readonly tenantId: TenantId | null;
+  readonly id: string;
 }
 
 /** Paginated page of {@link MeterDefinition} entities. */

--- a/packages/@granit/openiddict-admin/src/types/admin-oidc-application.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-oidc-application.ts
@@ -25,8 +25,8 @@ export interface AdminOidcApplicationResponse {
 /** Request body for `POST /oidc/applications`. */
 export interface AdminOidcCreateApplicationRequest {
   readonly clientId: string;
-  readonly clientSecret?: string;
   readonly displayName?: string;
+  readonly clientSecret?: string;
   readonly type?: string;
   readonly permissions?: string[];
   readonly redirectUris?: string[];

--- a/packages/@granit/openiddict-admin/src/types/admin-oidc-authorization.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-oidc-authorization.ts
@@ -11,8 +11,8 @@ export interface AdminOidcAuthorizationListParams {
 /** OIDC authorization descriptor — mirrors `AdminOidcAuthorizationResponse`. */
 export interface AdminOidcAuthorizationResponse {
   readonly id: string;
-  readonly clientId: string | null;
   readonly subject: string | null;
+  readonly clientId: string | null;
   readonly status: string | null;
   readonly type: string | null;
   readonly scopes: readonly string[];

--- a/packages/@granit/privacy/src/types/index.ts
+++ b/packages/@granit/privacy/src/types/index.ts
@@ -15,10 +15,10 @@ export type PrivacyExportStatusResponse = {
   readonly subjectUserId: string;
   /** Who requested the export. Differs from {@link subjectUserId} in the on-behalf-of flow. */
   readonly callerUserId: string;
-  readonly requestedAt: ISODateString;
   readonly state: PrivacyExportStatus;
-  readonly archiveBlobReferenceId: string | null;
+  readonly requestedAt: ISODateString;
   readonly completedAt: ISODateString | null;
+  readonly archiveBlobReferenceId: string | null;
   readonly missingProviders: readonly string[];
 };
 

--- a/packages/@granit/subscriptions/src/types/index.ts
+++ b/packages/@granit/subscriptions/src/types/index.ts
@@ -22,17 +22,17 @@ export type SubscriptionStatus =
 
 export interface PlanCreateRequest {
   readonly name: string;
-  readonly description: string | null;
   readonly pricingModel: PricingModel;
   readonly defaultInterval: BillingInterval;
+  readonly description: string | null;
   readonly trialDays?: number | null;
   readonly seatLimit?: number | null;
 }
 
 export interface PlanUpdateRequest {
   readonly name: string;
-  readonly description: string | null;
   readonly sortOrder: number;
+  readonly description: string | null;
 }
 
 export interface CreatePriceVersionRequest {

--- a/packages/@granit/taxonomy/src/types/index.ts
+++ b/packages/@granit/taxonomy/src/types/index.ts
@@ -90,9 +90,9 @@ export interface CategoryResponse {
   readonly scope: string;
   /** `null` when the node is a scope root. */
   readonly parentId: string | null;
+  readonly name: string;
   /** Materialised path, root-anchored, e.g. `"/legal/contracts/2026"`. */
   readonly path: string;
-  readonly name: string;
   /** 0 for scope roots; one greater than the parent's depth otherwise. */
   readonly depth: number;
   /** `null` when no icon is assigned. */
@@ -127,9 +127,9 @@ export interface CategoryListFilter {
 
 export interface CreateCategoryRequest {
   readonly scope: string;
+  readonly name: string;
   /** `null` to create a scope root. */
   readonly parentId: string | null;
-  readonly name: string;
   /** `null` to create without an icon. */
   readonly iconName: string | null;
   /** `null` lets the backend apply its default (false). */

--- a/packages/@granit/templating/src/types/template-types.ts
+++ b/packages/@granit/templating/src/types/template-types.ts
@@ -101,9 +101,9 @@ export type TemplateDetail = {
 // ── Save ──────────────────────────────────────────────────────────────────────
 
 export type SaveTemplateRequest = {
+  readonly content: string;
   readonly name?: string | null;
   readonly culture?: string | null;
-  readonly content: string;
   readonly mimeType?: string;
   readonly layoutName?: string | null;
   /** Optimistic concurrency stamp from the current draft revision. Pass when updating. */

--- a/packages/@granit/timeline/src/types/stream.ts
+++ b/packages/@granit/timeline/src/types/stream.ts
@@ -32,21 +32,13 @@ export interface TimelineAttachmentInfoResponse {
 
 export interface TimelineStreamEntryResponse {
   readonly id: TimelineEntryId;
+  readonly occurredAt: ISODateString;
   readonly entryType: TimelineEntryType;
-  readonly body: string;
   readonly authorId: UserId | null;
   readonly authorName: string | null;
-  readonly parentEntryId: TimelineEntryId | null;
-  readonly occurredAt: ISODateString;
+  readonly body: string;
   readonly attachments: readonly TimelineAttachmentInfoResponse[];
-  /**
-   * Aggregated reactions on this entry — dict keyed by the canonical emoji
-   * glyph, carrying only emojis with at least one reactor. The backend
-   * serializes `null` and omits the field interchangeably when there are zero
-   * reactions; both resolve to "no reactions" on the frontend. Mirrors
-   * `type: ["null", "object"]` in the OpenAPI schema.
-   */
-  readonly reactions?: ReactionMap | null;
+  readonly parentEntryId: TimelineEntryId | null;
   /**
    * Where this entry originates. `'Native'` for rows stored directly
    * in the timeline; `'External'` for entries projected from a
@@ -70,6 +62,14 @@ export interface TimelineStreamEntryResponse {
    * field.
    */
   readonly editedAt?: ISODateString | null;
+  /**
+   * Aggregated reactions on this entry — dict keyed by the canonical emoji
+   * glyph, carrying only emojis with at least one reactor. The backend
+   * serializes `null` and omits the field interchangeably when there are zero
+   * reactions; both resolve to "no reactions" on the frontend. Mirrors
+   * `type: ["null", "object"]` in the OpenAPI schema.
+   */
+  readonly reactions?: ReactionMap | null;
 }
 
 export type TimelineEntryPage = PagedResult<TimelineStreamEntryResponse>;


### PR DESCRIPTION
## Summary

- Adds a `field-order` rule to `checkSchemaConformance` in `@granit/contract-tests`: compares the relative order of shared fields (spec vs. front) using Map insertion order. Optional fields absent from the front are excluded from the comparison to avoid false positives.
- Fixes 21 pre-existing order drifts across 10 packages (all confirmed against vendored OpenAPI snapshots)
- 3 new unit tests for the rule (pass, flag, message content)

**Notable pattern**: C# entity base classes (`AuditedEntity`, `Entity<T>`) serialize `id`/`tenantId`/audit fields LAST because they're inherited properties — reflected in `BankAccount`, `MeterDefinition`, `UsageAggregate`, `LocalizationOverride`.

## Packages fixed

| Package | DTOs |
|---------|------|
| `@granit/timeline` | `TimelineStreamEntryResponse` |
| `@granit/openiddict-admin` | `AdminOidcAuthorizationResponse`, `AdminOidcCreateApplicationRequest` |
| `@granit/localization` | `LocalizationOverride` |
| `@granit/templating` | `SaveTemplateRequest` |
| `@granit/catalog` | `ProductUpdateRequest` |
| `@granit/documents` | `DocumentResponse`, `FinalizeUploadRequest`, `FolderResponse`, `CreateFolderRequest` |
| `@granit/entities-views` | `EntityViewCreateBodyRequest`, `EntityViewUpdateBodyRequest` |
| `@granit/taxonomy` | `CategoryResponse`, `CreateCategoryRequest` |
| `@granit/subscriptions` | `PlanCreateRequest`, `PlanUpdateRequest` |
| `@granit/privacy` | `PrivacyExportStatusResponse` |
| `@granit/cms` | `PageTranslation` |
| `@granit/bank-accounts` | `BankAccount` |
| `@granit/metering` | `MeterDefinition`, `UsageAggregate` |

## Test plan

- [ ] `npx vitest run packages/@granit/contract-tests` — 499 tests ✓
- [ ] `pnpm tsc` clean
- [ ] `pnpm lint` clean