### PR TITLE
test(arch-tests): ban empty catch blocks (no-empty-catch rule)

### DIFF
--- a/packages/@granit/arch-tests-kit/src/index.ts
+++ b/packages/@granit/arch-tests-kit/src/index.ts
@@ -29,6 +29,7 @@ export {
   scanAnonymousDefaultExports,
   scanWallClockInApi,
   scanUseFormResolver,
+  scanEmptyCatch,
 } from './scanners/patterns';
 
 export { scanReadmePresence, scanSharedDepVersions } from './scanners/uniformity';

--- a/packages/@granit/arch-tests-kit/src/scanners/patterns.ts
+++ b/packages/@granit/arch-tests-kit/src/scanners/patterns.ts
@@ -102,3 +102,42 @@ export function scanUseFormResolver(opts: AllowlistedScanContext): Violation[] {
   }
   return out;
 }
+
+// An empty `try { … } catch { }` swallows the error with no log, no rethrow,
+// and no fallback — the canonical "silent failure" anti-pattern. A catch block
+// must DO something: log via createLogger, rethrow, return a fallback, or set
+// an error state. Comments are stripped first, so `catch { /* ignore */ }`
+// counts as empty too — "ignoring" must be a deliberate, visible decision.
+//
+// Promise `.catch(() => …)` handlers are intentionally OUT of scope: the
+// framework uses `.catch(() => undefined)` as an accepted fire-and-forget idiom
+// for non-critical work (e.g. React-Query cache invalidation after a mutation
+// that already succeeded).
+const EMPTY_CATCH_RE = /\bcatch\s*(?:\([^)]*\))?\s*\{\s*\}/g;
+
+export function scanEmptyCatch(opts: AllowlistedScanContext): Violation[] {
+  const out: Violation[] = [];
+  const allowedModules = new Set(opts.allowedModules ?? []);
+  const allowedFiles = opts.allowedFiles ?? [];
+  for (const m of opts.modules) {
+    if (allowedModules.has(m.name)) continue;
+    for (const f of walkSourceFiles(m.srcDir, (file) => !isTestFile(file) && !isTestingDir(file))) {
+      const relPath = rel(f, opts.repoRoot);
+      if (allowedFiles.some((needle) => relPath.includes(needle))) continue;
+      // stripComments collapses block comments (shifting line numbers), so we
+      // report at file granularity — the message points the dev to the fix.
+      const src = stripComments(readFile(f));
+      if (EMPTY_CATCH_RE.test(src)) {
+        out.push({
+          rule: 'no-empty-catch',
+          module: m.name,
+          file: relPath,
+          message:
+            'empty catch swallows the error silently — log it via createLogger from @granit/logger, rethrow, return a fallback, or set an error state',
+        });
+      }
+      EMPTY_CATCH_RE.lastIndex = 0;
+    }
+  }
+  return out;
+}

--- a/packages/@granit/arch-tests/src/__tests__/patterns.test.ts
+++ b/packages/@granit/arch-tests/src/__tests__/patterns.test.ts
@@ -1,5 +1,6 @@
 import {
   scanAnonymousDefaultExports,
+  scanEmptyCatch,
   scanUseFormResolver,
   scanWallClockInApi,
 } from '@granit/arch-tests-kit';
@@ -16,6 +17,35 @@ describe('patterns (delegated to kit)', () => {
 
   it('api/ helpers do not read the wall clock (Date.now / new Date)', () => {
     expect(scanWallClockInApi(ctx)).toEqual([]);
+  });
+
+  it('no empty catch blocks (errors must be logged, rethrown, or handled)', () => {
+    // Each exemption is a reviewed, genuinely-benign swallow — NOT an unhandled
+    // error. New empty catches outside this list must log, rethrow, or fall back.
+    expect(
+      scanEmptyCatch({
+        ...ctx,
+        allowedFiles: [
+          // Error surfaces via state and is already logged in the owning hook —
+          // the catch only prevents an unhandled rejection (double-logging would
+          // be worse than this empty body).
+          'react-blob-storage/src/components/blob-upload-field.tsx',
+          'react-documents/src/components/upload-button.tsx',
+          // Defensive HTMLDialogElement.showModal() — throws only on an
+          // already-open dialog (jsdom corner case); nothing to handle.
+          'react-documents/src/components/document-quick-look.tsx',
+          'react-documents/src/components/document-search-palette.tsx',
+          'react-documents/src/components/transfer-ownership-dialog.tsx',
+          // Best-effort localStorage writes — quota/disabled is ignorable and
+          // the package ships no logger; reads already fall back to null.
+          'react-documents/src/hooks/use-document-bookmarks.ts',
+          'react-documents/src/hooks/use-view-preferences.ts',
+          // Build-time conformance tool (not shipped runtime) — skipping an
+          // unreadable/out-of-tree import is normal operation.
+          'contract-tests/src/conformance.ts',
+        ],
+      })
+    ).toEqual([]);
   });
 
   it('every useForm() call pairs with a resolver (no silent validation skips)', () => {

--- a/packages/@granit/react-bff/src/providers/bff-provider.tsx
+++ b/packages/@granit/react-bff/src/providers/bff-provider.tsx
@@ -63,9 +63,12 @@ function setLoginPending(pending: boolean): void {
     } else {
       globalThis.sessionStorage?.removeItem(LOGIN_PENDING_KEY);
     }
-  } catch {
+  } catch (error) {
     // sessionStorage unavailable (SSR / privacy mode) — the backoff simply
     // never engages, which degrades gracefully to the previous behaviour.
+    fallbackLogger.debug('login-pending flag not persisted (sessionStorage unavailable)', {
+      error: String(error),
+    });
   }
 }
 


### PR DESCRIPTION
## Why

Follow-up to #683 (observability). The logging sweep was a one-time judgment pass; this makes coverage **durable** by turning "don't silently swallow errors" into an enforced architecture rule, so new empty catches are caught in CI rather than re-audited by hand.

## What

- **`scanEmptyCatch`** (`@granit/arch-tests-kit`): flags empty `try { … } catch { }` blocks. Comments are stripped first, so `catch { /* ignore */ }` counts as empty — *ignoring* must be a deliberate, visible decision (log / rethrow / fallback / error-state).
- Promise `.catch(() => …)` handlers are **out of scope** — `.catch(() => undefined)` is an accepted fire-and-forget idiom (e.g. React-Query cache invalidation after a successful mutation); flagging ~30 of those would make the rule unusable.
- Wired into `@granit/arch-tests` `patterns.test.ts`.

## Existing empty catches (9) — all reviewed

The rule surfaced 9 empty catches the manual sweep had missed (comment-only bodies). All are **genuinely benign**, allowlisted with per-file justification:
- **error already handled+logged in the owning hook** (surfaced via `state.error`/`lastError`): `react-blob-storage/blob-upload-field`, `react-documents/upload-button`
- **defensive `HTMLDialogElement.showModal()`** (throws only on already-open dialog, jsdom corner case): 3 `react-documents` dialogs
- **best-effort `localStorage` writes** (quota/disabled ignorable, no logger in package): `react-documents` bookmarks + view-preferences
- **build-time conformance tool** (not shipped runtime): `contract-tests/conformance`

The one worth a trace — `react-bff` `setLoginPending` sessionStorage write — now logs at `debug`.

## Verification
- ✅ full arch-tests suite (2293 tests), lint, `tsc --noEmit` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)