### PR TITLE
feat(ai-chat,react-ai-chat): add message report API + useReportMessage hook

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2900,6 +2900,23 @@
           "members": []
         },
         {
+          "name": "useReportMessage",
+          "kind": "function",
+          "signature": "function useReportMessage(): UseReportMessageReturn"
+        },
+        {
+          "name": "ReportMessageVariables",
+          "kind": "interface",
+          "signature": "interface ReportMessageVariables",
+          "members": []
+        },
+        {
+          "name": "UseReportMessageReturn",
+          "kind": "interface",
+          "signature": "interface UseReportMessageReturn",
+          "members": []
+        },
+        {
           "name": "useChatStream",
           "kind": "function",
           "signature": "function useChatStream(): UseChatStreamReturn"

--- a/contracts/openapi/ai-chat.json
+++ b/contracts/openapi/ai-chat.json
@@ -165,8 +165,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -175,8 +175,8 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -228,8 +228,8 @@
           "204": {
             "description": "No Content"
           },
-          "404": {
-            "description": "Not Found",
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -238,8 +238,8 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -313,8 +313,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -323,8 +323,8 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -370,7 +370,7 @@
       "post": {
         "tags": ["AI - Conversations"],
         "summary": "Sends a message and streams a tool-grounded answer over SSE.",
-        "description": "Runs the agentic loop within the caller's permissions, persists the user and assistant messages, and streams the answer as Server-Sent Events: a 'conversation' frame with the (possibly new) conversation id, incremental 'delta' content frames, then a 'usage' frame. Rejects a non-chat-capable workspace before streaming.",
+        "description": "Runs the agentic loop within the caller's permissions, persists the user and assistant messages, and streams the answer as Server-Sent Events: a 'conversation' frame with the (possibly new) conversation id (flushed immediately), then live 'tool_call'/'tool_result' frames as the agent uses tools and incremental 'delta' content frames as the model writes, then a 'usage' frame (and 'suggestions' / 'clarification' when applicable). Rejects a non-chat-capable workspace before streaming.",
         "operationId": "SendChatMessage",
         "requestBody": {
           "content": {
@@ -405,6 +405,111 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/conversations/messages/{messageId}/report": {
+      "post": {
+        "tags": ["AI - Conversations"],
+        "summary": "Reports a message in one of the current user's conversations.",
+        "description": "Records a user report flagging the message for review and raises a domain event the application can route. Scoped to the caller: a message outside the caller's own conversations is reported as not found. The report stores identifiers plus the user-entered reason — never the message content (ADR-071).",
+        "operationId": "ReportChatMessage",
+        "parameters": [
+          {
+            "name": "messageId",
+            "in": "path",
+            "description": "Unique identifier of the message.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReportMessageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -714,6 +819,9 @@
           }
         }
       },
+      "MessageReportCategory": {
+        "enum": ["Inaccurate", "Harmful", "Other", null]
+      },
       "MessageResponse": {
         "required": ["id", "role", "content", "createdAt"],
         "type": "object",
@@ -766,6 +874,26 @@
           "title": {
             "maxLength": 500,
             "type": "string"
+          }
+        }
+      },
+      "ReportMessageRequest": {
+        "required": ["reason"],
+        "type": "object",
+        "properties": {
+          "reason": {
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "category": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MessageReportCategory"
+              }
+            ]
           }
         }
       },

--- a/packages/@granit/ai-chat/src/__tests__/conversations-api.test.ts
+++ b/packages/@granit/ai-chat/src/__tests__/conversations-api.test.ts
@@ -8,12 +8,15 @@ import {
   listChatWorkspaces,
   listConversations,
   renameConversation,
+  reportConversationMessage,
 } from '../api/conversations-api';
+import { MESSAGE_REPORT_CATEGORIES } from '../types/index';
 
-import type { ConversationId, ConversationResponse } from '../types/index';
+import type { ConversationId, ConversationResponse, MessageId } from '../types/index';
 
 const BASE = '/api/v1/conversations';
 const ID = 'a1111111-1111-1111-1111-111111111111' as ConversationId;
+const MESSAGE_ID = 'c3333333-3333-3333-3333-333333333333' as MessageId;
 
 const CONVERSATION: ConversationResponse = {
   id: ID,
@@ -73,6 +76,21 @@ describe('conversations-api', () => {
     await deleteConversation(client, BASE, ID);
 
     expect(client.delete).toHaveBeenCalledWith(`${BASE}/${ID}`);
+  });
+
+  it('reportConversationMessage POSTs to {basePath}/messages/{messageId}/report with the body', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
+
+    await reportConversationMessage(client, BASE, MESSAGE_ID, {
+      reason: 'Inaccurate answer',
+      category: MESSAGE_REPORT_CATEGORIES.INACCURATE,
+    });
+
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/messages/${MESSAGE_ID}/report`, {
+      reason: 'Inaccurate answer',
+      category: 'Inaccurate',
+    });
   });
 
   it('listChatWorkspaces GETs {basePath}/workspaces', async () => {

--- a/packages/@granit/ai-chat/src/api/conversations-api.ts
+++ b/packages/@granit/ai-chat/src/api/conversations-api.ts
@@ -13,7 +13,9 @@ import type {
   ConversationResponse,
   ConversationSummaryResponse,
   CreateConversationRequest,
+  MessageId,
   RenameConversationRequest,
+  ReportMessageRequest,
   SendMessageRequest,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
@@ -86,6 +88,25 @@ export async function deleteConversation(
   id: ConversationId
 ): Promise<void> {
   await client.delete(`${basePath}/${encodeURIComponent(id)}`);
+}
+
+/**
+ * Report (flag) a message in one of the current user's conversations for review.
+ *
+ * Per ADR-071 only the `messageId` and the user-entered reason/category travel
+ * over the wire — never the message content or its tool activity. The server
+ * responds `202 Accepted` with no body; a message outside the caller's own
+ * conversations is reported as `404`.
+ *
+ * `POST {basePath}/messages/{messageId}/report`
+ */
+export async function reportConversationMessage(
+  client: AxiosInstance,
+  basePath: string,
+  messageId: MessageId,
+  request: ReportMessageRequest
+): Promise<void> {
+  await client.post(`${basePath}/messages/${encodeURIComponent(messageId)}/report`, request);
 }
 
 /**

--- a/packages/@granit/ai-chat/src/index.ts
+++ b/packages/@granit/ai-chat/src/index.ts
@@ -13,9 +13,11 @@ export type {
   CreateConversationRequest,
   MentionRequest,
   MessageId,
+  MessageReportCategory,
   MessageResponse,
   PromptId,
   RenameConversationRequest,
+  ReportMessageRequest,
   SendMessageRequest,
   SuggestedActionResponse,
 } from './types/index';
@@ -25,6 +27,8 @@ export {
   AUTO_WORKSPACE,
   CHAT_STREAM_EVENT_TYPES,
   CONVERSATION_TITLE_MAX_LENGTH,
+  MESSAGE_REPORT_CATEGORIES,
+  REPORT_REASON_MAX_LENGTH,
   SEND_MESSAGE_LIMITS,
 } from './types/index';
 
@@ -36,6 +40,7 @@ export {
   listChatWorkspaces,
   listConversations,
   renameConversation,
+  reportConversationMessage,
   streamConversationMessage,
 } from './api/conversations-api';
 

--- a/packages/@granit/ai-chat/src/permissions.ts
+++ b/packages/@granit/ai-chat/src/permissions.ts
@@ -15,5 +15,7 @@ export const AIChatPermissions = {
     Manage: 'AIChat.Conversations.Manage',
     /** Delete a conversation. */
     Delete: 'AIChat.Conversations.Delete',
+    /** Report (flag) a message in one's own conversations for review. */
+    Report: 'AIChat.Conversations.Report',
   },
 } as const;

--- a/packages/@granit/ai-chat/src/types/index.ts
+++ b/packages/@granit/ai-chat/src/types/index.ts
@@ -74,6 +74,27 @@ export const SEND_MESSAGE_LIMITS = {
 /** `title` maximum length for create/rename conversation requests. */
 export const CONVERSATION_TITLE_MAX_LENGTH = 500;
 
+/** `reason` maximum length for a {@link ReportMessageRequest}. */
+export const REPORT_REASON_MAX_LENGTH = 2000;
+
+/**
+ * The closed set of categories a user may attach to a message report. Mirrors
+ * `Granit.AI.Chat.Domain.MessageReportCategory`; the values are the PascalCase
+ * enum names the backend's default `JsonStringEnumConverter` accepts.
+ */
+export const MESSAGE_REPORT_CATEGORIES = {
+  /** The answer is factually wrong or misleading. */
+  INACCURATE: 'Inaccurate',
+  /** The content is harmful, unsafe, or offensive. */
+  HARMFUL: 'Harmful',
+  /** Any other reason; the free-text reason carries the detail. */
+  OTHER: 'Other',
+} as const;
+
+/** A report category value. @see MESSAGE_REPORT_CATEGORIES */
+export type MessageReportCategory =
+  (typeof MESSAGE_REPORT_CATEGORIES)[keyof typeof MESSAGE_REPORT_CATEGORIES];
+
 // -- Composer inputs ---------------------------------------------------------
 
 /** An `@` mention the server resolves to grounded, untrusted context. */
@@ -198,6 +219,17 @@ export interface CreateConversationRequest {
 /** Body of `PUT /conversations/{id}/title`. */
 export interface RenameConversationRequest {
   readonly title: string;
+}
+
+/**
+ * Body of `POST /conversations/messages/{messageId}/report`.
+ *
+ * Per ADR-071 a report carries only the user-entered reason and an optional
+ * category — never the message content or its tool activity.
+ */
+export interface ReportMessageRequest {
+  readonly reason: string;
+  readonly category?: MessageReportCategory | null;
 }
 
 /** The workspaces a user may set as their default chat workspace. */

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -187,6 +187,7 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'MessageResponse',
       'CreateConversationRequest',
       'RenameConversationRequest',
+      'ReportMessageRequest',
       'SendMessageRequest',
       'MentionRequest',
       'AttachmentRequest',

--- a/packages/@granit/react-ai-chat/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-ai-chat/src/__tests__/testing-handlers.test.ts
@@ -58,6 +58,16 @@ describe('createAIChatHandlers', () => {
     expect(list[0]?.title).toBe('Fresh');
   });
 
+  it('accepts a message report with 202', async () => {
+    server.use(...createAIChatHandlers(BASE));
+    const response = await fetch(`${BASE}/messages/c3333333-3333-3333-3333-333333333333/report`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: 'Inaccurate answer', category: 'Inaccurate' }),
+    });
+    expect(response.status).toBe(202);
+  });
+
   it('streams flat ChatStreamEvent frames ending without a [DONE] sentinel', async () => {
     server.use(...createAIChatHandlers(BASE));
     const response = await fetch(`${BASE}/messages`, {

--- a/packages/@granit/react-ai-chat/src/__tests__/use-conversations.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/use-conversations.test.tsx
@@ -6,11 +6,12 @@ import { useChatWorkspaces } from '../hooks/use-chat-workspaces';
 import { useConversations } from '../hooks/use-conversations';
 import { useCreateConversation } from '../hooks/use-create-conversation';
 import { useDeleteConversation } from '../hooks/use-delete-conversation';
+import { useReportMessage } from '../hooks/use-report-message';
 import { mockConversation, mockConversationSummaries } from '../testing/data';
 
 import { createWrapper, TEST_BASE_PATH } from './test-utils';
 
-import type { ConversationId } from '@granit/ai-chat';
+import type { ConversationId, MessageId } from '@granit/ai-chat';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -72,5 +73,28 @@ describe('conversation hooks', () => {
     });
 
     expect(client.delete).toHaveBeenCalledWith(`${TEST_BASE_PATH}/${id}`);
+  });
+
+  it('useReportMessage POSTs the reason and category to the message report endpoint', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
+
+    const { result } = renderHook(() => useReportMessage(), {
+      wrapper: createWrapper(client),
+    });
+
+    const messageId = 'c3333333-3333-3333-3333-333333333333' as MessageId;
+    await act(async () => {
+      await result.current.reportAsync({
+        messageId,
+        reason: 'Inaccurate answer',
+        category: 'Inaccurate',
+      });
+    });
+
+    expect(client.post).toHaveBeenCalledWith(`${TEST_BASE_PATH}/messages/${messageId}/report`, {
+      reason: 'Inaccurate answer',
+      category: 'Inaccurate',
+    });
   });
 });

--- a/packages/@granit/react-ai-chat/src/hooks/use-report-message.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-report-message.ts
@@ -1,0 +1,50 @@
+import { reportConversationMessage } from '@granit/ai-chat';
+import { useMutation } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { useAIChatConfig } from '../providers/ai-chat-provider';
+
+import type { MessageId, MessageReportCategory } from '@granit/ai-chat';
+
+export interface ReportMessageVariables {
+  readonly messageId: MessageId;
+  readonly reason: string;
+  readonly category?: MessageReportCategory | null;
+}
+
+export interface UseReportMessageReturn {
+  readonly report: (variables: ReportMessageVariables) => void;
+  readonly reportAsync: (variables: ReportMessageVariables) => Promise<void>;
+  readonly isPending: boolean;
+  readonly error: Error | null;
+}
+
+/**
+ * Mutation to report (flag) a message for review. Does not invalidate any cache
+ * — a report never changes conversation state. Requires
+ * `AIChat.Conversations.Report`.
+ */
+export function useReportMessage(): UseReportMessageReturn {
+  const config = useAIChatConfig();
+
+  const mutation = useMutation({
+    mutationFn: ({ messageId, reason, category }: ReportMessageVariables) =>
+      reportConversationMessage(config.client, config.basePath, messageId, { reason, category }),
+  });
+
+  const report = useCallback(
+    (variables: ReportMessageVariables) => {
+      mutation.mutate(variables);
+    },
+    [mutation]
+  );
+
+  const reportAsync = useCallback(
+    async (variables: ReportMessageVariables) => {
+      await mutation.mutateAsync(variables);
+    },
+    [mutation]
+  );
+
+  return { report, reportAsync, isPending: mutation.isPending, error: mutation.error };
+}

--- a/packages/@granit/react-ai-chat/src/index.ts
+++ b/packages/@granit/react-ai-chat/src/index.ts
@@ -22,6 +22,12 @@ export type {
 } from './hooks/use-rename-conversation';
 export { useDeleteConversation } from './hooks/use-delete-conversation';
 export type { UseDeleteConversationReturn } from './hooks/use-delete-conversation';
+export { useReportMessage } from './hooks/use-report-message';
+export type { ReportMessageVariables, UseReportMessageReturn } from './hooks/use-report-message';
+
+// Re-exports from @granit/ai-chat — the report contract the showcase dialog needs.
+export { MESSAGE_REPORT_CATEGORIES } from '@granit/ai-chat';
+export type { MessageReportCategory, ReportMessageRequest } from '@granit/ai-chat';
 
 // Hooks — streaming
 export { useChatStream } from './hooks/use-chat-stream';

--- a/packages/@granit/react-ai-chat/src/testing/handlers.ts
+++ b/packages/@granit/react-ai-chat/src/testing/handlers.ts
@@ -87,6 +87,12 @@ export function createAIChatHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return new HttpResponse(null, { status: 204 });
     }),
 
+    // POST /conversations/messages/:messageId/report — flag a message (ADR-071), 202.
+    http.post(
+      `${baseUrl}/messages/:messageId/report`,
+      () => new HttpResponse(null, { status: 202 })
+    ),
+
     // POST /conversations/messages — SSE stream (no [DONE] sentinel).
     http.post(`${baseUrl}/messages`, async ({ request }) => {
       const body = (await request.json()) as { message: string; conversationId?: string | null };


### PR DESCRIPTION
## Why

The backend now exposes an endpoint to **report (flag) an agentic chat message** for review (`POST /conversations/messages/{messageId}/report`, `202`, ADR-071: only `messageId` + reason/category travel — never message content or tool activity). This wires the **client + hook** so apps can call it from their report dialog (today a demo toast).

Follow-up to **#690** (merged) — same "chat" batch. Opened on a fresh branch since #690's branch was deleted on merge.

## Contract (verified against backend)

Aligned to the authoritative generated spec (`Granit.OpenApi.Generator_ai-chat.json`), not the indicative shapes:

- **Route**: `POST {basePath}/messages/{messageId}/report` → `202 Accepted`, no body.
- **`reason`**: required `string` (maxLength 2000).
- **`category`**: optional/nullable — `oneOf [null, MessageReportCategory]`, absent from `required`. Modelled as `category?: MessageReportCategory | null`.
- **`MessageReportCategory`**: closed enum `Inaccurate | Harmful | Other` — **PascalCase**, matching the backend's default `JsonStringEnumConverter` (unlike `Role`, which is explicitly lower-cased).
- **Permission**: endpoint requires `AIChat.Conversations.Report` (was missing from the front constants).

## Changes

**@granit/ai-chat**
- `ReportMessageRequest` DTO, `MESSAGE_REPORT_CATEGORIES` const + `MessageReportCategory` type, `REPORT_REASON_MAX_LENGTH`.
- `reportConversationMessage(client, basePath, messageId, request)` (modelled on `renameConversation`).
- `AIChatPermissions.Conversations.Report`.

**@granit/react-ai-chat**
- `useReportMessage()` mutation (reads client/basePath from `AIChatProvider`; **no** cache invalidation — a report doesn't change conversation state).
- `createAIChatHandlers`: `202` mock handler for the report route.
- Re-exports the report contract (`ReportMessageRequest`, `MessageReportCategory`, `MESSAGE_REPORT_CATEGORIES`) for the showcase dialog.

**Contract oracle**
- Refreshed vendored `contracts/openapi/ai-chat.json` (via `sync-openapi-contracts.mjs`) and registered `ReportMessageRequest` in `@granit/contract-tests` — drift suite green.

## Verification

- `@granit/contract-tests` drift: **507 passed** (DTO conformance + endpoint coverage, no drift).
- `@granit/ai-chat` + `@granit/react-ai-chat`: tsup build OK, **63 tests passed**.
- tsc + ESLint (`--max-warnings 0`) + prettier: clean.

## Out of scope (per task)
- No new i18n keys (dialog labels are app-side).
- Streaming flow and `renderMessageActions` slot untouched.