### PR TITLE
fix(ai-chat): audit conformance — disambiguate ChatStreamEvent, metadata-only conversation detail

### DIFF
--- a/contracts/openapi/ai-chat.json
+++ b/contracts/openapi/ai-chat.json
@@ -140,7 +140,7 @@
       "get": {
         "tags": ["AI - Conversations"],
         "summary": "Returns one of the current user's conversations by ID.",
-        "description": "Returns the conversation and its messages. Scoped to the caller: another user's conversation is reported as not found.",
+        "description": "Returns the conversation's metadata (title, favorite, timestamps); its messages are paged separately via GET /{id}/messages. Scoped to the caller: another user's conversation is reported as not found.",
         "operationId": "GetConversation",
         "parameters": [
           {
@@ -929,7 +929,7 @@
         }
       },
       "ConversationResponse": {
-        "required": ["id", "title", "ownerId", "isFavorite", "createdAt", "modifiedAt", "messages"],
+        "required": ["id", "title", "ownerId", "isFavorite", "createdAt", "modifiedAt"],
         "type": "object",
         "properties": {
           "id": {
@@ -953,12 +953,6 @@
           "modifiedAt": {
             "type": ["null", "string"],
             "format": "date-time"
-          },
-          "messages": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MessageResponse"
-            }
           }
         }
       },

--- a/packages/@granit/ai-chat/src/__tests__/conversations-api.test.ts
+++ b/packages/@granit/ai-chat/src/__tests__/conversations-api.test.ts
@@ -33,7 +33,6 @@ const CONVERSATION: ConversationResponse = {
   isFavorite: false,
   createdAt: '2026-06-15T10:00:00Z' as ConversationResponse['createdAt'],
   modifiedAt: null,
-  messages: [],
 };
 
 describe('conversations-api', () => {

--- a/packages/@granit/ai-chat/src/api/conversations-api.ts
+++ b/packages/@granit/ai-chat/src/api/conversations-api.ts
@@ -38,7 +38,9 @@ export async function listConversations(
 }
 
 /**
- * Get one of the current user's conversations and its messages.
+ * Get one of the current user's conversations (metadata only — title, favorite,
+ * timestamps). The message thread is paged separately via
+ * {@link getConversationMessages}.
  *
  * `GET {basePath}/{id}`
  */

--- a/packages/@granit/ai-chat/src/types/index.ts
+++ b/packages/@granit/ai-chat/src/types/index.ts
@@ -237,7 +237,11 @@ export interface MessageResponse {
   readonly createdAt: ISODateString;
 }
 
-/** A conversation with its messages. */
+/**
+ * A conversation's metadata (title, favorite, timestamps). The message thread is
+ * NOT embedded — page it separately via {@link getConversationMessages}
+ * (`GET /{id}/messages`), so opening a conversation never loads its whole history.
+ */
 export interface ConversationResponse {
   readonly id: ConversationId;
   readonly title: string;
@@ -245,7 +249,6 @@ export interface ConversationResponse {
   readonly isFavorite: boolean;
   readonly createdAt: ISODateString;
   readonly modifiedAt: ISODateString | null;
-  readonly messages: readonly MessageResponse[];
 }
 
 /** A conversation list item, without its messages. */

--- a/packages/@granit/ai/src/__tests__/ai-chat-stream.test.ts
+++ b/packages/@granit/ai/src/__tests__/ai-chat-stream.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { chatStream } from '../api/ai-chat-api';
 
-import type { ChatStreamEvent } from '../types/index';
+import type { AIChatCompletionEvent } from '../types/index';
 
 function createSSEStream(chunks: string[]): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
@@ -31,7 +31,7 @@ describe('chatStream', () => {
     ]);
     vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
 
-    const events: ChatStreamEvent[] = [];
+    const events: AIChatCompletionEvent[] = [];
     for await (const event of chatStream(client, '', 'default', {
       messages: [{ role: 'user', content: 'Hi' }],
     })) {
@@ -49,7 +49,7 @@ describe('chatStream', () => {
     const stream = createSSEStream(['data: {"cont', 'ent":"split"}\n\ndata: [DONE]\n\n']);
     vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
 
-    const events: ChatStreamEvent[] = [];
+    const events: AIChatCompletionEvent[] = [];
     for await (const event of chatStream(client, '', 'default', {
       messages: [{ role: 'user', content: 'Hi' }],
     })) {
@@ -79,7 +79,7 @@ describe('chatStream', () => {
     ]);
     vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
 
-    const events: ChatStreamEvent[] = [];
+    const events: AIChatCompletionEvent[] = [];
     for await (const event of chatStream(client, '', 'default', {
       messages: [{ role: 'user', content: 'Hi' }],
     })) {
@@ -115,7 +115,7 @@ describe('chatStream', () => {
     const client = createMockClient();
     vi.spyOn(client, 'post').mockResolvedValue({ data: null });
 
-    const events: ChatStreamEvent[] = [];
+    const events: AIChatCompletionEvent[] = [];
     for await (const event of chatStream(client, '', 'default', {
       messages: [{ role: 'user', content: 'Hi' }],
     })) {
@@ -135,7 +135,7 @@ describe('chatStream', () => {
     ]);
     vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
 
-    const events: ChatStreamEvent[] = [];
+    const events: AIChatCompletionEvent[] = [];
     for await (const event of chatStream(client, '', 'default', {
       messages: [{ role: 'user', content: 'Hi' }],
     })) {
@@ -156,7 +156,7 @@ describe('chatStream', () => {
     ]);
     vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
 
-    const events: ChatStreamEvent[] = [];
+    const events: AIChatCompletionEvent[] = [];
     for await (const event of chatStream(client, '', 'default', {
       messages: [{ role: 'user', content: 'Hi' }],
     })) {

--- a/packages/@granit/ai/src/api/ai-chat-api.ts
+++ b/packages/@granit/ai/src/api/ai-chat-api.ts
@@ -8,11 +8,11 @@ import { createLogger } from '@granit/logger';
 import { AI_STREAM_DONE_MARKER } from '../types/index';
 
 import type {
+  AIChatCompletionEvent,
   AIChatRequest,
   AIChatResponse,
   AIChatStreamChunk,
   AIChatStreamUsage,
-  ChatStreamEvent,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
@@ -76,7 +76,7 @@ function parseSseLine(line: string, currentEventType: string | null): ParsedLine
  *
  * Uses `adapter: 'fetch'` with `responseType: 'stream'` so the request goes
  * through the full Axios interceptor pipeline (CSRF, auth, tenant headers).
- * Yields {@link ChatStreamEvent} items as they arrive: content chunks and a
+ * Yields {@link AIChatCompletionEvent} items as they arrive: content chunks and a
  * final usage summary. The stream ends when the server sends `data: [DONE]`
  * or closes the connection.
  *
@@ -98,7 +98,7 @@ export async function* chatStream(
   workspaceName: string,
   request: AIChatRequest,
   signal?: AbortSignal
-): AsyncGenerator<ChatStreamEvent, void, undefined> {
+): AsyncGenerator<AIChatCompletionEvent, void, undefined> {
   const url = `${basePath}/chat/${encodeURIComponent(workspaceName)}/stream`;
 
   const response = await client.post(url, request, {

--- a/packages/@granit/ai/src/index.ts
+++ b/packages/@granit/ai/src/index.ts
@@ -1,5 +1,6 @@
 // Types & Constants
 export type {
+  AIChatCompletionEvent,
   AIChatMessageRequest,
   AIChatMessageRole,
   AIChatRequest,

--- a/packages/@granit/ai/src/types/index.ts
+++ b/packages/@granit/ai/src/types/index.ts
@@ -121,9 +121,16 @@ export interface AIChatStreamUsage {
 }
 
 /** Discriminated union yielded by {@link chatStream}. */
-export type ChatStreamEvent =
+export type AIChatCompletionEvent =
   | { readonly type: 'chunk'; readonly content: string }
   | { readonly type: 'usage'; readonly usage: AIChatStreamUsage };
+
+/**
+ * @deprecated Renamed to {@link AIChatCompletionEvent} to avoid the name
+ * collision with `@granit/ai-chat`'s agentic `ChatStreamEvent` (a different
+ * shape). Import the new name; this alias will be removed in a future major.
+ */
+export type ChatStreamEvent = AIChatCompletionEvent;
 
 // -- Embeddings --------------------------------------------------------------
 

--- a/packages/@granit/react-ai-chat/src/hooks/use-conversation-messages.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-conversation-messages.ts
@@ -63,9 +63,8 @@ export interface UseConversationMessagesResult {
  * `messages` is reversed to oldest-first for natural top-to-bottom rendering.
  *
  * This is the thread's source of truth — `useConversation` is left for
- * conversation METADATA (title, favorite, dates). `getConversation` still
- * returns its `messages` for backward compatibility, but the thread no longer
- * relies on them.
+ * conversation METADATA (title, favorite, dates); `getConversation` no longer
+ * embeds the message thread.
  *
  * @param id - the conversation id, or `null` to disable the query (e.g. before
  *   the first turn of a brand-new conversation resolves an id).

--- a/packages/@granit/react-ai-chat/src/hooks/use-conversation.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-conversation.ts
@@ -9,7 +9,9 @@ import type { ConversationId, ConversationResponse } from '@granit/ai-chat';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 /**
- * Fetch one of the current user's conversations and its messages.
+ * Fetch one of the current user's conversations (metadata only — title,
+ * favorite, timestamps). The message thread is loaded separately via
+ * {@link useConversationMessages}.
  *
  * @param id - the conversation id, or `null` to disable the query (e.g. before
  *   the first turn of a brand-new conversation).

--- a/packages/@granit/react-ai-chat/src/testing/data.ts
+++ b/packages/@granit/react-ai-chat/src/testing/data.ts
@@ -10,7 +10,7 @@ const OWNER = toEntityId<'User'>('b2222222-2222-2222-2222-222222222222');
 
 const CONVERSATION_ID = toEntityId<'Conversation'>('a1111111-1111-1111-1111-111111111111');
 
-/** A full conversation with two messages, returned by `GET /conversations/{id}`. */
+/** Conversation metadata returned by `GET /conversations/{id}` (no embedded thread). */
 export const mockConversation: ConversationResponse = {
   id: CONVERSATION_ID,
   title: 'Invoice questions',
@@ -18,21 +18,27 @@ export const mockConversation: ConversationResponse = {
   isFavorite: false,
   createdAt: toISODateString('2026-06-15T09:00:00.000Z'),
   modifiedAt: toISODateString('2026-06-15T09:05:00.000Z'),
-  messages: [
-    {
-      id: toEntityId<'Message'>('c3333333-3333-3333-3333-333333333331'),
-      role: 'user',
-      content: 'What changed on invoice 42 last week?',
-      createdAt: toISODateString('2026-06-15T09:00:00.000Z'),
-    },
-    {
-      id: toEntityId<'Message'>('c3333333-3333-3333-3333-333333333332'),
-      role: 'assistant',
-      content: 'The total was revised from €1,200 to €1,350 and the due date moved to June 30.',
-      createdAt: toISODateString('2026-06-15T09:00:08.000Z'),
-    },
-  ] satisfies MessageResponse[],
 };
+
+/**
+ * The {@link mockConversation} thread (oldest-first), served by the paginated
+ * `GET /conversations/{id}/messages` handler — the thread is no longer embedded
+ * in the conversation detail response.
+ */
+export const mockConversationMessages: readonly MessageResponse[] = [
+  {
+    id: toEntityId<'Message'>('c3333333-3333-3333-3333-333333333331'),
+    role: 'user',
+    content: 'What changed on invoice 42 last week?',
+    createdAt: toISODateString('2026-06-15T09:00:00.000Z'),
+  },
+  {
+    id: toEntityId<'Message'>('c3333333-3333-3333-3333-333333333332'),
+    role: 'assistant',
+    content: 'The total was revised from €1,200 to €1,350 and the due date moved to June 30.',
+    createdAt: toISODateString('2026-06-15T09:00:08.000Z'),
+  },
+];
 
 /** A long conversation used to exercise reverse (keyset) message pagination. */
 export const mockLongConversationId = toEntityId<'Conversation'>(

--- a/packages/@granit/react-ai-chat/src/testing/handlers.ts
+++ b/packages/@granit/react-ai-chat/src/testing/handlers.ts
@@ -5,6 +5,7 @@ import { DEFAULT_BASE_PATH } from '../constants';
 import {
   mockChatWorkspaces,
   mockConversation,
+  mockConversationMessages,
   mockConversationSummaries,
   mockLongConversationId,
   mockLongConversationMessages,
@@ -52,7 +53,7 @@ export function createAIChatHandlers(baseUrl = DEFAULT_BASE_PATH) {
       const id = params.id as string;
       // Source fixture is ascending (oldest-first).
       const all: readonly MessageResponse[] =
-        id === mockLongConversationId ? mockLongConversationMessages : mockConversation.messages;
+        id === mockLongConversationId ? mockLongConversationMessages : mockConversationMessages;
 
       const url = new URL(request.url);
       const pageSize = Math.min(Math.max(Number(url.searchParams.get('pageSize')) || 30, 1), 100);
@@ -93,7 +94,6 @@ export function createAIChatHandlers(baseUrl = DEFAULT_BASE_PATH) {
         ...mockConversation,
         id: mockConversation.id,
         title: body.title,
-        messages: [],
       };
       summaries = [
         {

--- a/packages/@granit/react-ai-chat/src/testing/index.ts
+++ b/packages/@granit/react-ai-chat/src/testing/index.ts
@@ -5,6 +5,7 @@
 export {
   mockChatWorkspaces,
   mockConversation,
+  mockConversationMessages,
   mockConversationSummaries,
   mockLongConversationId,
   mockLongConversationMessages,


### PR DESCRIPTION
Two framework-conformance fixes surfaced by `/audit` of the Chat IA modules (`@granit/ai`, `@granit/ai-chat`, `@granit/react-ai-chat`). Two scope-separated commits.

## 1. `refactor(ai)`: disambiguate `ChatStreamEvent` → `AIChatCompletionEvent`

`@granit/ai`'s chat-completion stream union shared the name `ChatStreamEvent` with `@granit/ai-chat`'s agentic frame type — a latent collision for any consumer importing both (different shapes).

- Renamed the completion union to `AIChatCompletionEvent`.
- Kept `ChatStreamEvent` as a `@deprecated` alias (API-stability rule — no hard rename of an exported symbol).
- Blast radius: **0 active import sites** across consumers (showcase referenced the name only in a comment).

## 2. `refactor(ai-chat)`: metadata-only `ConversationResponse`

`GET /conversations/{id}` previously embedded the **entire** message thread, even though the front renders the thread via the paginated `GET /{id}/messages` (`useConversationMessages`). Opening a long conversation loaded its whole history just to read the header.

- Dropped `messages` from `ConversationResponse` (type + vendored `contracts/openapi/ai-chat.json` snapshot).
- Testing fixtures now serve the thread from the paginated handler (`mockConversationMessages`).
- De-staled the now-inaccurate "backward compatibility" doc notes.

> ⚠️ **Pairs with a `granit-dotnet` contract change** (GET-by-id loads metadata only — no message `Include`) that must deploy for the live spec to match. Merge order: **backend first**, then this PR. The front is self-consistent (vendored snapshot) so its CI is green standalone.

## Verification
- `tsc` (ai, ai-chat, react-ai, react-ai-chat, contract-tests): PASS
- Contract conformance + unit tests: **616 + 177 passed**
- ESLint (`--max-warnings 0`): PASS