### PR TITLE
feat(ai-chat,react-ai-chat): handle chat stream errors (quota / server)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2944,6 +2944,22 @@
           "members": []
         },
         {
+          "name": "SystemMessage",
+          "kind": "function",
+          "signature": "function SystemMessage("
+        },
+        {
+          "name": "SystemMessageProps",
+          "kind": "interface",
+          "signature": "interface SystemMessageProps",
+          "members": []
+        },
+        {
+          "name": "SystemMessageVariant",
+          "kind": "type",
+          "signature": "type SystemMessageVariant = 'error' | 'info'"
+        },
+        {
           "name": "SuggestedActions",
           "kind": "function",
           "signature": "function SuggestedActions("

--- a/contracts/openapi/ai-chat.json
+++ b/contracts/openapi/ai-chat.json
@@ -670,6 +670,9 @@
           },
           "succeeded": {
             "type": ["null", "boolean"]
+          },
+          "code": {
+            "type": ["null", "string"]
           }
         }
       },

--- a/packages/@granit/ai-chat/src/index.ts
+++ b/packages/@granit/ai-chat/src/index.ts
@@ -2,6 +2,7 @@
 export type {
   AttachmentRequest,
   ChatMessageRole,
+  ChatStreamErrorCode,
   ChatStreamEvent,
   ChatStreamEventType,
   ChatWorkspacesResponse,
@@ -25,6 +26,7 @@ export type {
 // Constants
 export {
   AUTO_WORKSPACE,
+  CHAT_STREAM_ERROR_CODES,
   CHAT_STREAM_EVENT_TYPES,
   CONVERSATION_TITLE_MAX_LENGTH,
   MESSAGE_REPORT_CATEGORIES,

--- a/packages/@granit/ai-chat/src/types/index.ts
+++ b/packages/@granit/ai-chat/src/types/index.ts
@@ -50,11 +50,36 @@ export const CHAT_STREAM_EVENT_TYPES = {
   SUGGESTIONS: 'suggestions',
   /** The turn is blocked on a clarifying question. */
   CLARIFICATION: 'clarification',
+  /**
+   * Terminal failure frame — the agent failed *after* the stream was committed
+   * (pre-stream failures still come back as an HTTP problem, never this frame).
+   * Carries a machine `code` (see {@link CHAT_STREAM_ERROR_CODES}); the answer so
+   * far may be partial. A client-cancelled turn emits no error frame.
+   */
+  ERROR: 'error',
 } as const;
 
 /** Discriminator union for {@link ChatStreamEvent.type}. */
 export type ChatStreamEventType =
   (typeof CHAT_STREAM_EVENT_TYPES)[keyof typeof CHAT_STREAM_EVENT_TYPES];
+
+/**
+ * Stable machine codes carried by an `error` {@link ChatStreamEvent}. Map these
+ * to a localized message front-side — never display the backend text (none is
+ * sent). The set is closed and mirrors `ChatSendEndpoints` on the backend.
+ */
+export const CHAT_STREAM_ERROR_CODES = {
+  /** Quota / rate limit exhausted (provider or denial-of-wallet guard). */
+  RATE_LIMIT: 'rate_limit',
+  /** Provider unreachable — a 5xx, a timeout, or a transport fault. */
+  PROVIDER_UNAVAILABLE: 'provider_unavailable',
+  /** Any other unclassified server-side failure. */
+  SERVER_ERROR: 'server_error',
+} as const;
+
+/** A code value carried by an `error` frame. @see CHAT_STREAM_ERROR_CODES */
+export type ChatStreamErrorCode =
+  (typeof CHAT_STREAM_ERROR_CODES)[keyof typeof CHAT_STREAM_ERROR_CODES];
 
 /** Role of a persisted chat message. */
 export type ChatMessageRole = 'user' | 'assistant' | 'system';
@@ -181,6 +206,11 @@ export interface ChatStreamEvent {
   readonly toolCallId?: string | null;
   /** Whether the tool succeeded. Present only on `tool_result` frames. */
   readonly succeeded?: boolean | null;
+  /**
+   * Machine error code. Present only on the terminal `error` frame; one of
+   * {@link CHAT_STREAM_ERROR_CODES}. Carries no human text — localize from it.
+   */
+  readonly code?: string | null;
 }
 
 // -- Conversation CRUD -------------------------------------------------------

--- a/packages/@granit/react-ai-chat/src/__tests__/error-handling.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/error-handling.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ConversationThread } from '../components/conversation-thread';
+import { SystemMessage } from '../components/system-message';
+
+describe('SystemMessage', () => {
+  it('announces an error assertively and renders an action slot', async () => {
+    const onClick = vi.fn();
+    const { container } = render(
+      <SystemMessage
+        variant="error"
+        action={
+          <button type="button" onClick={onClick}>
+            Retry
+          </button>
+        }
+      >
+        Something went wrong.
+      </SystemMessage>
+    );
+
+    const notice = container.querySelector('[data-slot="system-message"]');
+    expect(notice).toHaveAttribute('data-variant', 'error');
+    expect(notice).toHaveAttribute('role', 'alert');
+    expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders info as a polite status', () => {
+    const { container } = render(<SystemMessage>Heads up.</SystemMessage>);
+    const notice = container.querySelector('[data-slot="system-message"]');
+    expect(notice).toHaveAttribute('data-variant', 'info');
+    expect(notice).toHaveAttribute('role', 'status');
+  });
+});
+
+describe('ConversationThread error notice', () => {
+  it('renders a localized error message + retry for an errorKind', async () => {
+    const onRetry = vi.fn();
+    const { container } = render(
+      <ConversationThread messages={[]} errorKind="rate-limit" onRetry={onRetry} />
+    );
+
+    const notice = container.querySelector('[data-slot="system-message"][data-variant="error"]');
+    expect(notice).toBeInTheDocument();
+    expect(notice).toHaveTextContent(/rate limit/i);
+
+    await userEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    // An error is not the empty state.
+    expect(container.querySelector('[data-slot="thread-empty"]')).not.toBeInTheDocument();
+  });
+
+  it('omits the retry button when onRetry is not supplied', () => {
+    const { container } = render(<ConversationThread messages={[]} errorKind="server" />);
+    expect(container.querySelector('[data-slot="system-message"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="thread-retry"]')).not.toBeInTheDocument();
+  });
+
+  it('renders no error notice when errorKind is null', () => {
+    const { container } = render(<ConversationThread messages={[]} errorKind={null} />);
+    expect(container.querySelector('[data-slot="system-message"]')).not.toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ai-chat/src/__tests__/use-chat-stream.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/use-chat-stream.test.tsx
@@ -205,4 +205,65 @@ describe('useChatStream', () => {
     expect(result.current.error?.message).toContain('403');
     expect(result.current.isStreaming).toBe(false);
   });
+
+  it('classifies a 429 pre-stream failure as rate-limit', async () => {
+    const client = createMockClient();
+    vi.spyOn(client, 'post').mockRejectedValue(
+      Object.assign(new Error('Too Many Requests'), { response: { status: 429 } })
+    );
+
+    const { result } = renderHook(() => useChatStream(), { wrapper: createWrapper(client) });
+    act(() => {
+      result.current.send({ message: 'Hi' });
+    });
+
+    await waitFor(() => expect(result.current.errorKind).toBe('rate-limit'));
+  });
+
+  it('classifies a response-less failure as a network error', async () => {
+    const client = createMockClient();
+    vi.spyOn(client, 'post').mockRejectedValue(new Error('Network Error'));
+
+    const { result } = renderHook(() => useChatStream(), { wrapper: createWrapper(client) });
+    act(() => {
+      result.current.send({ message: 'Hi' });
+    });
+
+    await waitFor(() => expect(result.current.errorKind).toBe('network'));
+  });
+
+  it('surfaces a terminal mid-stream error frame and keeps the partial answer', async () => {
+    const client = createMockClient();
+    const stream = createSSEStream([
+      `data: {"type":"conversation","conversationId":"${CONV_ID}"}\n\n`,
+      'data: {"type":"delta","content":"Partial"}\n\n',
+      'data: {"type":"error","code":"rate_limit"}\n\n',
+    ]);
+    vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
+
+    const { result } = renderHook(() => useChatStream(), { wrapper: createWrapper(client) });
+    act(() => {
+      result.current.send({ message: 'Hi' });
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+    expect(result.current.errorKind).toBe('rate-limit');
+    expect(result.current.error).not.toBeNull();
+    // The answer streamed before the failure stays rendered.
+    expect(result.current.content).toBe('Partial');
+    expect(result.current.isThinking).toBe(false);
+  });
+
+  it('maps a provider_unavailable error frame to the server kind', async () => {
+    const client = createMockClient();
+    const stream = createSSEStream(['data: {"type":"error","code":"provider_unavailable"}\n\n']);
+    vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
+
+    const { result } = renderHook(() => useChatStream(), { wrapper: createWrapper(client) });
+    act(() => {
+      result.current.send({ message: 'Hi' });
+    });
+
+    await waitFor(() => expect(result.current.errorKind).toBe('server'));
+  });
 });

--- a/packages/@granit/react-ai-chat/src/components/conversation-thread.tsx
+++ b/packages/@granit/react-ai-chat/src/components/conversation-thread.tsx
@@ -1,14 +1,30 @@
 import { cn } from '@granit/utils';
 
-import { defaultChatLabels } from '../locales/index';
+import { defaultChatLabels, defaultErrorLabels } from '../locales/index';
 
 import { ChatMessage } from './chat-message';
+import { SystemMessage } from './system-message';
 import { ToolActivity } from './tool-activity';
 
-import type { ToolCallActivity } from '../hooks/use-chat-stream';
+import type { ChatErrorKind, ToolCallActivity } from '../hooks/use-chat-stream';
 import type { ChatTranslations } from '../locales/index';
 import type { MessageResponse } from '@granit/ai-chat';
 import type { ReactNode } from 'react';
+
+/** Resolve the user-facing message for an error kind, falling back to English. */
+function errorMessage(kind: ChatErrorKind, labels: ChatTranslations['Errors']): string {
+  const e = labels ?? defaultErrorLabels;
+  switch (kind) {
+    case 'rate-limit':
+      return e.RateLimit;
+    case 'server':
+      return e.Server;
+    case 'network':
+      return e.Network;
+    default:
+      return e.Unknown;
+  }
+}
 
 export interface ConversationThreadProps {
   /** Persisted messages, oldest first. */
@@ -33,8 +49,18 @@ export interface ConversationThreadProps {
    * indicator, whose content is not yet finalised.
    */
   readonly renderMessageActions?: (message: MessageResponse, index: number) => ReactNode;
+  /**
+   * The classified failure of the current turn (`useChatStream().errorKind`).
+   * When set, a {@link SystemMessage} is rendered after the messages with a
+   * localized message and, if {@link onRetry} is given, a retry button.
+   */
+  readonly errorKind?: ChatErrorKind | null;
+  /** Invoked by the error notice's retry button; omit to hide it. */
+  readonly onRetry?: () => void;
   readonly labels?: ChatTranslations['Thread'];
   readonly toolLabels?: ChatTranslations['Tools'];
+  /** Localized error copy; defaults to the bundled English strings. */
+  readonly errorLabels?: ChatTranslations['Errors'];
   readonly className?: string;
 }
 
@@ -53,11 +79,14 @@ export function ConversationThread({
   isThinking = false,
   resolveToolLabel,
   renderMessageActions,
+  errorKind,
+  onRetry,
   labels = defaultChatLabels.Thread,
   toolLabels = defaultChatLabels.Tools,
+  errorLabels = defaultChatLabels.Errors,
   className,
 }: Readonly<ConversationThreadProps>) {
-  const isEmpty = messages.length === 0 && !streamingContent && !isStreaming;
+  const isEmpty = messages.length === 0 && !streamingContent && !isStreaming && !errorKind;
   const hasToolActivity = toolCalls.length > 0 || isThinking;
 
   return (
@@ -113,6 +142,26 @@ export function ConversationThread({
             aria-hidden
           />
         </div>
+      ) : null}
+
+      {errorKind ? (
+        <SystemMessage
+          variant="error"
+          action={
+            onRetry ? (
+              <button
+                type="button"
+                data-slot="thread-retry"
+                onClick={onRetry}
+                className="hover:bg-destructive/10 rounded-md px-2 py-1 text-xs font-medium underline-offset-2 hover:underline"
+              >
+                {errorLabels?.Retry ?? defaultErrorLabels.Retry}
+              </button>
+            ) : null
+          }
+        >
+          {errorMessage(errorKind, errorLabels)}
+        </SystemMessage>
       ) : null}
     </div>
   );

--- a/packages/@granit/react-ai-chat/src/components/system-message.tsx
+++ b/packages/@granit/react-ai-chat/src/components/system-message.tsx
@@ -1,0 +1,51 @@
+import { cn } from '@granit/utils';
+import { CircleAlert, Info } from 'lucide-react';
+
+import type { ReactNode } from 'react';
+
+export type SystemMessageVariant = 'error' | 'info';
+
+export interface SystemMessageProps {
+  /** Visual + semantic tone. `error` announces assertively; defaults to `info`. */
+  readonly variant?: SystemMessageVariant;
+  /** The notice text (or richer node). */
+  readonly children: ReactNode;
+  /** Optional trailing affordance, e.g. a retry button. */
+  readonly action?: ReactNode;
+  readonly className?: string;
+}
+
+const VARIANT_ICON = { error: CircleAlert, info: Info } as const;
+
+/**
+ * A non-conversational notice rendered inline in the thread — a stream failure,
+ * a quota message, or any system info. Presentational and headless of meaning:
+ * the host supplies the text (e.g. localized from a `ChatErrorKind`). `error`
+ * is announced as an `alert`, `info` as a polite `status`.
+ */
+export function SystemMessage({
+  variant = 'info',
+  children,
+  action,
+  className,
+}: Readonly<SystemMessageProps>) {
+  const Icon = VARIANT_ICON[variant];
+  return (
+    <div
+      data-slot="system-message"
+      data-variant={variant}
+      role={variant === 'error' ? 'alert' : 'status'}
+      className={cn(
+        'flex items-center gap-2 rounded-lg border px-3 py-2 text-sm',
+        variant === 'error'
+          ? 'border-destructive/30 bg-destructive/10 text-destructive'
+          : 'border-border bg-muted/50 text-muted-foreground',
+        className
+      )}
+    >
+      <Icon className="size-4 shrink-0" aria-hidden />
+      <span className="flex-1">{children}</span>
+      {action ? <span className="shrink-0">{action}</span> : null}
+    </div>
+  );
+}

--- a/packages/@granit/react-ai-chat/src/hooks/use-chat-stream.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-chat-stream.ts
@@ -1,4 +1,8 @@
-import { CHAT_STREAM_EVENT_TYPES, streamConversationMessage } from '@granit/ai-chat';
+import {
+  CHAT_STREAM_ERROR_CODES,
+  CHAT_STREAM_EVENT_TYPES,
+  streamConversationMessage,
+} from '@granit/ai-chat';
 import { createLogger } from '@granit/logger';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -21,6 +25,45 @@ import type {
 export interface ChatStreamUsage {
   readonly inputTokens: number;
   readonly outputTokens: number;
+}
+
+/**
+ * The kind of a failed turn, for picking a user-facing message:
+ * - `rate-limit` — quota / rate limit hit (HTTP 429 or an `error` frame with
+ *   `rate_limit`); typically "try again shortly".
+ * - `server` — a server/provider failure (HTTP 5xx, or an `error` frame with
+ *   `provider_unavailable` / `server_error`).
+ * - `network` — the request never reached the server (offline, transport fault).
+ * - `unknown` — anything else.
+ */
+export type ChatErrorKind = 'rate-limit' | 'server' | 'network' | 'unknown';
+
+/** Map an `error`-frame {@link CHAT_STREAM_ERROR_CODES} code to a {@link ChatErrorKind}. */
+function codeToErrorKind(code: string | null | undefined): ChatErrorKind {
+  switch (code) {
+    case CHAT_STREAM_ERROR_CODES.RATE_LIMIT:
+      return 'rate-limit';
+    case CHAT_STREAM_ERROR_CODES.PROVIDER_UNAVAILABLE:
+    case CHAT_STREAM_ERROR_CODES.SERVER_ERROR:
+      return 'server';
+    default:
+      return 'unknown';
+  }
+}
+
+/**
+ * Classify a thrown stream error (pre-stream HTTP problem or transport fault)
+ * without an Axios import: read the HTTP status when present, else treat the
+ * absence of a response as a network failure.
+ */
+function classifyThrownError(err: unknown): ChatErrorKind {
+  const status = (err as { response?: { status?: number } })?.response?.status;
+  if (typeof status === 'number') {
+    if (status === 429) return 'rate-limit';
+    if (status >= 500) return 'server';
+    return 'unknown';
+  }
+  return 'network';
 }
 
 /** Lifecycle of a single tool invocation within a turn. */
@@ -76,6 +119,12 @@ export interface UseChatStreamReturn {
   readonly isStreaming: boolean;
   /** Error from the last stream attempt, or `null`. */
   readonly error: Error | null;
+  /**
+   * Classified kind of the last error, or `null`. Covers both a pre-stream HTTP
+   * problem / transport fault and a terminal mid-stream `error` frame. Use it to
+   * pick a user-facing message (e.g. via `ConversationThread`'s `errorKind`).
+   */
+  readonly errorKind: ChatErrorKind | null;
   /** Start a new turn. Aborts any in-progress stream first. */
   readonly send: (request: SendMessageRequest) => void;
   /** Abort the current stream (stop button / unmount). */
@@ -112,6 +161,7 @@ export function useChatStream(): UseChatStreamReturn {
   const [usage, setUsage] = useState<ChatStreamUsage | null>(null);
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const [errorKind, setErrorKind] = useState<ChatErrorKind | null>(null);
 
   const abortRef = useRef<AbortController | null>(null);
 
@@ -137,12 +187,19 @@ export function useChatStream(): UseChatStreamReturn {
       setIsThinking(false);
       setUsage(null);
       setError(null);
+      setErrorKind(null);
       setIsStreaming(true);
 
       const controller = new AbortController();
       abortRef.current = controller;
 
-      const turn: TurnState = { accumulated: '', tools: [], thinking: false, resolvedId: null };
+      const turn: TurnState = {
+        accumulated: '',
+        tools: [],
+        thinking: false,
+        resolvedId: null,
+        errorCode: null,
+      };
       const sinks = createEventSinks(turn, {
         setContent,
         setConversationId,
@@ -151,6 +208,8 @@ export function useChatStream(): UseChatStreamReturn {
         setUsage,
         setToolCalls,
         setIsThinking,
+        setError,
+        setErrorKind,
       });
 
       void (async () => {
@@ -178,6 +237,7 @@ export function useChatStream(): UseChatStreamReturn {
           if (err instanceof DOMException && err.name === 'AbortError') return;
           logger.error('Chat stream turn failed', err, { conversationId: turn.resolvedId });
           setError(err instanceof Error ? err : new Error(String(err)));
+          setErrorKind(classifyThrownError(err));
         } finally {
           setIsStreaming(false);
           abortRef.current = null;
@@ -197,6 +257,7 @@ export function useChatStream(): UseChatStreamReturn {
     usage,
     isStreaming,
     error,
+    errorKind,
     send,
     abort,
   };
@@ -212,6 +273,7 @@ interface EventSinks {
   readonly startToolCall: (toolCallId: string, toolName: string) => void;
   readonly resolveToolCall: (toolCallId: string, succeeded: boolean) => void;
   readonly setThinking: (thinking: boolean) => void;
+  readonly fail: (code: string | null | undefined) => void;
 }
 
 /** Mutable accumulators for a single streaming turn, threaded through {@link createEventSinks}. */
@@ -220,6 +282,7 @@ interface TurnState {
   tools: readonly ToolCallActivity[];
   thinking: boolean;
   resolvedId: ConversationId | null;
+  errorCode: string | null;
 }
 
 /** React state setters the sinks dispatch to. */
@@ -231,6 +294,8 @@ interface EventSinkSetters {
   readonly setUsage: (usage: ChatStreamUsage) => void;
   readonly setToolCalls: (tools: readonly ToolCallActivity[]) => void;
   readonly setIsThinking: (thinking: boolean) => void;
+  readonly setError: (error: Error | null) => void;
+  readonly setErrorKind: (kind: ChatErrorKind | null) => void;
 }
 
 /**
@@ -267,6 +332,11 @@ function createEventSinks(turn: TurnState, setters: EventSinkSetters): EventSink
         turn.thinking = next;
         setters.setIsThinking(next);
       }
+    },
+    fail: (code) => {
+      turn.errorCode = code ?? CHAT_STREAM_ERROR_CODES.SERVER_ERROR;
+      setters.setError(new Error(`Chat stream failed: ${turn.errorCode}`));
+      setters.setErrorKind(codeToErrorKind(turn.errorCode));
     },
   };
 }
@@ -305,6 +375,13 @@ function applyEvent(event: ChatStreamEvent, sinks: EventSinks): void {
         inputTokens: event.inputTokens ?? 0,
         outputTokens: event.outputTokens ?? 0,
       });
+      break;
+    case CHAT_STREAM_EVENT_TYPES.ERROR:
+      // Terminal failure after the stream committed — record it; the answer so
+      // far stays rendered as a partial bubble. Resolving "thinking" avoids a
+      // dangling indicator if the agent failed between steps.
+      sinks.setThinking(false);
+      sinks.fail(event.code);
       break;
   }
 }

--- a/packages/@granit/react-ai-chat/src/index.ts
+++ b/packages/@granit/react-ai-chat/src/index.ts
@@ -32,6 +32,7 @@ export type { MessageReportCategory, ReportMessageRequest } from '@granit/ai-cha
 // Hooks — streaming
 export { useChatStream } from './hooks/use-chat-stream';
 export type {
+  ChatErrorKind,
   ChatStreamUsage,
   ToolCallActivity,
   ToolCallStatus,
@@ -43,6 +44,8 @@ export { ChatMessage } from './components/chat-message';
 export type { ChatMessageProps } from './components/chat-message';
 export { ConversationThread } from './components/conversation-thread';
 export type { ConversationThreadProps } from './components/conversation-thread';
+export { SystemMessage } from './components/system-message';
+export type { SystemMessageProps, SystemMessageVariant } from './components/system-message';
 export { SuggestedActions } from './components/suggested-actions';
 export type { SuggestedActionsProps } from './components/suggested-actions';
 export { ClarificationPrompt } from './components/clarification-prompt';

--- a/packages/@granit/react-ai-chat/src/locales/en.ts
+++ b/packages/@granit/react-ai-chat/src/locales/en.ts
@@ -46,7 +46,29 @@ export interface ChatTranslations {
     readonly NoResults: string;
     readonly Loading: string;
   };
+  /** User-facing messages for a failed turn, keyed by {@link ChatErrorKind}. */
+  readonly Errors?: {
+    readonly RateLimit: string;
+    readonly Server: string;
+    readonly Network: string;
+    readonly Unknown: string;
+    /** Label for the retry affordance. */
+    readonly Retry: string;
+  };
 }
+
+/**
+ * English error copy, also the guaranteed fallback when an app supplies its own
+ * (optional) `Errors` translations but omits a key — `SystemMessage` rendering
+ * always has a message to show.
+ */
+export const defaultErrorLabels = {
+  RateLimit: 'You’ve reached the rate limit. Please wait a moment and try again.',
+  Server: 'The assistant ran into a problem. Please try again.',
+  Network: 'Connection lost. Check your network and try again.',
+  Unknown: 'Something went wrong. Please try again.',
+  Retry: 'Retry',
+} as const;
 
 export const aiChatTranslationsEn: ChatTranslations = {
   Thread: {
@@ -89,4 +111,5 @@ export const aiChatTranslationsEn: ChatTranslations = {
     NoResults: 'No results',
     Loading: 'Searching…',
   },
+  Errors: defaultErrorLabels,
 };

--- a/packages/@granit/react-ai-chat/src/locales/fr.ts
+++ b/packages/@granit/react-ai-chat/src/locales/fr.ts
@@ -41,4 +41,11 @@ export const aiChatTranslationsFr: ChatTranslations = {
     NoResults: 'Aucun résultat',
     Loading: 'Recherche…',
   },
+  Errors: {
+    RateLimit: 'Vous avez atteint la limite de requêtes. Patientez un instant puis réessayez.',
+    Server: 'L’assistant a rencontré un problème. Veuillez réessayer.',
+    Network: 'Connexion perdue. Vérifiez votre réseau puis réessayez.',
+    Unknown: 'Une erreur est survenue. Veuillez réessayer.',
+    Retry: 'Réessayer',
+  },
 };

--- a/packages/@granit/react-ai-chat/src/locales/index.ts
+++ b/packages/@granit/react-ai-chat/src/locales/index.ts
@@ -1,4 +1,4 @@
-export { aiChatTranslationsEn } from './en';
+export { aiChatTranslationsEn, defaultErrorLabels } from './en';
 export { aiChatTranslationsFr } from './fr';
 export type { ChatTranslations } from './en';
 


### PR DESCRIPTION
## Summary

Front side of the chat error-handling work. Consumes the backend's terminal `error` SSE frame ([granit-dotnet#2807](https://github.com/granit-fx/granit-dotnet/pull/2807)) **and** classifies pre-stream failures, then renders a user-facing notice — so "out of credit / quota" and "server problem" stop showing up as a silently truncated answer.

**Before:** `useChatStream` exposed a raw `error: Error`, unclassified, and no component rendered it. A mid-stream failure ended the stream with no error at all.

## `@granit/ai-chat`
- New `error` event type + `CHAT_STREAM_ERROR_CODES` (`rate_limit` / `provider_unavailable` / `server_error`) + a `code` field on `ChatStreamEvent`.
- Vendored the regenerated `ai-chat` OpenAPI snapshot — **scoped to the `code` addition only** (the favorite contract from #697 is intentionally not pulled in here; the snapshots converge on develop once both land). Conformance green.

## `@granit/react-ai-chat`
- **`useChatStream().errorKind`**: `'rate-limit' | 'server' | 'network' | 'unknown' | null`, derived from
  - a **mid-stream** `error` frame (`code` → kind), keeping the partial answer rendered, and
  - a **pre-stream / transport** throw (HTTP 429 → `rate-limit`, 5xx → `server`, no response → `network`) — classified without an Axios import.
  - A client abort still yields no error.
- **`SystemMessage`**: presentational `error`/`info` notice (`role=alert`/`status`, semantic `destructive` tokens, `data-slot`, optional action slot). Reusable for any system text.
- **`ConversationThread`**: optional `errorKind` + `onRetry` (+ `errorLabels`) → renders a localized `SystemMessage` with a retry button. New optional `Errors` i18n group (en/fr) with a guaranteed English fallback (`defaultErrorLabels`), so an app that omits it still gets a message.

```tsx
const { errorKind, send } = useChatStream();
<ConversationThread
  messages={messages}
  errorKind={errorKind}
  onRetry={() => send(lastRequest)}
/>
```

## Tests & DoD
- Hook: 429 → `rate-limit`; no-response → `network`; mid-stream `error` frame → kind + partial answer retained + thinking cleared; `provider_unavailable` → `server`.
- `SystemMessage` roles/action; `ConversationThread` error notice + retry + not-empty-state + null cases.
- `pnpm -F @granit/ai-chat build && test` ✓ · `pnpm -F @granit/react-ai-chat build && test` ✓ · contract-tests ✓ — **590 passed** total · ESLint `--max-warnings 0` ✓ · `tsc` ✓ · Prettier ✓.

## Coordination & stability
- **Merge order: backend [#2807](https://github.com/granit-fx/granit-dotnet/pull/2807) first** — the vendored snapshot already reflects its `code` field.
- Additive only: new event type/codes/field, new `errorKind`, `SystemMessage`, optional `ConversationThread` props, optional `Errors` locale group. No renames/removals.