### PR TITLE
fix(react-ai-chat-blob-storage): remove tsup build — source-direct package

### DIFF
--- a/packages/@granit/react-ai-chat-blob-storage/package.json
+++ b/packages/@granit/react-ai-chat-blob-storage/package.json
@@ -7,12 +7,6 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsup"
-  },
   "peerDependencies": {
     "@granit/blob-storage": "workspace:*",
     "@granit/react-ai-chat": "workspace:*",
@@ -25,14 +19,5 @@
     "@granit/react-blob-storage": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*"
-  },
-  "publishConfig": {
-    "exports": {
-      ".": {
-        "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
-      }
-    },
-    "registry": "https://npm.pkg.github.com"
   }
 }


### PR DESCRIPTION
## Summary

- Remove `scripts.build` (`tsup`), `files`, and `publishConfig` from `@granit/react-ai-chat-blob-storage/package.json`

The package was mistakenly created with a `tsup` publish configuration. It is an internal glue package consumed within the monorepo via Vite aliases — it must be source-direct (no `dist/`, no build step) per the package conventions in `CLAUDE.md`.

The erroneous `"build": "tsup"` script caused `pnpm -r run build` to fail in CI with `No input files, try "tsup <your-file>" instead` since no `tsup.config.ts` was ever created.

## Test plan

- [ ] `pnpm build` no longer invokes tsup for this package
- [ ] CI passes