### PR TITLE
test(react-tracing): fix gated-exporter warn assertions for styled logger

### DIFF
--- a/packages/@granit/react-tracing/src/__tests__/gated-exporter.test.tsx
+++ b/packages/@granit/react-tracing/src/__tests__/gated-exporter.test.tsx
@@ -166,7 +166,10 @@ describe('gated exporter', () => {
       expect(callback).toHaveBeenCalledWith({ code: 0 });
     });
 
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('OTLP collector unavailable'));
+    // The warn is emitted with `%c`-styled prefix args, so match across all call arguments.
+    expect(
+      warnSpy.mock.calls.some((args) => args.join(' ').includes('OTLP collector unavailable'))
+    ).toBe(true);
 
     // Subsequent exports should short-circuit with success
     const callback2 = vi.fn();
@@ -190,7 +193,10 @@ describe('gated exporter', () => {
       expect(callback).toHaveBeenCalledWith({ code: 0 });
     });
 
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('OTLP collector unreachable'));
+    // The warn is emitted with `%c`-styled prefix args, so match across all call arguments.
+    expect(
+      warnSpy.mock.calls.some((args) => args.join(' ').includes('OTLP collector unreachable'))
+    ).toBe(true);
 
     vi.unstubAllGlobals();
   });


### PR DESCRIPTION
The 2 failing tests in `react-tracing/gated-exporter.test.tsx` were stale: the gated exporter now logs via the styled logger (`%c warn %c react-tracing %c …`), so the OTLP-unavailable/unreachable warnings arrive as **multiple** `console.warn` arguments. The assertions used `toHaveBeenCalledWith(expect.stringContaining(...))` (single-arg match) and failed.

Fix: match the message across all recorded call args. Pre-existing failures on `develop`, unrelated to any feature work. 7/7 green in the file now.