### PR TITLE
feat(observability): structured logging across framework + consented-cookie helper

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1307,6 +1307,75 @@
           "name": "defaultConsentState",
           "kind": "function",
           "signature": "function defaultConsentState(): ConsentState"
+        },
+        {
+          "name": "getCookie",
+          "kind": "function",
+          "signature": "function getCookie(name: string): string | null"
+        },
+        {
+          "name": "setConsentedCookie",
+          "kind": "function",
+          "signature": "function setConsentedCookie( name: string, value: string, options: ConsentedCookieOptions ): boolean"
+        },
+        {
+          "name": "removeCookie",
+          "kind": "function",
+          "signature": "function removeCookie( name: string, attributes: Omit<CookieAttributes, 'maxAge' | 'expires'> ="
+        },
+        {
+          "name": "CookieAttributes",
+          "kind": "interface",
+          "signature": "interface CookieAttributes",
+          "members": [
+            {
+              "name": "path",
+              "kind": "property",
+              "signature": "path?: string"
+            },
+            {
+              "name": "domain",
+              "kind": "property",
+              "signature": "domain?: string"
+            },
+            {
+              "name": "maxAge",
+              "kind": "property",
+              "signature": "maxAge?: number"
+            },
+            {
+              "name": "expires",
+              "kind": "property",
+              "signature": "expires?: Date"
+            },
+            {
+              "name": "secure",
+              "kind": "property",
+              "signature": "secure?: boolean"
+            },
+            {
+              "name": "sameSite",
+              "kind": "property",
+              "signature": "sameSite?: 'strict' | 'lax' | 'none'"
+            }
+          ]
+        },
+        {
+          "name": "ConsentedCookieOptions",
+          "kind": "interface",
+          "signature": "interface ConsentedCookieOptions extends CookieAttributes",
+          "members": [
+            {
+              "name": "category",
+              "kind": "property",
+              "signature": "category: CookieCategory"
+            },
+            {
+              "name": "consents",
+              "kind": "property",
+              "signature": "consents: ConsentState"
+            }
+          ]
         }
       ]
     },
@@ -4187,6 +4256,33 @@
           "name": "useCookieConsent",
           "kind": "function",
           "signature": "function useCookieConsent(): CookieConsentContextValue"
+        },
+        {
+          "name": "useConsentedCookie",
+          "kind": "function",
+          "signature": "function useConsentedCookie(name: string, category: CookieCategory): ConsentedCookie"
+        },
+        {
+          "name": "ConsentedCookie",
+          "kind": "interface",
+          "signature": "interface ConsentedCookie",
+          "members": [
+            {
+              "name": "get",
+              "kind": "method",
+              "signature": "get(): string | null"
+            },
+            {
+              "name": "set",
+              "kind": "method",
+              "signature": "set(value: string, attributes?: CookieAttributes): boolean"
+            },
+            {
+              "name": "remove",
+              "kind": "method",
+              "signature": "remove(attributes?: Omit<CookieAttributes, 'maxAge' | 'expires'>): void"
+            }
+          ]
         },
         {
           "name": "CookieConsentContextValue",

--- a/packages/@granit/ai-chat/package.json
+++ b/packages/@granit/ai-chat/package.json
@@ -15,10 +15,12 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/types": "workspace:*"
   },
   "publishConfig": {

--- a/packages/@granit/ai-chat/src/api/conversations-api.ts
+++ b/packages/@granit/ai-chat/src/api/conversations-api.ts
@@ -4,6 +4,8 @@
 // stream. Routes are relative to `basePath` (the `/conversations` prefix).
 // ---------------------------------------------------------------------------
 
+import { createLogger } from '@granit/logger';
+
 import type {
   ChatStreamEvent,
   ChatWorkspacesResponse,
@@ -15,6 +17,8 @@ import type {
   SendMessageRequest,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
+
+const logger = createLogger('ai-chat');
 
 /**
  * List the current user's conversations, newest first, without their messages.
@@ -106,8 +110,11 @@ function parseEventLine(line: string): ChatStreamEvent | null {
   if (data === '') return null;
   try {
     return JSON.parse(data) as ChatStreamEvent;
-  } catch {
+  } catch (err) {
     // A malformed or partial frame — skip it rather than aborting the stream.
+    // Debug (not warn): a truncated tail frame is expected; raw data omitted as
+    // it is untrusted server content.
+    logger.debug('Skipped unparseable chat SSE frame', { err });
     return null;
   }
 }

--- a/packages/@granit/ai/package.json
+++ b/packages/@granit/ai/package.json
@@ -15,10 +15,12 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/types": "workspace:*"
   },
   "publishConfig": {

--- a/packages/@granit/ai/src/api/ai-chat-api.ts
+++ b/packages/@granit/ai/src/api/ai-chat-api.ts
@@ -3,6 +3,8 @@
 // Mirrors Granit.AI.Endpoints chat endpoints (sync + SSE stream).
 // ---------------------------------------------------------------------------
 
+import { createLogger } from '@granit/logger';
+
 import { AI_STREAM_DONE_MARKER } from '../types/index';
 
 import type {
@@ -13,6 +15,8 @@ import type {
   ChatStreamEvent,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
+
+const logger = createLogger('ai');
 
 /**
  * Send a chat completion request and return the full response.
@@ -58,7 +62,11 @@ function parseSseLine(line: string, currentEventType: string | null): ParsedLine
     }
     const parsed = JSON.parse(data) as AIChatStreamChunk;
     return { kind: 'chunk', content: parsed.content };
-  } catch {
+  } catch (err) {
+    // Partial/malformed frame mid-stream; skip it. Debug (not warn) because a
+    // truncated tail frame is expected, and the raw data is untrusted server
+    // content kept out of the log.
+    logger.debug('Skipped unparseable AI chat SSE frame', { currentEventType, err });
     return { kind: 'skip' };
   }
 }

--- a/packages/@granit/bff/src/csrf/csrf-manager.ts
+++ b/packages/@granit/bff/src/csrf/csrf-manager.ts
@@ -7,7 +7,11 @@
 // auto-injects it on mutation methods.
 // ---------------------------------------------------------------------------
 
+import { createLogger } from '@granit/logger';
+
 import type { BffCsrfTokenResponse } from '../types/index';
+
+const logger = createLogger('bff');
 
 const MUTATION_METHODS = new Set(['POST', 'PUT', 'DELETE', 'PATCH']);
 
@@ -85,7 +89,12 @@ export class CsrfManager {
    */
   private async ensureToken(): Promise<string | null> {
     if (this.token) return this.token;
-    this.pendingFetch ??= this.fetchToken().catch(() => null);
+    this.pendingFetch ??= this.fetchToken().catch((err: unknown) => {
+      // Degraded path: the caller falls back to a header-less mutation the BFF
+      // will reject. Surface why the token could not be refreshed.
+      logger.warn('CSRF token refresh failed; falling back to header-less request', { err });
+      return null;
+    });
     try {
       return await this.pendingFetch;
     } finally {

--- a/packages/@granit/cookies/package.json
+++ b/packages/@granit/cookies/package.json
@@ -14,10 +14,12 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "publishConfig": {

--- a/packages/@granit/cookies/src/__tests__/cookie-store.test.ts
+++ b/packages/@granit/cookies/src/__tests__/cookie-store.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { defaultConsentState } from '../consent-state';
+import { getCookie, removeCookie, setConsentedCookie } from '../cookie-store';
+
+import type { ConsentState } from '../types/index';
+
+function clearAllCookies(): void {
+  for (const part of document.cookie.split(';')) {
+    const name = part.split('=')[0]?.trim();
+    if (name) document.cookie = `${name}=; Max-Age=0; Path=/`;
+  }
+}
+
+afterEach(clearAllCookies);
+
+describe('setConsentedCookie', () => {
+  it('writes a strictly_necessary cookie regardless of consent', () => {
+    const consents: ConsentState = { ...defaultConsentState(), strictly_necessary: true };
+
+    const written = setConsentedCookie('session', 'abc', {
+      category: 'strictly_necessary',
+      consents,
+    });
+
+    expect(written).toBe(true);
+    expect(getCookie('session')).toBe('abc');
+  });
+
+  it('writes an optional cookie when its category is granted', () => {
+    const consents: ConsentState = { ...defaultConsentState(), analytics: true };
+
+    const written = setConsentedCookie('analytics_id', 'xyz', {
+      category: 'analytics',
+      consents,
+    });
+
+    expect(written).toBe(true);
+    expect(getCookie('analytics_id')).toBe('xyz');
+  });
+
+  it('does NOT write when the category is denied', () => {
+    const written = setConsentedCookie('mkt', 'tracking', {
+      category: 'marketing',
+      consents: defaultConsentState(),
+    });
+
+    expect(written).toBe(false);
+    expect(getCookie('mkt')).toBeNull();
+  });
+
+  it('encodes name and value', () => {
+    setConsentedCookie('a b', 'x;y=z', {
+      category: 'strictly_necessary',
+      consents: defaultConsentState(),
+    });
+
+    expect(document.cookie).toContain('a%20b=x%3By%3Dz');
+    expect(getCookie('a b')).toBe('x;y=z');
+  });
+});
+
+describe('getCookie', () => {
+  it('returns null for an absent cookie', () => {
+    expect(getCookie('nope')).toBeNull();
+  });
+
+  it('reads a value written directly', () => {
+    document.cookie = 'plain=value; Path=/';
+    expect(getCookie('plain')).toBe('value');
+  });
+});
+
+describe('removeCookie', () => {
+  it('deletes a previously written cookie', () => {
+    setConsentedCookie('tmp', '1', {
+      category: 'strictly_necessary',
+      consents: defaultConsentState(),
+    });
+    expect(getCookie('tmp')).toBe('1');
+
+    removeCookie('tmp');
+    expect(getCookie('tmp')).toBeNull();
+  });
+});

--- a/packages/@granit/cookies/src/cookie-store.ts
+++ b/packages/@granit/cookies/src/cookie-store.ts
@@ -1,0 +1,126 @@
+import { createLogger } from '@granit/logger';
+
+import type { CookieCategory, ConsentState } from './types/index';
+
+const logger = createLogger('cookies');
+
+/**
+ * Attributes applied when writing a cookie via {@link setConsentedCookie} or
+ * clearing one via {@link removeCookie}. Mirrors the standard `document.cookie`
+ * attributes with safe defaults (`path: '/'`, `secure: true`, `sameSite: 'lax'`).
+ */
+export interface CookieAttributes {
+  /** Cookie path (default `'/'`). */
+  path?: string;
+  /** Cookie domain (default: current host). */
+  domain?: string;
+  /** Lifetime in seconds (`Max-Age`). Takes precedence over nothing; combine freely with `expires`. */
+  maxAge?: number;
+  /** Absolute expiry (`Expires`). */
+  expires?: Date;
+  /** `Secure` flag (default `true`). */
+  secure?: boolean;
+  /** `SameSite` policy (default `'lax'`). */
+  sameSite?: 'strict' | 'lax' | 'none';
+}
+
+/**
+ * Options for {@link setConsentedCookie}: the consent {@link CookieCategory} the
+ * cookie belongs to plus the current {@link ConsentState} to gate the write.
+ */
+export interface ConsentedCookieOptions extends CookieAttributes {
+  /** Consent category this cookie belongs to. */
+  category: CookieCategory;
+  /** Current consent state — the cookie is only written when this grants `category`. */
+  consents: ConsentState;
+}
+
+/**
+ * Whether a category may be written given a consent state. `strictly_necessary`
+ * cookies never require consent; every other category must be explicitly granted.
+ */
+function isCategoryGranted(category: CookieCategory, consents: ConsentState): boolean {
+  return category === 'strictly_necessary' || consents[category] === true;
+}
+
+function serializeAttributes(attributes: CookieAttributes): string {
+  const { path = '/', domain, maxAge, expires, secure = true, sameSite = 'lax' } = attributes;
+
+  const parts = [`Path=${path}`];
+  if (domain !== undefined) parts.push(`Domain=${domain}`);
+  if (maxAge !== undefined) parts.push(`Max-Age=${maxAge}`);
+  if (expires !== undefined) parts.push(`Expires=${expires.toUTCString()}`);
+  parts.push(`SameSite=${sameSite === 'strict' ? 'Strict' : sameSite === 'none' ? 'None' : 'Lax'}`);
+  // `SameSite=None` is only valid alongside `Secure`; default-secure keeps it consistent.
+  if (secure || sameSite === 'none') parts.push('Secure');
+
+  return parts.join('; ');
+}
+
+/**
+ * Read a cookie value by name. Returns the decoded value, or `null` if the
+ * cookie is absent or `document` is unavailable (SSR).
+ */
+export function getCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null;
+
+  const target = `${encodeURIComponent(name)}=`;
+  for (const part of document.cookie.split(';')) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(target)) {
+      return decodeURIComponent(trimmed.slice(target.length));
+    }
+  }
+  return null;
+}
+
+/**
+ * Write a cookie **only if** the user has consented to its category.
+ *
+ * `strictly_necessary` cookies are always written; every other category is
+ * gated on `options.consents[category]`. No-op on the server (`document`
+ * undefined).
+ *
+ * @returns `true` if the cookie was written, `false` if consent was missing
+ * or `document` is unavailable.
+ *
+ * @example
+ * ```typescript
+ * const { consents } = useCookieConsent();
+ * setConsentedCookie('analytics_id', id, { category: 'analytics', consents });
+ * ```
+ */
+export function setConsentedCookie(
+  name: string,
+  value: string,
+  options: ConsentedCookieOptions
+): boolean {
+  if (typeof document === 'undefined') return false;
+
+  const { category, consents, ...attributes } = options;
+  if (!isCategoryGranted(category, consents)) {
+    // Value intentionally omitted from logs (may carry PII).
+    logger.debug('Cookie write blocked: consent not granted', { name, category });
+    return false;
+  }
+
+  const pair = `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
+  document.cookie = `${pair}; ${serializeAttributes(attributes)}`;
+  logger.debug('Cookie written', { name, category });
+  return true;
+}
+
+/**
+ * Delete a cookie by expiring it in the past. Pass the same `path`/`domain`
+ * attributes that were used to write it, otherwise the browser keeps the
+ * original cookie. No-op on the server.
+ */
+export function removeCookie(
+  name: string,
+  attributes: Omit<CookieAttributes, 'maxAge' | 'expires'> = {}
+): void {
+  if (typeof document === 'undefined') return;
+
+  const expired = serializeAttributes({ ...attributes, expires: new Date(0), maxAge: 0 });
+  document.cookie = `${encodeURIComponent(name)}=; ${expired}`;
+}

--- a/packages/@granit/cookies/src/index.ts
+++ b/packages/@granit/cookies/src/index.ts
@@ -1,5 +1,7 @@
 export { getCookieConsentConfig } from './api/cookie-consent-api';
 export { defaultConsentState } from './consent-state';
+export { getCookie, setConsentedCookie, removeCookie } from './cookie-store';
+export type { CookieAttributes, ConsentedCookieOptions } from './cookie-store';
 export type {
   CookieCategory,
   ConsentState,

--- a/packages/@granit/dashboards/package.json
+++ b/packages/@granit/dashboards/package.json
@@ -15,10 +15,12 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/dashboards/src/types/widget-bridge.ts
+++ b/packages/@granit/dashboards/src/types/widget-bridge.ts
@@ -21,9 +21,13 @@
 // shaped against the persistence view. This module is the round-trip
 // bridge between the two — pure data transformation, no React deps.
 
+import { createLogger } from '@granit/logger';
+
 import type { DashboardDetailResponse } from './dashboard-detail-response';
 import type { AddWidgetRequest, UpdateWidgetRequest, WidgetInstanceResponse } from './index';
 import type { DashboardDefinition, WidgetDefinition, WidgetDefinitionBase } from '../types/index';
+
+const logger = createLogger('dashboards');
 
 /**
  * The five structural fields that live outside `configJson` because the
@@ -140,7 +144,10 @@ function configJsonToWidgetFields(configJson: string): Readonly<Record<string, u
     const parsed = JSON.parse(configJson) as unknown;
     if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
     return parsed as Readonly<Record<string, unknown>>;
-  } catch {
+  } catch (err) {
+    // Malformed persisted config — the caller degrades the widget to a
+    // placeholder shape rather than crashing the editor.
+    logger.warn('Malformed widget configJson; falling back to placeholder', { err });
     return null;
   }
 }

--- a/packages/@granit/localization/package.json
+++ b/packages/@granit/localization/package.json
@@ -15,12 +15,14 @@
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/storage": "workspace:*",
     "@granit/types": "workspace:*",
     "i18next": "^26.0.0"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/storage": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"

--- a/packages/@granit/localization/src/apply-translations.ts
+++ b/packages/@granit/localization/src/apply-translations.ts
@@ -1,5 +1,9 @@
+import { createLogger } from '@granit/logger';
+
 import type { ApplicationLocalizationResponse } from './types/index';
 import type { i18n } from 'i18next';
+
+const logger = createLogger('localization');
 
 /**
  * Apply backend localization response to the i18next instance.
@@ -27,6 +31,13 @@ export function applyTranslations(instance: i18n, data: ApplicationLocalizationR
   instance.addResourceBundle(data.cultureName, 'translation', merged, true, true);
 
   if (instance.language !== data.cultureName) {
-    instance.changeLanguage(data.cultureName).catch(() => undefined);
+    instance.changeLanguage(data.cultureName).catch((err: unknown) => {
+      // Resources were merged, but the active language did not switch — the UI
+      // keeps rendering the previous locale until the next attempt.
+      logger.warn('Failed to switch active language after applying translations', {
+        cultureName: data.cultureName,
+        err,
+      });
+    });
   }
 }

--- a/packages/@granit/localization/src/create-localization.ts
+++ b/packages/@granit/localization/src/create-localization.ts
@@ -1,7 +1,10 @@
+import { createLogger } from '@granit/logger';
 import { createInstance } from 'i18next';
 
 import type { LocalizationConfig } from './types/index';
 import type { i18n } from 'i18next';
+
+const logger = createLogger('localization');
 
 /**
  * Create an isolated i18next instance with Digital Dynamics defaults.
@@ -49,7 +52,9 @@ export function createLocalization(config?: LocalizationConfig): i18n {
       },
       resources: {},
     })
-    .catch(() => undefined);
+    .catch((err: unknown) => {
+      logger.error('i18next initialization failed', err);
+    });
 
   return instance;
 }

--- a/packages/@granit/notifications-sse/package.json
+++ b/packages/@granit/notifications-sse/package.json
@@ -14,6 +14,7 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/logger": "workspace:*",
     "@granit/notifications": "workspace:*",
     "@microsoft/fetch-event-source": ">=2.0.0"
   },
@@ -27,6 +28,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@granit/logger": "workspace:*",
     "@granit/notifications": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*",

--- a/packages/@granit/notifications-sse/src/transports/create-sse-transport.ts
+++ b/packages/@granit/notifications-sse/src/transports/create-sse-transport.ts
@@ -1,7 +1,10 @@
+import { createLogger } from '@granit/logger';
 import { createTransportListeners } from '@granit/notifications';
 import { EventStreamContentType, fetchEventSource } from '@microsoft/fetch-event-source';
 
 import type { NotificationTransportMessage, NotificationTransport } from '@granit/notifications';
+
+const logger = createLogger('notifications-sse');
 
 export interface SseTransportConfig {
   /** SSE endpoint URL, e.g. '/api/v1/notifications/stream'. */
@@ -76,6 +79,7 @@ export function createSseTransport(config: SseTransportConfig): NotificationTran
         async onopen(response) {
           const contentType = response.headers.get('content-type') ?? '';
           if (response.ok && contentType.includes(EventStreamContentType)) {
+            logger.info('SSE stream connected');
             setState('connected');
             return;
           }
@@ -91,20 +95,28 @@ export function createSseTransport(config: SseTransportConfig): NotificationTran
           try {
             const message = JSON.parse(event.data) as NotificationTransportMessage;
             listeners.emit(message);
-          } catch {
-            // Malformed events are silently skipped.
+          } catch (err) {
+            // Skip the malformed frame rather than tearing down the stream;
+            // the raw payload is omitted to avoid logging untrusted server data.
+            logger.warn('Skipped malformed SSE notification frame', {
+              eventType: event.event,
+              err,
+            });
           }
         },
 
         onclose() {
+          logger.info('SSE stream closed by server');
           setState('disconnected');
         },
 
         onerror(err) {
           if (err instanceof FatalError) {
+            logger.error('SSE stream failed fatally; not reconnecting', err);
             setState('disconnected');
             throw err;
           }
+          logger.warn('SSE stream error; reconnecting', { err });
           setState('reconnecting');
         },
 

--- a/packages/@granit/react-ai-chat/package.json
+++ b/packages/@granit/react-ai-chat/package.json
@@ -17,6 +17,7 @@
   "peerDependencies": {
     "@granit/ai-chat": "workspace:*",
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/types": "workspace:*",
     "@granit/utils": "workspace:*",
@@ -46,6 +47,7 @@
   "devDependencies": {
     "@granit/ai-chat": "workspace:*",
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",

--- a/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
@@ -1,4 +1,5 @@
 import { SEND_MESSAGE_LIMITS } from '@granit/ai-chat';
+import { createLogger } from '@granit/logger';
 import { cn } from '@granit/utils';
 import { Paperclip, Send, Square } from 'lucide-react';
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
@@ -21,6 +22,8 @@ import type { ActiveTrigger } from './detect-trigger';
 import type { ChatTranslations } from '../locales/index';
 import type { SendMessageRequest } from '@granit/ai-chat';
 import type { ChangeEvent, KeyboardEvent } from 'react';
+
+const logger = createLogger('react-ai-chat');
 
 export interface ChatComposerProps {
   /** Builds and submits a {@link SendMessageRequest} for the turn. */
@@ -105,7 +108,8 @@ export function ChatComposer({
             setMentionLoading(false);
           }
         })
-        .catch(() => {
+        .catch((err: unknown) => {
+          logger.warn('Mention search failed; cleared results', { err });
           if (seq === searchSeq.current) {
             setMentionResults([]);
             setMentionLoading(false);
@@ -262,7 +266,12 @@ export function ChatComposer({
               current.map((a) => (a.id === id ? { ...a, ...uploaded, status: 'ready' } : a))
             );
           })
-          .catch(() => {
+          .catch((err: unknown) => {
+            logger.warn('Composer attachment upload failed', {
+              fileName: file.name,
+              sizeBytes: file.size,
+              err,
+            });
             setAttachments((current) =>
               current.map((a) => (a.id === id ? { ...a, status: 'error' } : a))
             );

--- a/packages/@granit/react-ai-chat/src/hooks/use-chat-stream.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-chat-stream.ts
@@ -1,10 +1,13 @@
 import { CHAT_STREAM_EVENT_TYPES, streamConversationMessage } from '@granit/ai-chat';
+import { createLogger } from '@granit/logger';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useRef, useState } from 'react';
 
 import { useAIChatConfig } from '../providers/ai-chat-provider';
 
 import { conversationKeys } from './query-keys';
+
+const logger = createLogger('react-ai-chat');
 
 import type {
   ChatStreamEvent,
@@ -141,6 +144,7 @@ export function useChatStream(): UseChatStreamReturn {
           }
         } catch (err) {
           if (err instanceof DOMException && err.name === 'AbortError') return;
+          logger.error('Chat stream turn failed', err, { conversationId: resolvedId });
           setError(err instanceof Error ? err : new Error(String(err)));
         } finally {
           setIsStreaming(false);

--- a/packages/@granit/react-ai/package.json
+++ b/packages/@granit/react-ai/package.json
@@ -18,6 +18,7 @@
   "peerDependencies": {
     "@granit/ai": "workspace:*",
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
@@ -56,6 +57,7 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",

--- a/packages/@granit/react-ai/src/hooks/use-ai-chat-stream.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-chat-stream.ts
@@ -1,9 +1,12 @@
 import { chatStream } from '@granit/ai';
+import { createLogger } from '@granit/logger';
 import { useCallback, useRef, useState } from 'react';
 
 import { useAIConfig } from '../providers/ai-provider';
 
 import type { AIChatRequest, AIChatStreamUsage } from '@granit/ai';
+
+const logger = createLogger('react-ai');
 
 export interface UseAIChatStreamReturn {
   /**
@@ -95,6 +98,7 @@ export function useAIChatStream(): UseAIChatStreamReturn {
           }
         } catch (err) {
           if (err instanceof DOMException && err.name === 'AbortError') return;
+          logger.error('AI chat stream failed', err, { workspaceName });
           setError(err instanceof Error ? err : new Error(String(err)));
         } finally {
           setIsStreaming(false);

--- a/packages/@granit/react-authentication-cognito/package.json
+++ b/packages/@granit/react-authentication-cognito/package.json
@@ -17,6 +17,7 @@
     "@granit/api-client": "workspace:*",
     "@granit/authentication": "workspace:*",
     "@granit/authentication-cognito": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/react-authentication": "workspace:*",
     "amazon-cognito-identity-js": ">=6.0.0",
     "react": "^19.0.0"
@@ -31,6 +32,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*"
   }
 }

--- a/packages/@granit/react-authentication-cognito/src/hooks/use-cognito-init.ts
+++ b/packages/@granit/react-authentication-cognito/src/hooks/use-cognito-init.ts
@@ -1,4 +1,5 @@
 import { setTokenGetter, setOnUnauthorized } from '@granit/api-client';
+import { createLogger } from '@granit/logger';
 import { CognitoUserPool } from 'amazon-cognito-identity-js';
 import * as React from 'react';
 
@@ -12,6 +13,8 @@ import {
 import type { LoginOptions, LogoutOptions, OidcUserInfo } from '@granit/authentication';
 import type { CognitoAuthContextType, CognitoCoreConfig } from '@granit/authentication-cognito';
 import type { ICognitoStorage } from 'amazon-cognito-identity-js';
+
+const logger = createLogger('react-authentication-cognito');
 
 /**
  * In-memory implementation of the Cognito SDK storage contract. Tokens live
@@ -83,6 +86,7 @@ function createTokenRefresher(
     new Promise((resolve) => {
       cognitoUser.getSession((err, session) => {
         if (err || !session?.isValid()) {
+          logger.warn('Cognito token refresh failed; request will proceed unauthenticated');
           onTokenRefreshError?.();
           resolve(undefined);
           return;
@@ -127,11 +131,13 @@ export function useCognitoInit(config: CognitoCoreConfig): CognitoCoreResult {
 
     cognitoUser.getSession((err: Error | null, session: CognitoSessionLike | null) => {
       if (err || !session?.isValid()) {
+        logger.warn('Cognito session restore failed or expired; user is unauthenticated');
         setLoading(false);
         config.onSessionExpired?.();
         return;
       }
 
+      logger.info('Cognito session restored');
       setAuthenticated(true);
 
       cognitoUser.getUserAttributes((attrErr, attributes) => {
@@ -141,6 +147,8 @@ export function useCognitoInit(config: CognitoCoreConfig): CognitoCoreResult {
             attrMap[attr.Name] = attr.Value;
           }
           setUser(extractUser(attrMap));
+        } else if (attrErr) {
+          logger.warn('Failed to load Cognito user attributes; continuing without profile claims');
         }
         setLoading(false);
       });
@@ -196,6 +204,7 @@ export function useCognitoInit(config: CognitoCoreConfig): CognitoCoreResult {
     if (cognitoUser) {
       cognitoUser.signOut();
     }
+    logger.info('Cognito user signed out');
     setAuthenticated(false);
     setUser(null);
     if (options?.redirectUri) {

--- a/packages/@granit/react-authentication-google-cloud/package.json
+++ b/packages/@granit/react-authentication-google-cloud/package.json
@@ -17,6 +17,7 @@
     "@granit/api-client": "workspace:*",
     "@granit/authentication": "workspace:*",
     "@granit/authentication-google-cloud": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/react-authentication": "workspace:*",
     "firebase": ">=10.0.0",
     "react": "^19.0.0"
@@ -31,6 +32,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*"
   }
 }

--- a/packages/@granit/react-authentication-google-cloud/src/hooks/use-google-cloud-init.ts
+++ b/packages/@granit/react-authentication-google-cloud/src/hooks/use-google-cloud-init.ts
@@ -1,4 +1,5 @@
 import { setTokenGetter, setOnUnauthorized } from '@granit/api-client';
+import { createLogger } from '@granit/logger';
 import { initializeApp } from 'firebase/app';
 import {
   initializeAuth,
@@ -18,6 +19,8 @@ import type {
   GoogleCloudCoreConfig,
 } from '@granit/authentication-google-cloud';
 import type { Auth, Persistence, User } from 'firebase/auth';
+
+const logger = createLogger('react-authentication-google-cloud');
 
 /** Resolve the Firebase persistence from the configured posture (default: memory). */
 function resolvePersistence(tokenStorage: GoogleCloudCoreConfig['tokenStorage']): Persistence {
@@ -78,6 +81,7 @@ export function useGoogleCloudInit(config: GoogleCloudCoreConfig): GoogleCloudCo
 
     const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
       if (firebaseUser) {
+        logger.info('Firebase auth state: signed in');
         setAuthenticated(true);
         setUser(extractUser(firebaseUser));
 
@@ -85,6 +89,7 @@ export function useGoogleCloudInit(config: GoogleCloudCoreConfig): GoogleCloudCo
           try {
             return await firebaseUser.getIdToken();
           } catch {
+            logger.warn('Firebase ID token refresh failed; request will proceed unauthenticated');
             config.onTokenRefreshError?.();
             return undefined;
           }
@@ -94,6 +99,7 @@ export function useGoogleCloudInit(config: GoogleCloudCoreConfig): GoogleCloudCo
           signOut(auth);
         });
       } else {
+        logger.info('Firebase auth state: signed out');
         setAuthenticated(false);
         setUser(null);
         config.onSessionExpired?.();

--- a/packages/@granit/react-authentication-keycloak/package.json
+++ b/packages/@granit/react-authentication-keycloak/package.json
@@ -19,6 +19,7 @@
     "@granit/authentication": "workspace:*",
     "@granit/authentication-keycloak": "workspace:*",
     "@granit/csp": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/react-authentication": "workspace:*",
     "keycloak-js": "^26.0.0",
     "react": "^19.0.0"
@@ -38,6 +39,7 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/csp": "workspace:*"
+    "@granit/csp": "workspace:*",
+    "@granit/logger": "workspace:*"
   }
 }

--- a/packages/@granit/react-authentication-keycloak/src/hooks/use-keycloak-core.ts
+++ b/packages/@granit/react-authentication-keycloak/src/hooks/use-keycloak-core.ts
@@ -1,4 +1,5 @@
 import { setTokenGetter, setOnUnauthorized } from '@granit/api-client';
+import { createLogger } from '@granit/logger';
 import Keycloak from 'keycloak-js';
 import * as React from 'react';
 
@@ -34,6 +35,8 @@ export interface KeycloakCoreResult extends KeycloakAuthContextType {
   tokenParsed: Record<string, unknown> | undefined;
 }
 
+const logger = createLogger('react-authentication-keycloak');
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -43,6 +46,7 @@ function startTokenRefresh(keycloak: Keycloak): ReturnType<typeof setInterval> {
   return setInterval(() => {
     keycloak.updateToken(70).catch(() => {
       // Token refresh failed — app will handle re-login via onAuthRefreshError
+      logger.warn('Proactive token refresh failed; re-login handled via onAuthRefreshError');
     });
   }, 60_000);
 }
@@ -116,6 +120,7 @@ export function useKeycloakInit(config: KeycloakCoreConfig): KeycloakCoreResult 
         keycloak.onAuthLogout = () => {
           setAuthenticated(false);
           setUser(null);
+          logger.info('Keycloak session logged out');
           config.onAuthLogout?.();
           config.onEvent?.('onAuthLogout');
         };
@@ -127,7 +132,10 @@ export function useKeycloakInit(config: KeycloakCoreConfig): KeycloakCoreResult 
           }
         };
 
-        keycloak.onAuthSuccess = () => config.onEvent?.('onAuthSuccess');
+        keycloak.onAuthSuccess = () => {
+          logger.info('Keycloak authentication succeeded');
+          config.onEvent?.('onAuthSuccess');
+        };
         keycloak.onAuthError = (err) => config.onEvent?.('onAuthError', err);
         keycloak.onReady = () => config.onEvent?.('onReady');
 
@@ -159,6 +167,7 @@ export function useKeycloakInit(config: KeycloakCoreConfig): KeycloakCoreResult 
               setUser(userInfo as KeycloakUserInfo);
             } catch {
               // User info load failed — non-fatal
+              logger.warn('Failed to load Keycloak user info; continuing without profile claims');
             }
           }
 
@@ -168,6 +177,7 @@ export function useKeycloakInit(config: KeycloakCoreConfig): KeycloakCoreResult 
                 await keycloakRef.current.updateToken(5);
                 return keycloakRef.current.token;
               } catch {
+                logger.warn('Token refresh on demand failed; request will proceed unauthenticated');
                 return undefined;
               }
             }
@@ -178,8 +188,9 @@ export function useKeycloakInit(config: KeycloakCoreConfig): KeycloakCoreResult 
             keycloakRef.current?.logout();
           });
         }
-      } catch {
+      } catch (err) {
         // Keycloak init failed — stay unauthenticated
+        logger.error('Keycloak initialization failed; staying unauthenticated', err);
       } finally {
         setLoading(false);
       }

--- a/packages/@granit/react-blob-storage/package.json
+++ b/packages/@granit/react-blob-storage/package.json
@@ -17,6 +17,7 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/blob-storage": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
@@ -35,6 +36,7 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-upload.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-upload.ts
@@ -1,4 +1,5 @@
 import { cancelPendingUpload, confirmUpload, initiateUpload } from '@granit/blob-storage';
+import { createLogger } from '@granit/logger';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useRef, useState } from 'react';
 
@@ -7,6 +8,8 @@ import { useBlobStorageConfig } from '../providers/blob-storage-provider';
 import { blobListQueryKey, blobStorageKeys } from './query-keys';
 
 import type { BlobConfirmUploadResponse } from '@granit/blob-storage';
+
+const logger = createLogger('react-blob-storage');
 
 /** Upload progress phase. */
 export type BlobUploadPhase =
@@ -187,9 +190,13 @@ export function useBlobUpload(): UseBlobUploadReturn {
           await cancelPendingUpload(client, `${basePath}/blobs`, ticket.blobId, {
             containerName,
             reason: `Pre-signed PUT failed: ${reason}`.slice(0, 512),
-          }).catch(() => {
+          }).catch((cancelError: unknown) => {
             // Best-effort: orphan cleanup is the backstop if the cancel call
             // itself fails (offline, already left Pending, …).
+            logger.warn('Best-effort cancel of pending upload failed', {
+              blobId: ticket.blobId,
+              err: cancelError,
+            });
           });
           throw putError;
         }
@@ -217,6 +224,7 @@ export function useBlobUpload(): UseBlobUploadReturn {
         return confirmation;
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
+        logger.error('Blob upload failed', error, { containerName, fileName: file.name });
         setState((prev) => ({ ...prev, phase: 'error', error }));
         throw error;
       }

--- a/packages/@granit/react-cms/package.json
+++ b/packages/@granit/react-cms/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/cms": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
@@ -24,6 +25,7 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/cms": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/types": "workspace:*",

--- a/packages/@granit/react-cms/src/puck/catalog-to-config.tsx
+++ b/packages/@granit/react-cms/src/puck/catalog-to-config.tsx
@@ -1,7 +1,11 @@
+import { createLogger } from '@granit/logger';
+
 import { BLOCK_COMPONENTS } from '../blocks/registry';
 
 import type { BlockCatalogResponse, BlockFieldDescriptor, BlockFieldKind } from '@granit/cms';
 import type { Config, ExternalField, Fields } from '@puckeditor/core';
+
+const logger = createLogger('react-cms');
 
 /**
  * Callback supplied by the renderer to resolve live data for a data-bound block.
@@ -120,8 +124,12 @@ export function catalogToConfig(
                 Object.keys((result.data as Record<string, unknown>) ?? {}).map((k) => [k, true])
               ),
             };
-          } catch {
+          } catch (err: unknown) {
             // Data resolution failure must not crash the page — return as-is.
+            logger.warn('Block data resolution failed; rendering with editor props', {
+              dataSourceKey: capturedKey,
+              err,
+            });
             return { props: data.props as Record<string, unknown> };
           }
         };

--- a/packages/@granit/react-cookies/src/__tests__/use-consented-cookie.test.tsx
+++ b/packages/@granit/react-cookies/src/__tests__/use-consented-cookie.test.tsx
@@ -1,0 +1,129 @@
+import { defaultConsentState } from '@granit/cookies';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useConsentedCookie } from '../hooks/use-consented-cookie';
+import { CookieConsentProvider } from '../providers/cookie-consent-provider';
+
+import type { CookieCategory, CookieConsentAdapter, ConsentState } from '@granit/cookies';
+import type { ReactNode } from 'react';
+
+function createMockProvider(consents: Partial<ConsentState> = {}): CookieConsentAdapter {
+  const state: ConsentState = { ...defaultConsentState(), ...consents };
+  let changeCallback: ((consents: ConsentState) => void) | undefined;
+
+  return {
+    init: vi.fn().mockResolvedValue(undefined),
+    getConsents: vi.fn().mockReturnValue(state),
+    onConsentChange: vi.fn().mockImplementation((cb) => {
+      changeCallback = cb;
+      return () => {
+        changeCallback = undefined;
+      };
+    }),
+    setConsent: vi.fn().mockImplementation((category: CookieCategory, granted: boolean) => {
+      state[category] = granted;
+      changeCallback?.(structuredClone(state));
+    }),
+    setAllConsents: vi.fn(),
+    hasConsented: vi.fn().mockReturnValue(true),
+  };
+}
+
+function createWrapper(provider: CookieConsentAdapter) {
+  return function Wrapper({ children }: { readonly children: ReactNode }) {
+    return <CookieConsentProvider provider={provider}>{children}</CookieConsentProvider>;
+  };
+}
+
+function clearAllCookies(): void {
+  for (const part of document.cookie.split(';')) {
+    const name = part.split('=')[0]?.trim();
+    if (name) document.cookie = `${name}=; Max-Age=0; Path=/`;
+  }
+}
+
+afterEach(clearAllCookies);
+
+describe('useConsentedCookie', () => {
+  it('writes a strictly_necessary cookie even before consent is loaded', () => {
+    const provider = createMockProvider();
+
+    const { result } = renderHook(() => useConsentedCookie('session', 'strictly_necessary'), {
+      wrapper: createWrapper(provider),
+    });
+
+    expect(result.current.isAllowed).toBe(true);
+    let written = false;
+    act(() => {
+      written = result.current.set('abc');
+    });
+
+    expect(written).toBe(true);
+    expect(result.current.get()).toBe('abc');
+  });
+
+  it('blocks writes until the category is granted', async () => {
+    const provider = createMockProvider();
+
+    const { result } = renderHook(() => useConsentedCookie('analytics_id', 'analytics'), {
+      wrapper: createWrapper(provider),
+    });
+
+    await vi.waitFor(() => {
+      expect(result.current.isAllowed).toBe(false);
+    });
+
+    act(() => {
+      result.current.set('xyz');
+    });
+    expect(result.current.get()).toBeNull();
+  });
+
+  it('allows writes once consent is granted at runtime', async () => {
+    const provider = createMockProvider();
+
+    const { result } = renderHook(
+      () => {
+        const consent = useConsentedCookie('analytics_id', 'analytics');
+        return consent;
+      },
+      { wrapper: createWrapper(provider) }
+    );
+
+    // Grant analytics through the provider and wait for the context to update.
+    act(() => {
+      provider.setConsent('analytics', true);
+    });
+
+    await vi.waitFor(() => {
+      expect(result.current.isAllowed).toBe(true);
+    });
+
+    let written = false;
+    act(() => {
+      written = result.current.set('xyz');
+    });
+
+    expect(written).toBe(true);
+    expect(result.current.get()).toBe('xyz');
+  });
+
+  it('removes a cookie', () => {
+    const provider = createMockProvider();
+
+    const { result } = renderHook(() => useConsentedCookie('tmp', 'strictly_necessary'), {
+      wrapper: createWrapper(provider),
+    });
+
+    act(() => {
+      result.current.set('1');
+    });
+    expect(result.current.get()).toBe('1');
+
+    act(() => {
+      result.current.remove();
+    });
+    expect(result.current.get()).toBeNull();
+  });
+});

--- a/packages/@granit/react-cookies/src/hooks/use-consented-cookie.ts
+++ b/packages/@granit/react-cookies/src/hooks/use-consented-cookie.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { getCookie, removeCookie, setConsentedCookie } from '@granit/cookies';
+import { useMemo } from 'react';
+
+import { useCookieConsent } from './use-cookie-consent';
+
+import type { CookieAttributes, CookieCategory } from '@granit/cookies';
+
+/**
+ * Consent-aware accessor for a single cookie, returned by {@link useConsentedCookie}.
+ */
+export interface ConsentedCookie {
+  /** Read the current value, or `null` if absent. */
+  get(): string | null;
+  /**
+   * Write the cookie — only succeeds when the bound category is granted.
+   * @returns `true` if written, `false` if consent is missing.
+   */
+  set(value: string, attributes?: CookieAttributes): boolean;
+  /** Delete the cookie. Pass the same `path`/`domain` used to write it. */
+  remove(attributes?: Omit<CookieAttributes, 'maxAge' | 'expires'>): void;
+  /** Whether the bound category is currently granted (i.e. `set` would write). */
+  readonly isAllowed: boolean;
+}
+
+/**
+ * Hook returning a consent-gated accessor for a named cookie. Reads the live
+ * consent state from {@link useCookieConsent}, so `set` writes only when the
+ * `category` is granted and `isAllowed` reflects the current state.
+ *
+ * Must be used within a `CookieConsentProvider`.
+ *
+ * @example
+ * ```tsx
+ * const prefs = useConsentedCookie('ui_prefs', 'preferences');
+ *
+ * if (prefs.isAllowed) prefs.set(JSON.stringify(state), { maxAge: 31_536_000 });
+ * const raw = prefs.get();
+ * ```
+ */
+export function useConsentedCookie(name: string, category: CookieCategory): ConsentedCookie {
+  const { consents } = useCookieConsent();
+  const isAllowed = category === 'strictly_necessary' || consents[category] === true;
+
+  return useMemo<ConsentedCookie>(
+    () => ({
+      isAllowed,
+      get: () => getCookie(name),
+      set: (value, attributes) =>
+        setConsentedCookie(name, value, { ...attributes, category, consents }),
+      remove: (attributes) => removeCookie(name, attributes),
+    }),
+    [name, category, consents, isAllowed]
+  );
+}

--- a/packages/@granit/react-cookies/src/index.ts
+++ b/packages/@granit/react-cookies/src/index.ts
@@ -1,3 +1,5 @@
 export { CookieConsentProvider } from './providers/cookie-consent-provider';
 export { useCookieConsent } from './hooks/use-cookie-consent';
+export { useConsentedCookie } from './hooks/use-consented-cookie';
+export type { ConsentedCookie } from './hooks/use-consented-cookie';
 export type { CookieConsentContextValue } from './types/index';

--- a/packages/@granit/react-dashboards/package.json
+++ b/packages/@granit/react-dashboards/package.json
@@ -17,6 +17,7 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/dashboards": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/utils": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
@@ -45,6 +46,7 @@
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/dashboards": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-stream.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-stream.ts
@@ -1,3 +1,4 @@
+import { createLogger } from '@granit/logger';
 import { useEffect } from 'react';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider';
@@ -7,6 +8,8 @@ import type {
   RefreshHint,
   WidgetSnapshotStatus,
 } from '@granit/dashboards';
+
+const logger = createLogger('react-dashboards');
 
 /**
  * Wire shape of an `event: snapshot` frame on the dashboard SSE
@@ -126,10 +129,11 @@ export function useDashboardStream(
       try {
         const payload = JSON.parse(event.data) as DashboardStreamSnapshot;
         onSnapshot?.(payload);
-      } catch {
-        // Malformed JSON — drop the frame silently. The server is
-        // authoritative; bad frames are a server bug, not something
-        // the hook should retry around.
+      } catch (err: unknown) {
+        // Malformed JSON — drop the frame. The server is authoritative;
+        // bad frames are a server bug, not something the hook retries
+        // around, but they're worth surfacing for diagnostics.
+        logger.warn('Dropped malformed dashboard snapshot frame', { dashboardId, err });
       }
     };
     const handleResumeFailed = () => {

--- a/packages/@granit/react-data-exchange/package.json
+++ b/packages/@granit/react-data-exchange/package.json
@@ -17,6 +17,7 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/data-exchange": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
@@ -52,6 +53,7 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*"
   }

--- a/packages/@granit/react-data-exchange/src/export/hooks/use-export-job.ts
+++ b/packages/@granit/react-data-exchange/src/export/hooks/use-export-job.ts
@@ -1,4 +1,5 @@
 import { createExportJob, downloadExportFile, getExportJobStatus } from '@granit/data-exchange';
+import { createLogger } from '@granit/logger';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -9,6 +10,8 @@ import type {
   ExportJobResponse,
   ExportJobStatus,
 } from '@granit/data-exchange';
+
+const logger = createLogger('react-data-exchange');
 
 export interface UseExportJobReturn {
   /** Start a new export job. */
@@ -75,8 +78,8 @@ export function useExportJob(): UseExportJobReturn {
         link.click();
         URL.revokeObjectURL(url);
       })
-      .catch(() => {
-        /* download errors surfaced via UI */
+      .catch((err: unknown) => {
+        logger.error('Export file download failed', err, { jobId: job.id });
       });
   }, [job, config.client, config.basePath]);
 

--- a/packages/@granit/react-localization/package.json
+++ b/packages/@granit/react-localization/package.json
@@ -16,6 +16,7 @@
   "peerDependencies": {
     "@date-fns/tz": "^1.0.0",
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/utils": "workspace:*",
     "@granit/localization": "workspace:*",
     "@granit/query-engine": "workspace:*",
@@ -54,6 +55,7 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*",
     "@granit/utils": "workspace:*"

--- a/packages/@granit/react-localization/src/date-locale.ts
+++ b/packages/@granit/react-localization/src/date-locale.ts
@@ -1,7 +1,10 @@
+import { createLogger } from '@granit/logger';
 import { enUS } from 'date-fns/locale';
 import { useEffect, useState } from 'react';
 
 import type { Locale } from 'date-fns/locale';
+
+const logger = createLogger('react-localization');
 
 /** Alias for i18n codes that don't have a matching date-fns locale file. */
 const LOCALE_ALIAS: Record<string, string> = {
@@ -89,7 +92,8 @@ async function loadLocale(code: string): Promise<Locale> {
     if (!locale) throw new Error(`No locale found for ${dateFnsCode}`);
     cache.set(code, locale);
     return locale;
-  } catch {
+  } catch (err: unknown) {
+    logger.warn('Failed to load date-fns locale; falling back to default', { code, err });
     cache.set(code, DEFAULT_LOCALE);
     return DEFAULT_LOCALE;
   }

--- a/packages/@granit/react-localization/src/use-locale.ts
+++ b/packages/@granit/react-localization/src/use-locale.ts
@@ -1,7 +1,10 @@
 import { LOCALE_STORAGE_KEY } from '@granit/localization';
+import { createLogger } from '@granit/logger';
 import { createStorage } from '@granit/storage';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+
+const logger = createLogger('react-localization');
 
 export interface UseLocaleOptions {
   /** Called after locale is changed — use to persist to backend (e.g. settings API). */
@@ -37,7 +40,9 @@ export function useLocale(options?: UseLocaleOptions): {
   const setLocale = useCallback(
     (nextLocale: string) => {
       storage.set(nextLocale);
-      i18n.changeLanguage(nextLocale).catch(() => undefined);
+      i18n.changeLanguage(nextLocale).catch((err: unknown) => {
+        logger.warn('Failed to change i18next language', { locale: nextLocale, err });
+      });
       onLocaleChange?.(nextLocale);
     },
     [i18n, storage, onLocaleChange]

--- a/packages/@granit/react-notifications-mobile-push/package.json
+++ b/packages/@granit/react-notifications-mobile-push/package.json
@@ -16,6 +16,7 @@
   "peerDependencies": {
     "@capacitor/push-notifications": ">=6.0.0",
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/notifications-mobile-push": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/types": "workspace:*",
@@ -25,6 +26,7 @@
   "devDependencies": {
     "@capacitor/push-notifications": "^8.1.1",
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",

--- a/packages/@granit/react-notifications-mobile-push/src/hooks/use-mobile-push.ts
+++ b/packages/@granit/react-notifications-mobile-push/src/hooks/use-mobile-push.ts
@@ -1,10 +1,13 @@
 import { PushNotifications } from '@capacitor/push-notifications';
+import { createLogger } from '@granit/logger';
 import { registerDeviceToken, unregisterDeviceToken } from '@granit/notifications-mobile-push';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useMobilePushConfig } from '../providers/mobile-push-provider';
 
 import type { MobilePlatform } from '@granit/notifications-mobile-push';
+
+const logger = createLogger('react-notifications-mobile-push');
 
 /**
  * Returns a promise that resolves with the device token once Capacitor
@@ -90,7 +93,11 @@ export function useMobilePush(options: MobilePushHookOptions): UseMobilePushRetu
           token: token.value,
           platform: options.platform,
         });
+        logger.info('Mobile push device token refreshed', { platform: options.platform });
       } catch (err) {
+        logger.error('Mobile push token refresh sync failed', err, {
+          platform: options.platform,
+        });
         if (mountedRef.current) {
           setError(err instanceof Error ? err : new Error(String(err)));
         }
@@ -127,10 +134,12 @@ export function useMobilePush(options: MobilePushHookOptions): UseMobilePushRetu
         platform: options.platform,
       });
 
+      logger.info('Mobile push device token registered', { platform: options.platform });
       if (mountedRef.current) {
         setIsRegistered(true);
       }
     } catch (err) {
+      logger.error('Mobile push register failed', err, { platform: options.platform });
       if (mountedRef.current) {
         setError(err instanceof Error ? err : new Error(String(err)));
       }
@@ -147,12 +156,14 @@ export function useMobilePush(options: MobilePushHookOptions): UseMobilePushRetu
       if (tokenRef.current) {
         await unregisterDeviceToken(apiClient, basePath, tokenRef.current);
         tokenRef.current = null;
+        logger.info('Mobile push device token unregistered');
       }
 
       if (mountedRef.current) {
         setIsRegistered(false);
       }
     } catch (err) {
+      logger.error('Mobile push unregister failed', err);
       if (mountedRef.current) {
         setError(err instanceof Error ? err : new Error(String(err)));
       }

--- a/packages/@granit/react-notifications-web-push/package.json
+++ b/packages/@granit/react-notifications-web-push/package.json
@@ -15,6 +15,7 @@
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/notifications-web-push": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "react": "^19.0.0"
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/react-api-client": "workspace:*"
   }
 }

--- a/packages/@granit/react-notifications-web-push/src/hooks/use-web-push.ts
+++ b/packages/@granit/react-notifications-web-push/src/hooks/use-web-push.ts
@@ -1,3 +1,4 @@
+import { createLogger } from '@granit/logger';
 import {
   registerPushSubscription,
   unregisterPushSubscription,
@@ -6,6 +7,8 @@ import {
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useWebPushConfig } from '../providers/web-push-provider';
+
+const logger = createLogger('react-notifications-web-push');
 
 export interface UseWebPushReturn {
   /** Whether the browser supports Web Push. */
@@ -105,10 +108,12 @@ export function useWebPush(): UseWebPushReturn {
 
       await registerPushSubscription(config.apiClient, basePath, subscription.toJSON());
 
+      logger.info('Web push subscription registered');
       if (mountedRef.current) {
         setIsSubscribed(true);
       }
     } catch (err) {
+      logger.error('Web push subscribe failed', err);
       if (mountedRef.current) {
         setError(err instanceof Error ? err : new Error(String(err)));
       }
@@ -130,12 +135,14 @@ export function useWebPush(): UseWebPushReturn {
       if (subscription) {
         await unregisterPushSubscription(config.apiClient, basePath, subscription.endpoint);
         await subscription.unsubscribe();
+        logger.info('Web push subscription unregistered');
       }
 
       if (mountedRef.current) {
         setIsSubscribed(false);
       }
     } catch (err) {
+      logger.error('Web push unsubscribe failed', err);
       if (mountedRef.current) {
         setError(err instanceof Error ? err : new Error(String(err)));
       }

--- a/packages/@granit/react-notifications/package.json
+++ b/packages/@granit/react-notifications/package.json
@@ -16,6 +16,7 @@
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/notifications": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
@@ -44,6 +45,7 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@tanstack/react-query": "^5.0.0"

--- a/packages/@granit/react-notifications/src/hooks/use-unread-count.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-unread-count.ts
@@ -1,8 +1,11 @@
+import { createLogger } from '@granit/logger';
 import { getUnreadCount } from '@granit/notifications';
 import { useCallback, useEffect, useRef } from 'react';
 
 import { API_BASE_PATH } from '../constants';
 import { useNotificationConfig } from '../providers/notification-provider';
+
+const logger = createLogger('react-notifications');
 
 export interface UseUnreadCountOptions {
   /** Polling interval in ms. Set to 0 to disable polling. Default: 60 000 */
@@ -35,6 +38,7 @@ export function useUnreadCount(options: UseUnreadCountOptions = {}): UseUnreadCo
       }
     } catch {
       // Polling failures are non-critical — skip silently.
+      logger.debug('Unread-count poll failed; keeping last known count');
     }
   }, [config.apiClient, config.basePath, setUnreadCount]);
 

--- a/packages/@granit/react-notifications/src/providers/notification-provider.tsx
+++ b/packages/@granit/react-notifications/src/providers/notification-provider.tsx
@@ -1,3 +1,4 @@
+import { createLogger } from '@granit/logger';
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import type {
@@ -20,6 +21,8 @@ interface NotificationContextValue {
 }
 
 const NotificationContext = createContext<NotificationContextValue | null>(null);
+
+const logger = createLogger('react-notifications');
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -67,14 +70,21 @@ export function NotificationProvider({
 
     setConnectionState('connecting');
     transport.connect().then(
-      () => setConnectionState('connected'),
-      () => setConnectionState('disconnected')
+      () => {
+        logger.info('Notification real-time transport connected');
+        setConnectionState('connected');
+      },
+      () => {
+        logger.warn('Notification real-time transport failed to connect; REST polling only');
+        setConnectionState('disconnected');
+      }
     );
 
     return () => {
       unsubNotification();
       unsubState();
       transport.disconnect();
+      logger.info('Notification real-time transport disconnected');
     };
   }, [transport]);
 

--- a/packages/@granit/react-openiddict-admin/package.json
+++ b/packages/@granit/react-openiddict-admin/package.json
@@ -16,6 +16,7 @@
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/openiddict-admin": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*"

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-device-verification.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-device-verification.ts
@@ -1,6 +1,9 @@
+import { createLogger } from '@granit/logger';
 import { useState } from 'react';
 
 import { useAdminConfig } from '../providers/openiddict-admin-provider';
+
+const logger = createLogger('react-openiddict-admin');
 
 export type DeviceVerificationStatus = 'idle' | 'pending' | 'success' | 'error';
 
@@ -35,7 +38,11 @@ export function useDeviceVerification(verifyEndpoint = '/connect/verify'): Devic
       setStatus('success');
     } catch (error: unknown) {
       const data = (error as { response?: { data?: { error?: string } } })?.response?.data;
-      setErrorCode(data?.error ?? 'unknown_error');
+      const code = data?.error ?? 'unknown_error';
+      // Log only the OAuth error code — the submitted user_code is a credential
+      // and must never be logged (it can travel inside the raw error/request).
+      logger.warn('Device verification failed', { errorCode: code });
+      setErrorCode(code);
       setStatus('error');
     }
   };

--- a/packages/@granit/react-presence/package.json
+++ b/packages/@granit/react-presence/package.json
@@ -16,6 +16,7 @@
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/presence": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/presence": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",

--- a/packages/@granit/react-presence/src/hooks/use-heartbeat.ts
+++ b/packages/@granit/react-presence/src/hooks/use-heartbeat.ts
@@ -1,3 +1,4 @@
+import { createLogger } from '@granit/logger';
 import { pollMyPresence } from '@granit/presence';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
@@ -8,6 +9,8 @@ import { buildPresenceQueryKey, usePresenceConfig } from '../providers/presence-
 import { presenceKeys } from './query-keys';
 
 import type { PresenceResponse } from '@granit/presence';
+
+const logger = createLogger('react-presence');
 
 export interface UseHeartbeatOptions {
   /** Polling interval in ms while the tab is visible. Default: 30 000. */
@@ -83,6 +86,7 @@ export function useHeartbeat(options: UseHeartbeatOptions = {}): void {
         }
       } catch {
         // Heartbeat failures are non-critical — keep polling.
+        logger.warn('Presence heartbeat poll failed; will retry on next tick');
       } finally {
         inFlightRef.current = false;
       }

--- a/packages/@granit/react-presence/src/hooks/use-resource-presence.ts
+++ b/packages/@granit/react-presence/src/hooks/use-resource-presence.ts
@@ -1,3 +1,4 @@
+import { createLogger } from '@granit/logger';
 import { joinResourceRoom, leaveResourceRoom } from '@granit/presence';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -8,6 +9,8 @@ import {
 import { usePresenceConfig } from '../providers/presence-provider';
 
 import type { ResourcePresenceParticipantResponse, ResourceRoomResponse } from '@granit/presence';
+
+const logger = createLogger('react-presence');
 
 export interface UseResourcePresenceOptions {
   /** Heartbeat cadence ms. Default: 15 000. */
@@ -228,7 +231,9 @@ export function useResourcePresence(
       stopTimer();
       document.removeEventListener('visibilitychange', onVisibilityChange);
       // Best-effort leave — no retry, no await (component may already be destroyed).
-      void leaveResourceRoom(config.client, config.basePath, kind, id).catch(() => {});
+      void leaveResourceRoom(config.client, config.basePath, kind, id).catch(() => {
+        logger.warn('Best-effort leave of resource presence room failed on unmount');
+      });
     };
   }, [config, enabled, heartbeatIntervalMs, id, kind]);
 

--- a/packages/@granit/react-tracing/package.json
+++ b/packages/@granit/react-tracing/package.json
@@ -14,6 +14,7 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/logger": "workspace:*",
     "@granit/tracing": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/context-zone": "^2.6.0",
@@ -26,6 +27,9 @@
     "@opentelemetry/sdk-trace-web": "^2.6.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "react": "^19.0.0"
+  },
+  "devDependencies": {
+    "@granit/logger": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-tracing/src/providers/tracing-provider.tsx
+++ b/packages/@granit/react-tracing/src/providers/tracing-provider.tsx
@@ -1,3 +1,4 @@
+import { createLogger } from '@granit/logger';
 import { type Tracer, trace } from '@opentelemetry/api';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
@@ -21,6 +22,8 @@ import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-web';
 
 // ExportResultCode.SUCCESS = 0 (from @opentelemetry/core, not a direct dependency)
 const EXPORT_SUCCESS = { code: 0 as const };
+
+const logger = createLogger('react-tracing');
 
 function createGatedExporter(exporterConfig: TracingExporterConfig): SpanExporter {
   let delegate: OTLPTraceExporter | null = null;
@@ -52,19 +55,19 @@ function createGatedExporter(exporterConfig: TracingExporterConfig): SpanExporte
               delegate.export(spans, resultCallback);
             } else {
               disabled = true;
-              // eslint-disable-next-line no-console
-              console.warn(
-                `[@granit/tracing] OTLP collector unavailable at ${exporterConfig.url} (HTTP ${String(res.status)}). Trace export disabled for this session.`
-              );
+              logger.warn('OTLP collector unavailable; trace export disabled for this session', {
+                url: exporterConfig.url,
+                status: res.status,
+              });
               resultCallback(EXPORT_SUCCESS);
             }
           })
-          .catch(() => {
+          .catch((err: unknown) => {
             disabled = true;
-            // eslint-disable-next-line no-console
-            console.warn(
-              `[@granit/tracing] OTLP collector unreachable at ${exporterConfig.url}. Trace export disabled for this session.`
-            );
+            logger.warn('OTLP collector unreachable; trace export disabled for this session', {
+              url: exporterConfig.url,
+              err,
+            });
             resultCallback(EXPORT_SUCCESS);
           });
         return;

--- a/packages/@granit/react-validation/package.json
+++ b/packages/@granit/react-validation/package.json
@@ -15,11 +15,13 @@
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/validation": "workspace:*",
     "react": "^19.0.0"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*"
   },

--- a/packages/@granit/react-validation/src/use-server-validation-batch.ts
+++ b/packages/@granit/react-validation/src/use-server-validation-batch.ts
@@ -1,3 +1,4 @@
+import { createLogger } from '@granit/logger';
 import { isEmptyFieldValue, validateField, validateFieldsBatch } from '@granit/validation';
 import { useEffect, useRef, useState } from 'react';
 
@@ -5,6 +6,8 @@ import type { TranslateFunction } from './create-constraints-resolver';
 import type { ServerValidationState } from './use-server-validation';
 import type { AxiosInstance } from '@granit/api-client';
 import type { FieldConstraint } from '@granit/validation';
+
+const logger = createLogger('react-validation');
 
 export interface BatchFieldSpec {
   readonly name: string;
@@ -115,6 +118,10 @@ export function useServerValidationBatch(
         })
         .catch((err: unknown) => {
           if (controller.signal.aborted) return;
+          logger.warn('Server batch field validation request failed', {
+            fieldCount: eligible.length,
+            err,
+          });
           const errorState: Record<string, ServerValidationState> = {};
           for (const f of eligible) {
             errorState[f.name] = {

--- a/packages/@granit/react-validation/src/use-server-validation.ts
+++ b/packages/@granit/react-validation/src/use-server-validation.ts
@@ -1,9 +1,12 @@
+import { createLogger } from '@granit/logger';
 import { isEmptyFieldValue, validateField, validateFieldServer } from '@granit/validation';
 import { useEffect, useRef, useState } from 'react';
 
 import type { TranslateFunction } from './create-constraints-resolver';
 import type { AxiosInstance } from '@granit/api-client';
 import type { FieldConstraint } from '@granit/validation';
+
+const logger = createLogger('react-validation');
 
 export interface ServerValidationState {
   readonly status: 'idle' | 'validating' | 'valid' | 'invalid' | 'error';
@@ -96,6 +99,7 @@ export function useServerValidation(options: UseServerValidationOptions): Server
         })
         .catch((err: unknown) => {
           if (controller.signal.aborted) return;
+          logger.warn('Server field validation request failed', { validatorKey, err });
           setState({
             status: 'error',
             message: err instanceof Error ? err.message : String(err),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -217,6 +220,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -526,6 +532,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -582,6 +591,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -765,6 +777,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/storage':
         specifier: workspace:*
         version: link:../storage
@@ -861,6 +876,9 @@ importers:
 
   packages/@granit/notifications-sse:
     devDependencies:
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/notifications':
         specifier: workspace:*
         version: link:../notifications
@@ -1077,6 +1095,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
@@ -1114,6 +1135,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/react-api-client':
         specifier: workspace:*
         version: link:../react-api-client
@@ -1330,6 +1354,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
 
   packages/@granit/react-authentication-entraid:
     dependencies:
@@ -1377,6 +1404,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
 
   packages/@granit/react-authentication-keycloak:
     dependencies:
@@ -1402,6 +1432,9 @@ importers:
       '@granit/csp':
         specifier: workspace:*
         version: link:../csp
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
 
   packages/@granit/react-authentication-local:
     dependencies:
@@ -1582,6 +1615,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
@@ -1681,6 +1717,9 @@ importers:
       '@granit/cms':
         specifier: workspace:*
         version: link:../cms
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
@@ -1904,6 +1943,9 @@ importers:
       '@granit/dashboards':
         specifier: workspace:*
         version: link:../dashboards
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/react-api-client':
         specifier: workspace:*
         version: link:../react-api-client
@@ -1953,6 +1995,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -2376,6 +2421,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -2530,6 +2578,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -2558,6 +2609,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/react-api-client':
         specifier: workspace:*
         version: link:../react-api-client
@@ -2583,6 +2637,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/react-api-client':
         specifier: workspace:*
         version: link:../react-api-client
@@ -2611,6 +2668,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/react-api-client':
         specifier: workspace:*
         version: link:../react-api-client
@@ -2790,6 +2850,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/presence':
         specifier: workspace:*
         version: link:../presence
@@ -3221,6 +3284,10 @@ importers:
       react:
         specifier: 19.2.7
         version: 19.2.7
+    devDependencies:
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
 
   packages/@granit/react-validation:
     dependencies:
@@ -3234,6 +3301,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing


### PR DESCRIPTION
## Scope

Two related additions to framework plumbing.

### 1. Structured logging fleet
Adds `@granit/logger` instrumentation across ~22 packages, where it genuinely aids **post-launch monitoring** and **debugging**. Applied tight justification rules (no blanket instrumentation):

- **`info`** — reserved for lifecycle boundaries: auth login/logout, token acquired/refreshed, push subscription registered, presence/realtime/SSE connection open/close. (`react-authentication-{cognito,keycloak,google-cloud}`, `react-presence`, `react-notifications{,-web-push,-mobile-push}`, `notifications-sse`)
- **`error`/`warn`** — catch blocks that previously **swallowed** an IO/network/stream/parse failure. (`ai`, `ai-chat`, `react-ai`, `react-ai-chat`, `react-cms`, `react-dashboards`, `react-data-exchange`, `react-localization`, `react-validation`, `react-blob-storage`, `react-openiddict-admin`, `react-tracing`, `dashboards`, `localization`, `bff`)
- **`debug`** — only non-trivial branches (consent gate, per-frame stream skips).

**Security:** no secrets, tokens, cookie values, or PII are logged — only identifiers/metadata; caught errors are passed to the logger (which redacts), never interpolated into messages. Deliberately left intentional benign fallbacks (e.g. `parse → null` API contracts) untouched.

### 2. Consented-cookie helper
- `@granit/cookies`: `getCookie` / `setConsentedCookie` / `removeCookie` — **consent-gated** cookie writes (`strictly_necessary` always allowed; every other category gated on `ConsentState`). Writes are `debug`-logged with the value omitted.
- `@granit/react-cookies`: `useConsentedCookie(name, category)` hook bound to the live consent state from `useCookieConsent()`.

## Verification
- ✅ lint (`--max-warnings 0`), `tsc --noEmit`, full test suite green
- ✅ `check:csp` OK (cookie writes are not a DOM script sink)
- ✅ lockfile regenerated for the added `@granit/logger` peer deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)