### PR TITLE
feat(react-ai-chat): per-message timing metrics chip (TTFT, total, tok/s, chunks)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2843,16 +2843,6 @@
       "description": "React bindings for @granit/ai-chat — AIChatProvider, useChatStream (SSE), conversation CRUD hooks, and headless chat UI (thread, composer with / and @ pickers, attachments, suggested actions, clarifications)",
       "exports": [
         {
-          "name": "AIChatProvider",
-          "kind": "function",
-          "signature": "function AIChatProvider("
-        },
-        {
-          "name": "useAIChatConfig",
-          "kind": "function",
-          "signature": "function useAIChatConfig(): ResolvedAIChatConfig"
-        },
-        {
           "name": "conversationKeys",
           "kind": "const",
           "signature": "const conversationKeys"
@@ -2968,6 +2958,17 @@
           "name": "ChatMessageProps",
           "kind": "interface",
           "signature": "interface ChatMessageProps",
+          "members": []
+        },
+        {
+          "name": "MessageMetrics",
+          "kind": "function",
+          "signature": "function MessageMetrics("
+        },
+        {
+          "name": "MessageMetricsProps",
+          "kind": "interface",
+          "signature": "interface MessageMetricsProps",
           "members": []
         },
         {

--- a/packages/@granit/react-ai-chat/src/__tests__/components.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/components.test.tsx
@@ -1,3 +1,4 @@
+import { createMockClient } from '@granit/testing';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
@@ -6,16 +7,32 @@ import { AttachmentChips } from '../components/attachment-chips';
 import { ChatMessage } from '../components/chat-message';
 import { ClarificationPrompt } from '../components/clarification-prompt';
 import { ConversationThread } from '../components/conversation-thread';
+import { MessageMetrics } from '../components/message-metrics';
 import { SuggestedActions } from '../components/suggested-actions';
 import { ToolActivity } from '../components/tool-activity';
+import { AIChatProvider } from '../providers/ai-chat-provider';
 
 import type { ComposerAttachment } from '../components/attachment-chips';
-import type { ToolCallActivity } from '../hooks/use-chat-stream';
+import type { ChatTurnMetrics, ToolCallActivity } from '../hooks/use-chat-stream';
 import type {
   ClarificationResponse,
   MessageResponse,
   SuggestedActionResponse,
 } from '@granit/ai-chat';
+import type { ReactNode } from 'react';
+
+const turnMetrics: ChatTurnMetrics = {
+  firstTokenMs: 40,
+  totalMs: 293,
+  tokensPerSecond: 177.5,
+  chunkCount: 51,
+};
+
+/** Render under an {@link AIChatProvider} with the metrics flag toggled. */
+function renderWithMetricsFlag(ui: ReactNode, showMessageMetrics: boolean) {
+  const client = createMockClient();
+  return render(<AIChatProvider config={{ client, showMessageMetrics }}>{ui}</AIChatProvider>);
+}
 
 const messages: MessageResponse[] = [
   {
@@ -234,5 +251,40 @@ describe('AttachmentChips', () => {
     expect(screen.getByText('2.0 KB')).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: /remove attachment report\.pdf/i }));
     expect(onRemove).toHaveBeenCalledWith('a1');
+  });
+});
+
+describe('MessageMetrics', () => {
+  it('shows the total on the chip and the full breakdown in the popover', () => {
+    render(<MessageMetrics metrics={turnMetrics} />);
+    expect(screen.getByRole('button', { name: 'Response timing' })).toHaveTextContent('293ms');
+    expect(screen.getByText('First token')).toBeInTheDocument();
+    expect(screen.getByText('40ms')).toBeInTheDocument();
+    expect(screen.getByText('177.5 tok/s')).toBeInTheDocument();
+    expect(screen.getByText('51')).toBeInTheDocument();
+  });
+
+  it('renders a placeholder when tokens/sec is not derivable', () => {
+    render(<MessageMetrics metrics={{ ...turnMetrics, tokensPerSecond: null }} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+});
+
+describe('ConversationThread — metrics chip', () => {
+  it('renders the chip on the latest assistant message when the flag is on', () => {
+    renderWithMetricsFlag(<ConversationThread messages={messages} metrics={turnMetrics} />, true);
+    const chips = screen.getAllByRole('button', { name: 'Response timing' });
+    expect(chips).toHaveLength(1);
+    expect(chips[0]).toHaveTextContent('293ms');
+  });
+
+  it('hides the chip when the provider flag is off', () => {
+    renderWithMetricsFlag(<ConversationThread messages={messages} metrics={turnMetrics} />, false);
+    expect(screen.queryByRole('button', { name: 'Response timing' })).not.toBeInTheDocument();
+  });
+
+  it('renders no chip when there are no metrics, even with the flag on', () => {
+    renderWithMetricsFlag(<ConversationThread messages={messages} />, true);
+    expect(screen.queryByRole('button', { name: 'Response timing' })).not.toBeInTheDocument();
   });
 });

--- a/packages/@granit/react-ai-chat/src/__tests__/use-chat-stream.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/use-chat-stream.test.tsx
@@ -266,4 +266,100 @@ describe('useChatStream', () => {
 
     await waitFor(() => expect(result.current.errorKind).toBe('server'));
   });
+
+  it('captures timing metrics for a turn that streams text', async () => {
+    // Monotonic clock so first-token < completion regardless of incidental
+    // performance.now() calls, keeping the derived rate strictly positive.
+    let clock = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => (clock += 50));
+    const client = createMockClient();
+    const stream = createSSEStream([
+      'data: {"type":"delta","content":"Hel"}\n\n',
+      'data: {"type":"delta","content":"lo"}\n\n',
+      'data: {"type":"usage","inputTokens":12,"outputTokens":8}\n\n',
+    ]);
+    vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
+
+    const { result } = renderHook(() => useChatStream(), { wrapper: createWrapper(client) });
+
+    act(() => {
+      result.current.send({ message: 'Hi' });
+    });
+
+    await waitFor(() => expect(result.current.metrics).not.toBeNull());
+
+    expect(result.current.metrics?.chunkCount).toBe(2);
+    expect(result.current.metrics?.firstTokenMs ?? 0).toBeGreaterThan(0);
+    expect(result.current.metrics?.totalMs ?? 0).toBeGreaterThan(
+      result.current.metrics?.firstTokenMs ?? 0
+    );
+    expect(result.current.metrics?.tokensPerSecond ?? 0).toBeGreaterThan(0);
+    expect(Number.isFinite(result.current.metrics?.tokensPerSecond)).toBe(true);
+  });
+
+  it('reports no tokens/sec when the turn has no usage frame', async () => {
+    let clock = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => (clock += 50));
+    const client = createMockClient();
+    const stream = createSSEStream(['data: {"type":"delta","content":"Hi"}\n\n']);
+    vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
+
+    const { result } = renderHook(() => useChatStream(), { wrapper: createWrapper(client) });
+
+    act(() => {
+      result.current.send({ message: 'Hi' });
+    });
+
+    await waitFor(() => expect(result.current.metrics).not.toBeNull());
+    expect(result.current.metrics?.chunkCount).toBe(1);
+    expect(result.current.metrics?.tokensPerSecond).toBeNull();
+  });
+
+  it('produces no metrics for a turn that streamed no text', async () => {
+    const client = createMockClient();
+    const stream = createSSEStream([
+      'data: {"type":"clarification","clarification":{"question":"Which one?","options":[{"label":"A","value":"a"}],"allowOther":false}}\n\n',
+    ]);
+    vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
+
+    const { result } = renderHook(() => useChatStream(), { wrapper: createWrapper(client) });
+
+    act(() => {
+      result.current.send({ message: 'x' });
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+    expect(result.current.clarification).not.toBeNull();
+    expect(result.current.metrics).toBeNull();
+  });
+
+  it('resets metrics on a new send()', async () => {
+    let clock = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => (clock += 50));
+    const client = createMockClient();
+    const first = createSSEStream([
+      'data: {"type":"delta","content":"A"}\n\n',
+      'data: {"type":"usage","inputTokens":1,"outputTokens":4}\n\n',
+    ]);
+    const second = createSSEStream(['data: {"type":"delta","content":"B"}\n\n']);
+    vi.spyOn(client, 'post')
+      .mockResolvedValueOnce({ data: first })
+      .mockResolvedValueOnce({ data: second });
+
+    const { result } = renderHook(() => useChatStream(), { wrapper: createWrapper(client) });
+
+    act(() => {
+      result.current.send({ message: 'A' });
+    });
+    await waitFor(() => expect(result.current.metrics?.tokensPerSecond ?? 0).toBeGreaterThan(0));
+
+    act(() => {
+      result.current.send({ message: 'B' });
+    });
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+    // The second turn carries no usage frame, so its metrics replace the first
+    // turn's rather than lingering.
+    expect(result.current.metrics?.chunkCount).toBe(1);
+    expect(result.current.metrics?.tokensPerSecond).toBeNull();
+  });
 });

--- a/packages/@granit/react-ai-chat/src/components/conversation-thread.tsx
+++ b/packages/@granit/react-ai-chat/src/components/conversation-thread.tsx
@@ -2,12 +2,14 @@ import { cn } from '@granit/utils';
 import { Loader2 } from 'lucide-react';
 
 import { defaultChatLabels, defaultErrorLabels } from '../locales/index';
+import { useOptionalAIChatConfig } from '../providers/ai-chat-provider';
 
 import { ChatMessage } from './chat-message';
+import { MessageMetrics } from './message-metrics';
 import { SystemMessage } from './system-message';
 import { ToolActivity } from './tool-activity';
 
-import type { ChatErrorKind, ToolCallActivity } from '../hooks/use-chat-stream';
+import type { ChatErrorKind, ChatTurnMetrics, ToolCallActivity } from '../hooks/use-chat-stream';
 import type { ChatTranslations } from '../locales/index';
 import type { MessageResponse } from '@granit/ai-chat';
 import type { ReactNode, Ref } from 'react';
@@ -70,10 +72,17 @@ export interface ConversationThreadProps {
   readonly errorKind?: ChatErrorKind | null;
   /** Invoked by the error notice's retry button; omit to hide it. */
   readonly onRetry?: () => void;
+  /**
+   * Client-side timing for the last completed turn (from `useChatStream().metrics`).
+   * Shown as a chip under the latest assistant message only when the provider's
+   * `showMessageMetrics` is enabled; ignored otherwise.
+   */
+  readonly metrics?: ChatTurnMetrics | null;
   readonly labels?: ChatTranslations['Thread'];
   readonly toolLabels?: ChatTranslations['Tools'];
   /** Localized error copy; defaults to the bundled English strings. */
   readonly errorLabels?: ChatTranslations['Errors'];
+  readonly metricsLabels?: ChatTranslations['Metrics'];
   readonly className?: string;
 }
 
@@ -97,15 +106,25 @@ export function ConversationThread({
   isLoadingOlder = false,
   errorKind,
   onRetry,
+  metrics,
   labels = defaultChatLabels.Thread,
   toolLabels = defaultChatLabels.Tools,
   errorLabels = defaultChatLabels.Errors,
+  metricsLabels = defaultChatLabels.Metrics,
   className,
 }: Readonly<ConversationThreadProps>) {
   const isEmpty = messages.length === 0 && !streamingContent && !isStreaming && !errorKind;
   const hasToolActivity = toolCalls.length > 0 || isThinking;
   // Render the scroll-up paging affordances only when the host opted in.
   const isPaged = topSentinelRef !== undefined || hasMoreOlder !== undefined;
+
+  // Per-message metrics are an opt-in (provider flag) and only meaningful once a
+  // turn has finished streaming. Attach the chip to the most recent assistant
+  // reply — the one the current `metrics` describes.
+  const showMetrics = (useOptionalAIChatConfig()?.showMessageMetrics ?? false) && metrics != null;
+  const lastAssistantIndex = showMetrics
+    ? messages.findLastIndex((message) => message.role === 'assistant')
+    : -1;
 
   return (
     <div
@@ -136,15 +155,29 @@ export function ConversationThread({
         </p>
       ) : null}
 
-      {messages.map((message, index) => (
-        <ChatMessage
-          key={message.id}
-          role={message.role}
-          content={message.content}
-          authorLabel={message.role === 'user' ? labels.You : labels.Assistant}
-          actions={renderMessageActions?.(message, index)}
-        />
-      ))}
+      {messages.map((message, index) => {
+        const hostActions = renderMessageActions?.(message, index);
+        const metricsChip =
+          showMetrics && metrics && index === lastAssistantIndex ? (
+            <MessageMetrics metrics={metrics} labels={metricsLabels} />
+          ) : null;
+        const actions =
+          hostActions || metricsChip ? (
+            <>
+              {hostActions}
+              {metricsChip}
+            </>
+          ) : undefined;
+        return (
+          <ChatMessage
+            key={message.id}
+            role={message.role}
+            content={message.content}
+            authorLabel={message.role === 'user' ? labels.You : labels.Assistant}
+            actions={actions}
+          />
+        );
+      })}
 
       {hasToolActivity ? (
         <ToolActivity

--- a/packages/@granit/react-ai-chat/src/components/message-metrics.tsx
+++ b/packages/@granit/react-ai-chat/src/components/message-metrics.tsx
@@ -1,0 +1,69 @@
+import { cn } from '@granit/utils';
+
+import { defaultChatLabels } from '../locales/index';
+
+import type { ChatTurnMetrics } from '../hooks/use-chat-stream';
+import type { ChatTranslations } from '../locales/index';
+
+export interface MessageMetricsProps {
+  /** Timing for the turn, from `useChatStream().metrics`. */
+  readonly metrics: ChatTurnMetrics;
+  readonly labels?: ChatTranslations['Metrics'];
+  readonly className?: string;
+}
+
+const formatMs = (ms: number): string => `${Math.round(ms)}ms`;
+
+const PLACEHOLDER = '—';
+
+/**
+ * A compact timing chip showing the turn's total duration, revealing the full
+ * breakdown (time-to-first-token, total, tokens/sec, chunk count) in a popover
+ * on hover or keyboard focus. Pure CSS disclosure — no popover library — to
+ * match the package's dependency-free chip style. The trigger is a real
+ * `<button>` so the breakdown is reachable by keyboard and screen readers.
+ */
+export function MessageMetrics({
+  metrics,
+  labels = defaultChatLabels.Metrics,
+  className,
+}: Readonly<MessageMetricsProps>) {
+  const { firstTokenMs, totalMs, tokensPerSecond, chunkCount } = metrics;
+  const rows: ReadonlyArray<{ readonly label: string; readonly value: string }> = [
+    { label: labels.FirstToken, value: formatMs(firstTokenMs) },
+    { label: labels.Total, value: formatMs(totalMs) },
+    {
+      label: labels.Speed,
+      value: tokensPerSecond === null ? PLACEHOLDER : `${tokensPerSecond.toFixed(1)} tok/s`,
+    },
+    { label: labels.Chunks, value: String(chunkCount) },
+  ];
+
+  return (
+    <span
+      data-slot="message-metrics"
+      className={cn('group/metrics relative inline-flex', className)}
+    >
+      <button
+        type="button"
+        data-slot="message-metrics-trigger"
+        aria-label={labels.Label}
+        className="text-muted-foreground hover:bg-muted hover:text-foreground rounded-md px-1.5 py-0.5 text-xs tabular-nums transition-colors"
+      >
+        {formatMs(totalMs)}
+      </button>
+      <span
+        role="tooltip"
+        data-slot="message-metrics-popover"
+        className="bg-popover text-popover-foreground border-border pointer-events-none absolute bottom-full left-0 z-10 mb-1 hidden w-max min-w-40 flex-col gap-1 rounded-md border p-2 text-xs shadow-md group-hover/metrics:flex group-focus-within/metrics:flex"
+      >
+        {rows.map((row) => (
+          <span key={row.label} className="flex items-center justify-between gap-4">
+            <span className="text-muted-foreground">{row.label}</span>
+            <span className="font-medium tabular-nums">{row.value}</span>
+          </span>
+        ))}
+      </span>
+    </span>
+  );
+}

--- a/packages/@granit/react-ai-chat/src/hooks/use-chat-stream.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-chat-stream.ts
@@ -71,6 +71,28 @@ function classifyThrownError(err: unknown): ChatErrorKind {
   return 'network';
 }
 
+/**
+ * Timing metrics for a completed turn, measured client-side from the stream.
+ * Transient — held only for the most recent turn and reset on each `send()`,
+ * never persisted with the message. Produced once a turn that streamed at least
+ * one `delta` frame completes; `null` before that (and for turns that ended
+ * with only a clarification, an error, or no text).
+ */
+export interface ChatTurnMetrics {
+  /** Time to first token (ms): from `send()` to the first content `delta`. */
+  readonly firstTokenMs: number;
+  /** Total turn duration (ms): from `send()` to stream completion. */
+  readonly totalMs: number;
+  /**
+   * Output tokens per second over the generation window (`total − firstToken`,
+   * so the wait for the first token is excluded). `null` when the backend sent
+   * no usage frame or the window is too small to derive a rate.
+   */
+  readonly tokensPerSecond: number | null;
+  /** Number of streamed content `delta` frames. */
+  readonly chunkCount: number;
+}
+
 /** Lifecycle of a single tool invocation within a turn. */
 export type ToolCallStatus = 'running' | 'succeeded' | 'failed';
 
@@ -120,6 +142,11 @@ export interface UseChatStreamReturn {
   readonly isThinking: boolean;
   /** Token usage for the turn, or `null` until the `usage` frame arrives. */
   readonly usage: ChatStreamUsage | null;
+  /**
+   * Client-side timing for the last completed turn, or `null` until a turn that
+   * streamed text finishes. Transient — reset on each `send()`, never persisted.
+   */
+  readonly metrics: ChatTurnMetrics | null;
   /** Whether a stream is currently active. */
   readonly isStreaming: boolean;
   /** Error from the last stream attempt, or `null`. */
@@ -211,6 +238,7 @@ export function useChatStream(): UseChatStreamReturn {
   const [toolCalls, setToolCalls] = useState<readonly ToolCallActivity[]>([]);
   const [isThinking, setIsThinking] = useState(false);
   const [usage, setUsage] = useState<ChatStreamUsage | null>(null);
+  const [metrics, setMetrics] = useState<ChatTurnMetrics | null>(null);
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [errorKind, setErrorKind] = useState<ChatErrorKind | null>(null);
@@ -238,6 +266,7 @@ export function useChatStream(): UseChatStreamReturn {
       setToolCalls([]);
       setIsThinking(false);
       setUsage(null);
+      setMetrics(null);
       setError(null);
       setErrorKind(null);
       setIsStreaming(true);
@@ -252,6 +281,10 @@ export function useChatStream(): UseChatStreamReturn {
         resolvedId: null,
         errorCode: null,
         persistedMessages: null,
+        startedAt: performance.now(),
+        firstTokenAt: null,
+        chunkCount: 0,
+        outputTokens: null,
       };
       const sinks = createEventSinks(turn, {
         setContent,
@@ -274,6 +307,12 @@ export function useChatStream(): UseChatStreamReturn {
             controller.signal
           )) {
             applyEvent(event, sinks);
+          }
+
+          // Derive timing for the completed turn. Only when text actually
+          // streamed — clarification/tool-only turns carry no meaningful rate.
+          if (turn.firstTokenAt !== null) {
+            setMetrics(computeTurnMetrics(turn, performance.now()));
           }
 
           if (turn.resolvedId) {
@@ -328,6 +367,7 @@ export function useChatStream(): UseChatStreamReturn {
     toolCalls,
     isThinking,
     usage,
+    metrics,
     isStreaming,
     error,
     errorKind,
@@ -339,6 +379,8 @@ export function useChatStream(): UseChatStreamReturn {
 /** Per-frame state updaters, kept out of the hook body for readability. */
 interface EventSinks {
   readonly appendContent: (chunk: string) => void;
+  /** Record a content `delta`: stamps first-token time once, counts the chunk. */
+  readonly recordChunk: () => void;
   readonly setConversationId: (id: ConversationId) => void;
   readonly setSuggestedActions: (actions: readonly SuggestedActionResponse[]) => void;
   readonly setClarification: (clarification: ClarificationResponse) => void;
@@ -359,6 +401,26 @@ interface TurnState {
   errorCode: string | null;
   /** The turn's persisted rows from the `persisted` frame, or `null` if absent. */
   persistedMessages: readonly MessageResponse[] | null;
+  /** `performance.now()` captured at `send()` — the timing origin for the turn. */
+  startedAt: number;
+  /** `performance.now()` of the first content `delta`, or `null` before it. */
+  firstTokenAt: number | null;
+  /** Count of content `delta` frames seen this turn. */
+  chunkCount: number;
+  /** Output tokens from the `usage` frame, or `null` if none arrived. */
+  outputTokens: number | null;
+}
+
+/** Build {@link ChatTurnMetrics} from a turn's accumulators and its end time. */
+function computeTurnMetrics(turn: TurnState, completedAt: number): ChatTurnMetrics {
+  const firstTokenMs = (turn.firstTokenAt ?? completedAt) - turn.startedAt;
+  const totalMs = completedAt - turn.startedAt;
+  const generationMs = totalMs - firstTokenMs;
+  const tokensPerSecond =
+    turn.outputTokens && turn.outputTokens > 0 && generationMs > 0
+      ? turn.outputTokens / (generationMs / 1000)
+      : null;
+  return { firstTokenMs, totalMs, tokensPerSecond, chunkCount: turn.chunkCount };
 }
 
 /** React state setters the sinks dispatch to. */
@@ -384,13 +446,20 @@ function createEventSinks(turn: TurnState, setters: EventSinkSetters): EventSink
       turn.accumulated += chunk;
       setters.setContent(turn.accumulated);
     },
+    recordChunk: () => {
+      turn.firstTokenAt ??= performance.now();
+      turn.chunkCount += 1;
+    },
     setConversationId: (id) => {
       turn.resolvedId = id;
       setters.setConversationId(id);
     },
     setSuggestedActions: setters.setSuggestedActions,
     setClarification: setters.setClarification,
-    setUsage: setters.setUsage,
+    setUsage: (next) => {
+      turn.outputTokens = next.outputTokens;
+      setters.setUsage(next);
+    },
     startToolCall: (toolCallId, toolName) => {
       turn.tools = [...turn.tools, { toolCallId, toolName, status: 'running' }];
       setters.setToolCalls(turn.tools);
@@ -424,7 +493,10 @@ function createEventSinks(turn: TurnState, setters: EventSinkSetters): EventSink
 function applyEvent(event: ChatStreamEvent, sinks: EventSinks): void {
   switch (event.type) {
     case CHAT_STREAM_EVENT_TYPES.DELTA:
-      if (event.content) sinks.appendContent(event.content);
+      if (event.content) {
+        sinks.appendContent(event.content);
+        sinks.recordChunk();
+      }
       // Streamed text resumed — the agent is no longer between steps.
       sinks.setThinking(false);
       break;

--- a/packages/@granit/react-ai-chat/src/index.ts
+++ b/packages/@granit/react-ai-chat/src/index.ts
@@ -1,5 +1,9 @@
 // Provider
-export { AIChatProvider, useAIChatConfig } from './providers/ai-chat-provider';
+export {
+  AIChatProvider,
+  useAIChatConfig,
+  useOptionalAIChatConfig,
+} from './providers/ai-chat-provider';
 export type {
   AIChatConfig,
   AIChatProviderProps,
@@ -45,6 +49,7 @@ export { useChatStream } from './hooks/use-chat-stream';
 export type {
   ChatErrorKind,
   ChatStreamUsage,
+  ChatTurnMetrics,
   ToolCallActivity,
   ToolCallStatus,
   UseChatStreamReturn,
@@ -59,6 +64,8 @@ export type { UseReverseInfiniteScrollParams } from './hooks/use-reverse-infinit
 // Components
 export { ChatMessage } from './components/chat-message';
 export type { ChatMessageProps } from './components/chat-message';
+export { MessageMetrics } from './components/message-metrics';
+export type { MessageMetricsProps } from './components/message-metrics';
 export { ConversationThread } from './components/conversation-thread';
 export type { ConversationThreadProps } from './components/conversation-thread';
 export { ConversationScrollArea } from './components/conversation-scroll-area';

--- a/packages/@granit/react-ai-chat/src/locales/en.ts
+++ b/packages/@granit/react-ai-chat/src/locales/en.ts
@@ -59,6 +59,14 @@ export interface ChatTranslations {
     /** Label for the retry affordance. */
     readonly Retry: string;
   };
+  readonly Metrics: {
+    /** Accessible label for the timing chip that opens the details popover. */
+    readonly Label: string;
+    readonly FirstToken: string;
+    readonly Total: string;
+    readonly Speed: string;
+    readonly Chunks: string;
+  };
 }
 
 /**
@@ -118,4 +126,11 @@ export const aiChatTranslationsEn: ChatTranslations = {
     Loading: 'Searching…',
   },
   Errors: defaultErrorLabels,
+  Metrics: {
+    Label: 'Response timing',
+    FirstToken: 'First token',
+    Total: 'Total',
+    Speed: 'Speed',
+    Chunks: 'Chunks',
+  },
 };

--- a/packages/@granit/react-ai-chat/src/locales/fr.ts
+++ b/packages/@granit/react-ai-chat/src/locales/fr.ts
@@ -50,4 +50,11 @@ export const aiChatTranslationsFr: ChatTranslations = {
     Unknown: 'Une erreur est survenue. Veuillez réessayer.',
     Retry: 'Réessayer',
   },
+  Metrics: {
+    Label: 'Durée de la réponse',
+    FirstToken: 'Premier token',
+    Total: 'Total',
+    Speed: 'Vitesse',
+    Chunks: 'Chunks',
+  },
 };

--- a/packages/@granit/react-ai-chat/src/providers/ai-chat-provider.tsx
+++ b/packages/@granit/react-ai-chat/src/providers/ai-chat-provider.tsx
@@ -19,6 +19,13 @@ export interface AIChatConfig {
   readonly basePath?: string;
   /** React Query key prefix (default: `['ai-chat']`). */
   readonly queryKeyPrefix?: readonly string[];
+  /**
+   * Show per-message timing metrics (time-to-first-token, total, tokens/sec,
+   * chunk count) under the latest assistant reply. Off by default — a
+   * dev/debug aid the app opts into centrally (e.g. `import.meta.env.DEV`).
+   * Rendered by `ConversationThread` from `useChatStream().metrics`.
+   */
+  readonly showMessageMetrics?: boolean;
 }
 
 /** {@link AIChatConfig} after the provider has resolved `client` and defaults. */
@@ -26,6 +33,7 @@ export interface ResolvedAIChatConfig extends AIChatConfig {
   readonly client: AxiosInstance;
   readonly basePath: string;
   readonly queryKeyPrefix: readonly string[];
+  readonly showMessageMetrics: boolean;
 }
 
 export interface AIChatProviderProps {
@@ -50,6 +58,7 @@ export function AIChatProvider({ config, children }: Readonly<AIChatProviderProp
       client,
       basePath: config.basePath ?? DEFAULT_BASE_PATH,
       queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
+      showMessageMetrics: config.showMessageMetrics ?? false,
     };
   }, [config, contextClient]);
   return <AIChatConfigContext value={value}>{children}</AIChatConfigContext>;
@@ -62,4 +71,13 @@ export function useAIChatConfig(): ResolvedAIChatConfig {
     throw new Error('useAIChatConfig must be used within an AIChatProvider');
   }
   return ctx;
+}
+
+/**
+ * Like {@link useAIChatConfig} but returns `null` outside a provider instead of
+ * throwing — for presentational components (e.g. `ConversationThread`) that
+ * read an optional flag yet must still render standalone in tests/Storybook.
+ */
+export function useOptionalAIChatConfig(): ResolvedAIChatConfig | null {
+  return useContext(AIChatConfigContext);
 }


### PR DESCRIPTION
## Summary

Adds opt-in, client-side turn timing to `@granit/react-ai-chat`: time-to-first-token, total duration, tokens/sec, and streamed chunk count, surfaced as a compact chip under the latest assistant reply. A dev/observability aid for streaming LLM UIs — off by default, app-agnostic, never persisted.

## Changes

- `useChatStream`: capture timing from the stream and expose a transient `metrics: ChatTurnMetrics | null` (`firstTokenMs`, `totalMs`, `tokensPerSecond`, `chunkCount`), reset on each `send()` and produced only once a turn streams text (clarification/tool-only/error turns stay `null`).
- New `MessageMetrics` component: total-ms chip with a hover/focus popover for the full breakdown — pure CSS disclosure (no popover lib), real `<button>` trigger + `role="tooltip"` for keyboard/SR access.
- New provider flag `AIChatConfig.showMessageMetrics` (default `false`); `ConversationThread` reads it via the new non-throwing `useOptionalAIChatConfig` and attaches the chip to the latest assistant message.
- i18n: `Metrics` block added to `en` + `fr` locales, typed via `ChatTranslations`.
- Exports: `MessageMetrics`, `MessageMetricsProps`, `ChatTurnMetrics`, `useOptionalAIChatConfig`.

## Notes

- `tokensPerSecond` is a hybrid metric: backend `outputTokens` ÷ the client-measured generation window (`total − firstToken`), so the wait for the first token is excluded; `null` when no `usage` frame arrived or the window is too small.
- Consumer wiring is app-side: pass `metrics={useChatStream().metrics}` to `ConversationThread` and enable `showMessageMetrics` on the provider.

## Checklist

- [x] Tests pass (`pnpm test run`) — 69 passed in `react-ai-chat`
- [x] Lint passes (`pnpm lint`)
- [x] TypeScript compiles (`pnpm tsc`)
- [ ] Markdownlint passes on modified `.md` files — no `.md` changed
- [ ] Documentation updated (if applicable) — README is high-level; no API enumeration to update
- [x] No hardcoded secrets
- [ ] THIRD-PARTY-NOTICES.md updated (if dependencies changed) — no dependency changes