### PR TITLE
feat(cms,documents,api-client): contract follow-ups

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -177,6 +177,16 @@
           "signature": "type ApiClientMode = 'bearer' | 'bff'"
         },
         {
+          "name": "ApiClientTransport",
+          "kind": "type",
+          "signature": "type ApiClientTransport = 'xhr' | 'fetch'"
+        },
+        {
+          "name": "RequestFetchOptions",
+          "kind": "type",
+          "signature": "type RequestFetchOptions = Omit<RequestInit, 'method' | 'body'>"
+        },
+        {
           "name": "CsrfTokenGetter",
           "kind": "type",
           "signature": "type CsrfTokenGetter = () => string | null"
@@ -200,6 +210,11 @@
               "name": "mode",
               "kind": "property",
               "signature": "mode?: ApiClientMode"
+            },
+            {
+              "name": "transport",
+              "kind": "property",
+              "signature": "transport?: ApiClientTransport"
             },
             {
               "name": "csrfTokenGetter",
@@ -1032,7 +1047,7 @@
         {
           "name": "resolvePreview",
           "kind": "function",
-          "signature": "async function resolvePreview( client: AxiosInstance, basePath: string, token: string ): Promise<DraftPagePreviewResponse | null>"
+          "signature": "async function resolvePreview( client: AxiosInstance, basePath: string, token: string, fetchOptions?: RequestFetchOptions ): Promise<DraftPagePreviewResponse | null>"
         },
         {
           "name": "getBlockCatalog",
@@ -1042,12 +1057,12 @@
         {
           "name": "getPublicBlockCatalog",
           "kind": "function",
-          "signature": "async function getPublicBlockCatalog( client: AxiosInstance, basePath: string ): Promise<BlockCatalogResponse>"
+          "signature": "async function getPublicBlockCatalog( client: AxiosInstance, basePath: string, fetchOptions?: RequestFetchOptions ): Promise<BlockCatalogResponse>"
         },
         {
           "name": "resolveBlockData",
           "kind": "function",
-          "signature": "async function resolveBlockData( client: AxiosInstance, basePath: string, request: BlockDataResolveRequest ): Promise<BlockDataResponse>"
+          "signature": "async function resolveBlockData( client: AxiosInstance, basePath: string, request: BlockDataResolveRequest, fetchOptions?: RequestFetchOptions ): Promise<BlockDataResponse>"
         },
         {
           "name": "resolveMenu",
@@ -1144,22 +1159,34 @@
         {
           "name": "getManifest",
           "kind": "function",
-          "signature": "async function getManifest( client: AxiosInstance, basePath: string, siteId: string ): Promise<string | null>"
+          "signature": "async function getManifest( client: AxiosInstance, basePath: string, siteId: string, opts?: RawDocumentOptions ): Promise<RawDocumentResult>"
         },
         {
           "name": "getRobotsTxt",
           "kind": "function",
-          "signature": "async function getRobotsTxt( client: AxiosInstance, basePath: string, siteId: string ): Promise<string>"
+          "signature": "async function getRobotsTxt( client: AxiosInstance, basePath: string, siteId: string, opts?: RawDocumentOptions ): Promise<RawDocumentResult>"
         },
         {
           "name": "getSitemap",
           "kind": "function",
-          "signature": "async function getSitemap( client: AxiosInstance, basePath: string, siteId: string ): Promise<string>"
+          "signature": "async function getSitemap( client: AxiosInstance, basePath: string, siteId: string, opts?: RawDocumentOptions ): Promise<RawDocumentResult>"
         },
         {
           "name": "getSitemapFile",
           "kind": "function",
-          "signature": "async function getSitemapFile( client: AxiosInstance, basePath: string, siteId: string, file: string ): Promise<string | null>"
+          "signature": "async function getSitemapFile( client: AxiosInstance, basePath: string, siteId: string, file: string, opts?: RawDocumentOptions ): Promise<RawDocumentResult>"
+        },
+        {
+          "name": "RawDocumentOptions",
+          "kind": "interface",
+          "signature": "interface RawDocumentOptions",
+          "members": []
+        },
+        {
+          "name": "RawDocumentResult",
+          "kind": "interface",
+          "signature": "interface RawDocumentResult",
+          "members": []
         }
       ]
     },
@@ -1493,6 +1520,12 @@
           "signature": "const DocumentsPermissions"
         },
         {
+          "name": "QueryDocumentsParams",
+          "kind": "interface",
+          "signature": "interface QueryDocumentsParams",
+          "members": []
+        },
+        {
           "name": "assignDocumentTag",
           "kind": "function",
           "signature": "async function assignDocumentTag( client: AxiosInstance, basePath: string, documentId: string, tagId: string ): Promise<DocumentTagAssignmentResponse>"
@@ -1535,7 +1568,7 @@
         {
           "name": "batchResolveDocumentAssets",
           "kind": "function",
-          "signature": "async function batchResolveDocumentAssets( client: AxiosInstance, basePath: string, request: BatchResolveRequest ): Promise<readonly ResolvedDocumentResponse[]>"
+          "signature": "async function batchResolveDocumentAssets( client: AxiosInstance, basePath: string, request: BatchResolveRequest, fetchOptions?: RequestFetchOptions ): Promise<readonly ResolvedDocumentResponse[]>"
         }
       ]
     },

--- a/packages/@granit/api-client/src/__tests__/api-client.test.ts
+++ b/packages/@granit/api-client/src/__tests__/api-client.test.ts
@@ -85,6 +85,17 @@ describe('createApiClient', () => {
     const client = mod.createApiClient({ baseURL: 'https://api.example.com' });
     expect(client.defaults.headers['Content-Type']).toBe('application/json');
   });
+
+  it('should leave the adapter at axios default when transport is omitted (back-compat)', () => {
+    const client = mod.createApiClient({ baseURL: 'https://api.example.com' });
+    // axios' untouched default is the priority array, never the pinned 'fetch' string.
+    expect(client.defaults.adapter).not.toBe('fetch');
+  });
+
+  it("should select the fetch adapter when transport is 'fetch'", () => {
+    const client = mod.createApiClient({ baseURL: 'https://api.example.com', transport: 'fetch' });
+    expect(client.defaults.adapter).toBe('fetch');
+  });
 });
 
 describe('token interceptor', () => {

--- a/packages/@granit/api-client/src/__tests__/errors.test.ts
+++ b/packages/@granit/api-client/src/__tests__/errors.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import {
   ConcurrencyConflictError,
+  getHttpStatus,
   HttpError,
+  isBackendUnavailable,
   isConcurrencyConflict,
   TimeoutError,
   ValidationError,
@@ -92,5 +94,40 @@ describe('TimeoutError', () => {
     expect(error.name).toBe('TimeoutError');
     expect(error.message).toBe('Request timed out');
     expect(error.timeoutMs).toBe(5000);
+  });
+});
+
+describe('isBackendUnavailable', () => {
+  it('is true for an Axios transport error with no response (network/DNS)', () => {
+    expect(isBackendUnavailable({ isAxiosError: true, code: 'ERR_NETWORK' })).toBe(true);
+  });
+
+  it('is true for a client-side timeout (no response)', () => {
+    expect(isBackendUnavailable({ isAxiosError: true, code: 'ECONNABORTED' })).toBe(true);
+  });
+
+  it('is false for an HTTP error that carries a response (even 5xx)', () => {
+    expect(isBackendUnavailable({ isAxiosError: true, response: { status: 503 } })).toBe(false);
+  });
+
+  it('is false for non-Axios values', () => {
+    expect(isBackendUnavailable(new Error('boom'))).toBe(false);
+    expect(isBackendUnavailable(null)).toBe(false);
+    expect(isBackendUnavailable('nope')).toBe(false);
+  });
+});
+
+describe('getHttpStatus', () => {
+  it('returns the status when an HTTP response exists', () => {
+    expect(getHttpStatus({ response: { status: 500 } })).toBe(500);
+  });
+
+  it('returns undefined for a transport error with no response', () => {
+    expect(getHttpStatus({ isAxiosError: true, code: 'ERR_NETWORK' })).toBeUndefined();
+  });
+
+  it('returns undefined for non-error values', () => {
+    expect(getHttpStatus(null)).toBeUndefined();
+    expect(getHttpStatus(42)).toBeUndefined();
   });
 });

--- a/packages/@granit/api-client/src/errors.ts
+++ b/packages/@granit/api-client/src/errors.ts
@@ -76,6 +76,36 @@ export function isConcurrencyConflict(error: unknown): boolean {
 }
 
 /**
+ * Did the transport fail WITHOUT producing an HTTP response — i.e. the request
+ * never reached a responding server (connection refused, DNS failure, TLS error,
+ * or a client-side timeout/abort)? This is distinct from an HTTP error (4xx/5xx),
+ * which always carries a `response`.
+ *
+ * Works on the raw `AxiosError` propagated by the api-client (the client does not
+ * remap transport errors) under both the `xhr` and `fetch` adapters: a network /
+ * DNS / timeout failure yields an `AxiosError` with no `response`, whereas any
+ * HTTP status — including 5xx — populates `response`. Lets SSR consumers separate
+ * "backend unreachable → maintenance" from "transient 5xx → page-level error".
+ */
+export function isBackendUnavailable(error: unknown): boolean {
+  if (error === null || typeof error !== 'object') return false;
+  const e = error as { isAxiosError?: boolean; response?: unknown };
+  return e.isAxiosError === true && e.response == null;
+}
+
+/**
+ * HTTP status code if the error carries an HTTP response, otherwise `undefined`.
+ * `undefined` means the transport failed before any response (see
+ * {@link isBackendUnavailable}). Reads the raw Axios error shape so it works
+ * whether the caller mapped the error or let the bare Axios error propagate.
+ */
+export function getHttpStatus(error: unknown): number | undefined {
+  if (error === null || typeof error !== 'object') return undefined;
+  const response = (error as { response?: { status?: number } }).response;
+  return typeof response?.status === 'number' ? response.status : undefined;
+}
+
+/**
  * Validation error for client-side or server-returned validation failures.
  *
  * Used by `@granit/query-engine` (filter syntax) and `@granit/data-exchange` (import mapping).

--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -9,6 +9,21 @@ import axios, {
 /** Authentication mode for the API client. */
 export type ApiClientMode = 'bearer' | 'bff';
 
+/** HTTP transport adapter for the API client. */
+export type ApiClientTransport = 'xhr' | 'fetch';
+
+/**
+ * Per-request options forwarded verbatim into the fetch adapter's `RequestInit`
+ * (no-op unless the client is created with `transport: 'fetch'`). Stays neutral
+ * vis-à-vis the consuming framework: SSR caching hints such as Next.js' `next`
+ * field (`{ next: { revalidate, tags } }`) only materialise in apps that augment
+ * the global `RequestInit` (via `next-env.d.ts`) — this package never declares
+ * them. `method` and `body` are omitted on purpose: axios' fetch adapter spreads
+ * `fetchOptions` last into the request init, so allowing them would let a caller
+ * silently clobber the request axios already built.
+ */
+export type RequestFetchOptions = Omit<RequestInit, 'method' | 'body'>;
+
 // Fallback logger for the rare paths where no app logger is wired. Warnings
 // route through the @granit/logger façade (console transport in dev) rather
 // than the raw global console — keeps the no-console arch rule honest.
@@ -29,6 +44,16 @@ export interface ApiClientConfig {
    *   No Authorization header is sent (the BFF YARP proxy adds it server-side).
    */
   mode?: ApiClientMode;
+  /**
+   * HTTP transport adapter. Default: `'xhr'` (axios' default — unchanged behaviour).
+   *
+   * - `'xhr'` — XMLHttpRequest in the browser, http(s) module under Node.
+   * - `'fetch'` — routes through the global `fetch`, letting per-request
+   *   `fetchOptions` (see {@link RequestFetchOptions}) reach the runtime's fetch.
+   *   Required for SSR consumers (e.g. Next.js) that rely on a patched global
+   *   `fetch` for caching / revalidation.
+   */
+  transport?: ApiClientTransport;
   /**
    * CSRF token getter for BFF mode. Required when `mode` is `'bff'`.
    * Typically obtained from `CsrfManager.getToken` in `@granit/bff`.
@@ -183,6 +208,9 @@ export function createApiClient(config: ApiClientConfig): AxiosInstance {
     baseURL: config.baseURL,
     timeout: config.timeout ?? 10_000,
     withCredentials: isBff,
+    // Opt-in fetch adapter: required for SSR consumers that depend on a patched
+    // global fetch (per-request `fetchOptions` only take effect with this adapter).
+    ...(config.transport === 'fetch' ? { adapter: 'fetch' as const } : {}),
     headers: {
       'Content-Type': 'application/json',
     },
@@ -285,7 +313,9 @@ export function buildApiUrl(basePath: string, ...segments: string[]): string {
 
 export {
   ConcurrencyConflictError,
+  getHttpStatus,
   HttpError,
+  isBackendUnavailable,
   isConcurrencyConflict,
   TimeoutError,
   ValidationError,

--- a/packages/@granit/cms-redirects/src/__tests__/redirects.test.ts
+++ b/packages/@granit/cms-redirects/src/__tests__/redirects.test.ts
@@ -40,4 +40,21 @@ describe('resolveRedirect', () => {
 
     expect(result).toBeNull();
   });
+
+  it('forwards fetchOptions to the fetch adapter when provided', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ status: 204, data: null });
+
+    await resolveRedirect(
+      client,
+      basePath,
+      { siteId: 'site-1', path: '/old-path' },
+      { cache: 'force-cache' }
+    );
+
+    expect(client.get).toHaveBeenCalledWith(
+      `${basePath}/api/cms/redirects/resolve`,
+      expect.objectContaining({ fetchOptions: { cache: 'force-cache' } })
+    );
+  });
 });

--- a/packages/@granit/cms-redirects/src/api/redirects.ts
+++ b/packages/@granit/cms-redirects/src/api/redirects.ts
@@ -1,5 +1,5 @@
 import type { ResolveResponse } from '../types/index';
-import type { AxiosInstance } from '@granit/api-client';
+import type { AxiosInstance, RequestFetchOptions } from '@granit/api-client';
 
 /**
  * Resolves a request path to its redirect target (public, anonymous).
@@ -9,11 +9,14 @@ import type { AxiosInstance } from '@granit/api-client';
  *
  * Returns the redirect target + status code, or `null` when no redirect matches
  * (the endpoint returns 204 in that case).
+ *
+ * `fetchOptions` is forwarded verbatim to the fetch adapter (SSR caching hints).
  */
 export async function resolveRedirect(
   client: AxiosInstance,
   basePath: string,
-  params: { siteId: string; path: string; culture?: string }
+  params: { siteId: string; path: string; culture?: string },
+  fetchOptions?: RequestFetchOptions
 ): Promise<ResolveResponse | null> {
   const response = await client.get<ResolveResponse | null>(
     `${basePath}/api/cms/redirects/resolve`,
@@ -21,6 +24,7 @@ export async function resolveRedirect(
       params: { path: params.path, culture: params.culture },
       headers: { 'X-Granit-Site': params.siteId },
       validateStatus: (s) => s === 200 || s === 204,
+      ...(fetchOptions ? { fetchOptions } : {}),
     }
   );
   return response.status === 204 ? null : (response.data ?? null);

--- a/packages/@granit/cms-seo/src/__tests__/seo.test.ts
+++ b/packages/@granit/cms-seo/src/__tests__/seo.test.ts
@@ -67,23 +67,69 @@ describe('getEffectiveSeo', () => {
 });
 
 describe('getSitemap', () => {
-  it('GETs the raw sitemap.xml as text', async () => {
+  it('returns body + ETag/Last-Modified/Content-Type on 200', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(axiosResponse('<urlset/>'));
+    vi.mocked(client.get).mockResolvedValue({
+      status: 200,
+      data: '<urlset/>',
+      headers: {
+        etag: '"v1"',
+        'last-modified': 'Wed, 01 Jan 2026 00:00:00 GMT',
+        'content-type': 'application/xml',
+      },
+    });
 
     const result = await getSitemap(client, basePath, 'site-1');
 
-    expect(client.get).toHaveBeenCalledWith(`${basePath}/api/cms/seo/sites/site-1/sitemap.xml`, {
-      responseType: 'text',
+    expect(client.get).toHaveBeenCalledWith(
+      `${basePath}/api/cms/seo/sites/site-1/sitemap.xml`,
+      expect.objectContaining({ responseType: 'text' })
+    );
+    expect(result).toEqual({
+      status: 200,
+      body: '<urlset/>',
+      contentType: 'application/xml',
+      etag: '"v1"',
+      lastModified: 'Wed, 01 Jan 2026 00:00:00 GMT',
     });
-    expect(result).toBe('<urlset/>');
+  });
+
+  it('sends If-None-Match and yields a 304 with null body', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({
+      status: 304,
+      data: '',
+      headers: { etag: '"v1"' },
+    });
+
+    const result = await getSitemap(client, basePath, 'site-1', { ifNoneMatch: '"v1"' });
+
+    expect(client.get).toHaveBeenCalledWith(
+      `${basePath}/api/cms/seo/sites/site-1/sitemap.xml`,
+      expect.objectContaining({ headers: { 'If-None-Match': '"v1"' } })
+    );
+    expect(result.status).toBe(304);
+    expect(result.body).toBeNull();
+    expect(result.etag).toBe('"v1"');
+  });
+
+  it('forwards fetchOptions to the fetch adapter when provided', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ status: 200, data: '<urlset/>', headers: {} });
+
+    await getSitemap(client, basePath, 'site-1', { fetchOptions: { cache: 'force-cache' } });
+
+    expect(client.get).toHaveBeenCalledWith(
+      `${basePath}/api/cms/seo/sites/site-1/sitemap.xml`,
+      expect.objectContaining({ fetchOptions: { cache: 'force-cache' } })
+    );
   });
 });
 
 describe('getSitemapFile', () => {
   it('returns the child file body on 200', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue({ status: 200, data: '<urlset/>' });
+    vi.mocked(client.get).mockResolvedValue({ status: 200, data: '<urlset/>', headers: {} });
 
     const result = await getSitemapFile(client, basePath, 'site-1', 'sitemap-1.xml');
 
@@ -91,45 +137,71 @@ describe('getSitemapFile', () => {
       `${basePath}/api/cms/seo/sites/site-1/sitemap/sitemap-1.xml`,
       expect.objectContaining({ responseType: 'text' })
     );
-    expect(result).toBe('<urlset/>');
+    expect(result.status).toBe(200);
+    expect(result.body).toBe('<urlset/>');
   });
 
-  it('returns null on 404', async () => {
+  it('returns status 404 with a null body when the file is missing', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue({ status: 404, data: '' });
+    vi.mocked(client.get).mockResolvedValue({ status: 404, data: '', headers: {} });
 
-    expect(await getSitemapFile(client, basePath, 'site-1', 'missing.xml')).toBeNull();
+    const result = await getSitemapFile(client, basePath, 'site-1', 'missing.xml');
+
+    expect(result.status).toBe(404);
+    expect(result.body).toBeNull();
   });
 });
 
 describe('getRobotsTxt', () => {
   it('GETs robots.txt as text', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(axiosResponse('User-agent: *\nAllow: /'));
+    vi.mocked(client.get).mockResolvedValue({
+      status: 200,
+      data: 'User-agent: *\nAllow: /',
+      headers: { 'content-type': 'text/plain' },
+    });
 
     const result = await getRobotsTxt(client, basePath, 'site-1');
 
-    expect(client.get).toHaveBeenCalledWith(`${basePath}/api/cms/seo/sites/site-1/robots.txt`, {
-      responseType: 'text',
-    });
-    expect(result).toContain('User-agent');
+    expect(client.get).toHaveBeenCalledWith(
+      `${basePath}/api/cms/seo/sites/site-1/robots.txt`,
+      expect.objectContaining({ responseType: 'text' })
+    );
+    expect(result.body).toContain('User-agent');
+    expect(result.contentType).toBe('text/plain');
+  });
+
+  it('forwards fetchOptions to the fetch adapter when provided', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ status: 200, data: 'User-agent: *', headers: {} });
+
+    await getRobotsTxt(client, basePath, 'site-1', { fetchOptions: { cache: 'force-cache' } });
+
+    expect(client.get).toHaveBeenCalledWith(
+      `${basePath}/api/cms/seo/sites/site-1/robots.txt`,
+      expect.objectContaining({ fetchOptions: { cache: 'force-cache' } })
+    );
   });
 });
 
 describe('getManifest', () => {
   it('returns the manifest body on 200', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue({ status: 200, data: '{"name":"App"}' });
+    vi.mocked(client.get).mockResolvedValue({ status: 200, data: '{"name":"App"}', headers: {} });
 
     const result = await getManifest(client, basePath, 'site-1');
 
-    expect(result).toBe('{"name":"App"}');
+    expect(result.status).toBe(200);
+    expect(result.body).toBe('{"name":"App"}');
   });
 
-  it('returns null on 404', async () => {
+  it('returns status 404 with a null body when no manifest is set', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue({ status: 404, data: '' });
+    vi.mocked(client.get).mockResolvedValue({ status: 404, data: '', headers: {} });
 
-    expect(await getManifest(client, basePath, 'site-1')).toBeNull();
+    const result = await getManifest(client, basePath, 'site-1');
+
+    expect(result.status).toBe(404);
+    expect(result.body).toBeNull();
   });
 });

--- a/packages/@granit/cms-seo/src/api/seo.ts
+++ b/packages/@granit/cms-seo/src/api/seo.ts
@@ -1,5 +1,5 @@
 import type { EffectiveSeoResponse } from '../types/index';
-import type { AxiosInstance } from '@granit/api-client';
+import type { AxiosInstance, RequestFetchOptions } from '@granit/api-client';
 
 /**
  * Fetches the cascade-resolved, render-ready SEO for a content item.
@@ -7,6 +7,8 @@ import type { AxiosInstance } from '@granit/api-client';
  *
  * `contentTitle` and `contentDescription` seed the cascade when no explicit
  * title/description row exists for the content item.
+ *
+ * `fetchOptions` is forwarded verbatim to the fetch adapter (SSR caching hints).
  */
 export async function getEffectiveSeo(
   client: AxiosInstance,
@@ -18,79 +20,146 @@ export async function getEffectiveSeo(
     readonly culture: string;
     readonly contentTitle?: string;
     readonly contentDescription?: string;
-  }
+  },
+  fetchOptions?: RequestFetchOptions
 ): Promise<EffectiveSeoResponse> {
   const { siteId, contentType, contentId, culture, contentTitle, contentDescription } = params;
   const response = await client.get<EffectiveSeoResponse>(
     `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/metadata/${encodeURIComponent(contentType)}/${encodeURIComponent(contentId)}/${encodeURIComponent(culture)}/effective`,
-    { params: { contentTitle, contentDescription } }
+    { params: { contentTitle, contentDescription }, ...(fetchOptions ? { fetchOptions } : {}) }
   );
   return response.data;
 }
 
 /**
+ * Raw document response for the public SEO documents (sitemap / robots / manifest).
+ * Surfaces the upstream `status`, `ETag` and `Last-Modified` so a server route can
+ * do faithful conditional-GET pass-through (`If-None-Match` → `304`) and re-emit
+ * the correct `Content-Type`. `body` is `null` on `304` (not modified) and `404`.
+ */
+export interface RawDocumentResult {
+  readonly status: number;
+  readonly body: string | null;
+  readonly contentType?: string;
+  readonly etag?: string;
+  readonly lastModified?: string;
+}
+
+/** Per-request options for the raw SEO document reads. */
+export interface RawDocumentOptions {
+  /** Forwarded as `If-None-Match`; a matching upstream `ETag` yields `304` + `body: null`. */
+  readonly ifNoneMatch?: string;
+  /** Forwarded verbatim to the fetch adapter (SSR caching hints). */
+  readonly fetchOptions?: RequestFetchOptions;
+}
+
+function readHeader(headers: unknown, name: string): string | undefined {
+  const h = headers as { get?: (n: string) => string | null; [k: string]: unknown } | null;
+  const value = typeof h?.get === 'function' ? h.get(name) : h?.[name];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function toRawDocumentResult(res: {
+  status: number;
+  data: string;
+  headers: unknown;
+}): RawDocumentResult {
+  const noBody = res.status === 304 || res.status === 404;
+  return {
+    status: res.status,
+    body: noBody ? null : res.data,
+    contentType: readHeader(res.headers, 'content-type'),
+    etag: readHeader(res.headers, 'etag'),
+    lastModified: readHeader(res.headers, 'last-modified'),
+  };
+}
+
+function rawDocumentConfig(opts: RawDocumentOptions | undefined, allow404: boolean) {
+  return {
+    responseType: 'text' as const,
+    validateStatus: (s: number) => s === 200 || s === 304 || (allow404 && s === 404),
+    ...(opts?.ifNoneMatch ? { headers: { 'If-None-Match': opts.ifNoneMatch } } : {}),
+    ...(opts?.fetchOptions ? { fetchOptions: opts.fetchOptions } : {}),
+  };
+}
+
+/**
  * Public, anonymous sitemap document for a site (index or single urlset).
  * `GET {basePath}/api/cms/seo/sites/{siteId}/sitemap.xml` — returns raw XML.
+ *
+ * Supports conditional GET: pass `opts.ifNoneMatch` to relay the upstream `ETag`
+ * and short-circuit on `304`. See {@link RawDocumentResult}.
  */
 export async function getSitemap(
   client: AxiosInstance,
   basePath: string,
-  siteId: string
-): Promise<string> {
+  siteId: string,
+  opts?: RawDocumentOptions
+): Promise<RawDocumentResult> {
   const res = await client.get<string>(
     `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/sitemap.xml`,
-    { responseType: 'text' }
+    rawDocumentConfig(opts, false)
   );
-  return res.data;
+  return toRawDocumentResult(res);
 }
 
 /**
  * A named child sitemap file referenced by the sitemap index.
- * `GET {basePath}/api/cms/seo/sites/{siteId}/sitemap/{file}` — returns raw XML
- * or `null` on `404`.
+ * `GET {basePath}/api/cms/seo/sites/{siteId}/sitemap/{file}` — returns raw XML,
+ * `status: 404` (with `body: null`) when the file does not exist.
+ *
+ * Supports conditional GET via `opts.ifNoneMatch`. See {@link RawDocumentResult}.
  */
 export async function getSitemapFile(
   client: AxiosInstance,
   basePath: string,
   siteId: string,
-  file: string
-): Promise<string | null> {
+  file: string,
+  opts?: RawDocumentOptions
+): Promise<RawDocumentResult> {
   const res = await client.get<string>(
     `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/sitemap/${encodeURIComponent(file)}`,
-    { responseType: 'text', validateStatus: (s) => s === 200 || s === 404 }
+    rawDocumentConfig(opts, true)
   );
-  return res.status === 404 ? null : res.data;
+  return toRawDocumentResult(res);
 }
 
 /**
  * Public, anonymous `robots.txt` for a site.
  * `GET {basePath}/api/cms/seo/sites/{siteId}/robots.txt` — returns raw text.
+ *
+ * Supports conditional GET via `opts.ifNoneMatch`. See {@link RawDocumentResult}.
  */
 export async function getRobotsTxt(
   client: AxiosInstance,
   basePath: string,
-  siteId: string
-): Promise<string> {
+  siteId: string,
+  opts?: RawDocumentOptions
+): Promise<RawDocumentResult> {
   const res = await client.get<string>(
     `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/robots.txt`,
-    { responseType: 'text' }
+    rawDocumentConfig(opts, false)
   );
-  return res.data;
+  return toRawDocumentResult(res);
 }
 
 /**
  * Public, anonymous PWA web app manifest for a site.
  * `GET {basePath}/api/cms/seo/sites/{siteId}/manifest.webmanifest` — returns the
- * raw `application/manifest+json` text, or `null` on `404` (no manifest set).
+ * raw `application/manifest+json` text, `status: 404` (with `body: null`) when no
+ * manifest is set.
+ *
+ * Supports conditional GET via `opts.ifNoneMatch`. See {@link RawDocumentResult}.
  */
 export async function getManifest(
   client: AxiosInstance,
   basePath: string,
-  siteId: string
-): Promise<string | null> {
+  siteId: string,
+  opts?: RawDocumentOptions
+): Promise<RawDocumentResult> {
   const res = await client.get<string>(
     `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/manifest.webmanifest`,
-    { responseType: 'text', validateStatus: (s) => s === 200 || s === 404 }
+    rawDocumentConfig(opts, true)
   );
-  return res.status === 404 ? null : res.data;
+  return toRawDocumentResult(res);
 }

--- a/packages/@granit/cms-seo/src/index.ts
+++ b/packages/@granit/cms-seo/src/index.ts
@@ -45,6 +45,7 @@ export type {
 
 // ─── API — Public renderer & anonymous documents ─────────────────────────────
 export { getEffectiveSeo, getManifest, getRobotsTxt, getSitemap, getSitemapFile } from './api/seo';
+export type { RawDocumentOptions, RawDocumentResult } from './api/seo';
 
 // ─── API — SEO admin ─────────────────────────────────────────────────────────
 export {

--- a/packages/@granit/cms/src/__tests__/blocks.test.ts
+++ b/packages/@granit/cms/src/__tests__/blocks.test.ts
@@ -52,29 +52,54 @@ describe('getPublicBlockCatalog', () => {
 
     const result = await getPublicBlockCatalog(client, basePath);
 
-    expect(client.get).toHaveBeenCalledWith(`${basePath}/api/cms/blocks/public`);
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/api/cms/blocks/public`, undefined);
     expect(result).toEqual(catalog);
+  });
+
+  it('forwards fetchOptions to the fetch adapter when provided', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(catalog));
+
+    // `cache` is a real RequestInit field; the Next-only `next` field is exercised
+    // by the renderer (which augments RequestInit). The forwarding mechanism is identical.
+    await getPublicBlockCatalog(client, basePath, { cache: 'force-cache' });
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/api/cms/blocks/public`, {
+      fetchOptions: { cache: 'force-cache' },
+    });
   });
 });
 
 describe('resolveBlockData', () => {
+  const req: BlockDataResolveRequest = {
+    dataSourceKey: 'blog-latest',
+    query: null,
+    siteId: 'site-1',
+    culture: 'fr',
+  };
+  const resp: BlockDataResponse = {
+    data: { posts: [] },
+    consumedContentKeys: ['blog:post:1', 'blog:post:2'],
+  };
+
   it('posts the request and returns block data', async () => {
     const client = createMockClient();
-    const req: BlockDataResolveRequest = {
-      dataSourceKey: 'blog-latest',
-      query: null,
-      siteId: 'site-1',
-      culture: 'fr',
-    };
-    const resp: BlockDataResponse = {
-      data: { posts: [] },
-      consumedContentKeys: ['blog:post:1', 'blog:post:2'],
-    };
     vi.mocked(client.post).mockResolvedValue(axiosResponse(resp));
 
     const result = await resolveBlockData(client, basePath, req);
 
-    expect(client.post).toHaveBeenCalledWith(`${basePath}/api/cms/blocks/data`, req);
+    expect(client.post).toHaveBeenCalledWith(`${basePath}/api/cms/blocks/data`, req, undefined);
     expect(result).toEqual(resp);
+  });
+
+  it('forwards fetchOptions to the fetch adapter when provided', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(resp));
+
+    await resolveBlockData(client, basePath, req, { cache: 'no-store' });
+
+    expect(client.post).toHaveBeenCalledWith(`${basePath}/api/cms/blocks/data`, req, {
+      fetchOptions: { cache: 'no-store' },
+    });
   });
 });

--- a/packages/@granit/cms/src/api/blocks.ts
+++ b/packages/@granit/cms/src/api/blocks.ts
@@ -3,7 +3,7 @@ import type {
   BlockDataResolveRequest,
   BlockDataResponse,
 } from '../types/index';
-import type { AxiosInstance } from '@granit/api-client';
+import type { AxiosInstance, RequestFetchOptions } from '@granit/api-client';
 
 /**
  * Fetches the editor-agnostic block catalog.
@@ -24,12 +24,19 @@ export async function getBlockCatalog(
  * Same `BlockCatalogResponse` shape as {@link getBlockCatalog}, but served by an
  * `AllowAnonymous` route so the public renderer can build its render config
  * without a bearer token. Use {@link getBlockCatalog} for the admin editor.
+ *
+ * `fetchOptions` is forwarded verbatim to the fetch adapter (SSR caching hints,
+ * e.g. `{ next: { tags: ['cms-catalog'] } }`).
  */
 export async function getPublicBlockCatalog(
   client: AxiosInstance,
-  basePath: string
+  basePath: string,
+  fetchOptions?: RequestFetchOptions
 ): Promise<BlockCatalogResponse> {
-  const response = await client.get<BlockCatalogResponse>(`${basePath}/api/cms/blocks/public`);
+  const response = await client.get<BlockCatalogResponse>(
+    `${basePath}/api/cms/blocks/public`,
+    fetchOptions ? { fetchOptions } : undefined
+  );
   return response.data;
 }
 
@@ -39,12 +46,20 @@ export async function getPublicBlockCatalog(
  *
  * The `consumedContentKeys` in the response should be added as ISR cache tags
  * so a backend publish of any consumed content invalidates the page.
+ *
+ * `fetchOptions` is forwarded verbatim to the fetch adapter (SSR caching hints,
+ * e.g. `{ next: { tags: [`block-data:${siteId}:${key}`] } }`).
  */
 export async function resolveBlockData(
   client: AxiosInstance,
   basePath: string,
-  request: BlockDataResolveRequest
+  request: BlockDataResolveRequest,
+  fetchOptions?: RequestFetchOptions
 ): Promise<BlockDataResponse> {
-  const response = await client.post<BlockDataResponse>(`${basePath}/api/cms/blocks/data`, request);
+  const response = await client.post<BlockDataResponse>(
+    `${basePath}/api/cms/blocks/data`,
+    request,
+    fetchOptions ? { fetchOptions } : undefined
+  );
   return response.data;
 }

--- a/packages/@granit/cms/src/api/menus.ts
+++ b/packages/@granit/cms/src/api/menus.ts
@@ -1,5 +1,5 @@
 import type { ResolvedMenu } from '../types/index';
-import type { AxiosInstance } from '@granit/api-client';
+import type { AxiosInstance, RequestFetchOptions } from '@granit/api-client';
 
 /**
  * Resolves a menu into a render-ready tree (anonymous).
@@ -7,16 +7,20 @@ import type { AxiosInstance } from '@granit/api-client';
  * + `X-Granit-Site: {siteId}` header (the backend scopes by site via the header).
  *
  * Returns `null` when no menu with the given key exists.
+ *
+ * `fetchOptions` is forwarded verbatim to the fetch adapter (SSR caching hints).
  */
 export async function resolveMenu(
   client: AxiosInstance,
   basePath: string,
-  params: { siteId: string; key: string; culture: string }
+  params: { siteId: string; key: string; culture: string },
+  fetchOptions?: RequestFetchOptions
 ): Promise<ResolvedMenu | null> {
   try {
     const response = await client.get<ResolvedMenu>(`${basePath}/api/cms/menus/resolve`, {
       params: { key: params.key, culture: params.culture },
       headers: { 'X-Granit-Site': params.siteId },
+      ...(fetchOptions ? { fetchOptions } : {}),
     });
     return response.data;
   } catch (err: unknown) {

--- a/packages/@granit/cms/src/api/pages.ts
+++ b/packages/@granit/cms/src/api/pages.ts
@@ -4,7 +4,7 @@ import type {
   MintPreviewTokenResponse,
   PublishedPageResponse,
 } from '../types/index';
-import type { AxiosInstance } from '@granit/api-client';
+import type { AxiosInstance, RequestFetchOptions } from '@granit/api-client';
 
 /**
  * Resolves a published page by per-culture path.
@@ -12,16 +12,20 @@ import type { AxiosInstance } from '@granit/api-client';
  * + `X-Granit-Site: {siteId}` header.
  *
  * Returns `null` on 404 (draft, archived, or unknown path).
+ *
+ * `fetchOptions` is forwarded verbatim to the fetch adapter (SSR caching hints).
  */
 export async function getPageByPath(
   client: AxiosInstance,
   basePath: string,
-  params: { siteId: string; culture: string; path: string }
+  params: { siteId: string; culture: string; path: string },
+  fetchOptions?: RequestFetchOptions
 ): Promise<PublishedPageResponse | null> {
   try {
     const response = await client.get<PublishedPageResponse>(`${basePath}/api/cms/pages/by-path`, {
       params: { culture: params.culture, path: params.path },
       headers: { 'X-Granit-Site': params.siteId },
+      ...(fetchOptions ? { fetchOptions } : {}),
     });
     return response.data;
   } catch (err: unknown) {
@@ -52,16 +56,20 @@ export async function mintPreviewToken(
  * `GET {basePath}/api/cms/preview/resolve?token={token}`
  *
  * Returns `null` on 401 (invalid/expired token) or 404.
+ *
+ * `fetchOptions` is forwarded verbatim to the fetch adapter (typically
+ * `{ cache: 'no-store' }` so previews are never cached).
  */
 export async function resolvePreview(
   client: AxiosInstance,
   basePath: string,
-  token: string
+  token: string,
+  fetchOptions?: RequestFetchOptions
 ): Promise<DraftPagePreviewResponse | null> {
   try {
     const response = await client.get<DraftPagePreviewResponse>(
       `${basePath}/api/cms/preview/resolve`,
-      { params: { token } }
+      { params: { token }, ...(fetchOptions ? { fetchOptions } : {}) }
     );
     return response.data;
   } catch (err: unknown) {

--- a/packages/@granit/documents/package.json
+++ b/packages/@granit/documents/package.json
@@ -15,11 +15,13 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/types": "workspace:*"
   },
   "publishConfig": {

--- a/packages/@granit/documents/src/__tests__/documents-api.test.ts
+++ b/packages/@granit/documents/src/__tests__/documents-api.test.ts
@@ -10,6 +10,7 @@ import {
   listTrashedDocuments,
   moveDocument,
   permanentlyDeleteDocument,
+  queryDocuments,
   renameDocument,
   getDocumentDownloadUrl,
   requestUploadTicket,
@@ -29,6 +30,7 @@ import type {
   UploadTicketRequest,
   UploadTicketResponse,
 } from '../types/index';
+import type { PagedResult } from '@granit/query-engine';
 
 const basePath = '/api/v1/documents';
 
@@ -324,5 +326,57 @@ describe('listTrashedDocuments', () => {
     await listTrashedDocuments(client, basePath);
 
     expect(client.get).toHaveBeenCalledWith(`${basePath}/documents/trash`, { params: {} });
+  });
+});
+
+describe('queryDocuments', () => {
+  const paged: PagedResult<DocumentResponse> = {
+    items: [sampleDocument],
+    totalCount: 1,
+    hasMore: false,
+  };
+
+  it('hits the nested documents QueryEngine path with no query when no params are given', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(paged));
+
+    const result = await queryDocuments(client, basePath);
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/documents`, undefined);
+    expect(result).toEqual(paged);
+  });
+
+  it('serializes search/status/sort/page/pageSize via the QueryEngine serializer', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(paged));
+
+    await queryDocuments(client, basePath, {
+      search: 'report',
+      status: 'Active',
+      sort: '-name',
+      page: 2,
+      pageSize: 20,
+    });
+
+    const calledUrl = vi.mocked(client.get).mock.calls[0]![0] as string;
+    expect(calledUrl.startsWith(`${basePath}/documents?`)).toBe(true);
+    // status is emitted as a `filter[status.Eq]` entry (URL-encoded brackets),
+    // proving reuse of the shared serializer rather than a hand-rolled query.
+    expect(calledUrl).toContain('filter%5Bstatus.Eq%5D=Active');
+    expect(calledUrl).toContain('search=report');
+    expect(calledUrl).toContain('sort=-name');
+    expect(calledUrl).toContain('page=2');
+    expect(calledUrl).toContain('pageSize=20');
+  });
+
+  it('forwards fetchOptions to the fetch adapter when provided', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(paged));
+
+    await queryDocuments(client, basePath, undefined, { cache: 'force-cache' });
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/documents`, {
+      fetchOptions: { cache: 'force-cache' },
+    });
   });
 });

--- a/packages/@granit/documents/src/__tests__/resolution-api.test.ts
+++ b/packages/@granit/documents/src/__tests__/resolution-api.test.ts
@@ -1,0 +1,50 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { batchResolveDocumentAssets } from '../api/resolution-api';
+
+import type { BatchResolveRequest, ResolvedDocumentResponse } from '../types/index';
+
+const basePath = '/api/v1/documents';
+
+const request: BatchResolveRequest = {
+  requests: [{ documentId: 'doc-1', renditionType: 'Web' }],
+};
+
+const resolved: readonly ResolvedDocumentResponse[] = [
+  {
+    documentId: 'doc-1',
+    versionId: 'ver-1',
+    url: 'https://cdn.example.com/doc-1',
+    width: 1920,
+    height: 1080,
+    mimeType: 'image/webp',
+    sizeBytes: 2048,
+    lastModified: '2026-05-01T10:00:00Z',
+  },
+];
+
+describe('batchResolveDocumentAssets', () => {
+  it('POSTs to /resolution/resolve and returns the resolved assets', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(resolved));
+
+    const result = await batchResolveDocumentAssets(client, basePath, request);
+
+    expect(client.post).toHaveBeenCalledWith(`${basePath}/resolution/resolve`, request, undefined);
+    expect(result).toEqual(resolved);
+  });
+
+  it('forwards fetchOptions to the fetch adapter when provided', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(resolved));
+
+    await batchResolveDocumentAssets(client, basePath, request, {
+      cache: 'force-cache',
+    });
+
+    expect(client.post).toHaveBeenCalledWith(`${basePath}/resolution/resolve`, request, {
+      fetchOptions: { cache: 'force-cache' },
+    });
+  });
+});

--- a/packages/@granit/documents/src/api/documents-api.ts
+++ b/packages/@granit/documents/src/api/documents-api.ts
@@ -1,6 +1,9 @@
+import { serializeQueryRequest } from '@granit/query-engine';
+
 import type {
   AppendVersionRequest,
   DocumentResponse,
+  DocumentStatus,
   DocumentVersionResponse,
   DownloadUrlResponse,
   FinalizeUploadRequest,
@@ -13,7 +16,8 @@ import type {
   UploadTicketRequest,
   UploadTicketResponse,
 } from '../types/index';
-import type { AxiosInstance } from '@granit/api-client';
+import type { AxiosInstance, RequestFetchOptions } from '@granit/api-client';
+import type { PagedResult, QueryRequest, SortEntry } from '@granit/query-engine';
 
 /**
  * Issue a presigned upload ticket. The client PUTs the bytes directly to the
@@ -259,5 +263,60 @@ export async function listTrashedDocuments(
   const response = await client.get<ListTrashedDocumentsResponse>(`${basePath}/documents/trash`, {
     params,
   });
+  return response.data;
+}
+
+/** Parameters accepted by {@link queryDocuments}. */
+export interface QueryDocumentsParams {
+  /** Free-text search (backend GlobalSearch over Name + Description). */
+  readonly search?: string;
+  /** Status filter, emitted as `filter[status.Eq]=<status>`. */
+  readonly status?: DocumentStatus;
+  /** Sort field; prefix with `-` for descending (e.g. `-name`). Backend defaults to `name`. */
+  readonly sort?: string;
+  /** One-based page number. */
+  readonly page?: number;
+  /** Items per page (backend clamps to 1..500). */
+  readonly pageSize?: number;
+}
+
+function parseDocumentSort(sort: string): SortEntry {
+  return sort.startsWith('-')
+    ? { field: sort.slice(1), direction: 'desc' }
+    : { field: sort, direction: 'asc' };
+}
+
+/**
+ * Query the documents grid via the QueryEngine listing endpoint
+ * (`GET /` on the nested `documents` sub-group). Filterable / sortable / paged.
+ * Used by the CMS renderer's document picker.
+ *
+ * `GET {basePath}/documents?search=…&filter[status.Eq]=Active&sort=-name&page=1&pageSize=20`
+ *
+ * Query params are built through `serializeQueryRequest` from `@granit/query-engine`
+ * so the operator casing and `filter[...]` encoding stay consistent with every
+ * other Granit grid. `fetchOptions` is forwarded verbatim to the fetch adapter.
+ */
+export async function queryDocuments(
+  client: AxiosInstance,
+  basePath: string,
+  params?: QueryDocumentsParams,
+  fetchOptions?: RequestFetchOptions
+): Promise<PagedResult<DocumentResponse>> {
+  const request: QueryRequest = {
+    page: params?.page,
+    pageSize: params?.pageSize,
+    search: params?.search,
+    filters: params?.status
+      ? [{ field: 'status', operator: 'Eq', value: params.status }]
+      : undefined,
+    sort: params?.sort ? [parseDocumentSort(params.sort)] : undefined,
+  };
+  const qs = serializeQueryRequest(request);
+  const url = qs ? `${basePath}/documents?${qs}` : `${basePath}/documents`;
+  const response = await client.get<PagedResult<DocumentResponse>>(
+    url,
+    fetchOptions ? { fetchOptions } : undefined
+  );
   return response.data;
 }

--- a/packages/@granit/documents/src/api/resolution-api.ts
+++ b/packages/@granit/documents/src/api/resolution-api.ts
@@ -1,5 +1,5 @@
 import type { BatchResolveRequest, ResolvedDocumentResponse } from '../types/index';
-import type { AxiosInstance } from '@granit/api-client';
+import type { AxiosInstance, RequestFetchOptions } from '@granit/api-client';
 
 /**
  * Resolve a batch of document assets to presigned CDN URLs in one round-trip.
@@ -10,15 +10,20 @@ import type { AxiosInstance } from '@granit/api-client';
  * Primarily used by the CMS renderer to embed document assets.
  *
  * `POST {basePath}/resolution/resolve`
+ *
+ * `fetchOptions` is forwarded verbatim to the fetch adapter (SSR caching hints,
+ * e.g. `{ next: { revalidate: 3600 } }`).
  */
 export async function batchResolveDocumentAssets(
   client: AxiosInstance,
   basePath: string,
-  request: BatchResolveRequest
+  request: BatchResolveRequest,
+  fetchOptions?: RequestFetchOptions
 ): Promise<readonly ResolvedDocumentResponse[]> {
   const response = await client.post<readonly ResolvedDocumentResponse[]>(
     `${basePath}/resolution/resolve`,
-    request
+    request,
+    fetchOptions ? { fetchOptions } : undefined
   );
   return response.data;
 }

--- a/packages/@granit/documents/src/index.ts
+++ b/packages/@granit/documents/src/index.ts
@@ -51,6 +51,10 @@ export type {
   UploadTicketResponse,
 } from './types/index';
 
+// Shared QueryEngine result type, re-exported so consumers of queryDocuments
+// don't reach into @granit/query-engine directly.
+export type { PagedResult } from '@granit/query-engine';
+
 // Permissions
 export { DocumentsPermissions } from './permissions';
 
@@ -76,6 +80,7 @@ export {
   listTrashedDocuments,
   moveDocument,
   permanentlyDeleteDocument,
+  queryDocuments,
   renameDocument,
   getDocumentDownloadUrl,
   requestUploadTicket,
@@ -83,6 +88,7 @@ export {
   transferDocumentOwner,
   trashDocument,
 } from './api/documents-api';
+export type { QueryDocumentsParams } from './api/documents-api';
 
 // API — Shares
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -627,6 +627,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing


### PR DESCRIPTION
## Scope

Follow-on contract work (predates the observability PR — split out per one-branch-one-scope).

- **api-client**: extended error model (`errors.ts`) + exports
- **cms**: blocks / menus / pages API adjustments
- **cms-seo**: reworked SEO API + types to match backend contract
- **cms-redirects**: redirects API adjustment
- **documents**: documents / resolution API enrichment (+ new `resolution-api` tests)

## Verification
- ✅ lint, `tsc --noEmit`, tests for the 5 packages green (234 tests)
- ✅ lockfile regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)