### PR TITLE
feat(react-cms): primitive block catalog components + slot allow/disallow & richtext

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,7 +4,7 @@ This file lists the third-party libraries used by the **granit-front** project
 along with their respective licenses. It is updated whenever an external
 dependency is added or modified.
 
-Last updated: 2026-06-02
+Last updated: 2026-06-18
 
 ---
 
@@ -12,8 +12,8 @@ Last updated: 2026-06-02
 
 | License      | Package count |
 | ------------ | ------------- |
-| MIT          | 43            |
-| Apache-2.0   | 14            |
+| MIT          | 44            |
+| Apache-2.0   | 15            |
 | BSD-3-Clause | 1             |
 
 ---
@@ -54,6 +54,7 @@ Last updated: 2026-06-02
 | eslint-plugin-import-x          | 4.16.2   | eslint-plugin-import-x Contributors        |
 | husky                           | 9.1.7    | Copyright (c) typicode                     |
 | i18next                         | 26.3.0   | Copyright (c) i18next Contributors         |
+| isomorphic-dompurify            | 2.x      | Copyright (c) Andrew Karpów                |
 | jsdom                           | 29.1.1   | Copyright (c) jsdom Contributors           |
 | lint-staged                     | 17.0.7   | Copyright (c) Andrey Okonetchnikov         |
 | lucide-react                    | 1.17.0   | Copyright (c) Lucide Contributors          |
@@ -86,6 +87,7 @@ Last updated: 2026-06-02
 | @opentelemetry/resources                        | 2.7.1   | Copyright The OpenTelemetry Authors |
 | @opentelemetry/sdk-trace-web                    | 2.7.1   | Copyright The OpenTelemetry Authors |
 | @opentelemetry/semantic-conventions             | 1.41.1  | Copyright The OpenTelemetry Authors |
+| dompurify                                       | 3.x     | Copyright (c) Cure53                |
 | echarts                                         | 6.1.0   | Copyright Apache ECharts Authors    |
 | firebase                                        | 12.x    | Copyright Google LLC                |
 | keycloak-js                                     | 26.2.4  | Copyright Red Hat, Inc.             |

--- a/packages/@granit/cms/src/types/index.ts
+++ b/packages/@granit/cms/src/types/index.ts
@@ -30,7 +30,8 @@ export type BlockFieldKind =
   | 'DocumentReference'
   | 'List'
   | 'Nested'
-  | 'Slot';
+  | 'Slot'
+  | 'RichText';
 
 /** One allowed value of a {@link BlockFieldKind} `Choice` field. */
 export interface BlockFieldOption {
@@ -48,6 +49,10 @@ export interface BlockFieldDescriptor {
   readonly options?: readonly BlockFieldOption[];
   readonly itemFields?: Readonly<Record<string, BlockFieldDescriptor>>;
   readonly fields?: Readonly<Record<string, BlockFieldDescriptor>>;
+  /** For `Slot`: block names the slot accepts (allow-list). */
+  readonly allow?: readonly string[];
+  /** For `Slot`: block names the slot rejects (deny-list). */
+  readonly disallow?: readonly string[];
 }
 
 /**

--- a/packages/@granit/react-cms/package.json
+++ b/packages/@granit/react-cms/package.json
@@ -45,5 +45,8 @@
     "msw": {
       "optional": true
     }
+  },
+  "dependencies": {
+    "isomorphic-dompurify": "^3.17.0"
   }
 }

--- a/packages/@granit/react-cms/src/__tests__/catalog-to-config.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/catalog-to-config.test.ts
@@ -36,6 +36,8 @@ const catalog: BlockCatalogResponse = {
               fields: { title: { kind: 'Text' } },
             },
             body: { kind: 'Slot' },
+            actions: { kind: 'Slot', allow: ['button'], disallow: ['columns'] },
+            richBody: { kind: 'RichText' },
           },
         },
       ],
@@ -134,6 +136,23 @@ describe('catalogToConfig', () => {
     const hero = config.components['hero'];
     expect(hero?.fields?.['body']).toEqual({ type: 'slot' });
     expect(hero?.defaultProps?.['body']).toEqual([]);
+  });
+
+  it('maps Slot allow/disallow onto the slot field', () => {
+    const config = catalogToConfig(catalog);
+    const hero = config.components['hero'];
+    expect(hero?.fields?.['actions']).toEqual({
+      type: 'slot',
+      allow: ['button'],
+      disallow: ['columns'],
+    });
+  });
+
+  it('maps RichText → richtext field with empty-string default', () => {
+    const config = catalogToConfig(catalog);
+    const hero = config.components['hero'];
+    expect(hero?.fields?.['richBody']).toEqual({ type: 'richtext' });
+    expect(hero?.defaultProps?.['richBody']).toBe('');
   });
 
   it('creates default props for each field', () => {

--- a/packages/@granit/react-cms/src/blocks/alert-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/alert-block.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import type { AlertBlockProps } from './types';
+
+/** A callout highlighting important information; the slot holds its body (text, link or button). */
+export function AlertBlock({ intent = 'Info', title, content: Content }: AlertBlockProps) {
+  return (
+    <div data-block="alert" data-intent={intent} role="note">
+      {title && <strong data-alert-title>{title}</strong>}
+      <Content />
+    </div>
+  );
+}

--- a/packages/@granit/react-cms/src/blocks/button-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/button-block.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import type { ButtonBlockProps } from './types';
+
+/** A standalone call-to-action link. */
+export function ButtonBlock({
+  label,
+  href,
+  variant = 'Primary',
+  size = 'Default',
+  target = 'Self',
+}: ButtonBlockProps) {
+  const newTab = target === 'Blank';
+  return (
+    <a
+      data-block="button"
+      data-variant={variant}
+      data-size={size}
+      href={href}
+      target={newTab ? '_blank' : undefined}
+      rel={newTab ? 'noopener noreferrer' : undefined}
+    >
+      {label}
+    </a>
+  );
+}

--- a/packages/@granit/react-cms/src/blocks/button-group-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/button-group-block.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import type { ButtonGroupBlockProps } from './types';
+
+/** Aligns several buttons in a row. The slot is restricted to `button` blocks by the catalog. */
+export function ButtonGroupBlock({ alignment = 'Left', buttons: Buttons }: ButtonGroupBlockProps) {
+  return (
+    <div data-block="button-group" data-align={alignment}>
+      <Buttons />
+    </div>
+  );
+}

--- a/packages/@granit/react-cms/src/blocks/card-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/card-block.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import type { CardBlockProps } from './types';
+
+/** A bordered, optionally elevated surface holding a composable slot. */
+export function CardBlock({ shadow = 'Sm', content: Content }: CardBlockProps) {
+  return (
+    <div data-block="card" data-shadow={shadow}>
+      <Content />
+    </div>
+  );
+}

--- a/packages/@granit/react-cms/src/blocks/container-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/container-block.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import type { ContainerBlockProps } from './types';
+
+/** Centres its content and caps the width on large screens. */
+export function ContainerBlock({ maxWidth = 'Lg', content: Content }: ContainerBlockProps) {
+  return (
+    <div data-block="container" data-max-width={maxWidth}>
+      <Content />
+    </div>
+  );
+}

--- a/packages/@granit/react-cms/src/blocks/divider-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/divider-block.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import type { DividerBlockProps } from './types';
+
+/** A horizontal rule with configurable vertical margins. */
+export function DividerBlock({ margins = 'Md' }: DividerBlockProps) {
+  return <hr data-block="divider" data-margins={margins} />;
+}

--- a/packages/@granit/react-cms/src/blocks/heading-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/heading-block.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import type { HeadingBlockProps } from './types';
+
+const TAGS = { H1: 'h1', H2: 'h2', H3: 'h3', H4: 'h4' } as const;
+
+/** A title whose semantic level (SEO/a11y) and visual size are chosen independently. */
+export function HeadingBlock({
+  text,
+  level = 'H2',
+  size = 'Default',
+  align = 'Left',
+}: HeadingBlockProps) {
+  const Tag = TAGS[level];
+  return (
+    <Tag data-block="heading" data-size={size} data-align={align}>
+      {text}
+    </Tag>
+  );
+}

--- a/packages/@granit/react-cms/src/blocks/icon-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/icon-block.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import {
+  ArrowRight,
+  Award,
+  Briefcase,
+  Check,
+  Clock,
+  Globe,
+  Heart,
+  Lock,
+  Mail,
+  Phone,
+  Settings,
+  Shield,
+  Star,
+  TrendingUp,
+  Users,
+  Zap,
+  type LucideIcon,
+} from 'lucide-react';
+
+import type { IconBlockProps, IconName, IconSize } from './types';
+
+/** Curated name → lucide component map. Keep in sync with the C# `IconName` enum. */
+const ICONS: Record<IconName, LucideIcon> = {
+  Check,
+  ArrowRight,
+  Star,
+  Shield,
+  Zap,
+  Users,
+  Settings,
+  Mail,
+  Phone,
+  Globe,
+  Lock,
+  Heart,
+  TrendingUp,
+  Award,
+  Clock,
+  Briefcase,
+};
+
+const SIZES: Record<IconSize, number> = { Sm: 16, Md: 24, Lg: 32 };
+
+/** Renders one icon from the curated set. */
+export function IconBlock({ name = 'Check', size = 'Md', color = 'Primary' }: IconBlockProps) {
+  const Glyph = ICONS[name] ?? Check;
+  return (
+    <span data-block="icon" data-color={color}>
+      <Glyph size={SIZES[size]} aria-hidden />
+    </span>
+  );
+}

--- a/packages/@granit/react-cms/src/blocks/image-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/image-block.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import type { ImageBlockProps } from './types';
+
+/** A single image resolved from the media library (`_resolved_imageId` injected at publish time). */
+export function ImageBlock({
+  _resolved_imageId,
+  alt = '',
+  aspectRatio = 'Auto',
+  objectFit = 'Cover',
+}: ImageBlockProps) {
+  if (!_resolved_imageId) return null;
+  return (
+    <img
+      data-block="image"
+      data-aspect={aspectRatio}
+      data-fit={objectFit}
+      src={_resolved_imageId.url}
+      width={_resolved_imageId.width ?? undefined}
+      height={_resolved_imageId.height ?? undefined}
+      alt={alt}
+    />
+  );
+}

--- a/packages/@granit/react-cms/src/blocks/registry.ts
+++ b/packages/@granit/react-cms/src/blocks/registry.ts
@@ -1,14 +1,26 @@
+import { AlertBlock } from './alert-block';
+import { ButtonBlock } from './button-block';
+import { ButtonGroupBlock } from './button-group-block';
+import { CardBlock } from './card-block';
 import { ColumnsBlock } from './columns-block';
+import { ContainerBlock } from './container-block';
 import { CtaBlock } from './cta-block';
+import { DividerBlock } from './divider-block';
 import { FeaturesBlock } from './features-block';
+import { HeadingBlock } from './heading-block';
 import { HeroBlock } from './hero-block';
+import { IconBlock } from './icon-block';
+import { ImageBlock } from './image-block';
 import { ImageTextBlock } from './image-text-block';
 import { LogosBlock } from './logos-block';
 import { MapBlock } from './map-block';
 import { PricingBlock } from './pricing-block';
+import { SectionBlock } from './section-block';
+import { SpacerBlock } from './spacer-block';
 import { StatsBlock } from './stats-block';
 import { StepsBlock } from './steps-block';
 import { TestimonialsBlock } from './testimonials-block';
+import { TextBlock } from './text-block';
 import { TimelineBlock } from './timeline-block';
 import { TrustBannerBlock } from './trust-banner-block';
 import { VideoBlock } from './video-block';
@@ -21,7 +33,25 @@ import type { ComponentType } from 'react';
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const BLOCK_COMPONENTS: Record<string, ComponentType<any>> = {
+  // Layout
+  section: SectionBlock,
+  container: ContainerBlock,
   columns: ColumnsBlock,
+  card: CardBlock,
+  // Content
+  heading: HeadingBlock,
+  text: TextBlock,
+  // Interaction
+  button: ButtonBlock,
+  'button-group': ButtonGroupBlock,
+  // Media
+  image: ImageBlock,
+  icon: IconBlock,
+  // General
+  alert: AlertBlock,
+  spacer: SpacerBlock,
+  divider: DividerBlock,
+  // Existing macro blocks
   hero: HeroBlock,
   pricing: PricingBlock,
   cta: CtaBlock,

--- a/packages/@granit/react-cms/src/blocks/section-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/section-block.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import type { SectionBlockProps } from './types';
+
+/** Full-bleed band owning background + vertical rhythm; holds a composable slot. */
+export function SectionBlock({
+  backgroundColor = 'White',
+  paddingY = 'Medium',
+  content: Content,
+}: SectionBlockProps) {
+  return (
+    <section data-block="section" data-bg={backgroundColor} data-py={paddingY}>
+      <Content />
+    </section>
+  );
+}

--- a/packages/@granit/react-cms/src/blocks/spacer-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/spacer-block.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import type { SpacerBlockProps } from './types';
+
+/** Pushes content down by a fixed vertical gap. */
+export function SpacerBlock({ size = 'Px32' }: SpacerBlockProps) {
+  return <div data-block="spacer" data-size={size} aria-hidden />;
+}

--- a/packages/@granit/react-cms/src/blocks/text-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/text-block.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import DOMPurify from 'isomorphic-dompurify';
+
+import type { TextBlockProps } from './types';
+
+/**
+ * A rich-text paragraph. `content` is HTML produced by Puck's WYSIWYG (`richtext`) control and is
+ * sanitized here with DOMPurify (isomorphic, so it runs at SSR and on the client editor) before
+ * being injected as markup.
+ */
+export function TextBlock({ content, size = 'Base', color = 'Default' }: TextBlockProps) {
+  const html = DOMPurify.sanitize(content ?? '');
+  return (
+    <div
+      data-block="text"
+      data-size={size}
+      data-color={color}
+      // eslint-disable-next-line no-restricted-syntax -- html is DOMPurify-sanitized on the line above
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/packages/@granit/react-cms/src/blocks/types.ts
+++ b/packages/@granit/react-cms/src/blocks/types.ts
@@ -177,3 +177,123 @@ export interface MapBlockProps {
   readonly zoom?: number;
   readonly label?: string;
 }
+
+// ─── Primitive layout/content catalog ────────────────────────────────────────
+// Each enum string union mirrors the C# enum member names (the projected Choice `value`).
+
+export type SectionBackground = 'Primary' | 'White' | 'Gray' | 'Dark';
+export type SectionPadding = 'None' | 'Small' | 'Medium' | 'Large';
+
+export interface SectionBlockProps {
+  readonly backgroundColor?: SectionBackground;
+  readonly paddingY?: SectionPadding;
+  readonly content: SlotComponent;
+}
+
+export type ContainerMaxWidth = 'Sm' | 'Md' | 'Lg' | 'Xl' | 'Xl2' | 'Full';
+
+export interface ContainerBlockProps {
+  readonly maxWidth?: ContainerMaxWidth;
+  readonly content: SlotComponent;
+}
+
+export type CardShadow = 'None' | 'Sm' | 'Md';
+
+export interface CardBlockProps {
+  readonly shadow?: CardShadow;
+  readonly content: SlotComponent;
+}
+
+export type HeadingLevel = 'H1' | 'H2' | 'H3' | 'H4';
+export type HeadingSize = 'Default' | 'Lg' | 'Xl' | 'Xl2';
+
+export interface HeadingBlockProps {
+  readonly text: string;
+  readonly level?: HeadingLevel;
+  readonly size?: HeadingSize;
+  readonly align?: BlockAlignment;
+}
+
+export type TextSize = 'Sm' | 'Base' | 'Lg';
+export type TextColor = 'Muted' | 'Default' | 'Primary';
+
+export interface TextBlockProps {
+  /** Rich-text HTML produced by the editor's WYSIWYG control. */
+  readonly content: string;
+  readonly size?: TextSize;
+  readonly color?: TextColor;
+}
+
+export type ButtonVariant = 'Primary' | 'Secondary' | 'Outline' | 'Ghost';
+export type ButtonSize = 'Sm' | 'Default' | 'Lg';
+export type LinkTarget = 'Self' | 'Blank';
+
+export interface ButtonBlockProps {
+  readonly label: string;
+  readonly href: string;
+  readonly variant?: ButtonVariant;
+  readonly size?: ButtonSize;
+  readonly target?: LinkTarget;
+}
+
+export interface ButtonGroupBlockProps {
+  readonly alignment?: BlockAlignment;
+  readonly buttons: SlotComponent;
+}
+
+export type ImageAspectRatio = 'Auto' | 'SixteenNine' | 'FourThree' | 'OneOne';
+export type ImageObjectFit = 'Cover' | 'Contain';
+
+export interface ImageBlockProps {
+  readonly imageId?: string | null;
+  readonly _resolved_imageId?: ResolvedAsset;
+  readonly alt?: string;
+  readonly aspectRatio?: ImageAspectRatio;
+  readonly objectFit?: ImageObjectFit;
+}
+
+export type IconName =
+  | 'Check'
+  | 'ArrowRight'
+  | 'Star'
+  | 'Shield'
+  | 'Zap'
+  | 'Users'
+  | 'Settings'
+  | 'Mail'
+  | 'Phone'
+  | 'Globe'
+  | 'Lock'
+  | 'Heart'
+  | 'TrendingUp'
+  | 'Award'
+  | 'Clock'
+  | 'Briefcase';
+export type IconSize = 'Sm' | 'Md' | 'Lg';
+export type IconColor = 'Primary' | 'Muted' | 'Success' | 'Warning';
+
+export interface IconBlockProps {
+  readonly name?: IconName;
+  readonly size?: IconSize;
+  readonly color?: IconColor;
+}
+
+export type AlertIntent = 'Info' | 'Success' | 'Warning' | 'Error';
+
+export interface AlertBlockProps {
+  readonly intent?: AlertIntent;
+  readonly title?: string;
+  readonly content: SlotComponent;
+}
+
+export type SpacerSize = 'Px16' | 'Px32' | 'Px64' | 'Px128';
+
+export interface SpacerBlockProps {
+  readonly size?: SpacerSize;
+}
+
+export type DividerMargins = 'None' | 'Sm' | 'Md' | 'Lg';
+
+export interface DividerBlockProps {
+  readonly margins?: DividerMargins;
+}

--- a/packages/@granit/react-cms/src/puck/catalog-to-config.tsx
+++ b/packages/@granit/react-cms/src/puck/catalog-to-config.tsx
@@ -190,6 +190,9 @@ function descriptorToField(
       return { type: 'select', options: opts };
     }
 
+    case 'RichText':
+      return { type: 'richtext' };
+
     case 'DocumentReference':
       return buildDocumentReferenceField(fetchDocuments);
 
@@ -209,7 +212,12 @@ function descriptorToField(
 
     case 'Slot':
       // A composable drop target: Puck holds an ordered list of child blocks inline in this prop.
-      return { type: 'slot' };
+      // `allow`/`disallow` restrict which block types may be dropped in.
+      return {
+        type: 'slot',
+        ...(descriptor.allow ? { allow: [...descriptor.allow] } : {}),
+        ...(descriptor.disallow ? { disallow: [...descriptor.disallow] } : {}),
+      };
 
     default:
       return { type: 'text' };
@@ -249,6 +257,8 @@ function buildDefaultProps(
 function defaultForKind(kind: BlockFieldKind): unknown {
   switch (kind) {
     case 'Text':
+      return '';
+    case 'RichText':
       return '';
     case 'Number':
       return 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1707,6 +1707,9 @@ importers:
 
   packages/@granit/react-cms:
     dependencies:
+      isomorphic-dompurify:
+        specifier: ^3.17.0
+        version: 3.17.0
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.9.3)(typescript@6.0.3)
@@ -6669,6 +6672,10 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
+  isomorphic-dompurify@3.17.0:
+    resolution: {integrity: sha512-++PY22SYWZv/kTWOr5WQ8rNznkIKj6I/SDUVZnXXM67EhRO7ScVLDdZYNxNgEsPAOA5sfpGBcqnnbLx8WJHO1g==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+
   isomorphic-unfetch@3.1.0:
     resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
 
@@ -11112,6 +11119,14 @@ snapshots:
   isexe@2.0.0: {}
 
   isobject@3.0.1: {}
+
+  isomorphic-dompurify@3.17.0:
+    dependencies:
+      dompurify: 3.4.10
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - canvas
 
   isomorphic-unfetch@3.1.0:
     dependencies:


### PR DESCRIPTION
## Context

Frontend half of the **primitive catalog** (composition-first), paired with granit-website MR !124. 12 new block components + contract mapping.

## Contract (catalogToConfig)
- `RichText` → Puck `{ type: 'richtext' }` (default `''`).
- Slot `allow`/`disallow` mapped onto the `SlotField` (e.g. button-group accepts only `button`).
- `@granit/cms` `BlockFieldDescriptor` gains `allow`/`disallow`; `BlockFieldKind` gains `'RichText'`.

## Components (12), registered in BLOCK_COMPONENTS (kebab = catalog names)
- **Layout**: section, container, card
- **Content**: heading, text
- **Interaction**: button, button-group
- **Media**: image (publish-resolved asset), icon (lucide-react curated set, mirrors C# `IconName`)
- **General**: alert, spacer, divider

## Rich text
`text` renders the WYSIWYG HTML, **sanitized with DOMPurify** (new dep `isomorphic-dompurify` for SSR-safe sanitization; THIRD-PARTY-NOTICES updated). Defense-in-depth publish-time sanitization remains a sensible future hardening.

## Tests / checks
`pnpm tsc` + lint clean; react-cms suite 174 green incl. new catalogToConfig cases (richtext, slot allow/disallow). (The 2 `react-tracing` failures on develop are fixed by PR #687, pending.)

## Cross-repo (lot feat/cms-blocks-layout-catalog)
- granit-website MR !124: kinds, schemas, projector.
- renderer: `[data-block]` theming for the new blocks. Merge website + this before the renderer.