### PR TITLE
feat(react-ai-chat): redesign ChatComposer as a single card + lighter assistant bubbles

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2993,6 +2993,17 @@
           "members": []
         },
         {
+          "name": "WorkspaceSelector",
+          "kind": "function",
+          "signature": "function WorkspaceSelector("
+        },
+        {
+          "name": "WorkspaceSelectorProps",
+          "kind": "interface",
+          "signature": "interface WorkspaceSelectorProps",
+          "members": []
+        },
+        {
           "name": "ComposerSuggestions",
           "kind": "function",
           "signature": "function ComposerSuggestions<T>("

--- a/packages/@granit/react-ai-chat/src/__tests__/chat-composer.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/chat-composer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -99,7 +99,7 @@ describe('ChatComposer', () => {
     expect(send.querySelector('svg')).toBeInTheDocument();
   });
 
-  it('renders an optional workspace icon slot ahead of the selector', () => {
+  it('renders the workspace picker as a chip trigger with the fallback icon', () => {
     render(
       <ChatComposer
         onSubmit={vi.fn()}
@@ -107,8 +107,76 @@ describe('ChatComposer', () => {
         workspaceIcon={<span data-testid="ws-icon" />}
       />
     );
+    const trigger = screen.getByRole('button', { name: /workspace/i });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
     expect(screen.getByTestId('ws-icon')).toBeInTheDocument();
-    expect(screen.getByRole('combobox', { name: /workspace/i })).toBeInTheDocument();
+  });
+
+  it('opens the model picker, shows capabilities/groups, and selects an option', async () => {
+    const onWorkspaceChange = vi.fn();
+    render(
+      <ChatComposer
+        onSubmit={vi.fn()}
+        workspace="auto"
+        onWorkspaceChange={onWorkspaceChange}
+        workspaceOptions={[
+          {
+            value: 'auto',
+            label: 'DeepSeek V3.2',
+            icon: <span data-testid="opt-icon" />,
+            group: 'Available',
+            capabilities: [<span key="t" data-testid="cap-tools" />],
+          },
+          { value: 'kimi', label: 'Kimi K2.5', group: 'Available' },
+          { value: 'qwen', label: 'Qwen3-14B', group: 'Alibaba', disabled: true },
+        ]}
+      />
+    );
+
+    // Trigger reflects the selected option's own icon + label.
+    const trigger = screen.getByRole('button', { name: /workspace/i });
+    expect(trigger).toHaveTextContent('DeepSeek V3.2');
+
+    await userEvent.click(trigger);
+
+    // Listbox with provider group headings and capability glyphs.
+    expect(screen.getByRole('listbox', { name: /workspace/i })).toBeInTheDocument();
+    expect(screen.getByText('Available')).toBeInTheDocument();
+    expect(screen.getByText('Alibaba')).toBeInTheDocument();
+    expect(screen.getByTestId('cap-tools')).toBeInTheDocument();
+
+    // Disabled option is announced as such and does not select.
+    const locked = screen.getByText('Qwen3-14B').closest('[role="option"]');
+    expect(locked).toHaveAttribute('aria-disabled', 'true');
+    await userEvent.click(locked!);
+    expect(onWorkspaceChange).not.toHaveBeenCalled();
+
+    // A selectable option commits its value.
+    await userEvent.click(screen.getByText('Kimi K2.5'));
+    expect(onWorkspaceChange).toHaveBeenCalledWith('kimi');
+  });
+
+  it('filters the model picker via its search field for long lists', async () => {
+    render(
+      <ChatComposer
+        onSubmit={vi.fn()}
+        workspace="m1"
+        onWorkspaceChange={vi.fn()}
+        workspaceOptions={Array.from({ length: 7 }, (_, i) => ({
+          value: `m${i + 1}`,
+          label: `Model ${i + 1}`,
+        }))}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /workspace/i }));
+    const search = screen.getByRole('textbox', { name: /search models/i });
+    await userEvent.type(search, 'Model 5');
+
+    // Scope to the listbox — the trigger keeps showing the selected label.
+    const listbox = screen.getByRole('listbox', { name: /workspace/i });
+    expect(within(listbox).getByText('Model 5')).toBeInTheDocument();
+    expect(within(listbox).queryByText('Model 1')).not.toBeInTheDocument();
   });
 
   it('uploads attachments via the adapter and includes the reference on submit', async () => {

--- a/packages/@granit/react-ai-chat/src/__tests__/chat-composer.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/chat-composer.test.tsx
@@ -89,6 +89,28 @@ describe('ChatComposer', () => {
     expect(onStop).toHaveBeenCalled();
   });
 
+  it('renders the send action as a circular icon button with an accessible label', () => {
+    render(<ChatComposer onSubmit={vi.fn()} />);
+    const send = screen.getByRole('button', { name: /send/i });
+    expect(send).toHaveAttribute('data-slot', 'composer-send');
+    // Circular icon-only button (ArrowUp), no visible text caption.
+    expect(send.className).toContain('rounded-full');
+    expect(send).toHaveTextContent('');
+    expect(send.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders an optional workspace icon slot ahead of the selector', () => {
+    render(
+      <ChatComposer
+        onSubmit={vi.fn()}
+        workspaces={['Auto', 'support']}
+        workspaceIcon={<span data-testid="ws-icon" />}
+      />
+    );
+    expect(screen.getByTestId('ws-icon')).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /workspace/i })).toBeInTheDocument();
+  });
+
   it('uploads attachments via the adapter and includes the reference on submit', async () => {
     const uploadAttachment = vi.fn(async (file: File) => ({
       reference: 'blob://xyz',

--- a/packages/@granit/react-ai-chat/src/__tests__/components.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/components.test.tsx
@@ -106,6 +106,20 @@ describe('ChatMessage', () => {
     const { container } = render(<ChatMessage role="assistant" content="Hi" />);
     expect(container.querySelector('[data-slot="chat-message-actions"]')).not.toBeInTheDocument();
   });
+
+  it('exposes a data-slot="chat-bubble" for app-level theming on both roles', () => {
+    const assistant = render(<ChatMessage role="assistant" content="Hi" />);
+    const assistantBubble = assistant.container.querySelector('[data-slot="chat-bubble"]');
+    expect(assistantBubble).toBeInTheDocument();
+    // Assistant bubble uses the lightened neutral surface and the left tail.
+    expect(assistantBubble?.className).toContain('bg-muted/50');
+    expect(assistantBubble?.className).toContain('rounded-bl-sm');
+
+    const user = render(<ChatMessage role="user" content="Hi" />);
+    const userBubble = user.container.querySelector('[data-slot="chat-bubble"]');
+    expect(userBubble?.className).toContain('bg-primary');
+    expect(userBubble?.className).toContain('rounded-br-sm');
+  });
 });
 
 describe('ToolActivity', () => {

--- a/packages/@granit/react-ai-chat/src/__tests__/components.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/components.test.tsx
@@ -112,17 +112,15 @@ describe('ChatMessage', () => {
     const assistantBubble = assistant.container.querySelector('[data-slot="chat-bubble"]');
     expect(assistantBubble).toBeInTheDocument();
     // Assistant bubble uses the lightened neutral surface and the left tail.
-    // Assistant tail = square bottom-left: every corner rounded except bl.
+    // Assistant tail = square bottom-left (inline style, purge-proof).
     expect(assistantBubble?.className).toContain('bg-muted/50');
-    expect(assistantBubble?.className).toContain('rounded-br-2xl');
-    expect(assistantBubble?.className).not.toContain('rounded-bl-2xl');
+    expect(assistantBubble).toHaveStyle({ borderBottomLeftRadius: '0px' });
 
-    // User tail = square bottom-right: every corner rounded except br.
+    // User tail = square bottom-right.
     const user = render(<ChatMessage role="user" content="Hi" />);
     const userBubble = user.container.querySelector('[data-slot="chat-bubble"]');
     expect(userBubble?.className).toContain('bg-primary');
-    expect(userBubble?.className).toContain('rounded-bl-2xl');
-    expect(userBubble?.className).not.toContain('rounded-br-2xl');
+    expect(userBubble).toHaveStyle({ borderBottomRightRadius: '0px' });
   });
 });
 

--- a/packages/@granit/react-ai-chat/src/__tests__/components.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/components.test.tsx
@@ -112,13 +112,17 @@ describe('ChatMessage', () => {
     const assistantBubble = assistant.container.querySelector('[data-slot="chat-bubble"]');
     expect(assistantBubble).toBeInTheDocument();
     // Assistant bubble uses the lightened neutral surface and the left tail.
+    // Assistant tail = square bottom-left: every corner rounded except bl.
     expect(assistantBubble?.className).toContain('bg-muted/50');
-    expect(assistantBubble?.className).toContain('rounded-bl-none');
+    expect(assistantBubble?.className).toContain('rounded-br-2xl');
+    expect(assistantBubble?.className).not.toContain('rounded-bl-2xl');
 
+    // User tail = square bottom-right: every corner rounded except br.
     const user = render(<ChatMessage role="user" content="Hi" />);
     const userBubble = user.container.querySelector('[data-slot="chat-bubble"]');
     expect(userBubble?.className).toContain('bg-primary');
-    expect(userBubble?.className).toContain('rounded-br-none');
+    expect(userBubble?.className).toContain('rounded-bl-2xl');
+    expect(userBubble?.className).not.toContain('rounded-br-2xl');
   });
 });
 

--- a/packages/@granit/react-ai-chat/src/__tests__/components.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/components.test.tsx
@@ -113,12 +113,12 @@ describe('ChatMessage', () => {
     expect(assistantBubble).toBeInTheDocument();
     // Assistant bubble uses the lightened neutral surface and the left tail.
     expect(assistantBubble?.className).toContain('bg-muted/50');
-    expect(assistantBubble?.className).toContain('rounded-bl-sm');
+    expect(assistantBubble?.className).toContain('rounded-bl-none');
 
     const user = render(<ChatMessage role="user" content="Hi" />);
     const userBubble = user.container.querySelector('[data-slot="chat-bubble"]');
     expect(userBubble?.className).toContain('bg-primary');
-    expect(userBubble?.className).toContain('rounded-br-sm');
+    expect(userBubble?.className).toContain('rounded-br-none');
   });
 });
 

--- a/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
@@ -1,7 +1,7 @@
 import { SEND_MESSAGE_LIMITS } from '@granit/ai-chat';
 import { createLogger } from '@granit/logger';
 import { cn } from '@granit/utils';
-import { Paperclip, Send, Square } from 'lucide-react';
+import { ArrowUp, Paperclip, Sparkles, Square } from 'lucide-react';
 import { useCallback, useId, useMemo, useRef, useState } from 'react';
 
 import { defaultChatLabels } from '../locales/index';
@@ -21,7 +21,7 @@ import type {
 import type { ActiveTrigger } from './detect-trigger';
 import type { ChatTranslations } from '../locales/index';
 import type { SendMessageRequest } from '@granit/ai-chat';
-import type { ChangeEvent, KeyboardEvent } from 'react';
+import type { ChangeEvent, KeyboardEvent, ReactNode } from 'react';
 
 const logger = createLogger('react-ai-chat');
 
@@ -42,6 +42,12 @@ export interface ChatComposerProps {
   readonly workspaces?: readonly string[];
   readonly workspace?: string;
   readonly onWorkspaceChange?: (workspace: string) => void;
+  /**
+   * Optional leading glyph for the workspace chip. Defaults to a generic
+   * `Sparkles` icon — the framework stays brand-agnostic; apps may inject their
+   * own model/provider mark here.
+   */
+  readonly workspaceIcon?: ReactNode;
   readonly labels?: ChatTranslations['Composer'];
   readonly pickerLabels?: ChatTranslations['Pickers'];
   readonly disabled?: boolean;
@@ -64,6 +70,7 @@ export function ChatComposer({
   workspaces,
   workspace,
   onWorkspaceChange,
+  workspaceIcon,
   labels = defaultChatLabels.Composer,
   pickerLabels = defaultChatLabels.Pickers,
   disabled = false,
@@ -295,7 +302,7 @@ export function ChatComposer({
             <li
               key={badge.id}
               data-slot="prompt-badge"
-              className="bg-primary/10 text-primary inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium"
+              className="bg-primary/10 text-primary inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium"
             >
               <span>/{badge.name}</span>
               <button
@@ -315,7 +322,13 @@ export function ChatComposer({
 
       <AttachmentChips attachments={attachments} labels={labels} onRemove={removeAttachment} />
 
-      <div className="relative">
+      <div
+        data-slot="composer-card"
+        className={cn(
+          'border-border bg-background relative flex flex-col gap-2 rounded-2xl border px-3 py-2 shadow-sm transition-colors',
+          'focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px]'
+        )}
+      >
         {showSuggestions && trigger?.kind === '/' ? (
           <ComposerSuggestions<PromptOption>
             title={pickerLabels.Prompts}
@@ -380,70 +393,78 @@ export function ChatComposer({
           }
           onChange={handleChange}
           onKeyDown={handleKeyDown}
-          className="border-input bg-background w-full resize-none rounded-md border px-3 py-2 text-sm"
+          className="placeholder:text-muted-foreground w-full resize-none bg-transparent px-1 text-sm outline-none disabled:opacity-50"
         />
-      </div>
 
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          {workspaces && workspaces.length > 0 ? (
-            <select
-              data-slot="composer-workspace"
-              aria-label={labels.Workspace}
-              value={workspace ?? workspaces[0]}
-              disabled={disabled}
-              onChange={(event) => onWorkspaceChange?.(event.target.value)}
-              className="border-input bg-background rounded-md border px-2 py-1 text-xs"
-            >
-              {workspaces.map((ws) => (
-                <option key={ws} value={ws}>
-                  {ws}
-                </option>
-              ))}
-            </select>
-          ) : null}
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1">
+            {uploadAttachment ? (
+              <label
+                data-slot="composer-attach"
+                className="text-muted-foreground hover:bg-accent hover:text-foreground inline-flex size-8 cursor-pointer items-center justify-center rounded-full transition-colors"
+                title={labels.Attach}
+              >
+                <Paperclip className="size-4" aria-hidden />
+                <span className="sr-only">{labels.Attach}</span>
+                <input
+                  type="file"
+                  multiple
+                  className="hidden"
+                  disabled={disabled}
+                  onChange={handleFiles}
+                />
+              </label>
+            ) : null}
 
-          {uploadAttachment ? (
-            <label
-              data-slot="composer-attach"
-              className="hover:bg-accent inline-flex cursor-pointer items-center rounded-md p-1.5"
-              title={labels.Attach}
+            {workspaces && workspaces.length > 0 ? (
+              <div className="text-muted-foreground hover:bg-accent hover:text-foreground relative inline-flex items-center rounded-full transition-colors">
+                <span className="pointer-events-none absolute left-2.5 inline-flex">
+                  {workspaceIcon ?? <Sparkles className="size-3.5" aria-hidden />}
+                </span>
+                <select
+                  data-slot="composer-workspace"
+                  aria-label={labels.Workspace}
+                  value={workspace ?? workspaces[0]}
+                  disabled={disabled}
+                  onChange={(event) => onWorkspaceChange?.(event.target.value)}
+                  className="cursor-pointer appearance-none rounded-full bg-transparent py-1 pr-2.5 pl-7 text-xs outline-none"
+                >
+                  {workspaces.map((ws) => (
+                    <option key={ws} value={ws}>
+                      {ws}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ) : null}
+          </div>
+
+          {isStreaming ? (
+            <button
+              type="button"
+              data-slot="composer-stop"
+              onClick={onStop}
+              aria-label={labels.Stop}
+              className="bg-primary text-primary-foreground inline-flex size-8 items-center justify-center rounded-full transition-colors"
             >
-              <Paperclip className="size-4" aria-hidden />
-              <span className="sr-only">{labels.Attach}</span>
-              <input
-                type="file"
-                multiple
-                className="hidden"
-                disabled={disabled}
-                onChange={handleFiles}
-              />
-            </label>
-          ) : null}
+              <Square className="size-4" aria-hidden />
+            </button>
+          ) : (
+            <button
+              type="button"
+              data-slot="composer-send"
+              disabled={!canSend}
+              onClick={submit}
+              aria-label={labels.Send}
+              className={cn(
+                'inline-flex size-8 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed',
+                canSend ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
+              )}
+            >
+              <ArrowUp className="size-4" aria-hidden />
+            </button>
+          )}
         </div>
-
-        {isStreaming ? (
-          <button
-            type="button"
-            data-slot="composer-stop"
-            onClick={onStop}
-            className="bg-muted text-foreground inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm"
-          >
-            <Square className="size-3.5" aria-hidden />
-            {labels.Stop}
-          </button>
-        ) : (
-          <button
-            type="button"
-            data-slot="composer-send"
-            disabled={!canSend}
-            onClick={submit}
-            className="bg-primary text-primary-foreground inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm disabled:opacity-50"
-          >
-            <Send className="size-3.5" aria-hidden />
-            {labels.Send}
-          </button>
-        )}
       </div>
     </div>
   );

--- a/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
@@ -9,6 +9,7 @@ import { defaultChatLabels } from '../locales/index';
 import { AttachmentChips } from './attachment-chips';
 import { ComposerSuggestions } from './composer-suggestions';
 import { detectTrigger } from './detect-trigger';
+import { WorkspaceSelector } from './workspace-selector';
 
 import type { ComposerAttachment } from './attachment-chips';
 import type {
@@ -17,6 +18,7 @@ import type {
   SearchMentions,
   StagedMention,
   UploadAttachment,
+  WorkspaceOption,
 } from './composer-types';
 import type { ActiveTrigger } from './detect-trigger';
 import type { ChatTranslations } from '../locales/index';
@@ -40,12 +42,18 @@ export interface ChatComposerProps {
   readonly uploadAttachment?: UploadAttachment;
   /** Selectable workspaces (`Auto` first); omit to hide the selector. */
   readonly workspaces?: readonly string[];
+  /**
+   * Rich workspace/model options (leading mark, capability glyphs, provider
+   * grouping). When supplied, drives the picker instead of {@link workspaces};
+   * brand-agnostic — the host owns every glyph.
+   */
+  readonly workspaceOptions?: readonly WorkspaceOption[];
   readonly workspace?: string;
   readonly onWorkspaceChange?: (workspace: string) => void;
   /**
-   * Optional leading glyph for the workspace chip. Defaults to a generic
-   * `Sparkles` icon — the framework stays brand-agnostic; apps may inject their
-   * own model/provider mark here.
+   * Optional leading glyph for the workspace chip when the selected option has
+   * no `icon` of its own. Defaults to a generic `Sparkles` icon — the framework
+   * stays brand-agnostic; apps may inject their own model/provider mark here.
    */
   readonly workspaceIcon?: ReactNode;
   readonly labels?: ChatTranslations['Composer'];
@@ -68,6 +76,7 @@ export function ChatComposer({
   searchMentions,
   uploadAttachment,
   workspaces,
+  workspaceOptions,
   workspace,
   onWorkspaceChange,
   workspaceIcon,
@@ -185,6 +194,12 @@ export function ChatComposer({
 
   const hasUploading = attachments.some((a) => a.status === 'uploading');
   const canSend = text.trim().length > 0 && !hasUploading && !disabled;
+
+  // Rich options win; otherwise derive plain options from the workspace names.
+  const resolvedWorkspaceOptions = useMemo<readonly WorkspaceOption[]>(() => {
+    if (workspaceOptions && workspaceOptions.length > 0) return workspaceOptions;
+    return (workspaces ?? []).map((ws) => ({ value: ws }));
+  }, [workspaceOptions, workspaces]);
 
   const submit = useCallback(() => {
     if (!canSend) return;
@@ -416,26 +431,17 @@ export function ChatComposer({
               </label>
             ) : null}
 
-            {workspaces && workspaces.length > 0 ? (
-              <div className="text-muted-foreground hover:bg-accent hover:text-foreground relative inline-flex items-center rounded-full transition-colors">
-                <span className="pointer-events-none absolute left-2.5 inline-flex">
-                  {workspaceIcon ?? <Sparkles className="size-3.5" aria-hidden />}
-                </span>
-                <select
-                  data-slot="composer-workspace"
-                  aria-label={labels.Workspace}
-                  value={workspace ?? workspaces[0]}
-                  disabled={disabled}
-                  onChange={(event) => onWorkspaceChange?.(event.target.value)}
-                  className="cursor-pointer appearance-none rounded-full bg-transparent py-1 pr-2.5 pl-7 text-xs outline-none"
-                >
-                  {workspaces.map((ws) => (
-                    <option key={ws} value={ws}>
-                      {ws}
-                    </option>
-                  ))}
-                </select>
-              </div>
+            {resolvedWorkspaceOptions.length > 0 ? (
+              <WorkspaceSelector
+                options={resolvedWorkspaceOptions}
+                value={workspace}
+                onChange={(next) => onWorkspaceChange?.(next)}
+                label={labels.Workspace}
+                searchPlaceholder={labels.SearchWorkspaces}
+                emptyLabel={pickerLabels.NoResults}
+                fallbackIcon={workspaceIcon ?? <Sparkles className="size-3.5" aria-hidden />}
+                disabled={disabled}
+              />
             ) : null}
           </div>
 

--- a/packages/@granit/react-ai-chat/src/components/chat-message.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-message.tsx
@@ -42,10 +42,13 @@ export function ChatMessage({
       <div
         data-slot="chat-bubble"
         className={cn(
-          'max-w-[80%] rounded-2xl px-3 py-2 text-sm whitespace-pre-wrap',
+          // Per-corner radii only — mixing the `rounded-2xl` shorthand with a
+          // single-corner override lets the shorthand reset the tail corner.
+          // The emitter-side bottom corner is left at the default 0 (the tail).
+          'max-w-[80%] rounded-tl-2xl rounded-tr-2xl px-3 py-2 text-sm whitespace-pre-wrap',
           isUser
-            ? 'bg-primary text-primary-foreground rounded-br-none'
-            : 'bg-muted/50 text-foreground rounded-bl-none'
+            ? 'bg-primary text-primary-foreground rounded-bl-2xl'
+            : 'bg-muted/50 text-foreground rounded-br-2xl'
         )}
       >
         {content}

--- a/packages/@granit/react-ai-chat/src/components/chat-message.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-message.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@granit/utils';
 
 import type { ChatMessageRole } from '@granit/ai-chat';
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 export interface ChatMessageProps {
   readonly role: ChatMessageRole;
@@ -30,6 +30,13 @@ export function ChatMessage({
   className,
 }: Readonly<ChatMessageProps>) {
   const isUser = role === 'user';
+  // Flatten the emitter-side bottom corner into a speech-bubble tail. Done
+  // inline rather than with per-corner Tailwind utilities: those classes are
+  // novel here and get purged by the consuming app's Tailwind scan, whereas an
+  // inline style always renders and reliably wins over the `rounded-2xl` base.
+  const tailStyle: CSSProperties = isUser
+    ? { borderBottomRightRadius: 0 }
+    : { borderBottomLeftRadius: 0 };
   return (
     <div
       data-slot="chat-message"
@@ -41,14 +48,10 @@ export function ChatMessage({
       ) : null}
       <div
         data-slot="chat-bubble"
+        style={tailStyle}
         className={cn(
-          // Per-corner radii only — mixing the `rounded-2xl` shorthand with a
-          // single-corner override lets the shorthand reset the tail corner.
-          // The emitter-side bottom corner is left at the default 0 (the tail).
-          'max-w-[80%] rounded-tl-2xl rounded-tr-2xl px-3 py-2 text-sm whitespace-pre-wrap',
-          isUser
-            ? 'bg-primary text-primary-foreground rounded-bl-2xl'
-            : 'bg-muted/50 text-foreground rounded-br-2xl'
+          'max-w-[80%] rounded-2xl px-3 py-2 text-sm whitespace-pre-wrap',
+          isUser ? 'bg-primary text-primary-foreground' : 'bg-muted/50 text-foreground'
         )}
       >
         {content}

--- a/packages/@granit/react-ai-chat/src/components/chat-message.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-message.tsx
@@ -42,10 +42,10 @@ export function ChatMessage({
       <div
         data-slot="chat-bubble"
         className={cn(
-          'max-w-[80%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap',
+          'max-w-[80%] rounded-2xl px-3 py-2 text-sm whitespace-pre-wrap',
           isUser
-            ? 'bg-primary text-primary-foreground rounded-br-sm'
-            : 'bg-muted/50 text-foreground rounded-bl-sm'
+            ? 'bg-primary text-primary-foreground rounded-br-none'
+            : 'bg-muted/50 text-foreground rounded-bl-none'
         )}
       >
         {content}

--- a/packages/@granit/react-ai-chat/src/components/chat-message.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-message.tsx
@@ -40,9 +40,12 @@ export function ChatMessage({
         <span className="text-muted-foreground text-xs font-medium">{authorLabel}</span>
       ) : null}
       <div
+        data-slot="chat-bubble"
         className={cn(
           'max-w-[80%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap',
-          isUser ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground'
+          isUser
+            ? 'bg-primary text-primary-foreground rounded-br-sm'
+            : 'bg-muted/50 text-foreground rounded-bl-sm'
         )}
       >
         {content}

--- a/packages/@granit/react-ai-chat/src/components/composer-types.ts
+++ b/packages/@granit/react-ai-chat/src/components/composer-types.ts
@@ -1,4 +1,26 @@
 import type { MentionRequest, PromptId } from '@granit/ai-chat';
+import type { ReactNode } from 'react';
+
+/**
+ * Rich metadata for a workspace/model option, used to render the workspace
+ * selector as a model picker (leading mark, capability glyphs, provider
+ * grouping). Brand-agnostic: the host supplies every glyph ({@link icon},
+ * {@link capabilities}) — the framework never hardcodes a provider mark.
+ */
+export interface WorkspaceOption {
+  /** Value submitted to the backend; matches an entry in `workspaces`. */
+  readonly value: string;
+  /** Display label; defaults to {@link value}. */
+  readonly label?: string;
+  /** Leading glyph identifying the model/provider. */
+  readonly icon?: ReactNode;
+  /** Trailing capability glyphs (e.g. vision, tools, reasoning). */
+  readonly capabilities?: readonly ReactNode[];
+  /** Provider/section heading this option is grouped under. */
+  readonly group?: string;
+  /** Render the option as locked/unavailable — listed but not selectable. */
+  readonly disabled?: boolean;
+}
 
 /** A `/` prompt-badge option shown in the prompt picker. */
 export interface PromptOption {

--- a/packages/@granit/react-ai-chat/src/components/workspace-selector.tsx
+++ b/packages/@granit/react-ai-chat/src/components/workspace-selector.tsx
@@ -1,0 +1,273 @@
+import { cn } from '@granit/utils';
+import { ChevronDown, Search } from 'lucide-react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+
+import type { WorkspaceOption } from './composer-types';
+import type { KeyboardEvent, ReactNode } from 'react';
+
+/** Below this option count the search field is hidden — the list is short enough. */
+const SEARCH_THRESHOLD = 5;
+
+export interface WorkspaceSelectorProps {
+  /** Options to choose from (already brand-decorated by the host). */
+  readonly options: readonly WorkspaceOption[];
+  /** Currently selected value; defaults to the first option. */
+  readonly value?: string;
+  readonly onChange: (value: string) => void;
+  /** Accessible name for the trigger and listbox (e.g. "Workspace"). */
+  readonly label: string;
+  /** Placeholder for the search field (shown only for long lists). */
+  readonly searchPlaceholder?: string;
+  /** Shown when a search yields nothing. */
+  readonly emptyLabel: string;
+  /** Leading glyph used when the selected option has no `icon` of its own. */
+  readonly fallbackIcon?: ReactNode;
+  readonly disabled?: boolean;
+  readonly className?: string;
+}
+
+/**
+ * The workspace/model picker: a discreet chip trigger that opens a popover
+ * listbox of options, each with an optional leading mark and trailing
+ * capability glyphs, grouped by provider and optionally searchable. Headless of
+ * any brand — every glyph is supplied by the host via {@link WorkspaceOption}.
+ */
+export function WorkspaceSelector({
+  options,
+  value,
+  onChange,
+  label,
+  searchPlaceholder,
+  emptyLabel,
+  fallbackIcon,
+  disabled = false,
+  className,
+}: Readonly<WorkspaceSelectorProps>) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  const baseId = useId();
+  const listboxId = `${baseId}-ws-listbox`;
+  const getOptionId = useCallback((index: number) => `${baseId}-ws-opt-${index}`, [baseId]);
+
+  const selected = useMemo(
+    () => options.find((o) => o.value === value) ?? options[0],
+    [options, value]
+  );
+
+  const filtered = useMemo<readonly WorkspaceOption[]>(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return options;
+    return options.filter((o) => (o.label ?? o.value).toLowerCase().includes(q));
+  }, [options, query]);
+
+  const showSearch = options.length > SEARCH_THRESHOLD;
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setQuery('');
+  }, []);
+
+  const commit = useCallback(
+    (option: WorkspaceOption | undefined) => {
+      if (!option || option.disabled) return;
+      onChange(option.value);
+      close();
+    },
+    [onChange, close]
+  );
+
+  // Move the active highlight, skipping disabled rows.
+  const moveActive = useCallback(
+    (delta: number) => {
+      if (filtered.length === 0) return;
+      setActiveIndex((current) => {
+        let next = current;
+        for (let step = 0; step < filtered.length; step++) {
+          next = (next + delta + filtered.length) % filtered.length;
+          if (!filtered[next]?.disabled) return next;
+        }
+        return current;
+      });
+    },
+    [filtered]
+  );
+
+  // Reset the highlight to the first selectable row whenever the list changes.
+  useEffect(() => {
+    if (!open) return;
+    const firstEnabled = filtered.findIndex((o) => !o.disabled);
+    setActiveIndex(firstEnabled === -1 ? 0 : firstEnabled);
+  }, [open, filtered]);
+
+  // Focus the search field (or the popover) on open.
+  useEffect(() => {
+    if (!open) return;
+    if (showSearch) searchRef.current?.focus();
+    else popoverRef.current?.focus();
+  }, [open, showSearch]);
+
+  // Close on outside pointer or focus loss.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) close();
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => document.removeEventListener('pointerdown', onPointerDown);
+  }, [open, close]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+        return;
+      }
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        moveActive(1);
+        return;
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        moveActive(-1);
+        return;
+      }
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        commit(filtered[activeIndex]);
+      }
+    },
+    [close, moveActive, commit, filtered, activeIndex]
+  );
+
+  const selectedLabel = selected ? (selected.label ?? selected.value) : label;
+
+  // Render the filtered list with a provider heading inserted whenever the
+  // group changes. Indices stay aligned with `filtered` for keyboard nav.
+  let lastGroup: string | undefined;
+  const rows: ReactNode[] = filtered.map((option, index) => {
+    const heading = option.group && option.group !== lastGroup ? option.group : null;
+    lastGroup = option.group;
+    const isActive = index === activeIndex;
+    return (
+      <li key={option.value} role="presentation">
+        {heading ? (
+          <p
+            data-slot="workspace-group"
+            className="text-muted-foreground px-2 pt-2 pb-1 text-xs font-medium"
+          >
+            {heading}
+          </p>
+        ) : null}
+        <div
+          id={getOptionId(index)}
+          role="option"
+          aria-selected={option.value === selected?.value}
+          aria-disabled={option.disabled}
+          data-slot="workspace-option"
+          data-disabled={option.disabled}
+          onMouseEnter={() => {
+            if (!option.disabled) setActiveIndex(index);
+          }}
+          onMouseDown={(event) => {
+            event.preventDefault();
+            commit(option);
+          }}
+          className={cn(
+            'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm',
+            option.disabled
+              ? 'text-muted-foreground cursor-not-allowed opacity-60'
+              : 'cursor-pointer',
+            isActive && !option.disabled ? 'bg-accent text-accent-foreground' : ''
+          )}
+        >
+          <span className="flex size-4 shrink-0 items-center justify-center">{option.icon}</span>
+          <span className="flex-1 truncate">{option.label ?? option.value}</span>
+          {option.capabilities && option.capabilities.length > 0 ? (
+            <span
+              data-slot="workspace-capabilities"
+              className="text-muted-foreground flex shrink-0 items-center gap-1.5"
+            >
+              {option.capabilities.map((cap, capIndex) => (
+                <span key={capIndex} className="inline-flex">
+                  {cap}
+                </span>
+              ))}
+            </span>
+          ) : null}
+        </div>
+      </li>
+    );
+  });
+
+  return (
+    <div ref={containerRef} className={cn('relative', className)}>
+      <button
+        type="button"
+        data-slot="composer-workspace"
+        aria-label={label}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        disabled={disabled}
+        onClick={() => setOpen((v) => !v)}
+        className="text-muted-foreground hover:bg-accent hover:text-foreground inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs transition-colors disabled:opacity-50"
+      >
+        <span className="flex size-3.5 shrink-0 items-center justify-center">
+          {selected?.icon ?? fallbackIcon}
+        </span>
+        <span className="max-w-40 truncate">{selectedLabel}</span>
+        <ChevronDown className="size-3.5 shrink-0" aria-hidden />
+      </button>
+
+      {open ? (
+        <div
+          ref={popoverRef}
+          data-slot="workspace-popover"
+          tabIndex={-1}
+          onKeyDown={handleKeyDown}
+          className="border-border bg-popover absolute bottom-full z-20 mb-1 min-w-64 overflow-hidden rounded-xl border shadow-md outline-none"
+        >
+          {showSearch ? (
+            <div className="border-border flex items-center gap-2 border-b px-2.5 py-2">
+              <Search className="text-muted-foreground size-4 shrink-0" aria-hidden />
+              <input
+                ref={searchRef}
+                type="text"
+                value={query}
+                aria-label={searchPlaceholder ?? label}
+                placeholder={searchPlaceholder}
+                onChange={(event) => {
+                  setQuery(event.target.value);
+                }}
+                className="placeholder:text-muted-foreground w-full bg-transparent text-sm outline-none"
+              />
+            </div>
+          ) : null}
+
+          {filtered.length === 0 ? (
+            <p data-slot="workspace-empty" className="text-muted-foreground px-2 py-2 text-sm">
+              {emptyLabel}
+            </p>
+          ) : (
+            <ul
+              role="listbox"
+              id={listboxId}
+              aria-label={label}
+              className="max-h-72 overflow-auto p-1"
+            >
+              {rows}
+            </ul>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/@granit/react-ai-chat/src/index.ts
+++ b/packages/@granit/react-ai-chat/src/index.ts
@@ -57,6 +57,8 @@ export type {
 } from './components/attachment-chips';
 export { ChatComposer } from './components/chat-composer';
 export type { ChatComposerProps } from './components/chat-composer';
+export { WorkspaceSelector } from './components/workspace-selector';
+export type { WorkspaceSelectorProps } from './components/workspace-selector';
 export { ComposerSuggestions } from './components/composer-suggestions';
 export type { ComposerSuggestionsProps } from './components/composer-suggestions';
 export { detectTrigger } from './components/detect-trigger';
@@ -67,6 +69,7 @@ export type {
   SearchMentions,
   StagedMention,
   UploadAttachment,
+  WorkspaceOption,
 } from './components/composer-types';
 
 // i18n

--- a/packages/@granit/react-ai-chat/src/locales/en.ts
+++ b/packages/@granit/react-ai-chat/src/locales/en.ts
@@ -12,6 +12,8 @@ export interface ChatTranslations {
     readonly Stop: string;
     readonly Attach: string;
     readonly Workspace: string;
+    /** Placeholder for the workspace picker's search field. */
+    readonly SearchWorkspaces?: string;
     readonly RemoveAttachment: string;
     readonly RemovePrompt: string;
   };
@@ -59,6 +61,7 @@ export const aiChatTranslationsEn: ChatTranslations = {
     Stop: 'Stop',
     Attach: 'Attach a file',
     Workspace: 'Workspace',
+    SearchWorkspaces: 'Search models…',
     RemoveAttachment: 'Remove attachment',
     RemovePrompt: 'Remove prompt',
   },

--- a/packages/@granit/react-ai-chat/src/locales/fr.ts
+++ b/packages/@granit/react-ai-chat/src/locales/fr.ts
@@ -13,6 +13,7 @@ export const aiChatTranslationsFr: ChatTranslations = {
     Stop: 'Arrêter',
     Attach: 'Joindre un fichier',
     Workspace: 'Espace de travail',
+    SearchWorkspaces: 'Rechercher un modèle…',
     RemoveAttachment: 'Supprimer la pièce jointe',
     RemovePrompt: 'Supprimer le prompt',
   },


### PR DESCRIPTION
## Summary

Redesigns the `@granit/react-ai-chat` prompt bar (`ChatComposer`) into a single rounded card, replaces the native workspace `<select>` with a model-picker dropdown, and lightens the assistant message bubbles. Headless/framework-agnostic, no breaking API changes.

### ChatComposer
- **Single card**: textarea + action row in one rounded container (`rounded-2xl`, `border-border`, `bg-background`, `shadow-sm`, accented `focus-within` ring); borderless/transparent textarea.
- **Circular send button**: `Send` → circular `ArrowUp` (`rounded-full size-8`) — muted when empty, `bg-primary` when sendable. Streaming shows a circular **Stop** (`Square`). Both keep `aria-label`s.
- **Paperclip**: ghost circular icon button; prompt `/` badges rounded.
- Behaviour unchanged: `@` mentions, `/` prompts, attachment chips, Send↔Stop during streaming, keyboard nav, ARIA combobox.

### Workspace → model picker (`WorkspaceSelector`)
- The native `<select>` is replaced by a headless dropdown: a discreet chip trigger that opens a popover listbox.
- Each option renders an optional **leading model mark** + label + **trailing capability glyphs**, **grouped by provider**, with a **search box** auto-shown past a short-list threshold (>5).
- Full keyboard nav (↑/↓/Enter/Esc, skips disabled rows), outside-click dismissal, `listbox`/`option` ARIA, disabled/locked rows.
- **New optional prop** `workspaceOptions?: WorkspaceOption[]` (`{ value, label?, icon?, capabilities?, group?, disabled? }`) — **brand-agnostic**, the host supplies every glyph as a `ReactNode`. Passing plain `workspaces: string[]` still works (derived plain rows). New optional `Composer.SearchWorkspaces` i18n key (en/fr).

### ChatMessage
- Added `data-slot="chat-bubble"` for app-level theming.
- Lightened the **assistant** bubble (`bg-muted` → `bg-muted/50`); user bubble unchanged. Text on `*-foreground` tokens → WCAG AA in light/dark.
- Speech-bubble tail: rounded base + the emitter-side bottom corner flattened via inline style (user → bottom-right, assistant → bottom-left). Inline rather than per-corner Tailwind utilities, which are novel here and get purged by the consuming app's Tailwind scan.

## Tests
- Circular `ArrowUp` send button (label + slot); `chat-bubble` slot/tail per role; workspace chip trigger + fallback icon; opening the picker, group headings + capability glyphs, disabled-row non-selection, committing a value; search filtering on long lists.
- `pnpm -F @granit/react-ai-chat build` ✓ · 52 tests ✓ · ESLint (`--max-warnings 0`) ✓ · `tsc --noEmit` ✓ · Prettier ✓

## API stability
No public props removed or renamed. Additions are all optional and backward-compatible: `workspaceIcon`, `workspaceOptions`, `WorkspaceOption`, `WorkspaceSelector`, and the optional `Composer.SearchWorkspaces` locale key.