### PR TITLE
feat(ai,react-ai): mirror nullable ConversationId on AIUsageRecord

### DIFF
--- a/packages/@granit/ai/src/index.ts
+++ b/packages/@granit/ai/src/index.ts
@@ -22,6 +22,7 @@ export type {
   AIWorkspaceResponse,
   AIWorkspaceUpdateRequest,
   ChatStreamEvent,
+  ConversationId,
 } from './types/index';
 export { AI_CAPABILITY_EXTENSIONS, AI_STREAM_DONE_MARKER, AI_WORKSPACE_KINDS } from './types/index';
 

--- a/packages/@granit/ai/src/types/index.ts
+++ b/packages/@granit/ai/src/types/index.ts
@@ -186,6 +186,14 @@ export interface AIProviderModelResponse {
 /** Branded AI usage record identifier. */
 export type AIUsageRecordId = EntityId<'AIUsageRecord'>;
 
+/**
+ * Branded chat conversation identifier. Defined locally rather than imported
+ * from `@granit/ai-chat`: that package depends on `@granit/ai`, so importing
+ * back would create a dependency cycle. Brand matches `EntityId<'Conversation'>`
+ * used by `@granit/ai-chat`.
+ */
+export type ConversationId = EntityId<'Conversation'>;
+
 /** AI usage record for querying. Mirrors `Granit.AI.AIUsageRecord`. */
 export interface AIUsageRecord {
   readonly id: AIUsageRecordId;
@@ -200,4 +208,5 @@ export interface AIUsageRecord {
   readonly costCurrency: string | null;
   readonly timestamp: ISODateString;
   readonly duration: string | null;
+  readonly conversationId: ConversationId | null;
 }

--- a/packages/@granit/react-ai/src/testing/data.ts
+++ b/packages/@granit/react-ai/src/testing/data.ts
@@ -178,6 +178,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-20T09:15:00Z'),
     duration: '00:00:02.340',
+    conversationId: toEntityId<'Conversation'>('c0000000-0001-0001-0001-000000000001'),
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000002'),
@@ -192,6 +193,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-20T10:30:00Z'),
     duration: '00:00:01.870',
+    conversationId: null,
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000003'),
@@ -206,6 +208,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-20T11:45:00Z'),
     duration: '00:00:03.120',
+    conversationId: toEntityId<'Conversation'>('c0000000-0001-0001-0001-000000000003'),
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000004'),
@@ -220,6 +223,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-19T14:20:00Z'),
     duration: '00:00:05.450',
+    conversationId: toEntityId<'Conversation'>('c0000000-0001-0001-0001-000000000004'),
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000005'),
@@ -234,6 +238,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-19T16:00:00Z'),
     duration: '00:00:01.200',
+    conversationId: null,
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000006'),
@@ -248,6 +253,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-18T08:10:00Z'),
     duration: '00:00:01.540',
+    conversationId: toEntityId<'Conversation'>('c0000000-0001-0001-0001-000000000006'),
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000007'),
@@ -262,6 +268,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-18T13:30:00Z'),
     duration: '00:00:04.010',
+    conversationId: toEntityId<'Conversation'>('c0000000-0001-0001-0001-000000000007'),
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000008'),
@@ -276,6 +283,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: null,
     timestamp: toISODateString('2026-03-17T10:00:00Z'),
     duration: '00:00:06.780',
+    conversationId: null,
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000009'),
@@ -290,6 +298,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-21T08:05:00Z'),
     duration: '00:00:02.810',
+    conversationId: toEntityId<'Conversation'>('c0000000-0001-0001-0001-000000000009'),
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000010'),
@@ -304,6 +313,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-21T09:30:00Z'),
     duration: '00:00:07.120',
+    conversationId: toEntityId<'Conversation'>('c0000000-0001-0001-0001-000000000010'),
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000011'),
@@ -318,6 +328,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-21T10:15:00Z'),
     duration: '00:00:03.450',
+    conversationId: null,
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000012'),
@@ -332,6 +343,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-21T11:00:00Z'),
     duration: '00:00:01.670',
+    conversationId: toEntityId<'Conversation'>('c0000000-0001-0001-0001-000000000012'),
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000013'),
@@ -346,6 +358,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-21T13:20:00Z'),
     duration: '00:00:09.300',
+    conversationId: toEntityId<'Conversation'>('c0000000-0001-0001-0001-000000000013'),
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000014'),
@@ -360,6 +373,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-20T15:45:00Z'),
     duration: '00:00:02.560',
+    conversationId: null,
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000015'),
@@ -374,6 +388,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-20T16:30:00Z'),
     duration: '00:00:02.100',
+    conversationId: toEntityId<'Conversation'>('c0000000-0001-0001-0001-000000000015'),
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000016'),
@@ -388,6 +403,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: null,
     timestamp: toISODateString('2026-03-19T09:00:00Z'),
     duration: '00:00:08.900',
+    conversationId: null,
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000017'),
@@ -402,6 +418,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-19T11:30:00Z'),
     duration: '00:00:05.600',
+    conversationId: toEntityId<'Conversation'>('c0000000-0001-0001-0001-000000000017'),
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000018'),
@@ -416,6 +433,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-18T14:00:00Z'),
     duration: '00:00:06.340',
+    conversationId: toEntityId<'Conversation'>('c0000000-0001-0001-0001-000000000018'),
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000019'),
@@ -430,6 +448,7 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-18T15:20:00Z'),
     duration: '00:00:01.280',
+    conversationId: null,
   },
   {
     id: toEntityId<'AIUsageRecord'>('a1b2c3d4-0001-0001-0001-000000000020'),
@@ -444,5 +463,6 @@ export const mockUsageRecords: AIUsageRecord[] = [
     costCurrency: 'USD',
     timestamp: toISODateString('2026-03-17T16:45:00Z'),
     duration: '00:00:04.200',
+    conversationId: toEntityId<'Conversation'>('c0000000-0001-0001-0001-000000000020'),
   },
 ];

--- a/packages/@granit/react-ai/src/testing/handlers.ts
+++ b/packages/@granit/react-ai/src/testing/handlers.ts
@@ -142,6 +142,7 @@ function addUsageRecord(
     costCurrency,
     timestamp: toISODateString(new Date().toISOString()),
     duration,
+    conversationId: null,
   });
 }
 
@@ -233,6 +234,15 @@ function buildUsageMeta(): QueryMetadata {
         isFilterable: false,
         isVisible: true,
       },
+      {
+        name: 'conversationId',
+        label: 'Conversation',
+        type: 'String',
+        order: 10,
+        isSortable: false,
+        isFilterable: true,
+        isVisible: true,
+      },
     ],
     filterableFields: [
       { name: 'workspaceName', type: 'String', operators: ['Eq', 'Contains', 'In'] },
@@ -240,6 +250,7 @@ function buildUsageMeta(): QueryMetadata {
       { name: 'model', type: 'String', operators: ['Eq', 'In'] },
       { name: 'costCurrency', type: 'String', operators: ['Eq', 'In'] },
       { name: 'timestamp', type: 'DateTime', operators: ['Gte', 'Lte'] },
+      { name: 'conversationId', type: 'String', operators: ['Eq', 'In'] },
     ],
     sortableFields: [
       { name: 'timestamp' },
@@ -264,6 +275,7 @@ function buildUsageMeta(): QueryMetadata {
       { name: 'workspaceName', type: 'String' },
       { name: 'provider', type: 'String' },
       { name: 'model', type: 'String' },
+      { name: 'conversationId', type: 'String' },
     ],
     pagination: {
       defaultPageSize: 20,


### PR DESCRIPTION
## Context

Backend change merged in `granit-dotnet` (PR #2810, issue #2808): a nullable `ConversationId` (Guid) was added to `Granit.AI.AIUsageRecord`, exposed as a **filterable + group-by** column on the AI usage query/export surface. The front mirror type had drifted; this PR syncs it.

## Changes

**`@granit/ai`**
- Add `readonly conversationId: ConversationId | null` to the `AIUsageRecord` interface (after `duration`), mirroring `Granit.AI.AIUsageRecord`.
- Define `ConversationId` **locally** as `EntityId<'Conversation'>` (matching the brand `@granit/ai-chat` already uses) and export it from the barrel.
  - ⚠️ **Architecture**: importing `ConversationId` from `@granit/ai-chat` would create a dependency cycle — `ai-chat` depends on `@granit/ai`, not the reverse.

**`@granit/react-ai` (testing fixtures)**
- Add `conversationId` to the 20 mock usage records — a sparse mix of non-null and `null` to mirror the optional backend field.
- Add `conversationId: null` to the runtime `addUsageRecord` builder.
- Expose `conversationId` as a **filterable + group-by** column in the usage `/meta` metadata, mirroring the backend query surface.

`useAIUsage` is generic over the query engine, so the new column flows through query metadata with no hook changes.

## DoD
- ✅ `pnpm tsc` clean
- ✅ `eslint --max-warnings 0` clean
- ✅ Tests green (161 passed across `@granit/ai` + `@granit/react-ai`)
- No `.md` files changed