### PR TITLE
feat(react-ai-chat): scroll-to-latest button + stick-to-bottom for the conversation thread

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2922,6 +2922,23 @@
           "signature": "function useChatStream(): UseChatStreamReturn"
         },
         {
+          "name": "useStickToBottom",
+          "kind": "function",
+          "signature": "function useStickToBottom< S extends HTMLElement = HTMLDivElement, C extends HTMLElement = HTMLDivElement, >("
+        },
+        {
+          "name": "UseStickToBottomOptions",
+          "kind": "interface",
+          "signature": "interface UseStickToBottomOptions",
+          "members": []
+        },
+        {
+          "name": "UseStickToBottomReturn",
+          "kind": "interface",
+          "signature": "interface UseStickToBottomReturn<S extends HTMLElement, C extends HTMLElement>",
+          "members": []
+        },
+        {
           "name": "ChatMessage",
           "kind": "function",
           "signature": "function ChatMessage("
@@ -2941,6 +2958,28 @@
           "name": "ConversationThreadProps",
           "kind": "interface",
           "signature": "interface ConversationThreadProps",
+          "members": []
+        },
+        {
+          "name": "ConversationScrollArea",
+          "kind": "function",
+          "signature": "function ConversationScrollArea("
+        },
+        {
+          "name": "ConversationScrollAreaProps",
+          "kind": "interface",
+          "signature": "interface ConversationScrollAreaProps",
+          "members": []
+        },
+        {
+          "name": "ScrollToBottomButton",
+          "kind": "function",
+          "signature": "function ScrollToBottomButton("
+        },
+        {
+          "name": "ScrollToBottomButtonProps",
+          "kind": "interface",
+          "signature": "interface ScrollToBottomButtonProps",
           "members": []
         },
         {

--- a/packages/@granit/react-ai-chat/src/__tests__/scroll-to-bottom.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/scroll-to-bottom.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ConversationScrollArea } from '../components/conversation-scroll-area';
+import { ScrollToBottomButton } from '../components/scroll-to-bottom-button';
+import { useStickToBottom } from '../hooks/use-stick-to-bottom';
+
+/** Override jsdom's always-0 layout getters for one element. */
+function setMetrics(el: HTMLElement, scrollHeight: number, clientHeight: number): void {
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, value: scrollHeight });
+  Object.defineProperty(el, 'clientHeight', { configurable: true, value: clientHeight });
+}
+
+function Harness() {
+  const { scrollRef, contentRef, isAtBottom, scrollToBottom } = useStickToBottom();
+  return (
+    <div>
+      <span data-testid="at-bottom">{String(isAtBottom)}</span>
+      <button type="button" onClick={() => scrollToBottom('auto')}>
+        go
+      </button>
+      <div data-testid="viewport" ref={scrollRef}>
+        <div ref={contentRef}>content</div>
+      </div>
+    </div>
+  );
+}
+
+describe('useStickToBottom', () => {
+  it('flips isAtBottom as the user scrolls away from and back to the bottom', () => {
+    render(<Harness />);
+    const viewport = screen.getByTestId('viewport');
+    const atBottom = screen.getByTestId('at-bottom');
+
+    // Starts pinned.
+    expect(atBottom).toHaveTextContent('true');
+
+    // Tall content, scrolled to the top → not at bottom.
+    setMetrics(viewport, 1000, 300);
+    viewport.scrollTop = 0;
+    fireEvent.scroll(viewport);
+    expect(atBottom).toHaveTextContent('false');
+
+    // Scrolled to the bottom → at bottom again.
+    viewport.scrollTop = 700;
+    fireEvent.scroll(viewport);
+    expect(atBottom).toHaveTextContent('true');
+  });
+
+  it('scrollToBottom moves the viewport to the end and re-engages stick', async () => {
+    render(<Harness />);
+    const viewport = screen.getByTestId('viewport');
+    const atBottom = screen.getByTestId('at-bottom');
+
+    setMetrics(viewport, 1000, 300);
+    viewport.scrollTop = 0;
+    fireEvent.scroll(viewport);
+    expect(atBottom).toHaveTextContent('false');
+
+    await userEvent.click(screen.getByRole('button', { name: 'go' }));
+
+    expect(viewport.scrollTop).toBe(1000);
+    expect(atBottom).toHaveTextContent('true');
+  });
+});
+
+describe('ScrollToBottomButton', () => {
+  it('is interactive and labelled when visible', async () => {
+    const onClick = vi.fn();
+    render(<ScrollToBottomButton visible onClick={onClick} />);
+
+    const button = screen.getByRole('button', { name: /scroll to latest/i });
+    expect(button).toHaveAttribute('data-slot', 'scroll-to-bottom');
+    expect(button).toHaveAttribute('aria-hidden', 'false');
+    expect(button).toHaveAttribute('tabindex', '0');
+
+    await userEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('is hidden from the a11y tree and the tab order when not visible', () => {
+    render(<ScrollToBottomButton visible={false} onClick={vi.fn()} label="Down" />);
+    const button = screen.getByLabelText('Down');
+    expect(button).toHaveAttribute('aria-hidden', 'true');
+    expect(button).toHaveAttribute('tabindex', '-1');
+    expect(button.className).toContain('pointer-events-none');
+  });
+});
+
+describe('ConversationScrollArea', () => {
+  it('renders children in a scroll viewport with the overlay button', () => {
+    const { container } = render(
+      <ConversationScrollArea>
+        <p>message body</p>
+      </ConversationScrollArea>
+    );
+
+    expect(container.querySelector('[data-slot="conversation-scroll-area"]')).toBeInTheDocument();
+    const viewport = container.querySelector('[data-slot="scroll-viewport"]');
+    expect(viewport).toHaveClass('overflow-y-auto');
+    expect(screen.getByText('message body')).toBeInTheDocument();
+
+    // Pinned at mount → the button is present but hidden from the a11y tree.
+    const button = container.querySelector('[data-slot="scroll-to-bottom"]');
+    expect(button).toHaveAttribute('aria-hidden', 'true');
+    expect(button).toHaveAttribute('aria-label', 'Scroll to latest');
+  });
+});

--- a/packages/@granit/react-ai-chat/src/components/conversation-scroll-area.tsx
+++ b/packages/@granit/react-ai-chat/src/components/conversation-scroll-area.tsx
@@ -1,0 +1,68 @@
+import { cn } from '@granit/utils';
+
+import { useStickToBottom } from '../hooks/use-stick-to-bottom';
+
+import { ScrollToBottomButton } from './scroll-to-bottom-button';
+
+import type { ReactNode } from 'react';
+
+export interface ConversationScrollAreaProps {
+  /** The conversation content — typically a `ConversationThread`. */
+  readonly children: ReactNode;
+  /**
+   * Distance (px) from the bottom within which auto-stick stays engaged.
+   * @see UseStickToBottomOptions.threshold
+   */
+  readonly threshold?: number;
+  /** Accessible label for the scroll-to-latest button. */
+  readonly scrollButtonLabel?: string;
+  /** Class for the outer (positioned) wrapper — set the height here. */
+  readonly className?: string;
+  /** Class for the inner scroll viewport. */
+  readonly viewportClassName?: string;
+}
+
+/**
+ * Batteries-included scroll container for a conversation: owns the scroller,
+ * keeps the view pinned to the latest message while streaming, and overlays a
+ * {@link ScrollToBottomButton} when the user has scrolled up. Opt-in — the
+ * headless `ConversationThread` stays layout-agnostic; reach for the
+ * {@link useStickToBottom} hook directly to wire your own scroller instead.
+ *
+ * Give the outer element a height (e.g. `className="h-full"` or `flex-1`).
+ */
+export function ConversationScrollArea({
+  children,
+  threshold,
+  scrollButtonLabel,
+  className,
+  viewportClassName,
+}: Readonly<ConversationScrollAreaProps>) {
+  const { scrollRef, contentRef, isAtBottom, scrollToBottom } = useStickToBottom({ threshold });
+
+  return (
+    <div
+      data-slot="conversation-scroll-area"
+      className={cn('relative flex min-h-0 flex-col', className)}
+    >
+      <div
+        ref={scrollRef}
+        data-slot="scroll-viewport"
+        className={cn('min-h-0 flex-1 overflow-y-auto', viewportClassName)}
+      >
+        <div ref={contentRef}>{children}</div>
+      </div>
+
+      <div className="pointer-events-none absolute inset-x-0 bottom-4 flex justify-center">
+        <ScrollToBottomButton
+          visible={!isAtBottom}
+          onClick={() => {
+            scrollToBottom();
+          }}
+          label={scrollButtonLabel}
+          className="pointer-events-auto"
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/@granit/react-ai-chat/src/components/scroll-to-bottom-button.tsx
+++ b/packages/@granit/react-ai-chat/src/components/scroll-to-bottom-button.tsx
@@ -1,0 +1,45 @@
+import { cn } from '@granit/utils';
+import { ArrowDown } from 'lucide-react';
+
+import { defaultChatLabels } from '../locales/index';
+
+export interface ScrollToBottomButtonProps {
+  /** Whether the button is shown — typically `!isAtBottom`. */
+  readonly visible: boolean;
+  /** Jump to the latest message. */
+  readonly onClick: () => void;
+  /** Accessible label; defaults to the `Thread.ScrollToLatest` translation. */
+  readonly label?: string;
+  readonly className?: string;
+}
+
+/**
+ * A circular "scroll to latest" button. Presentational and controlled: pair it
+ * with {@link useStickToBottom} (or any scroll state) — pass `visible` and
+ * `onClick`. Stays mounted and fades/scales out when hidden so it can animate,
+ * and is removed from the tab order and the accessibility tree while hidden.
+ */
+export function ScrollToBottomButton({
+  visible,
+  onClick,
+  label = defaultChatLabels.Thread.ScrollToLatest ?? 'Scroll to latest',
+  className,
+}: Readonly<ScrollToBottomButtonProps>) {
+  return (
+    <button
+      type="button"
+      data-slot="scroll-to-bottom"
+      aria-label={label}
+      aria-hidden={!visible}
+      tabIndex={visible ? 0 : -1}
+      onClick={onClick}
+      className={cn(
+        'border-border bg-background text-foreground hover:bg-accent inline-flex size-9 items-center justify-center rounded-full border shadow-md transition-all duration-150 ease-out',
+        visible ? 'scale-100 opacity-100' : 'pointer-events-none scale-95 opacity-0',
+        className
+      )}
+    >
+      <ArrowDown className="size-4" aria-hidden />
+    </button>
+  );
+}

--- a/packages/@granit/react-ai-chat/src/hooks/use-stick-to-bottom.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-stick-to-bottom.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { RefObject } from 'react';
+
+export interface UseStickToBottomOptions {
+  /**
+   * Distance (px) from the bottom within which the view counts as "at bottom".
+   * A small slack absorbs sub-pixel rounding and the last line's leading.
+   */
+  readonly threshold?: number;
+}
+
+export interface UseStickToBottomReturn<S extends HTMLElement, C extends HTMLElement> {
+  /** Attach to the scroll container (the element with `overflow-y: auto`). */
+  readonly scrollRef: RefObject<S | null>;
+  /** Attach to the growing content wrapper inside the scroll container. */
+  readonly contentRef: RefObject<C | null>;
+  /** Whether the view is currently pinned to (near) the bottom. */
+  readonly isAtBottom: boolean;
+  /** Scroll the container to the bottom and re-engage auto-stick. */
+  readonly scrollToBottom: (behavior?: ScrollBehavior) => void;
+}
+
+const DEFAULT_THRESHOLD = 32;
+
+/**
+ * Headless stick-to-bottom for a scroll container the host owns. Tracks whether
+ * the view is at the bottom and, while it is, keeps it pinned as the content
+ * grows (the streaming case). Attach {@link UseStickToBottomReturn.scrollRef} to
+ * the scroller and {@link UseStickToBottomReturn.contentRef} to the content
+ * wrapper; render a button on `!isAtBottom` that calls `scrollToBottom`.
+ *
+ * Dependency-free: a scroll listener computes `isAtBottom`, and a
+ * `ResizeObserver` (when available) re-pins on content growth. Both degrade
+ * gracefully where the platform lacks them.
+ */
+export function useStickToBottom<
+  S extends HTMLElement = HTMLDivElement,
+  C extends HTMLElement = HTMLDivElement,
+>({ threshold = DEFAULT_THRESHOLD }: UseStickToBottomOptions = {}): UseStickToBottomReturn<S, C> {
+  const scrollRef = useRef<S | null>(null);
+  const contentRef = useRef<C | null>(null);
+  // Mirrors `isAtBottom` for observers/listeners that must read the latest value
+  // without re-subscribing on every change.
+  const stickRef = useRef(true);
+  const [isAtBottom, setIsAtBottom] = useState(true);
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    const el = scrollRef.current;
+    if (!el) return;
+    stickRef.current = true;
+    setIsAtBottom(true);
+    if (typeof el.scrollTo === 'function') {
+      el.scrollTo({ top: el.scrollHeight, behavior });
+    } else {
+      // jsdom / very old engines have no Element.scrollTo.
+      el.scrollTop = el.scrollHeight;
+    }
+  }, []);
+
+  const update = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+    const atBottom = distance <= threshold;
+    stickRef.current = atBottom;
+    setIsAtBottom(atBottom);
+  }, [threshold]);
+
+  // Track the user's scroll position.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return undefined;
+    el.addEventListener('scroll', update, { passive: true });
+    update();
+    return () => el.removeEventListener('scroll', update);
+  }, [update]);
+
+  // Re-pin to the bottom as the content grows, but only while already pinned —
+  // a user who scrolled up is left where they are.
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content || typeof ResizeObserver === 'undefined') return undefined;
+    const observer = new ResizeObserver(() => {
+      if (stickRef.current) scrollToBottom('auto');
+    });
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [scrollToBottom]);
+
+  // Start pinned to the latest message on mount.
+  useEffect(() => {
+    scrollToBottom('auto');
+  }, [scrollToBottom]);
+
+  return { scrollRef, contentRef, isAtBottom, scrollToBottom };
+}

--- a/packages/@granit/react-ai-chat/src/index.ts
+++ b/packages/@granit/react-ai-chat/src/index.ts
@@ -38,11 +38,19 @@ export type {
   UseChatStreamReturn,
 } from './hooks/use-chat-stream';
 
+// Hooks — scrolling
+export { useStickToBottom } from './hooks/use-stick-to-bottom';
+export type { UseStickToBottomOptions, UseStickToBottomReturn } from './hooks/use-stick-to-bottom';
+
 // Components
 export { ChatMessage } from './components/chat-message';
 export type { ChatMessageProps } from './components/chat-message';
 export { ConversationThread } from './components/conversation-thread';
 export type { ConversationThreadProps } from './components/conversation-thread';
+export { ConversationScrollArea } from './components/conversation-scroll-area';
+export type { ConversationScrollAreaProps } from './components/conversation-scroll-area';
+export { ScrollToBottomButton } from './components/scroll-to-bottom-button';
+export type { ScrollToBottomButtonProps } from './components/scroll-to-bottom-button';
 export { SuggestedActions } from './components/suggested-actions';
 export type { SuggestedActionsProps } from './components/suggested-actions';
 export { ClarificationPrompt } from './components/clarification-prompt';

--- a/packages/@granit/react-ai-chat/src/locales/en.ts
+++ b/packages/@granit/react-ai-chat/src/locales/en.ts
@@ -5,6 +5,8 @@ export interface ChatTranslations {
     readonly You: string;
     readonly Assistant: string;
     readonly AssistantTyping: string;
+    /** Accessible label for the scroll-to-latest button. */
+    readonly ScrollToLatest?: string;
   };
   readonly Composer: {
     readonly Placeholder: string;
@@ -54,6 +56,7 @@ export const aiChatTranslationsEn: ChatTranslations = {
     You: 'You',
     Assistant: 'Assistant',
     AssistantTyping: 'Assistant is typing…',
+    ScrollToLatest: 'Scroll to latest',
   },
   Composer: {
     Placeholder: 'Ask your app… ( / for prompts, @ to mention )',

--- a/packages/@granit/react-ai-chat/src/locales/fr.ts
+++ b/packages/@granit/react-ai-chat/src/locales/fr.ts
@@ -6,6 +6,7 @@ export const aiChatTranslationsFr: ChatTranslations = {
     You: 'Vous',
     Assistant: 'Assistant',
     AssistantTyping: 'L’assistant écrit…',
+    ScrollToLatest: 'Aller au dernier message',
   },
   Composer: {
     Placeholder: 'Interrogez votre application… ( / pour les prompts, @ pour mentionner )',


### PR DESCRIPTION
## Context

Inspired by [prompt-kit's ScrollButton](https://www.prompt-kit.com/docs/scroll-button): a long or streaming conversation pushes the latest message out of view once the user scrolls up, and there's no quick way back down.

prompt-kit's component is thin — the work lives in the third-party `use-stick-to-bottom` package plus a `ChatContainer` that **owns the scroll container**. Adopting that would (a) add a runtime dependency for ~30 lines, (b) pull in shadcn `Button` + CVA we don't use, and (c) **invert** our deliberately-headless `ConversationThread` (the host owns layout/scroll) — a breaking change for consumers. So this implements the same UX the Granit way: headless building blocks + an opt-in container, no new dependency.

## What's added (all `@granit/react-ai-chat`)

- **`useStickToBottom()`** — headless hook returning `{ scrollRef, contentRef, isAtBottom, scrollToBottom }`. A scroll listener tracks `isAtBottom` (with a small threshold); a `ResizeObserver` re-pins to the bottom as content grows **only while already pinned** (the streaming case) — a user who scrolled up is left in place. Both `ResizeObserver` and `Element.scrollTo` are feature-detected, so it degrades gracefully. No runtime dependency.
- **`ScrollToBottomButton`** — circular, controlled, presentational (lucide `ArrowDown`, semantic tokens, `data-slot="scroll-to-bottom"`). Pass `visible` + `onClick`. Stays mounted to animate, and is removed from the tab order + a11y tree (`tabIndex=-1`, `aria-hidden`) while hidden.
- **`ConversationScrollArea`** — opt-in batteries-included container that owns the scroller and wires the hook + button + content anchor. `ConversationThread` **stays headless**; apps that own their own scroller use the hook directly.

```tsx
// Batteries-included
<ConversationScrollArea className="flex-1">
  <ConversationThread messages={messages} isStreaming={isStreaming} streamingContent={content} />
</ConversationScrollArea>

// Or wire your own scroller
const { scrollRef, contentRef, isAtBottom, scrollToBottom } = useStickToBottom();
```

## i18n
New **optional** `Thread.ScrollToLatest` key (en: "Scroll to latest", fr: "Aller au dernier message"). Optional → backward-compatible for apps supplying their own `Thread` labels.

## Tests & DoD
- Hook: `isAtBottom` flips on scroll away/back; `scrollToBottom` moves the viewport + re-engages stick.
- Button: interactive/labelled when visible; removed from tab order + a11y tree when not.
- Container: renders children in a scroll viewport with the overlay button.
- `pnpm -F @granit/react-ai-chat build && test` ✓ (57) · ESLint `--max-warnings 0` ✓ · `tsc --noEmit` ✓ · Prettier ✓

## API stability
Additive only — new hook, two new components, and an optional locale key. No renames/removals; `ConversationThread` unchanged.