### PR TITLE
feat(contract-tests): verify discriminated-union DTOs (anyOf + discriminator)

### DIFF
--- a/packages/@granit/contract-tests/src/__tests__/conformance.test.ts
+++ b/packages/@granit/contract-tests/src/__tests__/conformance.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest';
 
 import { checkSchemaConformance } from '../conformance';
 
-import type { OpenApiDocument } from '../conformance';
+import type { OpenApiDocument, OpenApiSchema } from '../conformance';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
@@ -236,5 +236,119 @@ describe('conformance oracle — positive & negative controls', () => {
         expect.objectContaining({ rule: 'type-family', field: 'ownerId' })
       );
     });
+  });
+});
+
+// A spec `anyOf` + discriminator (System.Text.Json polymorphism) verified
+// branch-by-branch against a front `type X = A | B` union, paired by tag value.
+describe('conformance oracle — discriminated unions', () => {
+  const unionFile = '/virtual/union.ts';
+  const unionSource = `
+    export interface MoveDelta {
+      readonly kind: 'move';
+      readonly from: string;
+      readonly to: string;
+    }
+    export interface DropDelta {
+      readonly kind: 'drop';
+      readonly target: string;
+    }
+    export type Delta = MoveDelta | DropDelta;
+  `;
+
+  const variant = (tag: string, props: Record<string, OpenApiSchema>, required: string[]) => ({
+    type: 'object',
+    required,
+    properties: { kind: { enum: [tag], type: 'string' }, ...props },
+  });
+
+  /** A union spec with the given discriminator mapping (defaults to move+drop). */
+  const unionSpec = (
+    schemas: Record<string, OpenApiSchema>,
+    mapping: Record<string, string>
+  ): OpenApiDocument => ({
+    components: {
+      schemas: {
+        Delta: {
+          type: 'object',
+          required: ['kind'],
+          anyOf: Object.values(mapping).map(($ref) => ({ $ref })),
+          discriminator: { propertyName: 'kind', mapping },
+        },
+        ...schemas,
+      },
+    },
+  });
+
+  const MOVE = '#/components/schemas/DeltaMove';
+  const DROP = '#/components/schemas/DeltaDrop';
+  const checkUnion = (spec: OpenApiDocument, typeName = 'Delta') =>
+    checkSchemaConformance({
+      spec,
+      schemaName: 'Delta',
+      sourceText: unionSource,
+      fileName: unionFile,
+      typeName,
+    });
+
+  const moveDrop = (from: OpenApiSchema = { type: 'string' }) =>
+    unionSpec(
+      {
+        DeltaMove: variant('move', { from, to: { type: 'string' } }, ['from', 'to']),
+        DeltaDrop: variant('drop', { target: { type: 'string' } }, ['target']),
+      },
+      { move: MOVE, drop: DROP }
+    );
+
+  it('passes when every branch is paired by tag and mirrors its variant schema', () => {
+    expect(checkUnion(moveDrop())).toEqual([]);
+  });
+
+  it('reports a field drift inside a single branch, scoped to that variant', () => {
+    // `from` is `integer` backend-side but `string` front-side, only in the move branch.
+    expect(checkUnion(moveDrop({ type: 'integer' }))).toContainEqual(
+      expect.objectContaining({ rule: 'type-family', schema: 'Delta#move', field: 'from' })
+    );
+  });
+
+  it('flags a spec variant with no matching front union member', () => {
+    const spec = unionSpec(
+      {
+        DeltaMove: variant('move', { from: { type: 'string' }, to: { type: 'string' } }, [
+          'from',
+          'to',
+        ]),
+        DeltaDrop: variant('drop', { target: { type: 'string' } }, ['target']),
+        DeltaRename: variant('rename', { name: { type: 'string' } }, ['name']),
+      },
+      { move: MOVE, drop: DROP, rename: '#/components/schemas/DeltaRename' }
+    );
+    expect(checkUnion(spec)).toContainEqual(
+      expect.objectContaining({
+        rule: 'missing-variant',
+        message: expect.stringContaining('rename'),
+      })
+    );
+  });
+
+  it('flags a front union member with no matching spec variant', () => {
+    const spec = unionSpec(
+      {
+        DeltaMove: variant('move', { from: { type: 'string' }, to: { type: 'string' } }, [
+          'from',
+          'to',
+        ]),
+      },
+      { move: MOVE } // front still has `drop`
+    );
+    expect(checkUnion(spec)).toContainEqual(
+      expect.objectContaining({ rule: 'orphan-variant', message: expect.stringContaining('drop') })
+    );
+  });
+
+  it('reports type-missing when the front type is not a union', () => {
+    expect(checkUnion(moveDrop(), 'MoveDelta')).toContainEqual(
+      expect.objectContaining({ rule: 'type-missing' })
+    );
   });
 });

--- a/packages/@granit/contract-tests/src/conformance.ts
+++ b/packages/@granit/contract-tests/src/conformance.ts
@@ -44,7 +44,7 @@ interface PropShape {
 
 // --- OpenAPI side ----------------------------------------------------------
 
-interface OpenApiSchema {
+export interface OpenApiSchema {
   type?: string | string[];
   format?: string;
   nullable?: boolean;
@@ -53,6 +53,11 @@ interface OpenApiSchema {
   required?: readonly string[];
   properties?: Record<string, OpenApiSchema>;
   items?: OpenApiSchema;
+  /** Polymorphic branches (`System.Text.Json` discriminated union). */
+  anyOf?: readonly OpenApiSchema[];
+  oneOf?: readonly OpenApiSchema[];
+  /** Discriminator for an `anyOf`/`oneOf` union: which field selects the branch. */
+  discriminator?: { propertyName: string; mapping?: Record<string, string> };
 }
 
 export interface OpenApiDocument {
@@ -217,16 +222,6 @@ function tsFamily(typeNode: ts.TypeNode, aliases: AliasMap): PropShape {
   }
   const first = bases[0];
   return { family: first ? familyOf(first, aliases) : 'unknown', nullable };
-}
-
-interface ParsedSource {
-  /**
-   * DTO members — from an `interface X {}`, a `type X = {…}` object-literal
-   * alias, or a `type X = Y<…>` alias resolved to its (possibly cross-package,
-   * possibly generic) target.
-   */
-  members?: readonly ts.TypeElement[];
-  aliases: AliasMap;
 }
 
 /**
@@ -417,10 +412,55 @@ function resolveDeclMembers(
   return undefined;
 }
 
-function parseSource(sourceText: string, fileName: string, typeName: string): ParsedSource {
-  const { aliases, decls } = collectSymbols(fileName, sourceText);
-  const resolved = resolveDeclMembers(typeName, [], decls, aliases);
-  return { members: resolved?.members, aliases: resolved?.aliases ?? aliases };
+/** A flattened front union member, with the file's alias map for family resolution. */
+interface FrontVariant {
+  members: readonly ts.TypeElement[];
+  aliases: AliasMap;
+}
+
+/**
+ * Resolve a front `type X = A | B | C` alias to its variant member lists. Each
+ * branch must be a named type the oracle can flatten ({@link resolveDeclMembers}).
+ * Returns `undefined` when `typeName` is not a union of named object types.
+ */
+function resolveUnionVariants(
+  typeName: string,
+  decls: DeclMap,
+  aliases: AliasMap
+): FrontVariant[] | undefined {
+  const decl = decls.get(typeName);
+  if (!decl?.aliasTarget || !ts.isUnionTypeNode(decl.aliasTarget)) return undefined;
+  const variants: FrontVariant[] = [];
+  for (const member of decl.aliasTarget.types) {
+    if (!ts.isTypeReferenceNode(member)) continue;
+    const resolved = resolveDeclMembers(
+      member.typeName.getText(),
+      member.typeArguments ?? [],
+      decls,
+      aliases
+    );
+    if (resolved) variants.push(resolved);
+  }
+  return variants.length ? variants : undefined;
+}
+
+/** Read the string-literal value of `propName` in a variant's members (its discriminator tag). */
+function discriminatorValueOf(
+  members: readonly ts.TypeElement[],
+  propName: string
+): string | undefined {
+  for (const member of members) {
+    if (
+      ts.isPropertySignature(member) &&
+      member.name.getText() === propName &&
+      member.type &&
+      ts.isLiteralTypeNode(member.type) &&
+      ts.isStringLiteral(member.type.literal)
+    ) {
+      return member.type.literal.text;
+    }
+  }
+  return undefined;
 }
 
 function tsProps(members: readonly ts.TypeElement[], aliases: AliasMap): Map<string, PropShape> {
@@ -478,11 +518,158 @@ function compareField(
 }
 
 /**
- * Verify a hand-written front interface conforms to its backend OpenAPI schema —
+ * Field-by-field comparison of one backend schema's properties against one front
+ * type's properties: presence (required only), type family, nullability, and the
+ * relative order of shared fields. `schema` is the label surfaced in violations
+ * (a bare schema name, or `Schema#variant` for a discriminated-union branch).
+ */
+function compareProps(
+  schema: string,
+  backend: Map<string, PropShape & { required: boolean }>,
+  front: Map<string, PropShape>
+): ConformanceViolation[] {
+  const out: ConformanceViolation[] = [];
+
+  for (const [name, sp] of backend) {
+    const tp = front.get(name);
+    if (!tp) {
+      if (sp.required) {
+        out.push({
+          rule: 'missing-field',
+          schema,
+          field: name,
+          message: `backend field "${name}" (${sp.family}) is missing from the front type`,
+        });
+      }
+      continue;
+    }
+    out.push(...compareField(schema, name, sp, tp));
+  }
+
+  for (const name of front.keys()) {
+    if (!backend.has(name)) {
+      out.push({
+        rule: 'orphan-field',
+        schema,
+        field: name,
+        message: `front field "${name}" has no counterpart in the backend schema (drift?)`,
+      });
+    }
+  }
+
+  // Field order — compare the relative order of shared fields only (missing /
+  // orphan fields are already reported above; they must not skew the position
+  // check). A mismatch here means a C# record parameter was reordered without
+  // updating the TS interface, or a field was inserted in the wrong place.
+  const sharedInSpec = [...backend.keys()].filter((k) => front.has(k));
+  const sharedInFront = [...front.keys()].filter((k) => backend.has(k));
+  if (sharedInSpec.join('\0') !== sharedInFront.join('\0')) {
+    out.push({
+      rule: 'field-order',
+      schema,
+      field: '*',
+      message: `field order differs — spec: [${sharedInSpec.join(', ')}], front: [${sharedInFront.join(', ')}]`,
+    });
+  }
+
+  return out;
+}
+
+/** A spec discriminated union, resolved to `discriminator value → branch schema`. */
+interface SpecUnion {
+  discriminatorProp: string;
+  variants: { value: string; schema: OpenApiSchema }[];
+}
+
+/**
+ * Detect an `anyOf`/`oneOf` + `discriminator` schema and resolve its mapping to
+ * the concrete branch schemas. Returns `undefined` for a plain object schema or
+ * a union without an explicit mapping (which cannot be matched by tag value).
+ */
+function specDiscriminatedUnion(schema: OpenApiSchema, schemas: SchemaMap): SpecUnion | undefined {
+  const branches = schema.anyOf ?? schema.oneOf;
+  const mapping = schema.discriminator?.mapping;
+  if (!schema.discriminator || !branches || !mapping) return undefined;
+  const variants: { value: string; schema: OpenApiSchema }[] = [];
+  for (const [value, ref] of Object.entries(mapping)) {
+    const name = ref.split('/').pop();
+    const target = name ? schemas[name] : undefined;
+    if (target) variants.push({ value, schema: target });
+  }
+  return { discriminatorProp: schema.discriminator.propertyName, variants };
+}
+
+/**
+ * Verify a front discriminated union (`type X = A | B | C`) against a spec
+ * `anyOf`/`oneOf` + discriminator: branches are paired by their tag value, then
+ * each pair is compared field-by-field. Reports a missing branch (spec tag with
+ * no front member) or an orphan branch (front member with no spec tag).
+ */
+function checkUnionConformance(
+  schemaName: string,
+  typeName: string,
+  union: SpecUnion,
+  decls: DeclMap,
+  aliases: AliasMap,
+  schemas: SchemaMap
+): ConformanceViolation[] {
+  const frontVariants = resolveUnionVariants(typeName, decls, aliases);
+  if (!frontVariants) {
+    return [
+      {
+        rule: 'type-missing',
+        schema: schemaName,
+        field: '*',
+        message: `front type "${typeName}" is not a discriminated union mirroring the spec`,
+      },
+    ];
+  }
+
+  const frontByTag = new Map<string, FrontVariant>();
+  for (const variant of frontVariants) {
+    const tag = discriminatorValueOf(variant.members, union.discriminatorProp);
+    if (tag !== undefined) frontByTag.set(tag, variant);
+  }
+
+  const out: ConformanceViolation[] = [];
+  for (const { value, schema } of union.variants) {
+    const front = frontByTag.get(value);
+    if (!front) {
+      out.push({
+        rule: 'missing-variant',
+        schema: schemaName,
+        field: union.discriminatorProp,
+        message: `spec variant "${value}" has no matching front union member`,
+      });
+      continue;
+    }
+    frontByTag.delete(value);
+    out.push(
+      ...compareProps(
+        `${schemaName}#${value}`,
+        specProps(schema, schemas),
+        tsProps(front.members, front.aliases)
+      )
+    );
+  }
+  for (const tag of frontByTag.keys()) {
+    out.push({
+      rule: 'orphan-variant',
+      schema: schemaName,
+      field: union.discriminatorProp,
+      message: `front union member "${tag}" has no matching spec variant`,
+    });
+  }
+  return out;
+}
+
+/**
+ * Verify a hand-written front type conforms to its backend OpenAPI schema —
  * field presence, nullability and coarse type family — while tolerating the
  * spec's representation (int unions, branded primitives, materialized generics)
- * via the normalization table. Returns one {@link ConformanceViolation} per drift;
- * an empty array means the front type still mirrors the contract.
+ * via the normalization table. Handles both plain object schemas and
+ * `anyOf`/`oneOf` + discriminator unions. Returns one {@link ConformanceViolation}
+ * per drift; an empty array means the front type still mirrors the contract.
  */
 export function checkSchemaConformance(opts: CheckSchemaOptions): ConformanceViolation[] {
   const typeName = opts.typeName ?? opts.schemaName;
@@ -499,8 +686,16 @@ export function checkSchemaConformance(opts: CheckSchemaOptions): ConformanceVio
     ];
   }
 
-  const { members, aliases } = parseSource(opts.sourceText, opts.fileName, typeName);
-  if (!members) {
+  const schemas = opts.spec.components?.schemas ?? {};
+  const { aliases, decls } = collectSymbols(opts.fileName, opts.sourceText);
+
+  const union = specDiscriminatedUnion(schema, schemas);
+  if (union) {
+    return checkUnionConformance(opts.schemaName, typeName, union, decls, aliases, schemas);
+  }
+
+  const resolved = resolveDeclMembers(typeName, [], decls, aliases);
+  if (!resolved) {
     return [
       {
         rule: 'type-missing',
@@ -511,51 +706,9 @@ export function checkSchemaConformance(opts: CheckSchemaOptions): ConformanceVio
     ];
   }
 
-  const backend = specProps(schema, opts.spec.components?.schemas ?? {});
-  const front = tsProps(members, aliases);
-  const out: ConformanceViolation[] = [];
-
-  for (const [name, sp] of backend) {
-    const tp = front.get(name);
-    if (!tp) {
-      if (sp.required) {
-        out.push({
-          rule: 'missing-field',
-          schema: opts.schemaName,
-          field: name,
-          message: `backend field "${name}" (${sp.family}) is missing from the front type`,
-        });
-      }
-      continue;
-    }
-    out.push(...compareField(opts.schemaName, name, sp, tp));
-  }
-
-  for (const name of front.keys()) {
-    if (!backend.has(name)) {
-      out.push({
-        rule: 'orphan-field',
-        schema: opts.schemaName,
-        field: name,
-        message: `front field "${name}" has no counterpart in the backend schema (drift?)`,
-      });
-    }
-  }
-
-  // Field order — compare the relative order of shared fields only (missing /
-  // orphan fields are already reported above; they must not skew the position
-  // check). A mismatch here means a C# record parameter was reordered without
-  // updating the TS interface, or a field was inserted in the wrong place.
-  const sharedInSpec = [...backend.keys()].filter((k) => front.has(k));
-  const sharedInFront = [...front.keys()].filter((k) => backend.has(k));
-  if (sharedInSpec.join('\0') !== sharedInFront.join('\0')) {
-    out.push({
-      rule: 'field-order',
-      schema: opts.schemaName,
-      field: '*',
-      message: `field order differs — spec: [${sharedInSpec.join(', ')}], front: [${sharedInFront.join(', ')}]`,
-    });
-  }
-
-  return out;
+  return compareProps(
+    opts.schemaName,
+    specProps(schema, schemas),
+    tsProps(resolved.members, resolved.aliases)
+  );
 }

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -398,9 +398,9 @@ export const CONTRACTS: readonly ModuleContract[] = [
   {
     slug: 'entities-customization',
     package: 'entities-customization',
-    // LayoutDelta stays unregistered — it is a discriminated union
-    // (Reorder|Regroup|Hide), which the field-by-field oracle cannot verify.
-    types: ['EntityCustomizationResponse', 'EntityCustomizationRequest'],
+    // LayoutDelta is a discriminated union (reorder|regroup|hide), verified
+    // branch-by-branch against the spec's anyOf + discriminator mapping.
+    types: ['EntityCustomizationResponse', 'EntityCustomizationRequest', 'LayoutDelta'],
   },
   {
     slug: 'entities-views',

--- a/packages/@granit/entities-customization/src/types/delta.ts
+++ b/packages/@granit/entities-customization/src/types/delta.ts
@@ -15,16 +15,16 @@ export type LayoutDeltaKind = 'reorder' | 'regroup' | 'hide';
  */
 export interface ReorderDelta {
   readonly $type: 'reorder';
-  readonly fieldName: string;
   readonly beforeFieldName: string | null;
   readonly afterFieldName: string | null;
+  readonly fieldName: string;
 }
 
 /** Move a field into a group (created on the fly if it doesn't exist yet). */
 export interface RegroupDelta {
   readonly $type: 'regroup';
-  readonly fieldName: string;
   readonly groupKey: string;
+  readonly fieldName: string;
 }
 
 /** Hide a field from the current layout; backend keeps it in the schema. */


### PR DESCRIPTION
## What

Closes the last coverage gap in the `@granit/contract-tests` conformance oracle: **discriminated unions**. The oracle could only flatten object types, so polymorphic DTOs serialized by `System.Text.Json` (`anyOf`/`oneOf` + `discriminator`) were deferred. This was the remaining `TODO`/deferred note in `manifest.ts`.

## How

A new union-verification mode in [conformance.ts](packages/@granit/contract-tests/src/conformance.ts):

- **Spec side** — detect `anyOf`/`oneOf` + `discriminator`, resolve the `mapping` (tag value → branch schema).
- **Front side** — resolve a `type X = A | B | C` alias to its variant member lists (reuses the cross-package/generic `resolveDeclMembers`, so generic variants work too).
- **Pair branches by discriminator tag value** (`$type`), then run the existing field-by-field comparison per branch (violations scoped as `Schema#tag`). Two new rules: `missing-variant` (spec tag with no front member) and `orphan-variant` (front member with no spec tag).

## Real drift found & fixed

Registering `LayoutDelta` immediately surfaced two genuine field-order drifts: `ReorderDelta` and `RegroupDelta` declared `fieldName` out of position versus the C# record. Aligned the front order to the spec in [delta.ts](packages/@granit/entities-customization/src/types/delta.ts) — non-breaking (TS structural typing; field order is irrelevant to consumers — verified `react-entities-customization`).

`LayoutDelta` is now registered and green. **No `TODO`/deferred entries remain in `manifest.ts`.**

## Tests

- 5 new union-mode unit tests: pass, per-branch drift (scoped `Delta#move`), `missing-variant`, `orphan-variant`, non-union front type.
- Full suite: **512 passing**. `tsc` + ESLint clean on `contract-tests`, `entities-customization`, `react-entities-customization`.

## Design note

Chose to **reorder the front variants** to honor the oracle's global field-order convention, rather than exempting union branches from the order rule. Easy to flip to the latter if preferred.