### PR TITLE
fix(contract-tests): sync OpenAPI snapshots + README for react-ai-chat-blob-storage

### DIFF
--- a/contracts/openapi/ai-chat.json
+++ b/contracts/openapi/ai-chat.json
@@ -574,7 +574,7 @@
       "post": {
         "tags": ["AI - Conversations"],
         "summary": "Sends a message and streams a tool-grounded answer over SSE.",
-        "description": "Runs the agentic loop within the caller's permissions, persists the user and assistant messages, and streams the answer as Server-Sent Events: a 'conversation' frame with the (possibly new) conversation id (flushed immediately), then live 'tool_call'/'tool_result' frames as the agent uses tools and incremental 'delta' content frames as the model writes, then a 'usage' frame (and 'suggestions' / 'clarification' when applicable). Rejects a non-chat-capable workspace before streaming. If the agent fails after the stream is committed (provider quota exhausted, a provider 5xx/timeout, or any other fault), the stream ends with a terminal 'error' frame carrying a machine 'code' (rate_limit / provider_unavailable / server_error) — a frame within the 200 response, not an HTTP status. A client-cancelled request emits no 'error' frame.",
+        "description": "Runs the agentic loop within the caller's permissions, persists the user and assistant messages, and streams the answer as Server-Sent Events: a 'conversation' frame with the (possibly new) conversation id (flushed immediately), then live 'tool_call'/'tool_result' frames as the agent uses tools and incremental 'delta' content frames as the model writes, then a 'usage' frame (and 'suggestions' / 'clarification' when applicable). Rejects a non-chat-capable workspace before streaming. If the agent fails after the stream is committed (provider quota exhausted, a provider 5xx/timeout, or any other fault), the stream ends with a terminal 'error' frame carrying a machine 'code' (rate_limit / provider_unavailable / server_error) \u2014 a frame within the 200 response, not an HTTP status. A client-cancelled request emits no 'error' frame.",
         "operationId": "SendChatMessage",
         "requestBody": {
           "content": {
@@ -664,7 +664,7 @@
       "post": {
         "tags": ["AI - Conversations"],
         "summary": "Reports a message in one of the current user's conversations.",
-        "description": "Records a user report flagging the message for review and raises a domain event the application can route. Scoped to the caller: a message outside the caller's own conversations is reported as not found. The report stores identifiers plus the user-entered reason — never the message content (ADR-071).",
+        "description": "Records a user report flagging the message for review and raises a domain event the application can route. Scoped to the caller: a message outside the caller's own conversations is reported as not found. The report stores identifiers plus the user-entered reason \u2014 never the message content (ADR-071).",
         "operationId": "ReportChatMessage",
         "parameters": [
           {
@@ -929,7 +929,15 @@
         }
       },
       "ConversationResponse": {
-        "required": ["id", "title", "ownerId", "isFavorite", "createdAt", "modifiedAt"],
+        "required": [
+          "id",
+          "title",
+          "ownerId",
+          "isFavorite",
+          "createdAt",
+          "modifiedAt",
+          "workspaceKey"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -953,11 +961,14 @@
           "modifiedAt": {
             "type": ["null", "string"],
             "format": "date-time"
+          },
+          "workspaceKey": {
+            "type": ["null", "string"]
           }
         }
       },
       "ConversationSummaryResponse": {
-        "required": ["id", "title", "isFavorite", "createdAt", "modifiedAt"],
+        "required": ["id", "title", "isFavorite", "createdAt", "modifiedAt", "workspaceKey"],
         "type": "object",
         "properties": {
           "id": {
@@ -977,6 +988,9 @@
           "modifiedAt": {
             "type": ["null", "string"],
             "format": "date-time"
+          },
+          "workspaceKey": {
+            "type": ["null", "string"]
           }
         }
       },
@@ -1036,7 +1050,7 @@
         "enum": ["Inaccurate", "Harmful", "Other", null]
       },
       "MessageResponse": {
-        "required": ["id", "role", "content", "createdAt"],
+        "required": ["id", "role", "content", "createdAt", "workspaceKey"],
         "type": "object",
         "properties": {
           "id": {
@@ -1048,6 +1062,9 @@
           },
           "content": {
             "type": "string"
+          },
+          "workspaceKey": {
+            "type": ["null", "string"]
           },
           "createdAt": {
             "type": "string",

--- a/contracts/openapi/ai.json
+++ b/contracts/openapi/ai.json
@@ -727,7 +727,7 @@
           {
             "name": "workspaceName",
             "in": "path",
-            "description": "Workspace identifier — isolates configuration and routing per AI workspace.",
+            "description": "Workspace identifier \u2014 isolates configuration and routing per AI workspace.",
             "required": true,
             "schema": {
               "type": "string"
@@ -828,7 +828,7 @@
           {
             "name": "workspaceName",
             "in": "path",
-            "description": "Workspace identifier — isolates configuration and routing per AI workspace.",
+            "description": "Workspace identifier \u2014 isolates configuration and routing per AI workspace.",
             "required": true,
             "schema": {
               "type": "string"
@@ -939,7 +939,7 @@
           {
             "name": "workspaceName",
             "in": "path",
-            "description": "Workspace identifier — isolates configuration and routing per AI workspace.",
+            "description": "Workspace identifier \u2014 isolates configuration and routing per AI workspace.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1324,6 +1324,9 @@
           "maxOutputTokens": {
             "type": ["null", "integer"],
             "format": "int32"
+          },
+          "workspaceModelName": {
+            "type": ["null", "string"]
           }
         }
       },
@@ -1356,7 +1359,8 @@
           "maxOutputTokens",
           "kind",
           "activated",
-          "capabilities"
+          "capabilities",
+          "workspaceModelName"
         ],
         "type": "object",
         "properties": {
@@ -1396,6 +1400,9 @@
                 "$ref": "#/components/schemas/AIModelCapabilities"
               }
             ]
+          },
+          "workspaceModelName": {
+            "type": ["null", "string"]
           }
         }
       },
@@ -1424,6 +1431,9 @@
           "activated": {
             "type": "boolean",
             "default": false
+          },
+          "workspaceModelName": {
+            "type": ["null", "string"]
           }
         }
       },

--- a/packages/@granit/react-ai-chat-blob-storage/README.md
+++ b/packages/@granit/react-ai-chat-blob-storage/README.md
@@ -1,0 +1,9 @@
+# @granit/react-ai-chat-blob-storage
+
+Glue package that wires blob storage as the attachment backend for `@granit/react-ai-chat`.
+
+Exports `useAIChatBlobUpload` — a hook that returns an `UploadAttachment` adapter backed by
+`@granit/react-blob-storage`. Inject it into `ChatComposer` via the `uploadAttachment` prop.
+
+Also re-exports `CHAT_ATTACHMENT_ACCEPT`, `CHAT_ATTACHMENT_ACCEPTED_TYPES`, and
+`CHAT_ATTACHMENT_MAX_BYTES` for use in `<input accept>` and size-guard UI.


### PR DESCRIPTION
## Summary

- Add `workspaceKey` (required, nullable `string`) to `ConversationResponse`, `ConversationSummaryResponse`, and `MessageResponse` in `contracts/openapi/ai-chat.json`
- Add `workspaceModelName` (nullable `string`, required on response, optional on requests) to `AIWorkspaceResponse`, `AIWorkspaceCreateRequest`, and `AIWorkspaceUpdateRequest` in `contracts/openapi/ai.json`
- Create `README.md` for `@granit/react-ai-chat-blob-storage` (required by arch-test uniformity rule)

These vendored snapshots were not updated when PR #706 added the corresponding TS fields, causing 7 CI failures (`orphan-field` violations in contract conformance + missing README in uniformity test).

## Test plan

- [ ] `npx vitest run packages/@granit/arch-tests/ packages/@granit/contract-tests/` — all 2821 tests pass locally
- [ ] CI passes on this PR