### PR TITLE
feat(cms,react-cms): support Puck slot fields and the columns block

### DIFF
--- a/packages/@granit/cms/src/types/index.ts
+++ b/packages/@granit/cms/src/types/index.ts
@@ -29,7 +29,8 @@ export type BlockFieldKind =
   | 'Choice'
   | 'DocumentReference'
   | 'List'
-  | 'Nested';
+  | 'Nested'
+  | 'Slot';
 
 /** One allowed value of a {@link BlockFieldKind} `Choice` field. */
 export interface BlockFieldOption {

--- a/packages/@granit/react-cms/src/__tests__/catalog-to-config.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/catalog-to-config.test.ts
@@ -35,6 +35,7 @@ const catalog: BlockCatalogResponse = {
               kind: 'Nested',
               fields: { title: { kind: 'Text' } },
             },
+            body: { kind: 'Slot' },
           },
         },
       ],
@@ -126,6 +127,13 @@ describe('catalogToConfig', () => {
     const hero = config.components['hero'];
     const fields = hero?.fields ?? {};
     expect(fields['meta']).toMatchObject({ type: 'object' });
+  });
+
+  it('maps Slot → slot field with [] default', () => {
+    const config = catalogToConfig(catalog);
+    const hero = config.components['hero'];
+    expect(hero?.fields?.['body']).toEqual({ type: 'slot' });
+    expect(hero?.defaultProps?.['body']).toEqual([]);
   });
 
   it('creates default props for each field', () => {

--- a/packages/@granit/react-cms/src/__tests__/resolve-documents.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/resolve-documents.test.ts
@@ -37,6 +37,15 @@ const catalog: BlockCatalogResponse = {
             },
           },
         },
+        {
+          name: 'Layout',
+          version: '1.0.0',
+          sourceModule: 'Granit.Cms.Blocks',
+          renderSide: 'Server',
+          dataSourceKey: null,
+          subscribedContentTypes: [],
+          fields: { cell: { kind: 'Slot' } },
+        },
       ],
     },
   ],
@@ -128,6 +137,26 @@ describe('resolveDocumentReferencesInData', () => {
     expect((items[0] as Record<string, unknown>)['_resolved_itemDoc']).toEqual(asset1);
 
     expect((items[1] as Record<string, unknown>)['_resolved_itemDoc']).toEqual(asset2);
+  });
+
+  it('resolves a DocumentReference inside a block dropped into a slot', async () => {
+    const resolveFn: ResolveDocumentsFn = vi.fn().mockResolvedValue(new Map([['guid-1', asset1]]));
+    const data = {
+      content: [
+        {
+          type: 'Layout',
+          props: {
+            cell: [{ type: 'Hero', props: { headline: 'In a slot', imageId: 'guid-1' } }],
+          },
+        },
+      ],
+    };
+
+    const result = await resolveDocumentReferencesInData(data, catalog, resolveFn);
+
+    expect(result.content[0].props.cell[0].props._resolved_imageId).toEqual(asset1);
+    expect(result.content[0].props.cell[0].type).toBe('Hero'); // child metadata preserved
+    expect(resolveFn).toHaveBeenCalledWith(['guid-1']);
   });
 
   it('passes through components not present in the catalog unchanged', async () => {

--- a/packages/@granit/react-cms/src/blocks/columns-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/columns-block.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import type { ColumnsBlockProps } from './types';
+
+/**
+ * The `columns` layout block: two composable cells side by side. Layout ratio and gap are exposed
+ * as `data-*` attributes so the renderer's `[data-block="columns"]` theme owns the grid (matching
+ * the data-attribute styling convention used across the blocks).
+ */
+export function ColumnsBlock({
+  layout = 'HalfHalf',
+  gap = 'Medium',
+  leftCol: LeftCol,
+  rightCol: RightCol,
+}: ColumnsBlockProps) {
+  return (
+    <section data-block="columns" data-layout={layout} data-gap={gap}>
+      {/* Inner grid wrapper: the host's `[data-block] > *` rule width-caps and centers this single
+          child, then the theme turns it into the two-column grid. */}
+      <div data-columns-grid>
+        <div data-column="left">
+          <LeftCol />
+        </div>
+        <div data-column="right">
+          <RightCol />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/@granit/react-cms/src/blocks/registry.ts
+++ b/packages/@granit/react-cms/src/blocks/registry.ts
@@ -1,3 +1,4 @@
+import { ColumnsBlock } from './columns-block';
 import { CtaBlock } from './cta-block';
 import { FeaturesBlock } from './features-block';
 import { HeroBlock } from './hero-block';
@@ -20,6 +21,7 @@ import type { ComponentType } from 'react';
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const BLOCK_COMPONENTS: Record<string, ComponentType<any>> = {
+  columns: ColumnsBlock,
   hero: HeroBlock,
   pricing: PricingBlock,
   cta: CtaBlock,

--- a/packages/@granit/react-cms/src/blocks/resolve-documents.ts
+++ b/packages/@granit/react-cms/src/blocks/resolve-documents.ts
@@ -45,7 +45,7 @@ export async function resolveDocumentReferencesInData(
   for (const component of data?.content ?? []) {
     const blockSchema = schema.get(component?.type as string);
     if (!blockSchema) continue;
-    collectGuids(component?.props as Record<string, unknown>, blockSchema, guids);
+    collectGuids(component?.props as Record<string, unknown>, blockSchema, guids, schema);
   }
 
   if (guids.size === 0) return data;
@@ -61,7 +61,8 @@ export async function resolveDocumentReferencesInData(
       props: injectResolved(
         (component as { props?: Record<string, unknown> }).props ?? {},
         blockSchema,
-        resolved
+        resolved,
+        schema
       ),
     };
   });
@@ -104,7 +105,8 @@ function extractGuid(value: unknown): string | null {
 function collectGuids(
   props: Record<string, unknown>,
   fieldSchema: Map<string, BlockFieldDescriptor>,
-  out: Set<string>
+  out: Set<string>,
+  schema: Map<string, Map<string, BlockFieldDescriptor>>
 ): void {
   for (const [key, descriptor] of fieldSchema) {
     const value = props[key];
@@ -114,7 +116,7 @@ function collectGuids(
     } else if (descriptor.kind === 'List' && Array.isArray(value) && descriptor.itemFields) {
       const itemSchema = new Map(Object.entries(descriptor.itemFields));
       for (const item of value as Record<string, unknown>[]) {
-        collectGuids(item, itemSchema, out);
+        collectGuids(item, itemSchema, out, schema);
       }
     } else if (
       descriptor.kind === 'Nested' &&
@@ -123,7 +125,14 @@ function collectGuids(
       descriptor.fields
     ) {
       const nestedSchema = new Map(Object.entries(descriptor.fields));
-      collectGuids(value as Record<string, unknown>, nestedSchema, out);
+      collectGuids(value as Record<string, unknown>, nestedSchema, out, schema);
+    } else if (descriptor.kind === 'Slot' && Array.isArray(value)) {
+      // A slot holds child blocks ({ type, props }), each resolved against its own schema —
+      // so references in a block dropped into a column (and any deeper nesting) are collected too.
+      for (const child of value as { type?: string; props?: Record<string, unknown> }[]) {
+        const childSchema = schema.get(child?.type ?? '');
+        if (childSchema) collectGuids(child.props ?? {}, childSchema, out, schema);
+      }
     }
   }
 }
@@ -131,7 +140,8 @@ function collectGuids(
 function injectResolved(
   props: Record<string, unknown>,
   fieldSchema: Map<string, BlockFieldDescriptor>,
-  resolved: Map<string, ResolvedDocumentAsset>
+  resolved: Map<string, ResolvedDocumentAsset>,
+  schema: Map<string, Map<string, BlockFieldDescriptor>>
 ): Record<string, unknown> {
   const next: Record<string, unknown> = { ...props };
 
@@ -146,7 +156,7 @@ function injectResolved(
     } else if (descriptor.kind === 'List' && Array.isArray(value) && descriptor.itemFields) {
       const itemSchema = new Map(Object.entries(descriptor.itemFields));
       next[key] = (value as Record<string, unknown>[]).map((item) =>
-        injectResolved(item, itemSchema, resolved)
+        injectResolved(item, itemSchema, resolved, schema)
       );
     } else if (
       descriptor.kind === 'Nested' &&
@@ -155,7 +165,16 @@ function injectResolved(
       descriptor.fields
     ) {
       const nestedSchema = new Map(Object.entries(descriptor.fields));
-      next[key] = injectResolved(value as Record<string, unknown>, nestedSchema, resolved);
+      next[key] = injectResolved(value as Record<string, unknown>, nestedSchema, resolved, schema);
+    } else if (descriptor.kind === 'Slot' && Array.isArray(value)) {
+      // Recurse into each child block of the slot, resolved against its own schema. Puck metadata
+      // (`type`, `id`, empty slots) is preserved; only the child's `props` are rewritten.
+      next[key] = (value as { type?: string; props?: Record<string, unknown> }[]).map((child) => {
+        const childSchema = schema.get(child?.type ?? '');
+        return childSchema
+          ? { ...child, props: injectResolved(child.props ?? {}, childSchema, resolved, schema) }
+          : child;
+      });
     }
   }
 

--- a/packages/@granit/react-cms/src/blocks/types.ts
+++ b/packages/@granit/react-cms/src/blocks/types.ts
@@ -11,6 +11,8 @@
  * these types must therefore track the schemas, not an idealised shape.
  */
 
+import type { SlotComponent } from '@puckeditor/core';
+
 export interface ResolvedAsset {
   readonly url: string;
   readonly width?: number | null;
@@ -30,6 +32,25 @@ export interface AssetRef {
 
 /** Mirrors the C# `BlockAlignment` enum projected as a `Choice`. */
 export type BlockAlignment = 'Left' | 'Center' | 'Right';
+
+/** Mirrors the C# `ColumnsLayout` enum projected as a `Choice` (value = member name). */
+export type ColumnsLayout = 'HalfHalf' | 'OneThirdTwoThirds' | 'TwoThirdsOneThird';
+
+/** Mirrors the C# `ColumnsGap` enum projected as a `Choice`. */
+export type ColumnsGap = 'Small' | 'Medium' | 'Large';
+
+/**
+ * The `columns` layout block. `leftCol`/`rightCol` are `Slot` fields: at render time Puck passes
+ * each as a `SlotComponent` the block renders as `<LeftCol />`. The render-prop type
+ * (`SlotComponent`) differs from the stored data type (an array of child blocks); the block only
+ * ever sees the former.
+ */
+export interface ColumnsBlockProps {
+  readonly layout?: ColumnsLayout;
+  readonly gap?: ColumnsGap;
+  readonly leftCol: SlotComponent;
+  readonly rightCol: SlotComponent;
+}
 
 /** Mirrors the C# `CtaStyle` enum projected as a `Choice`. */
 export type CtaStyle = 'Primary' | 'Secondary' | 'Outline';

--- a/packages/@granit/react-cms/src/puck/catalog-to-config.tsx
+++ b/packages/@granit/react-cms/src/puck/catalog-to-config.tsx
@@ -207,6 +207,10 @@ function descriptorToField(
       return { type: 'object', objectFields };
     }
 
+    case 'Slot':
+      // A composable drop target: Puck holds an ordered list of child blocks inline in this prop.
+      return { type: 'slot' };
+
     default:
       return { type: 'text' };
   }
@@ -258,6 +262,8 @@ function defaultForKind(kind: BlockFieldKind): unknown {
       return [];
     case 'Nested':
       return {};
+    case 'Slot':
+      return [];
     default:
       return null;
   }


### PR DESCRIPTION
## Context

Frontend support for composable **Puck slot fields**, paired with the backend Slot field kind. Ships the **columns** layout block (two composable cells: layout ratio + gap).

## Changes

- `'Slot'` added to the `BlockFieldKind` union (`@granit/cms`).
- `catalogToConfig`: `Slot → { type: 'slot' }`, default `[]`.
- `resolveDocumentReferencesInData` descends into slot children, resolving each against its own block schema (any depth) — so a `DocumentReference` inside a block dropped into a column resolves.
- `ColumnsBlock` component (cells exposed via `data-*` attributes for host theming) registered as `columns`.

## Tests

`pnpm tsc` + lint clean; new vitest coverage for the Slot mapping and slot-nested document resolution (33 passing in the touched suites). The 2 failing `@granit/react-tracing` tests are pre-existing and unrelated (OTLP exporter).

## Cross-repo

Part of the **feat/cms-blocks-slot-field** set:
- granit-website (GitLab MR !123): `BlockFieldKind.Slot`, projector, columns schema, publish-time slot walk.
- granit-cms-renderer (GitLab): `[data-block='columns']` theming.

Merge website + this before the renderer.