### PR TITLE
feat(ai-chat,react-ai-chat): consume conversation favorite field + endpoint

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2900,6 +2900,11 @@
           "members": []
         },
         {
+          "name": "useSetConversationFavorite",
+          "kind": "function",
+          "signature": "function useSetConversationFavorite(): UseSetConversationFavoriteReturn"
+        },
+        {
           "name": "useReportMessage",
           "kind": "function",
           "signature": "function useReportMessage(): UseReportMessageReturn"

--- a/contracts/openapi/ai-chat.json
+++ b/contracts/openapi/ai-chat.json
@@ -366,6 +366,101 @@
         }
       }
     },
+    "/conversations/{id}/favorite": {
+      "put": {
+        "tags": ["AI - Conversations"],
+        "summary": "Sets the favorite flag on one of the current user's conversations.",
+        "description": "Sets the conversation's favorite flag to the requested state (idempotent, not a toggle). Scoped to the caller: another user's conversation is reported as not found.",
+        "operationId": "SetConversationFavorite",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetConversationFavoriteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/conversations/messages": {
       "post": {
         "tags": ["AI - Conversations"],
@@ -716,7 +811,7 @@
         }
       },
       "ConversationResponse": {
-        "required": ["id", "title", "ownerId", "createdAt", "modifiedAt", "messages"],
+        "required": ["id", "title", "ownerId", "isFavorite", "createdAt", "modifiedAt", "messages"],
         "type": "object",
         "properties": {
           "id": {
@@ -729,6 +824,9 @@
           "ownerId": {
             "type": "string",
             "format": "uuid"
+          },
+          "isFavorite": {
+            "type": "boolean"
           },
           "createdAt": {
             "type": "string",
@@ -747,7 +845,7 @@
         }
       },
       "ConversationSummaryResponse": {
-        "required": ["id", "title", "createdAt", "modifiedAt"],
+        "required": ["id", "title", "isFavorite", "createdAt", "modifiedAt"],
         "type": "object",
         "properties": {
           "id": {
@@ -756,6 +854,9 @@
           },
           "title": {
             "type": "string"
+          },
+          "isFavorite": {
+            "type": "boolean"
           },
           "createdAt": {
             "type": "string",
@@ -930,6 +1031,15 @@
               "type": "string",
               "format": "uuid"
             }
+          }
+        }
+      },
+      "SetConversationFavoriteRequest": {
+        "required": ["isFavorite"],
+        "type": "object",
+        "properties": {
+          "isFavorite": {
+            "type": "boolean"
           }
         }
       },

--- a/packages/@granit/ai-chat/src/__tests__/conversations-api.test.ts
+++ b/packages/@granit/ai-chat/src/__tests__/conversations-api.test.ts
@@ -9,6 +9,7 @@ import {
   listConversations,
   renameConversation,
   reportConversationMessage,
+  setConversationFavorite,
 } from '../api/conversations-api';
 import { MESSAGE_REPORT_CATEGORIES } from '../types/index';
 
@@ -22,6 +23,7 @@ const CONVERSATION: ConversationResponse = {
   id: ID,
   title: 'Untitled',
   ownerId: 'b2222222-2222-2222-2222-222222222222' as ConversationResponse['ownerId'],
+  isFavorite: false,
   createdAt: '2026-06-15T10:00:00Z' as ConversationResponse['createdAt'],
   modifiedAt: null,
   messages: [],
@@ -67,6 +69,15 @@ describe('conversations-api', () => {
     await renameConversation(client, BASE, ID, { title: 'Renamed' });
 
     expect(client.put).toHaveBeenCalledWith(`${BASE}/${ID}/title`, { title: 'Renamed' });
+  });
+
+  it('setConversationFavorite PUTs {basePath}/{id}/favorite with the flag body', async () => {
+    const client = createMockClient();
+    vi.mocked(client.put).mockResolvedValue(axiosResponse(undefined));
+
+    await setConversationFavorite(client, BASE, ID, true);
+
+    expect(client.put).toHaveBeenCalledWith(`${BASE}/${ID}/favorite`, { isFavorite: true });
   });
 
   it('deleteConversation DELETEs {basePath}/{id}', async () => {

--- a/packages/@granit/ai-chat/src/api/conversations-api.ts
+++ b/packages/@granit/ai-chat/src/api/conversations-api.ts
@@ -78,6 +78,22 @@ export async function renameConversation(
 }
 
 /**
+ * Set the favorite flag on one of the current user's conversations to an
+ * explicit state (idempotent, not a toggle). The server responds `204`; a
+ * conversation outside the caller's own is reported as `404`.
+ *
+ * `PUT {basePath}/{id}/favorite`
+ */
+export async function setConversationFavorite(
+  client: AxiosInstance,
+  basePath: string,
+  id: ConversationId,
+  isFavorite: boolean
+): Promise<void> {
+  await client.put(`${basePath}/${encodeURIComponent(id)}/favorite`, { isFavorite });
+}
+
+/**
  * Delete one of the current user's conversations.
  *
  * `DELETE {basePath}/{id}`

--- a/packages/@granit/ai-chat/src/index.ts
+++ b/packages/@granit/ai-chat/src/index.ts
@@ -19,6 +19,7 @@ export type {
   RenameConversationRequest,
   ReportMessageRequest,
   SendMessageRequest,
+  SetConversationFavoriteRequest,
   SuggestedActionResponse,
 } from './types/index';
 
@@ -41,6 +42,7 @@ export {
   listConversations,
   renameConversation,
   reportConversationMessage,
+  setConversationFavorite,
   streamConversationMessage,
 } from './api/conversations-api';
 

--- a/packages/@granit/ai-chat/src/types/index.ts
+++ b/packages/@granit/ai-chat/src/types/index.ts
@@ -198,6 +198,7 @@ export interface ConversationResponse {
   readonly id: ConversationId;
   readonly title: string;
   readonly ownerId: UserId;
+  readonly isFavorite: boolean;
   readonly createdAt: ISODateString;
   readonly modifiedAt: ISODateString | null;
   readonly messages: readonly MessageResponse[];
@@ -207,6 +208,7 @@ export interface ConversationResponse {
 export interface ConversationSummaryResponse {
   readonly id: ConversationId;
   readonly title: string;
+  readonly isFavorite: boolean;
   readonly createdAt: ISODateString;
   readonly modifiedAt: ISODateString | null;
 }
@@ -219,6 +221,14 @@ export interface CreateConversationRequest {
 /** Body of `PUT /conversations/{id}/title`. */
 export interface RenameConversationRequest {
   readonly title: string;
+}
+
+/**
+ * Body of `PUT /conversations/{id}/favorite`. Sets the flag to an explicit
+ * state — idempotent, not a toggle.
+ */
+export interface SetConversationFavoriteRequest {
+  readonly isFavorite: boolean;
 }
 
 /**

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -187,6 +187,7 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'MessageResponse',
       'CreateConversationRequest',
       'RenameConversationRequest',
+      'SetConversationFavoriteRequest',
       'ReportMessageRequest',
       'SendMessageRequest',
       'MentionRequest',

--- a/packages/@granit/react-ai-chat/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-ai-chat/src/__tests__/testing-handlers.test.ts
@@ -58,6 +58,34 @@ describe('createAIChatHandlers', () => {
     expect(list[0]?.title).toBe('Fresh');
   });
 
+  it('sets the favorite flag (204) and reflects it on the next read', async () => {
+    server.use(...createAIChatHandlers(BASE));
+    const id = 'a1111111-1111-1111-1111-111111111111';
+
+    const put = await fetch(`${BASE}/${id}/favorite`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isFavorite: true }),
+    });
+    expect(put.status).toBe(204);
+
+    const detail = (await (await fetch(`${BASE}/${id}`)).json()) as { isFavorite: boolean };
+    expect(detail.isFavorite).toBe(true);
+
+    const list = (await (await fetch(BASE)).json()) as ConversationSummaryResponse[];
+    expect(list.find((c) => c.id === id)?.isFavorite).toBe(true);
+  });
+
+  it('returns 404 when favoriting an unknown conversation', async () => {
+    server.use(...createAIChatHandlers(BASE));
+    const response = await fetch(`${BASE}/00000000-0000-0000-0000-000000000000/favorite`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isFavorite: true }),
+    });
+    expect(response.status).toBe(404);
+  });
+
   it('accepts a message report with 202', async () => {
     server.use(...createAIChatHandlers(BASE));
     const response = await fetch(`${BASE}/messages/c3333333-3333-3333-3333-333333333333/report`, {

--- a/packages/@granit/react-ai-chat/src/__tests__/use-conversations.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/use-conversations.test.tsx
@@ -1,4 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
+import { useQueryClient } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -7,6 +8,7 @@ import { useConversations } from '../hooks/use-conversations';
 import { useCreateConversation } from '../hooks/use-create-conversation';
 import { useDeleteConversation } from '../hooks/use-delete-conversation';
 import { useReportMessage } from '../hooks/use-report-message';
+import { useSetConversationFavorite } from '../hooks/use-set-conversation-favorite';
 import { mockConversation, mockConversationSummaries } from '../testing/data';
 
 import { createWrapper, TEST_BASE_PATH } from './test-utils';
@@ -73,6 +75,33 @@ describe('conversation hooks', () => {
     });
 
     expect(client.delete).toHaveBeenCalledWith(`${TEST_BASE_PATH}/${id}`);
+  });
+
+  it('useSetConversationFavorite PUTs {id, isFavorite} and invalidates list + detail', async () => {
+    const client = createMockClient();
+    vi.mocked(client.put).mockResolvedValue(axiosResponse(undefined));
+
+    const wrapper = createWrapper(client);
+    const { result } = renderHook(
+      () => {
+        const queryClient = useQueryClient();
+        return { favorite: useSetConversationFavorite(), queryClient };
+      },
+      { wrapper }
+    );
+    const invalidateSpy = vi.spyOn(result.current.queryClient, 'invalidateQueries');
+
+    const id = mockConversation.id as ConversationId;
+    await act(async () => {
+      await result.current.favorite.setFavoriteAsync({ id, isFavorite: true });
+    });
+
+    expect(client.put).toHaveBeenCalledWith(`${TEST_BASE_PATH}/${id}/favorite`, {
+      isFavorite: true,
+    });
+    const invalidatedKeys = invalidateSpy.mock.calls.map(([arg]) => arg?.queryKey);
+    expect(invalidatedKeys).toContainEqual(expect.arrayContaining(['conversations', 'list']));
+    expect(invalidatedKeys).toContainEqual(expect.arrayContaining(['conversations', 'detail', id]));
   });
 
   it('useReportMessage POSTs the reason and category to the message report endpoint', async () => {

--- a/packages/@granit/react-ai-chat/src/hooks/use-set-conversation-favorite.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-set-conversation-favorite.ts
@@ -1,0 +1,61 @@
+import { setConversationFavorite } from '@granit/ai-chat';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { useAIChatConfig } from '../providers/ai-chat-provider';
+
+import { conversationKeys } from './query-keys';
+
+import type { ConversationId } from '@granit/ai-chat';
+
+export interface SetConversationFavoriteVariables {
+  readonly id: ConversationId;
+  /** Desired favorite state — explicit, not a toggle. */
+  readonly isFavorite: boolean;
+}
+
+export interface UseSetConversationFavoriteReturn {
+  readonly setFavorite: (variables: SetConversationFavoriteVariables) => void;
+  readonly setFavoriteAsync: (variables: SetConversationFavoriteVariables) => Promise<void>;
+  readonly isPending: boolean;
+  readonly error: Error | null;
+}
+
+/**
+ * Mutation to set a conversation's favorite flag to an explicit state.
+ * Invalidates the list and the affected detail on success. Requires
+ * `AIChat.Conversations.Manage`.
+ */
+export function useSetConversationFavorite(): UseSetConversationFavoriteReturn {
+  const config = useAIChatConfig();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: ({ id, isFavorite }: SetConversationFavoriteVariables) =>
+      setConversationFavorite(config.client, config.basePath, id, isFavorite),
+    onSuccess: (_data, { id }) => {
+      queryClient
+        .invalidateQueries({ queryKey: conversationKeys.list(config.queryKeyPrefix) })
+        .catch(() => undefined);
+      queryClient
+        .invalidateQueries({ queryKey: conversationKeys.detail(config.queryKeyPrefix, id) })
+        .catch(() => undefined);
+    },
+  });
+
+  const setFavorite = useCallback(
+    (variables: SetConversationFavoriteVariables) => {
+      mutation.mutate(variables);
+    },
+    [mutation]
+  );
+
+  const setFavoriteAsync = useCallback(
+    async (variables: SetConversationFavoriteVariables) => {
+      await mutation.mutateAsync(variables);
+    },
+    [mutation]
+  );
+
+  return { setFavorite, setFavoriteAsync, isPending: mutation.isPending, error: mutation.error };
+}

--- a/packages/@granit/react-ai-chat/src/index.ts
+++ b/packages/@granit/react-ai-chat/src/index.ts
@@ -22,6 +22,11 @@ export type {
 } from './hooks/use-rename-conversation';
 export { useDeleteConversation } from './hooks/use-delete-conversation';
 export type { UseDeleteConversationReturn } from './hooks/use-delete-conversation';
+export { useSetConversationFavorite } from './hooks/use-set-conversation-favorite';
+export type {
+  SetConversationFavoriteVariables,
+  UseSetConversationFavoriteReturn,
+} from './hooks/use-set-conversation-favorite';
 export { useReportMessage } from './hooks/use-report-message';
 export type { ReportMessageVariables, UseReportMessageReturn } from './hooks/use-report-message';
 

--- a/packages/@granit/react-ai-chat/src/testing/data.ts
+++ b/packages/@granit/react-ai-chat/src/testing/data.ts
@@ -15,6 +15,7 @@ export const mockConversation: ConversationResponse = {
   id: CONVERSATION_ID,
   title: 'Invoice questions',
   ownerId: OWNER,
+  isFavorite: false,
   createdAt: toISODateString('2026-06-15T09:00:00.000Z'),
   modifiedAt: toISODateString('2026-06-15T09:05:00.000Z'),
   messages: [
@@ -38,12 +39,14 @@ export const mockConversationSummaries: ConversationSummaryResponse[] = [
   {
     id: CONVERSATION_ID,
     title: 'Invoice questions',
+    isFavorite: false,
     createdAt: toISODateString('2026-06-15T09:00:00.000Z'),
     modifiedAt: toISODateString('2026-06-15T09:05:00.000Z'),
   },
   {
     id: toEntityId<'Conversation'>('a1111111-1111-1111-1111-111111111112'),
     title: 'Daily brief',
+    isFavorite: true,
     createdAt: toISODateString('2026-06-14T07:30:00.000Z'),
     modifiedAt: null,
   },

--- a/packages/@granit/react-ai-chat/src/testing/handlers.ts
+++ b/packages/@granit/react-ai-chat/src/testing/handlers.ts
@@ -9,6 +9,7 @@ import type {
   ConversationSummaryResponse,
   CreateConversationRequest,
   RenameConversationRequest,
+  SetConversationFavoriteRequest,
 } from '@granit/ai-chat';
 import type { Mutable } from '@granit/testing';
 
@@ -44,6 +45,7 @@ export function createAIChatHandlers(baseUrl = DEFAULT_BASE_PATH) {
         ...mockConversation,
         id: summary.id,
         title: summary.title,
+        isFavorite: summary.isFavorite,
       });
     }),
 
@@ -60,6 +62,7 @@ export function createAIChatHandlers(baseUrl = DEFAULT_BASE_PATH) {
         {
           id: created.id,
           title: created.title,
+          isFavorite: created.isFavorite,
           createdAt: created.createdAt,
           modifiedAt: created.modifiedAt,
         },
@@ -75,6 +78,16 @@ export function createAIChatHandlers(baseUrl = DEFAULT_BASE_PATH) {
       const index = summaries.findIndex((c) => c.id === id);
       if (index === -1) return new HttpResponse(null, { status: 404 });
       summaries = summaries.map((c) => (c.id === id ? { ...c, title: body.title } : c));
+      return new HttpResponse(null, { status: 204 });
+    }),
+
+    // PUT /conversations/:id/favorite — set the favorite flag (idempotent).
+    http.put(`${baseUrl}/:id/favorite`, async ({ params, request }) => {
+      const id = params.id as string;
+      const body = (await request.json()) as SetConversationFavoriteRequest;
+      const index = summaries.findIndex((c) => c.id === id);
+      if (index === -1) return new HttpResponse(null, { status: 404 });
+      summaries = summaries.map((c) => (c.id === id ? { ...c, isFavorite: body.isFavorite } : c));
       return new HttpResponse(null, { status: 204 });
     }),
 


### PR DESCRIPTION
## Summary

The backend (`Granit.AI.Chat`) added a per-conversation favorite flag and a `PUT /conversations/{id}/favorite` endpoint (idempotent set, not a toggle; `204`, `404` if not the caller's). This wires the front to consume both.

Contract verified against the authoritative source on `granit-dotnet`: [ConversationEndpoints.cs](https://github.com/granit-fx/granit-dotnet) (`MapPut("/{id:guid}/favorite", …)`), `SetConversationFavoriteRequest(bool IsFavorite)`, and `IsFavorite` on both response records.

## `@granit/ai-chat`
- `isFavorite: boolean` added to `ConversationResponse` and `ConversationSummaryResponse` (placed in the backend record's field order — conformance checks order).
- New `SetConversationFavoriteRequest` type.
- `setConversationFavorite(client, basePath, id, isFavorite)` → `PUT {base}/{id}/favorite` with `{ isFavorite }`.
- Exports the type + function; api test asserts URL + body.

## `@granit/react-ai-chat`
- `useSetConversationFavorite()` mutation — variables `{ id, isFavorite }`, invalidates the conversation **list** + the affected **detail** on success (mirrors `useRenameConversation`). Exported with its variable/return types.
- **Testing**: `PUT {base}/{id}/favorite` MSW handler updating the in-memory flag (`204`/`404`); `isFavorite` added to `mockConversation` + summaries; `create`/`detail` handlers kept coherent (the flag round-trips).
- Hook test (client call + cache invalidation), handler tests (set→read-back, unknown→404).

## Contract snapshot
Refreshed the vendored `contracts/openapi/ai-chat.json` from the backend generator output (`scripts/sync-openapi-contracts.mjs ai-chat`) so the conformance oracle — now also checking `SetConversationFavoriteRequest` — stays green. The diff is favorite-only after prettier (the endpoint, the schema, and `isFavorite` in both responses).

No new i18n keys — favorite labels live in the consuming app.

## DoD
- `pnpm -F @granit/ai-chat build && test` ✓ (17)
- `pnpm -F @granit/react-ai-chat build && test` ✓ (55)
- contract-tests ✓ (514) — full affected run: **586 passed**
- ESLint (`--max-warnings 0`) ✓ · `tsc --noEmit` ✓ · Prettier ✓

## API stability
Additive only: a new required field mirroring a new backend field, plus new exported symbols (`SetConversationFavoriteRequest`, `setConversationFavorite`, `useSetConversationFavorite`). No renames or removals.