### PR TITLE
feat(react-ai-chat-blob-storage): blob storage attachments for AI chat

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -78,21 +78,6 @@
       "description": "AI workspace management, chat completion, embedding generation, and usage tracking types and API functions — mirrors Granit.AI.Endpoints .NET",
       "exports": [
         {
-          "name": "AI_CAPABILITY_EXTENSIONS",
-          "kind": "const",
-          "signature": "const AI_CAPABILITY_EXTENSIONS"
-        },
-        {
-          "name": "AI_STREAM_DONE_MARKER",
-          "kind": "const",
-          "signature": "const AI_STREAM_DONE_MARKER"
-        },
-        {
-          "name": "AI_WORKSPACE_KINDS",
-          "kind": "const",
-          "signature": "const AI_WORKSPACE_KINDS"
-        },
-        {
           "name": "listAIProviderModels",
           "kind": "function",
           "signature": "async function listAIProviderModels( client: AxiosInstance, basePath: string, providerName: string ): Promise<readonly AIProviderModelResponse[]>"
@@ -3099,6 +3084,23 @@
           "name": "ActiveTrigger",
           "kind": "interface",
           "signature": "interface ActiveTrigger",
+          "members": []
+        }
+      ]
+    },
+    {
+      "name": "@granit/react-ai-chat-blob-storage",
+      "description": "Glue: UploadAttachment adapter for ChatComposer backed by @granit/react-blob-storage",
+      "exports": [
+        {
+          "name": "useAIChatBlobUpload",
+          "kind": "function",
+          "signature": "function useAIChatBlobUpload( containerName: string, options?: UseAIChatBlobUploadOptions, ): UploadAttachment"
+        },
+        {
+          "name": "UseAIChatBlobUploadOptions",
+          "kind": "interface",
+          "signature": "interface UseAIChatBlobUploadOptions",
           "members": []
         }
       ]

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3095,7 +3095,7 @@
         {
           "name": "useAIChatBlobUpload",
           "kind": "function",
-          "signature": "function useAIChatBlobUpload( containerName: string, options?: UseAIChatBlobUploadOptions, ): UploadAttachment"
+          "signature": "function useAIChatBlobUpload( containerName: string, options?: UseAIChatBlobUploadOptions ): UploadAttachment"
         },
         {
           "name": "UseAIChatBlobUploadOptions",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,10 @@
 
 ## Project
 
-TypeScript/React framework library (130+ `@granit/*` packages) — shared
-front-end framework for Digital Dynamics apps; JS/TS counterpart of
-`granit-dotnet`. Consumed by showcase-admin-react via pnpm `link:` + Vite
-aliases. Discover packages with `ls packages/@granit/` — never a hardcoded list.
+TypeScript/React framework library (130+ `@granit/*` packages) — shared front-end
+framework for Digital Dynamics apps; JS/TS counterpart of `granit-dotnet`. Consumed
+by showcase-admin-react via pnpm `link:` + Vite aliases. Discover packages with
+`ls packages/@granit/` — never a hardcoded list.
 
 **Stack**: TypeScript 6 (strict, ES2025) · React 19 · Vitest 4 · ESLint 10 ·
 pnpm workspace · Node 24.
@@ -26,8 +26,8 @@ pnpm --filter @granit/utils lint   # per package
 
 ## Package conventions
 
-- **Source-direct (default)**: export `.ts` source, no build/`dist/`, consumed
-  via Vite aliases — no bundling.
+- **Source-direct (default)**: export `.ts` source, no build/`dist/`, consumed via
+  Vite aliases — no bundling.
 - **Published (exception)**: a few packages ship a `tsup` build (`dist/` +
   `publishConfig`) via `npm.pkg.github.com` (e.g. `@granit/csp`,
   `@granit/arch-tests-kit`). Keep source-direct unless meant for publication.
@@ -37,17 +37,17 @@ pnpm --filter @granit/utils lint   # per package
 
 ### Canonical structure
 
-**Core** `@granit/{module}` (framework-agnostic): `src/{__tests__/, api/
-(Axios calls, if HTTP endpoints), types/ (DTOs+domain, dir w/ index.ts barrel),
-permissions.ts (only if backend permissions), index.ts}`.
+**Core** `@granit/{module}` (framework-agnostic): `src/{__tests__/, api/ (Axios calls,
+if HTTP endpoints), types/ (DTOs+domain, dir w/ index.ts barrel), permissions.ts (only
+if backend permissions), index.ts}`.
 
-**React** `@granit/react-{module}`: `src/{__tests__/, components/, constants.ts,
-hooks/ (React Query hooks + query-key factories — query-keys.ts lives here, not
-core), locales/, providers/ (when config via context), testing/ (MSW handlers),
-index.ts}`. hooks/ and providers/ required; rest optional.
+**React** `@granit/react-{module}`: `src/{__tests__/, components/, constants.ts, hooks/
+(React Query hooks + query-key factories — query-keys.ts lives here, not core), locales/,
+providers/ (when config via context), testing/ (MSW handlers), index.ts}`. hooks/ and
+providers/ required; rest optional.
 
-**Forbidden**: `hooks/` in a core package · `api/` in a react package · `types.ts`
-flat file at `src/` root (always `types/index.ts`) · `endpoints/` dir (DTOs → `types/`).
+**Forbidden**: `hooks/` in a core package · `api/` in a react package · `types.ts` flat
+file at `src/` root (always `types/index.ts`) · `endpoints/` dir (DTOs → `types/`).
 
 ## Coding conventions
 
@@ -62,29 +62,28 @@ Full frontend conventions: `../granit-dotnet/docs/guide/conventions/frontend/`
 - Logging via `@granit/logger` (`createLogger`) — never `console.log`.
 - **HTTP**: business/domain calls MUST use the centralized Axios client
   (`@granit/api-client`) for interceptors (CSRF, auth, tenant); for streaming use
-  `adapter: 'fetch'` + `responseType: 'stream'`. Native `fetch` allowed ONLY in
-  infra below the Axios client: `@granit/bff` (auth bootstrap), `@granit/react-bff`
-  (provider init), telemetry (`@granit/logger-otlp`, `@granit/react-tracing`),
-  Fetch-contract adapters (`@granit/notifications-sse`). Never add new `fetch()`
-  for domain endpoints.
+  `adapter: 'fetch'` + `responseType: 'stream'`. Native `fetch` allowed ONLY in infra
+  below the Axios client: `@granit/bff` (auth bootstrap), `@granit/react-bff` (provider
+  init), telemetry (`@granit/logger-otlp`, `@granit/react-tracing`), Fetch-contract
+  adapters (`@granit/notifications-sse`). Never add new `fetch()` for domain endpoints.
 
 ## API design rules
 
-- **Stability**: exported types/signatures consumed by showcase-admin-react —
-  breaking changes need coordinated updates; never rename exported symbols
-  without a deprecation notice (check importing apps first).
+- **Stability**: exported types/signatures consumed by showcase-admin-react — breaking
+  changes need coordinated updates; never rename exported symbols without a deprecation
+  notice (check importing apps first).
 - **App-agnostic**: no FHIR/Capacitor/admin-roles/HDS-specific code.
-- `@granit/authentication`: `BaseAuthContextType` is the shared base — providers
-  extend it, apps extend further.
+- `@granit/authentication`: `BaseAuthContextType` is the shared base — providers extend
+  it, apps extend further.
 - **Git hooks** (`.husky/`): `commit-msg` → commitlint (Conventional Commits);
   `pre-commit` → gitleaks → lint-staged → `tsc -r --noEmit` → regenerate
   `.mcp-front-index.json` when `packages/@granit/*/src/` changed.
 
 ### Mirroring DTOs from `contracts/openapi/*.json`
 
-Specs are authoritative for routes, HTTP methods, status codes, field names
-(PascalCase .NET → camelCase JSON). TS `?` comes from the `required` array, NOT
-nullability — these are independent axes:
+Specs are authoritative for routes, HTTP methods, status codes, field names (PascalCase
+.NET → camelCase JSON). TS `?` comes from the `required` array, NOT nullability — these
+are independent axes:
 
 - `string? Foo` with no C# default → `required` + `type:["null","string"]` →
   **`foo: T | null`** (required key, nullable value). NOT `foo?: T`.
@@ -98,10 +97,10 @@ Check/extend before adding new runtime patterns:
 - **`@granit/arch-tests`**: bans `console.*` in runtime, enforces `createLogger`,
   import boundaries.
 - **`@granit/arch-tests-kit`**: reusable helpers (published — see above).
-- **`pnpm check:csp`** (`scripts/check-csp-policies.mjs`): any `@granit/*` writing
-  to a DOM script sink (`.innerHTML`, `.outerHTML`, `.insertAdjacentHTML`,
-  `iframe/script.setAttribute('src',…)`, `.src=`) MUST expose a `<pkg>/csp`
-  subpath with idempotent `installPolicy()` (Trusted Types).
+- **`pnpm check:csp`** (`scripts/check-csp-policies.mjs`): any `@granit/*` writing to a
+  DOM script sink (`.innerHTML`, `.outerHTML`, `.insertAdjacentHTML`,
+  `iframe/script.setAttribute('src',…)`, `.src=`) MUST expose a `<pkg>/csp` subpath with
+  idempotent `installPolicy()` (Trusted Types).
 
 ## Code index (`.mcp-front-index.json`)
 

--- a/packages/@granit/ai-chat/src/__tests__/conversations-api.test.ts
+++ b/packages/@granit/ai-chat/src/__tests__/conversations-api.test.ts
@@ -33,7 +33,7 @@ const CONVERSATION: ConversationResponse = {
   isFavorite: false,
   createdAt: '2026-06-15T10:00:00Z' as ConversationResponse['createdAt'],
   modifiedAt: null,
-  messages: [],
+  workspaceKey: null,
 };
 
 describe('conversations-api', () => {

--- a/packages/@granit/ai-chat/src/types/index.ts
+++ b/packages/@granit/ai-chat/src/types/index.ts
@@ -234,6 +234,8 @@ export interface MessageResponse {
   readonly id: MessageId;
   readonly role: ChatMessageRole;
   readonly content: string;
+  /** Workspace used to process this message (null for pre-workspace messages). */
+  readonly workspaceKey: string | null;
   readonly createdAt: ISODateString;
 }
 
@@ -245,7 +247,8 @@ export interface ConversationResponse {
   readonly isFavorite: boolean;
   readonly createdAt: ISODateString;
   readonly modifiedAt: ISODateString | null;
-  readonly messages: readonly MessageResponse[];
+  /** Workspace key frozen at creation (null for pre-workspace conversations). */
+  readonly workspaceKey: string | null;
 }
 
 /** A conversation list item, without its messages. */
@@ -255,6 +258,8 @@ export interface ConversationSummaryResponse {
   readonly isFavorite: boolean;
   readonly createdAt: ISODateString;
   readonly modifiedAt: ISODateString | null;
+  /** Workspace key frozen at creation (null for pre-workspace conversations). */
+  readonly workspaceKey: string | null;
 }
 
 /** Body of `POST /conversations`. */

--- a/packages/@granit/ai/src/index.ts
+++ b/packages/@granit/ai/src/index.ts
@@ -24,7 +24,12 @@ export type {
   ChatStreamEvent,
   ConversationId,
 } from './types/index';
-export { AI_CAPABILITY_EXTENSIONS, AI_STREAM_DONE_MARKER, AI_WORKSPACE_KINDS } from './types/index';
+export {
+  AI_CAPABILITY_EXTENSIONS,
+  AI_STREAM_DONE_MARKER,
+  AI_WORKSPACE_KINDS,
+  AI_WORKSPACE_LIMITS,
+} from './types/index';
 
 // API — Providers
 export { listAIProviderModels, listAIProviders } from './api/ai-providers-api';

--- a/packages/@granit/ai/src/types/index.ts
+++ b/packages/@granit/ai/src/types/index.ts
@@ -27,6 +27,16 @@ export const AI_CAPABILITY_EXTENSIONS = {
 /** SSE stream termination marker. */
 export const AI_STREAM_DONE_MARKER = '[DONE]';
 
+/** Server-enforced limits for workspace fields. */
+export const AI_WORKSPACE_LIMITS = {
+  /** `name` maximum length. Pattern: `^[a-z0-9][a-z0-9-]*$`. */
+  NAME_MAX_LENGTH: 128,
+  /** Slug pattern for workspace names (lowercase alphanumeric + hyphens, no leading hyphen). */
+  NAME_PATTERN: /^[a-z0-9][a-z0-9-]*$/,
+  /** `workspaceModelName` maximum length (display label). */
+  MODEL_NAME_MAX_LENGTH: 64,
+} as const;
+
 // -- Workspace ---------------------------------------------------------------
 
 /** Workspace kind. Mirrors `Granit.AI.Workspaces.AIWorkspaceKind`. */
@@ -43,6 +53,8 @@ export interface AIWorkspaceResponse {
   readonly kind: AIWorkspaceKind;
   readonly activated: boolean;
   readonly capabilities: AIModelCapabilities | null;
+  /** Human-readable model label (e.g. "GPT-4o"); null if not set. */
+  readonly workspaceModelName: string | null;
 }
 
 /** List response wrapper. Mirrors `AIWorkspaceListResponse`. */
@@ -59,6 +71,7 @@ export interface AIWorkspaceCreateRequest {
   readonly systemPrompt?: string | null;
   readonly temperature?: number | null;
   readonly maxOutputTokens?: number | null;
+  readonly workspaceModelName?: string | null;
 }
 
 /** Update workspace request. Mirrors `AIWorkspaceUpdateRequest`. */
@@ -69,6 +82,8 @@ export interface AIWorkspaceUpdateRequest {
   readonly temperature?: number | null;
   readonly maxOutputTokens?: number | null;
   readonly activated: boolean;
+  /** Pass null to clear the label. */
+  readonly workspaceModelName?: string | null;
 }
 
 // -- Chat completion ---------------------------------------------------------

--- a/packages/@granit/react-ai-chat-blob-storage/package.json
+++ b/packages/@granit/react-ai-chat-blob-storage/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@granit/react-ai-chat-blob-storage",
+  "description": "Glue: UploadAttachment adapter for ChatComposer backed by @granit/react-blob-storage",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/blob-storage": "workspace:*",
+    "@granit/react-ai-chat": "workspace:*",
+    "@granit/react-blob-storage": "workspace:*",
+    "react": "^19.0.0"
+  },
+  "devDependencies": {
+    "@granit/blob-storage": "workspace:*",
+    "@granit/react-ai-chat": "workspace:*",
+    "@granit/react-blob-storage": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/react-ai-chat-blob-storage/src/__tests__/use-ai-chat-blob-upload.test.ts
+++ b/packages/@granit/react-ai-chat-blob-storage/src/__tests__/use-ai-chat-blob-upload.test.ts
@@ -1,0 +1,127 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CHAT_ATTACHMENT_MAX_BYTES } from '../constants';
+import { useAIChatBlobUpload } from '../hooks/use-ai-chat-blob-upload';
+
+import type { BlobConfirmUploadResponse } from '@granit/blob-storage';
+
+const mockUpload =
+  vi.fn<
+    (params: {
+      file: File;
+      containerName: string;
+      onProgress?: (pct: number) => void;
+    }) => Promise<BlobConfirmUploadResponse>
+  >();
+
+vi.mock('@granit/react-blob-storage', () => ({
+  useBlobUpload: () => ({ upload: mockUpload, state: {}, reset: vi.fn() }),
+}));
+
+const validConfirmation: BlobConfirmUploadResponse = {
+  blobId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+  isValid: true,
+  status: 'Valid',
+  verifiedContentType: 'application/pdf',
+  sizeBytes: 2048,
+  rejectionReason: null,
+};
+
+function makeFile(name: string, type: string, size: number): File {
+  const content = new Uint8Array(size);
+  return new File([content], name, { type });
+}
+
+beforeEach(() => {
+  mockUpload.mockReset();
+});
+
+describe('useAIChatBlobUpload', () => {
+  it('uploads and maps to AttachmentRequest shape', async () => {
+    mockUpload.mockResolvedValueOnce(validConfirmation);
+    const { result } = renderHook(() => useAIChatBlobUpload('chat-attachments'));
+
+    const file = makeFile('report.pdf', 'application/pdf', 1024);
+    const attachment = await result.current(file);
+
+    expect(mockUpload).toHaveBeenCalledWith({ file, containerName: 'chat-attachments' });
+    expect(attachment).toEqual({
+      reference: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+      fileName: 'report.pdf',
+      contentType: 'application/pdf',
+      sizeBytes: 2048,
+    });
+  });
+
+  it('falls back to file metadata when server returns nulls', async () => {
+    mockUpload.mockResolvedValueOnce({
+      ...validConfirmation,
+      verifiedContentType: null,
+      sizeBytes: null,
+    });
+    const { result } = renderHook(() => useAIChatBlobUpload('chat-attachments'));
+
+    const file = makeFile('notes.txt', 'text/plain', 512);
+    const attachment = await result.current(file);
+
+    expect(attachment.contentType).toBe('text/plain');
+    expect(attachment.sizeBytes).toBe(512);
+  });
+
+  it('rejects when file exceeds maxBytes', async () => {
+    const { result } = renderHook(() => useAIChatBlobUpload('chat-attachments'));
+
+    const file = makeFile('huge.pdf', 'application/pdf', CHAT_ATTACHMENT_MAX_BYTES + 1);
+    await expect(result.current(file)).rejects.toThrow('File too large');
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it('respects a custom maxBytes override', async () => {
+    const { result } = renderHook(() =>
+      useAIChatBlobUpload('chat-attachments', { maxBytes: 1024 })
+    );
+
+    const file = makeFile('small.txt', 'text/plain', 1025);
+    await expect(result.current(file)).rejects.toThrow('File too large');
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the backend marks the blob invalid', async () => {
+    mockUpload.mockResolvedValueOnce({
+      blobId: 'bad-blob',
+      isValid: false,
+      status: 'Rejected',
+      verifiedContentType: null,
+      sizeBytes: null,
+      rejectionReason: 'Content type not allowed',
+    });
+    const { result } = renderHook(() => useAIChatBlobUpload('chat-attachments'));
+
+    const file = makeFile('virus.exe', 'application/octet-stream', 100);
+    await expect(result.current(file)).rejects.toThrow('Content type not allowed');
+  });
+
+  it('rejects with generic message when rejectionReason is null', async () => {
+    mockUpload.mockResolvedValueOnce({
+      blobId: 'bad-blob',
+      isValid: false,
+      status: 'Rejected',
+      verifiedContentType: null,
+      sizeBytes: null,
+      rejectionReason: null,
+    });
+    const { result } = renderHook(() => useAIChatBlobUpload('chat-attachments'));
+
+    const file = makeFile('bad.bin', 'application/octet-stream', 100);
+    await expect(result.current(file)).rejects.toThrow('Blob validation failed');
+  });
+
+  it('propagates upload errors from useBlobUpload', async () => {
+    mockUpload.mockRejectedValueOnce(new Error('Network error'));
+    const { result } = renderHook(() => useAIChatBlobUpload('chat-attachments'));
+
+    const file = makeFile('doc.pdf', 'application/pdf', 256);
+    await expect(result.current(file)).rejects.toThrow('Network error');
+  });
+});

--- a/packages/@granit/react-ai-chat-blob-storage/src/constants.ts
+++ b/packages/@granit/react-ai-chat-blob-storage/src/constants.ts
@@ -1,0 +1,22 @@
+/** Default maximum attachment size (10 MiB). Mirrors the AI:Chat:Attachments backend default. */
+export const CHAT_ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Default MIME types accepted by the AI chat blob attachment backend.
+ * Pass {@link CHAT_ATTACHMENT_ACCEPT} to `ChatComposer.attachAccept` to filter the file picker.
+ */
+export const CHAT_ATTACHMENT_ACCEPTED_TYPES = [
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'text/plain',
+  'application/json',
+  'text/csv',
+  'text/html',
+  'text/markdown',
+  'message/rfc822',
+] as const;
+
+/** Comma-separated MIME string ready for `<input accept="...">`. */
+export const CHAT_ATTACHMENT_ACCEPT = CHAT_ATTACHMENT_ACCEPTED_TYPES.join(',');

--- a/packages/@granit/react-ai-chat-blob-storage/src/hooks/use-ai-chat-blob-upload.ts
+++ b/packages/@granit/react-ai-chat-blob-storage/src/hooks/use-ai-chat-blob-upload.ts
@@ -1,0 +1,45 @@
+import { useBlobUpload } from '@granit/react-blob-storage';
+import { useCallback } from 'react';
+
+import { CHAT_ATTACHMENT_MAX_BYTES } from '../constants';
+
+import type { UploadAttachment } from '@granit/react-ai-chat';
+
+export interface UseAIChatBlobUploadOptions {
+  /** Override the maximum file size in bytes (default: {@link CHAT_ATTACHMENT_MAX_BYTES}). */
+  readonly maxBytes?: number;
+}
+
+/**
+ * Returns an {@link UploadAttachment} adapter backed by blob storage.
+ * Inject into `ChatComposer` via the `uploadAttachment` prop.
+ */
+export function useAIChatBlobUpload(
+  containerName: string,
+  options?: UseAIChatBlobUploadOptions
+): UploadAttachment {
+  const { upload } = useBlobUpload();
+  const maxBytes = options?.maxBytes ?? CHAT_ATTACHMENT_MAX_BYTES;
+
+  return useCallback(
+    async (file: File) => {
+      if (file.size > maxBytes) {
+        throw new Error(`File too large: ${file.size} bytes (max ${maxBytes} bytes)`);
+      }
+
+      const result = await upload({ file, containerName });
+
+      if (!result.isValid) {
+        throw new Error(result.rejectionReason ?? 'Blob validation failed');
+      }
+
+      return {
+        reference: result.blobId,
+        fileName: file.name,
+        contentType: result.verifiedContentType ?? file.type,
+        sizeBytes: result.sizeBytes ?? file.size,
+      };
+    },
+    [upload, containerName, maxBytes]
+  );
+}

--- a/packages/@granit/react-ai-chat-blob-storage/src/index.ts
+++ b/packages/@granit/react-ai-chat-blob-storage/src/index.ts
@@ -1,0 +1,7 @@
+export { useAIChatBlobUpload } from './hooks/use-ai-chat-blob-upload';
+export type { UseAIChatBlobUploadOptions } from './hooks/use-ai-chat-blob-upload';
+export {
+  CHAT_ATTACHMENT_ACCEPT,
+  CHAT_ATTACHMENT_ACCEPTED_TYPES,
+  CHAT_ATTACHMENT_MAX_BYTES,
+} from './constants';

--- a/packages/@granit/react-ai-chat-blob-storage/tsconfig.json
+++ b/packages/@granit/react-ai-chat-blob-storage/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "compilerOptions": {
+    "paths": {
+      "@granit/blob-storage": ["../blob-storage/src/index.ts"],
+      "@granit/react-ai-chat": ["../react-ai-chat/src/index.ts"],
+      "@granit/react-blob-storage": ["../react-blob-storage/src/index.ts"],
+      "@granit/testing": ["../testing/src/index.ts"],
+      "@granit/react-testing": ["../react-testing/src/index.ts"]
+    }
+  }
+}

--- a/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
@@ -40,6 +40,8 @@ export interface ChatComposerProps {
   readonly searchMentions?: SearchMentions;
   /** App-specific attachment upload. Omit to hide the attach button. */
   readonly uploadAttachment?: UploadAttachment;
+  /** Comma-separated MIME types for the file picker `accept` attribute (e.g. from `CHAT_ATTACHMENT_ACCEPT`). */
+  readonly attachAccept?: string;
   /** Selectable workspaces (`Auto` first); omit to hide the selector. */
   readonly workspaces?: readonly string[];
   /**
@@ -75,6 +77,7 @@ export function ChatComposer({
   prompts = [],
   searchMentions,
   uploadAttachment,
+  attachAccept,
   workspaces,
   workspaceOptions,
   workspace,
@@ -424,6 +427,7 @@ export function ChatComposer({
                 <input
                   type="file"
                   multiple
+                  accept={attachAccept}
                   className="hidden"
                   disabled={disabled}
                   onChange={handleFiles}

--- a/packages/@granit/react-ai-chat/src/hooks/use-chat-stream.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-chat-stream.ts
@@ -170,9 +170,14 @@ function appendTurnToMessages(
     (prev) => {
       const newest = prev?.pages[0];
       if (!prev || !newest) return prev;
+      // Skip rows already present anywhere in the loaded pages (e.g. a background
+      // refetch ran between the persisted frame and stream completion).
+      const existingIds = new Set(prev.pages.flatMap((p) => p.items.map((m) => m.id)));
+      const fresh = [...rows].reverse().filter((m) => !existingIds.has(m.id));
+      if (fresh.length === 0) return prev;
       const updatedNewest: PagedResult<MessageResponse> = {
         ...newest,
-        items: [...[...rows].reverse(), ...newest.items],
+        items: [...fresh, ...newest.items],
       };
       return { ...prev, pages: [updatedNewest, ...prev.pages.slice(1)] };
     }
@@ -187,12 +192,17 @@ function appendTurnToMessages(
  * reportable until the next full load. When the backend sends `persisted`, its
  * authoritative rows (real ids + server `createdAt`) are used instead.
  */
-function synthesizeTurnRows(userMessage: string, assistantContent: string): MessageResponse[] {
+function synthesizeTurnRows(
+  userMessage: string,
+  assistantContent: string,
+  workspaceKey: string | null
+): MessageResponse[] {
   const now = toISODateString(new Date().toISOString());
   const synth = (role: MessageResponse['role'], content: string): MessageResponse => ({
     id: toEntityId<'Message'>(crypto.randomUUID()),
     role,
     content,
+    workspaceKey,
     createdAt: now,
   });
   const rows: MessageResponse[] = [synth('user', userMessage)];
@@ -286,7 +296,11 @@ export function useChatStream(): UseChatStreamReturn {
             const rows =
               turn.persistedMessages && turn.persistedMessages.length > 0
                 ? turn.persistedMessages
-                : synthesizeTurnRows(request.message, turn.accumulated);
+                : synthesizeTurnRows(
+                    request.message,
+                    turn.accumulated,
+                    request.workspaceName ?? null
+                  );
             appendTurnToMessages(
               queryClient,
               conversationKeys.messages(config.queryKeyPrefix, turn.resolvedId),

--- a/packages/@granit/react-ai-chat/src/testing/data.ts
+++ b/packages/@granit/react-ai-chat/src/testing/data.ts
@@ -18,21 +18,30 @@ export const mockConversation: ConversationResponse = {
   isFavorite: false,
   createdAt: toISODateString('2026-06-15T09:00:00.000Z'),
   modifiedAt: toISODateString('2026-06-15T09:05:00.000Z'),
-  messages: [
-    {
-      id: toEntityId<'Message'>('c3333333-3333-3333-3333-333333333331'),
-      role: 'user',
-      content: 'What changed on invoice 42 last week?',
-      createdAt: toISODateString('2026-06-15T09:00:00.000Z'),
-    },
-    {
-      id: toEntityId<'Message'>('c3333333-3333-3333-3333-333333333332'),
-      role: 'assistant',
-      content: 'The total was revised from €1,200 to €1,350 and the due date moved to June 30.',
-      createdAt: toISODateString('2026-06-15T09:00:08.000Z'),
-    },
-  ] satisfies MessageResponse[],
+  workspaceKey: null,
 };
+
+/**
+ * The {@link mockConversation} thread (oldest-first), served by the paginated
+ * `GET /conversations/{id}/messages` handler — the thread is no longer embedded
+ * in the conversation detail response.
+ */
+export const mockConversationMessages: readonly MessageResponse[] = [
+  {
+    id: toEntityId<'Message'>('c3333333-3333-3333-3333-333333333331'),
+    role: 'user',
+    content: 'What changed on invoice 42 last week?',
+    workspaceKey: null,
+    createdAt: toISODateString('2026-06-15T09:00:00.000Z'),
+  },
+  {
+    id: toEntityId<'Message'>('c3333333-3333-3333-3333-333333333332'),
+    role: 'assistant',
+    content: 'The total was revised from €1,200 to €1,350 and the due date moved to June 30.',
+    workspaceKey: null,
+    createdAt: toISODateString('2026-06-15T09:00:08.000Z'),
+  },
+];
 
 /** A long conversation used to exercise reverse (keyset) message pagination. */
 export const mockLongConversationId = toEntityId<'Conversation'>(
@@ -51,6 +60,7 @@ export const mockLongConversationMessages: readonly MessageResponse[] = Array.fr
       id: toEntityId<'Message'>(`d4444444-4444-4444-4444-${String(i).padStart(12, '0')}`),
       role: isUser ? 'user' : 'assistant',
       content: isUser ? `Question ${Math.floor(i / 2) + 1}` : `Answer ${Math.floor(i / 2) + 1}`,
+      workspaceKey: null,
       createdAt: toISODateString(
         new Date(Date.parse('2026-06-10T08:00:00.000Z') + i * 60_000).toISOString()
       ),
@@ -66,6 +76,7 @@ export const mockConversationSummaries: ConversationSummaryResponse[] = [
     isFavorite: false,
     createdAt: toISODateString('2026-06-15T09:00:00.000Z'),
     modifiedAt: toISODateString('2026-06-15T09:05:00.000Z'),
+    workspaceKey: null,
   },
   {
     id: toEntityId<'Conversation'>('a1111111-1111-1111-1111-111111111112'),
@@ -73,6 +84,7 @@ export const mockConversationSummaries: ConversationSummaryResponse[] = [
     isFavorite: true,
     createdAt: toISODateString('2026-06-14T07:30:00.000Z'),
     modifiedAt: null,
+    workspaceKey: null,
   },
 ];
 

--- a/packages/@granit/react-ai-chat/src/testing/handlers.ts
+++ b/packages/@granit/react-ai-chat/src/testing/handlers.ts
@@ -5,6 +5,7 @@ import { DEFAULT_BASE_PATH } from '../constants';
 import {
   mockChatWorkspaces,
   mockConversation,
+  mockConversationMessages,
   mockConversationSummaries,
   mockLongConversationId,
   mockLongConversationMessages,
@@ -52,7 +53,7 @@ export function createAIChatHandlers(baseUrl = DEFAULT_BASE_PATH) {
       const id = params.id as string;
       // Source fixture is ascending (oldest-first).
       const all: readonly MessageResponse[] =
-        id === mockLongConversationId ? mockLongConversationMessages : mockConversation.messages;
+        id === mockLongConversationId ? mockLongConversationMessages : mockConversationMessages;
 
       const url = new URL(request.url);
       const pageSize = Math.min(Math.max(Number(url.searchParams.get('pageSize')) || 30, 1), 100);
@@ -93,7 +94,6 @@ export function createAIChatHandlers(baseUrl = DEFAULT_BASE_PATH) {
         ...mockConversation,
         id: mockConversation.id,
         title: body.title,
-        messages: [],
       };
       summaries = [
         {
@@ -102,6 +102,7 @@ export function createAIChatHandlers(baseUrl = DEFAULT_BASE_PATH) {
           isFavorite: created.isFavorite,
           createdAt: created.createdAt,
           modifiedAt: created.modifiedAt,
+          workspaceKey: created.workspaceKey,
         },
         ...summaries,
       ];

--- a/packages/@granit/react-ai/src/testing/data.ts
+++ b/packages/@granit/react-ai/src/testing/data.ts
@@ -128,6 +128,7 @@ export const mockWorkspaces: AIWorkspaceResponse[] = [
     kind: 'System',
     activated: true,
     capabilities: gpt4oCaps,
+    workspaceModelName: 'GPT-4o',
   },
   {
     name: 'code-review',
@@ -139,6 +140,7 @@ export const mockWorkspaces: AIWorkspaceResponse[] = [
     kind: 'Dynamic',
     activated: true,
     capabilities: basicChatCaps,
+    workspaceModelName: null,
   },
   {
     name: 'translation',
@@ -150,6 +152,7 @@ export const mockWorkspaces: AIWorkspaceResponse[] = [
     kind: 'Dynamic',
     activated: true,
     capabilities: gpt4oCaps,
+    workspaceModelName: null,
   },
   {
     name: 'summarizer',
@@ -161,6 +164,7 @@ export const mockWorkspaces: AIWorkspaceResponse[] = [
     kind: 'Dynamic',
     activated: false,
     capabilities: ollamaCaps,
+    workspaceModelName: null,
   },
 ];
 

--- a/packages/@granit/react-ai/src/testing/handlers.ts
+++ b/packages/@granit/react-ai/src/testing/handlers.ts
@@ -365,6 +365,7 @@ export function createAIHandlers(baseUrl = '/api/v1/ai') {
         kind: 'Dynamic',
         activated: true,
         capabilities: model?.capabilities ?? null,
+        workspaceModelName: body.workspaceModelName ?? null,
       };
 
       workspaces = [...workspaces, created];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1166,6 +1166,28 @@ importers:
         specifier: workspace:*
         version: link:../utils
 
+  packages/@granit/react-ai-chat-blob-storage:
+    dependencies:
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+    devDependencies:
+      '@granit/blob-storage':
+        specifier: workspace:*
+        version: link:../blob-storage
+      '@granit/react-ai-chat':
+        specifier: workspace:*
+        version: link:../react-ai-chat
+      '@granit/react-blob-storage':
+        specifier: workspace:*
+        version: link:../react-blob-storage
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/react-ai-prompts:
     dependencies:
       '@tanstack/react-query':

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -232,10 +232,23 @@ export default defineConfig({
         __dirname,
         'packages/@granit/reference-data/src/index.ts'
       ),
+      '@granit/ai-chat': path.resolve(__dirname, 'packages/@granit/ai-chat/src/index.ts'),
       '@granit/react-ai': path.resolve(__dirname, 'packages/@granit/react-ai/src/index.ts'),
       '@granit/react-ai/testing': path.resolve(
         __dirname,
         'packages/@granit/react-ai/src/testing/index.ts'
+      ),
+      '@granit/react-ai-chat': path.resolve(
+        __dirname,
+        'packages/@granit/react-ai-chat/src/index.ts'
+      ),
+      '@granit/react-ai-chat/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-ai-chat/src/testing/index.ts'
+      ),
+      '@granit/react-ai-chat-blob-storage': path.resolve(
+        __dirname,
+        'packages/@granit/react-ai-chat-blob-storage/src/index.ts'
       ),
       '@granit/react-auditing': path.resolve(
         __dirname,


### PR DESCRIPTION
## Summary

Branche l'upload de pièces jointes dans le chat AI sur BlobStorage (backend PR granit-fx/granit-dotnet#2821 — `BlobStorageAIAttachmentSource`).

- **Nouveau package `@granit/react-ai-chat-blob-storage`** : adaptateur glue entre `@granit/react-blob-storage` et `@granit/react-ai-chat`
  - `useAIChatBlobUpload(containerName, options?)` → retourne `UploadAttachment` (à injecter dans `ChatComposer.uploadAttachment`)
  - Valide la taille côté client (défaut 10 MiB) avant de lancer l'upload
  - Orchestre le flow 3 étapes : POST /upload → PUT presigned → POST /confirm
  - Rejette si le backend retourne `isValid: false` après confirmation
  - Mappe vers `{ reference: blobId, fileName, contentType, sizeBytes }`
  - Exporte `CHAT_ATTACHMENT_ACCEPTED_TYPES`, `CHAT_ATTACHMENT_ACCEPT`, `CHAT_ATTACHMENT_MAX_BYTES`
- **`ChatComposer` (`@granit/react-ai-chat`)** : prop optionnelle `attachAccept?: string` passée au `<input accept>` pour filtrer le sélecteur de fichiers
- **Audit conformance** (`@granit/ai`, `@granit/ai-chat`) : `workspaceKey` sur `MessageResponse` / `ConversationResponse` / `ConversationSummaryResponse` ; `workspaceModelName` + `AI_WORKSPACE_LIMITS` sur `@granit/ai` ; fixtures de test mises à jour

## Intégration côté app (showcase)

```tsx
const uploadAttachment = useAIChatBlobUpload('chat-attachments');

<ChatComposer
  uploadAttachment={uploadAttachment}
  attachAccept={CHAT_ATTACHMENT_ACCEPT}
  ...
/>
```

`BlobStorageProvider` doit envelopper le composant (précondition habituelle pour tout usage de `@granit/react-blob-storage`).

## Test plan

- [ ] `npx vitest run packages/@granit/react-ai-chat-blob-storage/` → 7 tests passent
- [ ] `pnpm tsc` → clean
- [ ] `pnpm lint` → clean
- [ ] Vérifier dans le showcase que le sélecteur de fichiers n'affiche que les types autorisés (`accept`)
- [ ] Uploader un PDF valide → vérifier que le blob apparaît dans `AttachmentChips` puis est inclus dans le message envoyé
- [ ] Uploader un fichier > 10 MiB → chip en erreur (rejet client avant upload)
- [ ] Uploader un type non autorisé côté backend → chip en erreur (rejet serveur après confirm)