### PR TITLE
feat(react-ai-chat): Markdown assistant messages + inline composer/user chips

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2946,6 +2946,17 @@
           "members": []
         },
         {
+          "name": "ChatMarkdown",
+          "kind": "function",
+          "signature": "function ChatMarkdown("
+        },
+        {
+          "name": "ChatMarkdownProps",
+          "kind": "interface",
+          "signature": "interface ChatMarkdownProps",
+          "members": []
+        },
+        {
           "name": "MessageMetrics",
           "kind": "function",
           "signature": "function MessageMetrics("

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,7 +4,7 @@ This file lists the third-party libraries used by the **granit-front** project
 along with their respective licenses. It is updated whenever an external
 dependency is added or modified.
 
-Last updated: 2026-06-18
+Last updated: 2026-06-20
 
 ---
 
@@ -12,7 +12,7 @@ Last updated: 2026-06-18
 
 | License      | Package count |
 | ------------ | ------------- |
-| MIT          | 44            |
+| MIT          | 46            |
 | Apache-2.0   | 15            |
 | BSD-3-Clause | 1             |
 
@@ -65,6 +65,8 @@ Last updated: 2026-06-18
 | react-dom                       | 19.2.7   | Copyright (c) Meta Platforms, Inc.         |
 | react-hook-form                 | 7.77.0   | Copyright (c) react-hook-form Contributors |
 | react-i18next                   | 17.0.8   | Copyright (c) i18next Contributors         |
+| react-markdown                  | 9.1.0    | Copyright (c) Espen Hovlandsdal            |
+| remark-gfm                      | 4.0.1    | Copyright (c) Titus Wormer                 |
 | tailwind-merge                  | 3.6.0    | Copyright (c) Dany Castillo                |
 | tsup                            | 8.5.1    | Copyright (c) EGOIST                       |
 | typescript-eslint               | 8.61.0   | typescript-eslint Contributors             |

--- a/packages/@granit/react-ai-chat/package.json
+++ b/packages/@granit/react-ai-chat/package.json
@@ -14,6 +14,10 @@
   "scripts": {
     "build": "tsup"
   },
+  "dependencies": {
+    "react-markdown": "^9",
+    "remark-gfm": "^4"
+  },
   "peerDependencies": {
     "@granit/ai-chat": "workspace:*",
     "@granit/api-client": "workspace:*",

--- a/packages/@granit/react-ai-chat/src/__tests__/chat-composer.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/chat-composer.test.tsx
@@ -1,10 +1,12 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { ChatComposer } from '../components/chat-composer';
+import { createChipElement } from '../components/composer-content';
 
-import type { MentionOption, PromptOption } from '../components/composer-types';
+import type { ChipSpec } from '../components/composer-content';
+import type { PromptOption } from '../components/composer-types';
 import type { PromptId, SendMessageRequest } from '@granit/ai-chat';
 
 const PROMPTS: PromptOption[] = [
@@ -12,60 +14,72 @@ const PROMPTS: PromptOption[] = [
   { id: 'p2' as PromptId, name: 'Daily brief', shortDescription: 'Your day' },
 ];
 
+/** The contenteditable message input. */
+const getEditor = () => screen.getByRole('textbox', { name: /ask your app/i });
+
+/**
+ * Build the editor content from interleaved text + chip specs (as the editor
+ * holds it after picks) and fire the input event the component listens on.
+ */
+const setEditorContent = (...segments: ReadonlyArray<string | ChipSpec>) => {
+  const editor = getEditor();
+  editor.replaceChildren();
+  for (const segment of segments) {
+    editor.appendChild(
+      typeof segment === 'string'
+        ? document.createTextNode(segment)
+        : createChipElement(document, segment)
+    );
+  }
+  fireEvent.input(editor);
+  return editor;
+};
+
 describe('ChatComposer', () => {
-  it('inserts a prompt badge from the / picker and keeps it out of the message text', async () => {
+  it('serializes chips into the message and the structured prompt/mention refs', async () => {
     const onSubmit = vi.fn<(r: SendMessageRequest) => void>();
     render(<ChatComposer onSubmit={onSubmit} prompts={PROMPTS} />);
 
-    const input = screen.getByRole('combobox');
-    await userEvent.type(input, '/Sum');
-    await userEvent.click(await screen.findByText('Summarize'));
-
-    // Badge present, textarea cleared of the /token.
-    expect(screen.getByText('/Summarize')).toBeInTheDocument();
-    expect((input as HTMLTextAreaElement).value).toBe('');
-
-    await userEvent.type(input, 'do it');
+    setEditorContent(
+      'Fait moi un ',
+      { kind: 'prompt', id: 'p1', label: 'Daily brief' },
+      ' sur ',
+      { kind: 'mention', id: 'ua1', type: 'account', label: 'United Airlines' },
+      ' de manière précise.'
+    );
     await userEvent.click(screen.getByRole('button', { name: /send/i }));
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     const request = onSubmit.mock.calls[0]![0];
-    expect(request.message).toBe('do it');
-    expect(request.promptRefs).toEqual(['p1']);
-  });
-
-  it('resolves @ mentions via the injected adapter and includes them in the request', async () => {
-    const searchMentions = vi.fn(
-      async (query: string): Promise<readonly MentionOption[]> => [
-        { type: 'contact', id: 'c42', label: `Customer ${query}`, description: 'A contact' },
-      ]
+    // Each chip leaves a bold marker inline so the sent message re-renders it.
+    expect(request.message).toBe(
+      'Fait moi un **/Daily brief** sur **@United Airlines** de manière précise.'
     );
-    const onSubmit = vi.fn<(r: SendMessageRequest) => void>();
-    render(<ChatComposer onSubmit={onSubmit} searchMentions={searchMentions} />);
-
-    const input = screen.getByRole('combobox');
-    await userEvent.type(input, 'hi @ali');
-
-    await waitFor(() => expect(searchMentions).toHaveBeenCalledWith('ali'));
-    await userEvent.click(await screen.findByText('Customer ali'));
-
-    await userEvent.click(screen.getByRole('button', { name: /send/i }));
-    const request = onSubmit.mock.calls[0]![0];
-    expect(request.mentions).toEqual([{ type: 'contact', id: 'c42' }]);
-    expect(request.message).toContain('@Customer ali');
+    expect(request.promptRefs).toEqual(['p1']);
+    expect(request.mentions).toEqual([{ type: 'account', id: 'ua1' }]);
   });
 
-  it('submits on Enter and inserts a newline on Shift+Enter', async () => {
+  it('opens the / prompt picker as the query is typed', async () => {
+    render(<ChatComposer onSubmit={vi.fn()} prompts={PROMPTS} />);
+
+    await userEvent.type(getEditor(), '/Sum');
+
+    // The picker is open and filtered to the matching prompt.
+    expect(await screen.findByText('Summarize')).toBeInTheDocument();
+    expect(screen.queryByText('Daily brief')).not.toBeInTheDocument();
+  });
+
+  it('submits on Enter and stays put on Shift+Enter', async () => {
     const onSubmit = vi.fn();
     render(<ChatComposer onSubmit={onSubmit} />);
-    const input = screen.getByRole('combobox');
+    const editor = setEditorContent('hello');
 
-    await userEvent.type(input, 'line one{Shift>}{Enter}{/Shift}line two');
+    fireEvent.keyDown(editor, { key: 'Enter', shiftKey: true });
     expect(onSubmit).not.toHaveBeenCalled();
-    expect((input as HTMLTextAreaElement).value).toBe('line one\nline two');
 
-    await userEvent.type(input, '{Enter}');
+    fireEvent.keyDown(editor, { key: 'Enter' });
     expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0]![0].message).toBe('hello');
   });
 
   it('passes the selected workspace and disables send on an empty message', async () => {
@@ -76,10 +90,19 @@ describe('ChatComposer', () => {
 
     expect(screen.getByRole('button', { name: /send/i })).toBeDisabled();
 
-    await userEvent.type(screen.getByRole('combobox', { name: /ask your app/i }), 'hello');
+    setEditorContent('hello');
+    expect(screen.getByRole('button', { name: /send/i })).toBeEnabled();
     await userEvent.click(screen.getByRole('button', { name: /send/i }));
 
     expect(onSubmit.mock.calls[0]![0].workspaceName).toBe('support');
+  });
+
+  it('shows the placeholder only while the editor is empty', () => {
+    render(<ChatComposer onSubmit={vi.fn()} />);
+    expect(screen.getByText(/ask your app/i)).toHaveAttribute('data-slot', 'composer-placeholder');
+
+    setEditorContent('typed');
+    expect(screen.queryByText((_, el) => el?.dataset?.slot === 'composer-placeholder')).toBeNull();
   });
 
   it('shows a Stop button while streaming', async () => {
@@ -193,9 +216,9 @@ describe('ChatComposer', () => {
     const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
     await userEvent.upload(fileInput, file);
 
-    await waitFor(() => expect(screen.getByText('note.txt')).toBeInTheDocument());
+    await screen.findByText('note.txt');
 
-    await userEvent.type(screen.getByRole('combobox'), 'see attached');
+    setEditorContent('see attached');
     await userEvent.click(screen.getByRole('button', { name: /send/i }));
 
     const request = onSubmit.mock.calls[0]![0];

--- a/packages/@granit/react-ai-chat/src/__tests__/components.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/components.test.tsx
@@ -128,16 +128,56 @@ describe('ChatMessage', () => {
     const assistant = render(<ChatMessage role="assistant" content="Hi" />);
     const assistantBubble = assistant.container.querySelector('[data-slot="chat-bubble"]');
     expect(assistantBubble).toBeInTheDocument();
-    // Assistant bubble uses the lightened neutral surface and the left tail.
-    // Assistant tail = square bottom-left (inline style, purge-proof).
-    expect(assistantBubble?.className).toContain('bg-muted/50');
-    expect(assistantBubble).toHaveStyle({ borderBottomLeftRadius: '0px' });
+    // Assistant bubble uses the lightened neutral `bg-muted` surface and the
+    // left tail. Assert the surface family, not a specific opacity step, so the
+    // bubble's exact tint can change without breaking the theming contract.
+    // Assistant tail = square top-left (inline style, purge-proof).
+    expect(assistantBubble?.className).toContain('bg-muted');
+    expect(assistantBubble).toHaveStyle({ borderTopLeftRadius: '0px' });
 
-    // User tail = square bottom-right.
+    // User tail = square top-right.
     const user = render(<ChatMessage role="user" content="Hi" />);
     const userBubble = user.container.querySelector('[data-slot="chat-bubble"]');
     expect(userBubble?.className).toContain('bg-primary');
-    expect(userBubble).toHaveStyle({ borderBottomRightRadius: '0px' });
+    expect(userBubble).toHaveStyle({ borderTopRightRadius: '0px' });
+  });
+});
+
+describe('ChatMessage — Markdown rendering', () => {
+  it('renders assistant Markdown to formatted elements, not literal syntax', () => {
+    const { container } = render(<ChatMessage role="assistant" content={'**bold** and `code`'} />);
+    expect(container.querySelector('strong')).toHaveTextContent('bold');
+    expect(container.querySelector('code')).toHaveTextContent('code');
+    expect(container.textContent).not.toContain('**');
+  });
+
+  it('renders a Markdown list as a real <ul><li> tree', () => {
+    const { container } = render(<ChatMessage role="assistant" content={'- a\n- b'} />);
+    expect(container.querySelector('ul')).toBeInTheDocument();
+    expect(container.querySelectorAll('li')).toHaveLength(2);
+  });
+
+  it('keeps user messages as verbatim plain text (no Markdown)', () => {
+    const { container } = render(<ChatMessage role="user" content="**raw**" />);
+    expect(container.querySelector('strong')).not.toBeInTheDocument();
+    expect(screen.getByText('**raw**')).toBeInTheDocument();
+  });
+
+  it('opens Markdown links out-of-document with a safe rel', () => {
+    const { container } = render(
+      <ChatMessage role="assistant" content="[link](https://example.com)" />
+    );
+    const link = container.querySelector('a');
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer nofollow');
+  });
+
+  it('escapes raw HTML instead of emitting a live DOM sink', () => {
+    const { container } = render(
+      <ChatMessage role="assistant" content={'<img src=x onerror=alert(1)>'} />
+    );
+    expect(container.querySelector('img')).not.toBeInTheDocument();
   });
 });
 
@@ -267,6 +307,13 @@ describe('MessageMetrics', () => {
   it('renders a placeholder when tokens/sec is not derivable', () => {
     render(<MessageMetrics metrics={{ ...turnMetrics, tokensPerSecond: null }} />);
     expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('formats durations over a second in seconds rather than milliseconds', () => {
+    render(<MessageMetrics metrics={{ ...turnMetrics, firstTokenMs: 2400, totalMs: 25909 }} />);
+    // ≥10s rounds to whole seconds; <10s keeps one decimal.
+    expect(screen.getByRole('button', { name: 'Response timing' })).toHaveTextContent('26s');
+    expect(screen.getByText('2.4s')).toBeInTheDocument();
   });
 });
 

--- a/packages/@granit/react-ai-chat/src/__tests__/composer-content.test.ts
+++ b/packages/@granit/react-ai-chat/src/__tests__/composer-content.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createChipElement,
+  formatChipToken,
+  isEditorEmpty,
+  serializeEditor,
+  tokenizeMessageContent,
+} from '../components/composer-content';
+
+/** Build an editor root from text + chip specs interleaved in document order. */
+function editor(
+  ...nodes: ReadonlyArray<string | Parameters<typeof createChipElement>[1]>
+): HTMLElement {
+  const root = document.createElement('div');
+  for (const node of nodes) {
+    if (typeof node === 'string') root.appendChild(document.createTextNode(node));
+    else root.appendChild(createChipElement(document, node));
+  }
+  return root;
+}
+
+describe('serializeEditor', () => {
+  it('injects each chip label into the message at its place in the sentence', () => {
+    const root = editor(
+      'Fait moi un ',
+      { kind: 'prompt', id: 'daily-brief', label: 'Daily brief' },
+      ' sur ',
+      { kind: 'mention', id: 'ua-1', type: 'account', label: 'United Airlines' },
+      ' de manière précise.'
+    );
+
+    const { message } = serializeEditor(root);
+    // Chips leave a bold marker so the message re-renders them on reload.
+    expect(message).toBe(
+      'Fait moi un **/Daily brief** sur **@United Airlines** de manière précise.'
+    );
+  });
+
+  it('collects mentions and prompt refs from the chips', () => {
+    const root = editor(
+      { kind: 'prompt', id: 'p1', label: 'Summarize' },
+      ' ',
+      { kind: 'mention', id: 'a1', type: 'account', label: 'Acme' },
+      ' ',
+      { kind: 'mention', id: 'c2', type: 'contact', label: 'Jane' }
+    );
+
+    const { mentions, promptRefs } = serializeEditor(root);
+    expect(promptRefs).toEqual(['p1']);
+    expect(mentions).toEqual([
+      { type: 'account', id: 'a1', label: 'Acme' },
+      { type: 'contact', id: 'c2', label: 'Jane' },
+    ]);
+  });
+
+  it('trims ends and collapses whitespace introduced around chips', () => {
+    const root = editor(
+      '  hello   ',
+      { kind: 'mention', id: 'a1', type: 'account', label: 'Acme' },
+      '   world  '
+    );
+
+    expect(serializeEditor(root).message).toBe('hello **@Acme** world');
+  });
+
+  it('returns an empty request for an empty editor', () => {
+    const { message, mentions, promptRefs } = serializeEditor(editor());
+    expect(message).toBe('');
+    expect(mentions).toEqual([]);
+    expect(promptRefs).toEqual([]);
+  });
+});
+
+describe('formatChipToken / tokenizeMessageContent round-trip', () => {
+  it('wraps a chip label in a bold, kind-prefixed marker', () => {
+    expect(formatChipToken('prompt', 'Daily brief')).toBe('**/Daily brief**');
+    expect(formatChipToken('mention', 'United Airlines')).toBe('**@United Airlines**');
+  });
+
+  it('splits a message back into text and chip segments', () => {
+    const segments = tokenizeMessageContent(
+      'Fait moi un **/Daily brief** sur **@United Airlines** précise.'
+    );
+    expect(segments).toEqual([
+      { type: 'text', value: 'Fait moi un ' },
+      { type: 'chip', kind: 'prompt', label: 'Daily brief' },
+      { type: 'text', value: ' sur ' },
+      { type: 'chip', kind: 'mention', label: 'United Airlines' },
+      { type: 'text', value: ' précise.' },
+    ]);
+  });
+
+  it('returns a single text segment when there are no chip markers', () => {
+    expect(tokenizeMessageContent('just text')).toEqual([{ type: 'text', value: 'just text' }]);
+  });
+
+  it('leaves plain bold (no leading / or @) untouched as text', () => {
+    expect(tokenizeMessageContent('a **bold** word')).toEqual([
+      { type: 'text', value: 'a **bold** word' },
+    ]);
+  });
+});
+
+describe('isEditorEmpty', () => {
+  it('is true for blank text and a lone <br>', () => {
+    expect(isEditorEmpty(editor())).toBe(true);
+    expect(isEditorEmpty(editor('   '))).toBe(true);
+    const withBr = editor();
+    withBr.appendChild(document.createElement('br'));
+    expect(isEditorEmpty(withBr)).toBe(true);
+  });
+
+  it('is false when a chip is present even without text', () => {
+    expect(isEditorEmpty(editor({ kind: 'prompt', id: 'p1', label: 'X' }))).toBe(false);
+  });
+
+  it('is false when text is present', () => {
+    expect(isEditorEmpty(editor('hi'))).toBe(false);
+  });
+});
+
+describe('createChipElement', () => {
+  it('stores the payload on data attributes and renders the label', () => {
+    const chip = createChipElement(document, {
+      kind: 'mention',
+      id: 'a1',
+      type: 'account',
+      label: 'Acme',
+    });
+    expect(chip.dataset.slot).toBe('composer-chip');
+    expect(chip.dataset.kind).toBe('mention');
+    expect(chip.dataset.id).toBe('a1');
+    expect(chip.dataset.type).toBe('account');
+    expect(chip.contentEditable).toBe('false');
+    expect(chip.textContent).toBe('Acme');
+  });
+
+  it('adds a colored dot when an icon color is supplied', () => {
+    const chip = createChipElement(document, { kind: 'prompt', id: 'p1', label: 'X' }, '#ff0000');
+    const dot = chip.querySelector('span[aria-hidden="true"]');
+    expect(dot).not.toBeNull();
+    expect((dot as HTMLElement).style.backgroundColor).toBe('rgb(255, 0, 0)');
+  });
+});

--- a/packages/@granit/react-ai-chat/src/__tests__/message-chips.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/message-chips.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ChatMessage } from '../components/chat-message';
+
+describe('ChatMessage — user chip markers', () => {
+  it('renders bold chip markers as inline pills, keeping the surrounding text', () => {
+    const { container } = render(
+      <ChatMessage
+        role="user"
+        content="Fait moi un **/Daily brief** sur **@United Airlines** précise."
+      />
+    );
+
+    const chips = container.querySelectorAll('[data-slot="message-chip"]');
+    expect(chips).toHaveLength(2);
+    expect(chips[0]).toHaveAttribute('data-kind', 'prompt');
+    expect(chips[0]).toHaveTextContent('Daily brief');
+    expect(chips[1]).toHaveAttribute('data-kind', 'mention');
+    expect(chips[1]).toHaveTextContent('United Airlines');
+
+    // The markers themselves never leak into the rendered text.
+    const bubble = container.querySelector('[data-slot="chat-bubble"]');
+    expect(bubble?.textContent).toBe('Fait moi un Daily brief sur United Airlines précise.');
+    expect(bubble?.textContent).not.toContain('**');
+  });
+
+  it('renders a plain user message unchanged with no chips', () => {
+    const { container } = render(<ChatMessage role="user" content="just a message" />);
+    expect(screen.getByText('just a message')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="message-chip"]')).toBeNull();
+  });
+});

--- a/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
@@ -7,25 +7,36 @@ import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import { defaultChatLabels } from '../locales/index';
 
 import { AttachmentChips } from './attachment-chips';
+import { CHIP_SLOT, createChipElement, isEditorEmpty, serializeEditor } from './composer-content';
 import { ComposerSuggestions } from './composer-suggestions';
 import { detectTrigger } from './detect-trigger';
 import { WorkspaceSelector } from './workspace-selector';
 
 import type { ComposerAttachment } from './attachment-chips';
+import type { ChipSpec } from './composer-content';
 import type {
   MentionOption,
   PromptOption,
   SearchMentions,
-  StagedMention,
   UploadAttachment,
   WorkspaceOption,
 } from './composer-types';
 import type { ActiveTrigger } from './detect-trigger';
 import type { ChatTranslations } from '../locales/index';
 import type { SendMessageRequest } from '@granit/ai-chat';
-import type { ChangeEvent, KeyboardEvent, ReactNode } from 'react';
+import type {
+  ChangeEvent,
+  ClipboardEvent,
+  FormEvent,
+  KeyboardEvent,
+  MouseEvent,
+  ReactNode,
+} from 'react';
 
 const logger = createLogger('react-ai-chat');
+
+/** Caret-moving keys that should re-evaluate the `/` `@` trigger on key-up. */
+const CARET_KEYS = new Set(['ArrowLeft', 'ArrowRight', 'Home', 'End']);
 
 export interface ChatComposerProps {
   /** Builds and submits a {@link SendMessageRequest} for the turn. */
@@ -65,10 +76,12 @@ export interface ChatComposerProps {
 }
 
 /**
- * The streaming chat composer: a textarea with `/` prompt and `@` mention
- * autocomplete, attachment chips, an optional workspace selector, and a
- * Send/Stop button. App-specific concerns (mention search, blob upload) are
- * injected as adapters; everything else is headless and framework-agnostic.
+ * The streaming chat composer: a `contenteditable` rich input where `/` prompts
+ * and `@` mentions resolve to inline chips in the text flow, plus attachment
+ * chips, an optional workspace selector, and a Send/Stop button. Selected chips
+ * contribute their label to the message and populate the request's structured
+ * `promptRefs`/`mentions`. App-specific concerns (mention search, blob upload)
+ * are injected as adapters; everything else is headless and framework-agnostic.
  */
 export function ChatComposer({
   onSubmit,
@@ -88,16 +101,19 @@ export function ChatComposer({
   disabled = false,
   className,
 }: Readonly<ChatComposerProps>) {
-  const [text, setText] = useState('');
-  const [promptBadges, setPromptBadges] = useState<readonly PromptOption[]>([]);
-  const [mentions, setMentions] = useState<readonly StagedMention[]>([]);
+  // The editor DOM is the single source of truth for the message + its chips;
+  // `isEmpty` is the only mirrored bit, driving the placeholder and Send state.
+  const [isEmpty, setIsEmpty] = useState(true);
   const [attachments, setAttachments] = useState<readonly ComposerAttachment[]>([]);
   const [trigger, setTrigger] = useState<ActiveTrigger | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
   const [mentionResults, setMentionResults] = useState<readonly MentionOption[]>([]);
   const [mentionLoading, setMentionLoading] = useState(false);
 
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const editorRef = useRef<HTMLDivElement>(null);
+  // The trigger token's location, captured so a picked chip can replace it even
+  // after the picker click moved focus out of the editor.
+  const triggerLocRef = useRef<{ node: Text; start: number; end: number } | null>(null);
   const searchSeq = useRef(0);
   const attachmentSeq = useRef(0);
 
@@ -138,54 +154,119 @@ export function ChatComposer({
     [searchMentions]
   );
 
-  const handleChange = useCallback(
-    (event: ChangeEvent<HTMLTextAreaElement>) => {
-      const next = event.target.value;
-      setText(next);
-      const caret = event.target.selectionStart ?? next.length;
-      const active = detectTrigger(next, caret);
-      setTrigger(active);
-      setActiveIndex(0);
-      if (active?.kind === '@') runMentionSearch(active.query);
-      else setMentionResults([]);
-    },
-    [runMentionSearch]
-  );
-
-  const replaceTriggerToken = useCallback(
-    (replacement: string) => {
-      if (!trigger) return;
-      const caret = textareaRef.current?.selectionStart ?? text.length;
-      setText((current) => current.slice(0, trigger.start) + replacement + current.slice(caret));
+  /**
+   * Re-evaluate the `/` `@` trigger from the live caret. A trigger is only valid
+   * inside a single text node (chips are node boundaries), so we run the shared
+   * {@link detectTrigger} against the caret's text node and remember the token's
+   * span for {@link insertChip}.
+   */
+  const refreshTrigger = useCallback(() => {
+    const editor = editorRef.current;
+    const selection = typeof window !== 'undefined' ? window.getSelection() : null;
+    const node = selection?.anchorNode ?? null;
+    if (!editor || !selection || !selection.isCollapsed || !node || node.nodeType !== 3) {
+      triggerLocRef.current = null;
+      setTrigger(null);
+      return;
+    }
+    if (!editor.contains(node)) {
+      triggerLocRef.current = null;
+      setTrigger(null);
+      return;
+    }
+    const caret = selection.anchorOffset;
+    const active = detectTrigger(node.textContent ?? '', caret);
+    if (!active) {
+      triggerLocRef.current = null;
       setTrigger(null);
       setMentionResults([]);
+      return;
+    }
+    triggerLocRef.current = { node: node as Text, start: active.start, end: caret };
+    setTrigger(active);
+    setActiveIndex(0);
+    if (active.kind === '@') runMentionSearch(active.query);
+    else setMentionResults([]);
+  }, [runMentionSearch]);
+
+  const handleInput = useCallback(
+    (event: FormEvent<HTMLDivElement>) => {
+      setIsEmpty(isEditorEmpty(event.currentTarget));
+      refreshTrigger();
     },
-    [trigger, text.length]
+    [refreshTrigger]
   );
+
+  const handleKeyUp = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (CARET_KEYS.has(event.key)) refreshTrigger();
+    },
+    [refreshTrigger]
+  );
+
+  const handleMouseUp = useCallback(() => refreshTrigger(), [refreshTrigger]);
+
+  /** Count the chips of a kind already placed, to honour the per-turn limits. */
+  const chipCount = useCallback((kind: ChipSpec['kind']) => {
+    return (
+      editorRef.current?.querySelectorAll(`[data-slot="${CHIP_SLOT}"][data-kind="${kind}"]`)
+        .length ?? 0
+    );
+  }, []);
+
+  /** Replace the active trigger token with a chip + trailing space; re-focus. */
+  const insertChip = useCallback((spec: ChipSpec, iconColor?: string | null) => {
+    const editor = editorRef.current;
+    const loc = triggerLocRef.current;
+    if (!editor || !loc) return;
+    const doc = editor.ownerDocument;
+    const length = loc.node.textContent?.length ?? 0;
+    const range = doc.createRange();
+    range.setStart(loc.node, Math.min(loc.start, length));
+    range.setEnd(loc.node, Math.min(loc.end, length));
+    range.deleteContents();
+
+    const chip = createChipElement(doc, spec, iconColor);
+    range.insertNode(chip);
+    // A non-breaking space keeps the caret off the non-editable chip and gives a
+    // visible gap; serialization collapses it back to a normal space.
+    const spacer = doc.createTextNode(' ');
+    chip.after(spacer);
+
+    editor.focus();
+    const after = doc.createRange();
+    after.setStartAfter(spacer);
+    after.collapse(true);
+    const selection = doc.defaultView?.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(after);
+
+    triggerLocRef.current = null;
+    setTrigger(null);
+    setMentionResults([]);
+    setIsEmpty(isEditorEmpty(editor));
+  }, []);
 
   const selectPrompt = useCallback(
     (option: PromptOption) => {
-      setPromptBadges((current) => {
-        if (current.some((p) => p.id === option.id)) return current;
-        if (current.length >= SEND_MESSAGE_LIMITS.PROMPT_REFS_MAX) return current;
-        return [...current, option];
-      });
-      replaceTriggerToken('');
-      textareaRef.current?.focus();
+      if (chipCount('prompt') >= SEND_MESSAGE_LIMITS.PROMPT_REFS_MAX) {
+        setTrigger(null);
+        return;
+      }
+      insertChip({ kind: 'prompt', id: option.id, label: option.name }, option.iconColor);
     },
-    [replaceTriggerToken]
+    [chipCount, insertChip]
   );
 
   const selectMention = useCallback(
     (option: MentionOption) => {
-      setMentions((current) => {
-        if (current.length >= SEND_MESSAGE_LIMITS.MENTIONS_MAX) return current;
-        return [...current, { type: option.type, id: option.id, label: option.label }];
-      });
-      replaceTriggerToken(`@${option.label} `);
-      textareaRef.current?.focus();
+      if (chipCount('mention') >= SEND_MESSAGE_LIMITS.MENTIONS_MAX) {
+        setTrigger(null);
+        return;
+      }
+      insertChip({ kind: 'mention', id: option.id, type: option.type, label: option.label });
     },
-    [replaceTriggerToken]
+    [chipCount, insertChip]
   );
 
   const selectActive = useCallback(() => {
@@ -196,7 +277,7 @@ export function ChatComposer({
   }, [suggestionItems, activeIndex, trigger, selectPrompt, selectMention]);
 
   const hasUploading = attachments.some((a) => a.status === 'uploading');
-  const canSend = text.trim().length > 0 && !hasUploading && !disabled;
+  const canSend = !isEmpty && !hasUploading && !disabled;
 
   // Rich options win; otherwise derive plain options from the workspace names.
   const resolvedWorkspaceOptions = useMemo<readonly WorkspaceOption[]>(() => {
@@ -205,11 +286,15 @@ export function ChatComposer({
   }, [workspaceOptions, workspaces]);
 
   const submit = useCallback(() => {
-    if (!canSend) return;
+    const editor = editorRef.current;
+    if (!editor || hasUploading || disabled) return;
+    const { message, mentions, promptRefs } = serializeEditor(editor);
+    if (message.length === 0) return;
+
     const request: SendMessageRequest = {
-      message: text.trim(),
+      message,
       ...(workspace ? { workspaceName: workspace } : {}),
-      ...(promptBadges.length > 0 ? { promptRefs: promptBadges.map((p) => p.id) } : {}),
+      ...(promptRefs.length > 0 ? { promptRefs: [...promptRefs] } : {}),
       ...(mentions.length > 0 ? { mentions: mentions.map(({ type, id }) => ({ type, id })) } : {}),
       ...(attachments.length > 0
         ? {
@@ -225,15 +310,15 @@ export function ChatComposer({
         : {}),
     };
     onSubmit(request);
-    setText('');
-    setPromptBadges([]);
-    setMentions([]);
+    editor.replaceChildren();
+    setIsEmpty(true);
     setAttachments([]);
     setTrigger(null);
-  }, [canSend, text, workspace, promptBadges, mentions, attachments, onSubmit]);
+    setMentionResults([]);
+  }, [hasUploading, disabled, workspace, attachments, onSubmit]);
 
   const handleKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    (event: KeyboardEvent<HTMLDivElement>) => {
       if (showSuggestions && suggestionItems.length > 0) {
         if (event.key === 'ArrowDown') {
           event.preventDefault();
@@ -262,6 +347,40 @@ export function ChatComposer({
       }
     },
     [showSuggestions, suggestionItems.length, selectActive, submit]
+  );
+
+  /** Keep the message within the wire limit by blocking inserts past it. */
+  const handleBeforeInput = useCallback((event: FormEvent<HTMLDivElement>) => {
+    const inputType = (event.nativeEvent as InputEvent).inputType ?? '';
+    if (!inputType.startsWith('insert') || inputType === 'insertParagraph') return;
+    const length = event.currentTarget.textContent?.length ?? 0;
+    if (length >= SEND_MESSAGE_LIMITS.MESSAGE_MAX_LENGTH) event.preventDefault();
+  }, []);
+
+  /** Paste as plain text so foreign markup never enters the editor. */
+  const handlePaste = useCallback(
+    (event: ClipboardEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const editor = editorRef.current;
+      const pasted = event.clipboardData.getData('text/plain');
+      if (!editor || !pasted) return;
+      const remaining = SEND_MESSAGE_LIMITS.MESSAGE_MAX_LENGTH - (editor.textContent?.length ?? 0);
+      const text = pasted.slice(0, Math.max(0, remaining));
+      if (!text) return;
+      const selection = editor.ownerDocument.defaultView?.getSelection();
+      if (!selection || selection.rangeCount === 0) return;
+      const range = selection.getRangeAt(0);
+      range.deleteContents();
+      const node = editor.ownerDocument.createTextNode(text);
+      range.insertNode(node);
+      range.setStartAfter(node);
+      range.collapse(true);
+      selection.removeAllRanges();
+      selection.addRange(range);
+      setIsEmpty(isEditorEmpty(editor));
+      refreshTrigger();
+    },
+    [refreshTrigger]
   );
 
   const patchAttachment = useCallback((id: string, patch: Partial<ComposerAttachment>) => {
@@ -304,40 +423,18 @@ export function ChatComposer({
     [uploadAttachment, patchAttachment]
   );
 
-  const removePromptBadge = useCallback((id: string) => {
-    setPromptBadges((current) => current.filter((p) => p.id !== id));
-  }, []);
-
   const removeAttachment = useCallback((id: string) => {
     setAttachments((current) => current.filter((a) => a.id !== id));
   }, []);
 
+  const onSuggestionMouseDown = useCallback((event: MouseEvent) => {
+    // Keep the editor selection alive through the click so insertChip can replace
+    // the trigger token (the chip's location is captured, but focus matters).
+    event.preventDefault();
+  }, []);
+
   return (
     <div data-slot="chat-composer" className={cn('flex flex-col gap-2', className)}>
-      {promptBadges.length > 0 ? (
-        <ul data-slot="prompt-badges" className="flex flex-wrap gap-2">
-          {promptBadges.map((badge) => (
-            <li
-              key={badge.id}
-              data-slot="prompt-badge"
-              className="bg-primary/10 text-primary inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium"
-            >
-              <span>/{badge.name}</span>
-              <button
-                type="button"
-                aria-label={`${labels.RemovePrompt} ${badge.name}`}
-                onClick={() => {
-                  removePromptBadge(badge.id);
-                }}
-                className="hover:text-primary/70"
-              >
-                ×
-              </button>
-            </li>
-          ))}
-        </ul>
-      ) : null}
-
       <AttachmentChips attachments={attachments} labels={labels} onRemove={removeAttachment} />
 
       <div
@@ -348,71 +445,92 @@ export function ChatComposer({
         )}
       >
         {showSuggestions && trigger?.kind === '/' ? (
-          <ComposerSuggestions<PromptOption>
-            title={pickerLabels.Prompts}
-            items={promptMatches}
-            activeIndex={activeIndex}
-            loadingLabel={pickerLabels.Loading}
-            emptyLabel={pickerLabels.NoResults}
-            listboxId={listboxId}
-            getOptionId={getOptionId}
-            getKey={(item) => item.id}
-            onHover={setActiveIndex}
-            onSelect={selectPrompt}
-            renderItem={(item) => (
-              <div className="flex flex-col">
-                <span className="font-medium">{item.name}</span>
-                {item.shortDescription ? (
-                  <span className="text-muted-foreground text-xs">{item.shortDescription}</span>
-                ) : null}
-              </div>
-            )}
-          />
+          <div onMouseDown={onSuggestionMouseDown}>
+            <ComposerSuggestions<PromptOption>
+              title={pickerLabels.Prompts}
+              items={promptMatches}
+              activeIndex={activeIndex}
+              loadingLabel={pickerLabels.Loading}
+              emptyLabel={pickerLabels.NoResults}
+              listboxId={listboxId}
+              getOptionId={getOptionId}
+              getKey={(item) => item.id}
+              onHover={setActiveIndex}
+              onSelect={selectPrompt}
+              renderItem={(item) => (
+                <div className="flex flex-col">
+                  <span className="font-medium">{item.name}</span>
+                  {item.shortDescription ? (
+                    <span className="text-muted-foreground text-xs">{item.shortDescription}</span>
+                  ) : null}
+                </div>
+              )}
+            />
+          </div>
         ) : null}
 
         {showSuggestions && trigger?.kind === '@' ? (
-          <ComposerSuggestions<MentionOption>
-            title={pickerLabels.Mentions}
-            items={mentionResults}
-            activeIndex={activeIndex}
-            loading={mentionLoading}
-            loadingLabel={pickerLabels.Loading}
-            emptyLabel={pickerLabels.NoResults}
-            listboxId={listboxId}
-            getOptionId={getOptionId}
-            getKey={(item) => `${item.type}:${item.id}`}
-            onHover={setActiveIndex}
-            onSelect={selectMention}
-            renderItem={(item) => (
-              <div className="flex flex-col">
-                <span className="font-medium">{item.label}</span>
-                {item.description ? (
-                  <span className="text-muted-foreground text-xs">{item.description}</span>
-                ) : null}
-              </div>
-            )}
-          />
+          <div onMouseDown={onSuggestionMouseDown}>
+            <ComposerSuggestions<MentionOption>
+              title={pickerLabels.Mentions}
+              items={mentionResults}
+              activeIndex={activeIndex}
+              loading={mentionLoading}
+              loadingLabel={pickerLabels.Loading}
+              emptyLabel={pickerLabels.NoResults}
+              listboxId={listboxId}
+              getOptionId={getOptionId}
+              getKey={(item) => `${item.type}:${item.id}`}
+              onHover={setActiveIndex}
+              onSelect={selectMention}
+              renderItem={(item) => (
+                <div className="flex flex-col">
+                  <span className="font-medium">{item.label}</span>
+                  {item.description ? (
+                    <span className="text-muted-foreground text-xs">{item.description}</span>
+                  ) : null}
+                </div>
+              )}
+            />
+          </div>
         ) : null}
 
-        <textarea
-          ref={textareaRef}
-          data-slot="composer-input"
-          value={text}
-          disabled={disabled}
-          rows={2}
-          maxLength={SEND_MESSAGE_LIMITS.MESSAGE_MAX_LENGTH}
-          placeholder={labels.Placeholder}
-          aria-label={labels.Placeholder}
-          role="combobox"
-          aria-expanded={showSuggestions}
-          aria-controls={showSuggestions ? listboxId : undefined}
-          aria-activedescendant={
-            showSuggestions && suggestionItems.length > 0 ? getOptionId(activeIndex) : undefined
-          }
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          className="placeholder:text-muted-foreground w-full resize-none bg-transparent px-1 text-sm outline-none disabled:opacity-50"
-        />
+        <div className="relative">
+          {isEmpty ? (
+            <p
+              data-slot="composer-placeholder"
+              aria-hidden
+              className="text-muted-foreground pointer-events-none absolute inset-x-1 top-1 text-sm"
+            >
+              {labels.Placeholder}
+            </p>
+          ) : null}
+          <div
+            ref={editorRef}
+            data-slot="composer-input"
+            contentEditable={!disabled}
+            suppressContentEditableWarning
+            role="textbox"
+            aria-multiline="true"
+            aria-label={labels.Placeholder}
+            aria-autocomplete="list"
+            aria-expanded={showSuggestions}
+            aria-controls={showSuggestions ? listboxId : undefined}
+            aria-activedescendant={
+              showSuggestions && suggestionItems.length > 0 ? getOptionId(activeIndex) : undefined
+            }
+            onInput={handleInput}
+            onBeforeInput={handleBeforeInput}
+            onKeyDown={handleKeyDown}
+            onKeyUp={handleKeyUp}
+            onMouseUp={handleMouseUp}
+            onPaste={handlePaste}
+            className={cn(
+              'min-h-[3rem] w-full px-1 py-1 text-sm break-words whitespace-pre-wrap outline-none',
+              disabled && 'opacity-50'
+            )}
+          />
+        </div>
 
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-1">

--- a/packages/@granit/react-ai-chat/src/components/chat-markdown.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-markdown.tsx
@@ -1,0 +1,103 @@
+import { cn } from '@granit/utils';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+import type { Components } from 'react-markdown';
+
+export interface ChatMarkdownProps {
+  /**
+   * Markdown source. ⚠️ **Untrusted** — this is assistant-generated output. It is
+   * rendered to an escaped React element tree by `react-markdown` (no
+   * `rehype-raw`), so raw HTML in the source is emitted as literal text, never as
+   * live DOM. This is not an HTML sink.
+   */
+  readonly content: string;
+  readonly className?: string;
+}
+
+/**
+ * Styled element overrides for the rendered tree. Tokens are semantic Tailwind
+ * classes (`bg-muted`, `text-primary`, `border-border`…) so the consuming app's
+ * theme drives the palette — never hard-coded colours. The consuming showcase
+ * scans the `react-*` package sources via `@source`, so these utilities are
+ * emitted downstream.
+ */
+const components: Components = {
+  p: ({ children }) => <p className="[&:not(:first-child)]:mt-2">{children}</p>,
+  // Links carry untrusted text and hrefs: open out-of-document and strip the
+  // opener + referrer, and tell crawlers not to confer rank (`nofollow`).
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer nofollow"
+      className="text-primary underline"
+    >
+      {children}
+    </a>
+  ),
+  ul: ({ children }) => <ul className="[&:not(:first-child)]:mt-2 list-disc pl-5">{children}</ul>,
+  ol: ({ children }) => (
+    <ol className="[&:not(:first-child)]:mt-2 list-decimal pl-5">{children}</ol>
+  ),
+  li: ({ children }) => <li className="mt-1">{children}</li>,
+  h1: ({ children }) => (
+    <h1 className="[&:not(:first-child)]:mt-3 text-base font-semibold">{children}</h1>
+  ),
+  h2: ({ children }) => (
+    <h2 className="[&:not(:first-child)]:mt-3 text-base font-semibold">{children}</h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="[&:not(:first-child)]:mt-2 text-sm font-semibold">{children}</h3>
+  ),
+  h4: ({ children }) => (
+    <h4 className="[&:not(:first-child)]:mt-2 text-sm font-semibold">{children}</h4>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="[&:not(:first-child)]:mt-2 border-border text-muted-foreground border-l-2 pl-3">
+      {children}
+    </blockquote>
+  ),
+  // Distinguish inline code from a fenced block by the `language-*` class
+  // `remark`/`micromark` puts on the inner `<code>` of a fence. Inline code is
+  // self-contained (own surface); fenced code defers its surface to `pre`.
+  code: ({ className: codeClassName, children }) =>
+    codeClassName?.includes('language-') ? (
+      <code className={cn('font-mono text-xs', codeClassName)}>{children}</code>
+    ) : (
+      <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">{children}</code>
+    ),
+  pre: ({ children }) => (
+    <pre className="bg-muted [&:not(:first-child)]:mt-2 overflow-x-auto rounded-md p-2 font-mono text-xs">
+      {children}
+    </pre>
+  ),
+  table: ({ children }) => (
+    <div className="[&:not(:first-child)]:mt-2 overflow-x-auto">
+      <table className="border-border w-full border-collapse border text-xs">{children}</table>
+    </div>
+  ),
+  th: ({ children }) => (
+    <th className="border-border bg-muted border px-2 py-1 text-left font-semibold">{children}</th>
+  ),
+  td: ({ children }) => <td className="border-border border px-2 py-1">{children}</td>,
+  hr: () => <hr className="border-border my-3" />,
+};
+
+/**
+ * Renders assistant Markdown as a safe, escaped React element tree.
+ *
+ * Uses `react-markdown` + `remark-gfm` **without** `rehype-raw`: raw HTML in the
+ * source is escaped to text rather than parsed into DOM, so this stays within the
+ * "no HTML sink" rule of {@link ChatMessage}. Styling is supplied through the
+ * `components` map with semantic Tailwind tokens — no hard-coded colours.
+ */
+export function ChatMarkdown({ content, className }: Readonly<ChatMarkdownProps>) {
+  return (
+    <div data-slot="chat-markdown" className={cn('text-sm break-words', className)}>
+      <Markdown remarkPlugins={[remarkGfm]} components={components}>
+        {content}
+      </Markdown>
+    </div>
+  );
+}

--- a/packages/@granit/react-ai-chat/src/components/chat-message.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-message.tsx
@@ -1,13 +1,40 @@
 import { cn } from '@granit/utils';
 
+import { ChatMarkdown } from './chat-markdown';
+import { tokenizeMessageContent } from './composer-content';
+
 import type { ChatMessageRole } from '@granit/ai-chat';
 import type { CSSProperties, ReactNode } from 'react';
+
+/**
+ * Render a user message, turning the chip markers the composer left in the text
+ * (bold `@…`/slash-`…` runs like `**@United Airlines**`) back into inline pills.
+ * Plain runs stay verbatim; nothing here is an HTML sink (text + spans only).
+ */
+function UserContent({ content }: { readonly content: string }): ReactNode {
+  return tokenizeMessageContent(content).map((segment, index) =>
+    segment.type === 'text' ? (
+      <span key={`t${index}`}>{segment.value}</span>
+    ) : (
+      <span
+        key={`c${index}`}
+        data-slot="message-chip"
+        data-kind={segment.kind}
+        className="bg-primary-foreground/15 mx-0.5 inline-flex items-center rounded-md px-1.5 py-0.5 align-baseline font-medium"
+      >
+        {segment.label}
+      </span>
+    )
+  );
+}
 
 export interface ChatMessageProps {
   readonly role: ChatMessageRole;
   /**
-   * Message text. ⚠️ **Untrusted** for assistant messages — rendered here as a
-   * plain text node (React escapes it). Never replace this with an HTML sink.
+   * Message text. ⚠️ **Untrusted** for assistant messages — rendered via
+   * {@link ChatMarkdown} as an escaped React element tree (`react-markdown`, no
+   * `rehype-raw`), so it stays Markdown-formatted without becoming an HTML sink.
+   * User messages stay verbatim plain text. Never replace this with an HTML sink.
    */
   readonly content: string;
   /** Localised author label (e.g. "You" / "Assistant"). */
@@ -30,13 +57,13 @@ export function ChatMessage({
   className,
 }: Readonly<ChatMessageProps>) {
   const isUser = role === 'user';
-  // Flatten the emitter-side bottom corner into a speech-bubble tail. Done
+  // Flatten the emitter-side top corner into a speech-bubble tail. Done
   // inline rather than with per-corner Tailwind utilities: those classes are
   // novel here and get purged by the consuming app's Tailwind scan, whereas an
   // inline style always renders and reliably wins over the `rounded-2xl` base.
   const tailStyle: CSSProperties = isUser
-    ? { borderBottomRightRadius: 0 }
-    : { borderBottomLeftRadius: 0 };
+    ? { borderTopRightRadius: 0 }
+    : { borderTopLeftRadius: 0 };
   return (
     <div
       data-slot="chat-message"
@@ -50,11 +77,15 @@ export function ChatMessage({
         data-slot="chat-bubble"
         style={tailStyle}
         className={cn(
-          'max-w-[80%] rounded-2xl px-3 py-2 text-sm whitespace-pre-wrap',
-          isUser ? 'bg-primary text-primary-foreground' : 'bg-muted/50 text-foreground'
+          'max-w-[80%] rounded-2xl px-3 py-2 text-sm',
+          // Preserve authored whitespace only for the verbatim user branch; the
+          // assistant branch is laid out by ChatMarkdown's block elements.
+          isUser
+            ? 'bg-primary text-primary-foreground whitespace-pre-wrap'
+            : 'bg-muted/20 text-foreground'
         )}
       >
-        {content}
+        {isUser ? <UserContent content={content} /> : <ChatMarkdown content={content} />}
       </div>
       {actions ? (
         <div

--- a/packages/@granit/react-ai-chat/src/components/composer-content.ts
+++ b/packages/@granit/react-ai-chat/src/components/composer-content.ts
@@ -1,0 +1,171 @@
+import type { StagedMention } from './composer-types';
+import type { PromptId } from '@granit/ai-chat';
+
+/**
+ * Inline chip model for the composer's `contenteditable` input. Both `/` prompts
+ * and `@` mentions are rendered as non-editable chip elements sitting in the text
+ * flow; their data attributes are the source of truth that {@link serializeEditor}
+ * reads back into a submittable request — the DOM is the single store, so there is
+ * no parallel React state to keep in sync.
+ */
+
+/** `data-slot` marking a chip element in the editor. */
+export const CHIP_SLOT = 'composer-chip';
+
+/** A chip's kind, stored on `data-kind`. */
+export type ChipKind = 'prompt' | 'mention';
+
+/** Everything needed to render and later serialize a chip. */
+export interface ChipSpec {
+  readonly kind: ChipKind;
+  /** Prompt id (`/`) or mention id (`@`). */
+  readonly id: string;
+  /** Mention type (`@` only); omitted for prompts. */
+  readonly type?: string;
+  /** Visible text, also injected into the serialized message. */
+  readonly label: string;
+}
+
+/** The chip element's CSS — a subtle inline pill that reads as part of the text. */
+const CHIP_CLASS =
+  'mx-0.5 inline-flex select-none items-center gap-1 rounded-md bg-primary/10 px-1.5 py-0.5 align-baseline text-sm font-medium text-primary';
+
+/**
+ * Build a non-editable chip element for the editor. The element carries its
+ * payload on `data-*` so {@link serializeEditor} can reconstruct the request
+ * without any React state. A leading colored dot (when {@link iconColor} is set)
+ * mirrors the host's glyph without the framework hardcoding an icon set.
+ */
+export function createChipElement(
+  doc: Document,
+  spec: ChipSpec,
+  iconColor?: string | null
+): HTMLElement {
+  const chip = doc.createElement('span');
+  chip.dataset.slot = CHIP_SLOT;
+  chip.dataset.kind = spec.kind;
+  chip.dataset.id = spec.id;
+  if (spec.type) chip.dataset.type = spec.type;
+  chip.dataset.label = spec.label;
+  chip.contentEditable = 'false';
+  chip.className = CHIP_CLASS;
+
+  if (iconColor) {
+    const dot = doc.createElement('span');
+    dot.setAttribute('aria-hidden', 'true');
+    dot.className = 'size-2 shrink-0 rounded-full';
+    dot.style.backgroundColor = iconColor;
+    chip.appendChild(dot);
+  }
+
+  chip.appendChild(doc.createTextNode(spec.label));
+  return chip;
+}
+
+/**
+ * Marker a chip leaves in the serialized message so it survives the round-trip
+ * (send → persist → reload) with no extra wire fields: a bold run of the kind
+ * char + label — slash for a prompt, `**@United Airlines**` for a mention.
+ * Mirrors how Gemini keeps mentions
+ * as bold `@…` runs in the text; the markdown-bold delimiters bound multi-word
+ * labels unambiguously, {@link tokenizeMessageContent} turns them back into chips
+ * for display, and the raw text stays the canonical `content`.
+ */
+export function formatChipToken(kind: ChipKind, label: string): string {
+  return `**${kind === 'prompt' ? '/' : '@'}${label}**`;
+}
+
+/** Matches a chip token, capturing its kind char (`/`|`@`) and label. */
+const CHIP_TOKEN = /\*\*([/@])([^*]+)\*\*/g;
+
+/** A run of plain text or a chip, in document order. */
+export type ContentSegment =
+  | { readonly type: 'text'; readonly value: string }
+  | { readonly type: 'chip'; readonly kind: ChipKind; readonly label: string };
+
+/**
+ * Split a persisted message into text + chip segments for rendering. Inverse of
+ * {@link formatChipToken}: every `[[/…]]` / `[[@…]]` marker becomes a chip
+ * segment, everything else stays verbatim text — so a reloaded message shows the
+ * same chips the user composed, with no server-side metadata.
+ */
+export function tokenizeMessageContent(content: string): readonly ContentSegment[] {
+  const segments: ContentSegment[] = [];
+  let last = 0;
+  for (const match of content.matchAll(CHIP_TOKEN)) {
+    const index = match.index ?? 0;
+    if (index > last) segments.push({ type: 'text', value: content.slice(last, index) });
+    segments.push({
+      type: 'chip',
+      kind: match[1] === '/' ? 'prompt' : 'mention',
+      label: match[2]!,
+    });
+    last = index + match[0].length;
+  }
+  if (last < content.length) segments.push({ type: 'text', value: content.slice(last) });
+  return segments;
+}
+
+/** Whether a node is a composer chip element. */
+function isChip(node: Node): node is HTMLElement {
+  return node.nodeType === 1 && (node as HTMLElement).dataset?.slot === CHIP_SLOT;
+}
+
+/** The request fields a composer turn carries beyond plain text. */
+export interface SerializedEditor {
+  readonly message: string;
+  readonly mentions: readonly StagedMention[];
+  readonly promptRefs: readonly PromptId[];
+}
+
+/**
+ * Read the editor DOM back into a submittable shape. Walks in document order so
+ * each chip contributes its {@link formatChipToken} marker to
+ * {@link SerializedEditor.message} at its place in the sentence (so the message
+ * re-renders with the same chips) while also populating the structured
+ * {@link SerializedEditor.mentions}/{@link SerializedEditor.promptRefs}.
+ * Leading/trailing whitespace is trimmed and runs of inner whitespace collapsed,
+ * so the chip's surrounding spaces never produce doubled gaps.
+ */
+export function serializeEditor(root: HTMLElement): SerializedEditor {
+  const parts: string[] = [];
+  const mentions: StagedMention[] = [];
+  const promptRefs: PromptId[] = [];
+
+  const walk = (node: Node): void => {
+    for (const child of Array.from(node.childNodes)) {
+      if (child.nodeType === 3) {
+        parts.push(child.textContent ?? '');
+      } else if (isChip(child)) {
+        const { kind, id, type, label = '' } = child.dataset;
+        parts.push(formatChipToken(kind === 'mention' ? 'mention' : 'prompt', label));
+        if (kind === 'mention' && id && type) {
+          mentions.push({ type, id, label });
+        } else if (kind === 'prompt' && id) {
+          promptRefs.push(id as PromptId);
+        }
+      } else if (child.nodeName === 'BR') {
+        parts.push('\n');
+      } else {
+        walk(child);
+      }
+    }
+  };
+  walk(root);
+
+  const message = parts
+    .join('')
+    .replace(/[^\S\n]+/g, ' ')
+    .trim();
+  return { message, mentions, promptRefs };
+}
+
+/**
+ * True when the editor holds no text and no chips — used to drive the placeholder
+ * and disable Send. A lone `<br>` (browsers seed an empty editable with one)
+ * still counts as empty.
+ */
+export function isEditorEmpty(root: HTMLElement): boolean {
+  if (root.querySelector(`[data-slot="${CHIP_SLOT}"]`)) return false;
+  return (root.textContent ?? '').trim().length === 0;
+}

--- a/packages/@granit/react-ai-chat/src/components/message-metrics.tsx
+++ b/packages/@granit/react-ai-chat/src/components/message-metrics.tsx
@@ -12,7 +12,16 @@ export interface MessageMetricsProps {
   readonly className?: string;
 }
 
-const formatMs = (ms: number): string => `${Math.round(ms)}ms`;
+/**
+ * Render a duration in the most readable unit: milliseconds below a second,
+ * then seconds (one decimal under 10s, whole seconds above) so a slow turn reads
+ * `25.9s` / `26s` instead of `25909ms`.
+ */
+const formatMs = (ms: number): string => {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const seconds = ms / 1000;
+  return `${seconds < 10 ? seconds.toFixed(1) : Math.round(seconds)}s`;
+};
 
 const PLACEHOLDER = '—';
 
@@ -42,7 +51,7 @@ export function MessageMetrics({
   return (
     <span
       data-slot="message-metrics"
-      className={cn('group/metrics relative inline-flex', className)}
+      className={cn('group/metrics relative inline-flex self-center', className)}
     >
       <button
         type="button"

--- a/packages/@granit/react-ai-chat/src/index.ts
+++ b/packages/@granit/react-ai-chat/src/index.ts
@@ -64,6 +64,8 @@ export type { UseReverseInfiniteScrollParams } from './hooks/use-reverse-infinit
 // Components
 export { ChatMessage } from './components/chat-message';
 export type { ChatMessageProps } from './components/chat-message';
+export { ChatMarkdown } from './components/chat-markdown';
+export type { ChatMarkdownProps } from './components/chat-markdown';
 export { MessageMetrics } from './components/message-metrics';
 export type { MessageMetricsProps } from './components/message-metrics';
 export { ConversationThread } from './components/conversation-thread';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1134,6 +1134,12 @@ importers:
       react:
         specifier: 19.2.7
         version: 19.2.7
+      react-markdown:
+        specifier: ^9
+        version: 9.1.0(@types/react@19.2.17)(react@19.2.7)
+      remark-gfm:
+        specifier: ^4
+        version: 4.0.1
     devDependencies:
       '@granit/ai-chat':
         specifier: workspace:*
@@ -5559,11 +5565,17 @@ packages:
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -5576,6 +5588,9 @@ packages:
 
   '@types/leaflet@1.9.21':
     resolution: {integrity: sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -5602,6 +5617,9 @@ packages:
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
@@ -5670,6 +5688,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.61.1':
     resolution: {integrity: sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.12.2':
     resolution: {integrity: sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==}
@@ -5969,6 +5990,9 @@ packages:
   axios@1.18.0:
     resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -6025,9 +6049,15 @@ packages:
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
   character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
@@ -6087,6 +6117,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -6309,6 +6342,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-import-context@0.1.9:
     resolution: {integrity: sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -6384,6 +6421,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -6405,6 +6445,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-base64-decode@1.0.0:
     resolution: {integrity: sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==}
@@ -6587,6 +6630,12 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
@@ -6599,6 +6648,9 @@ packages:
 
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   http-parser-js@0.5.10:
     resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
@@ -6671,6 +6723,9 @@ packages:
   ini@6.0.0:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -6971,6 +7026,9 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
@@ -7006,6 +7064,9 @@ packages:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
     hasBin: true
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   markdownlint-cli2-formatter-default@0.0.6:
     resolution: {integrity: sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ==}
     peerDependencies:
@@ -7023,6 +7084,51 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
@@ -7050,8 +7156,20 @@ packages:
   micromark-extension-gfm-footnote@2.1.0:
     resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
 
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
   micromark-extension-gfm-table@2.1.1:
     resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-extension-math@3.1.0:
     resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
@@ -7085,6 +7203,9 @@ packages:
 
   micromark-util-decode-numeric-character-reference@2.0.2:
     resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
 
   micromark-util-encode@2.0.1:
     resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
@@ -7309,6 +7430,9 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   prosemirror-changeset@2.4.1:
     resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
 
@@ -7415,6 +7539,12 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-markdown@9.1.0:
+    resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: 19.2.7
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -7460,6 +7590,18 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -7598,6 +7740,9 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   stable-hash-x@0.2.0:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
     engines: {node: '>=12.0.0'}
@@ -7635,6 +7780,9 @@ packages:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
     engines: {node: '>=20'}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -7646,6 +7794,12 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -7725,6 +7879,12 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -7802,6 +7962,24 @@ packages:
     resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
     engines: {node: '>=20'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
@@ -7861,6 +8039,12 @@ packages:
 
   vanilla-cookieconsent@3.1.0:
     resolution: {integrity: sha512-/McNRtm/3IXzb9dhqMIcbquoU45SzbN2VB+To4jxEPqMmp7uVniP6BhGLjU8MC7ZCDsNQVOp27fhQTM/ruIXAA==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -8150,6 +8334,9 @@ packages:
         optional: true
       use-sync-external-store:
         optional: true
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -10082,9 +10269,17 @@ snapshots:
 
   '@types/esrecurse@4.3.1': {}
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
+
   '@types/estree@1.0.9': {}
 
   '@types/geojson@7946.0.16': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 2.0.11
 
   '@types/json-schema@7.0.15': {}
 
@@ -10097,6 +10292,10 @@ snapshots:
   '@types/leaflet@1.9.21':
     dependencies:
       '@types/geojson': 7946.0.16
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 2.0.11
 
   '@types/ms@2.1.0': {}
 
@@ -10122,6 +10321,8 @@ snapshots:
     optional: true
 
   '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
 
@@ -10221,6 +10422,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.61.1
       eslint-visitor-keys: 5.0.1
+
+  '@ungap/structured-clone@1.3.1': {}
 
   '@unrs/resolver-binding-android-arm-eabi@1.12.2':
     optional: true
@@ -10506,6 +10709,8 @@ snapshots:
       - debug
       - supports-color
 
+  bail@2.0.2: {}
+
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -10558,7 +10763,11 @@ snapshots:
 
   caniuse-lite@1.0.30001799: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
+
+  character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
 
@@ -10616,6 +10825,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@4.1.1: {}
 
@@ -10822,6 +11033,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-import-context@0.1.9(unrs-resolver@1.12.2):
     dependencies:
       get-tsconfig: 4.14.0
@@ -10930,6 +11143,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -10943,6 +11158,8 @@ snapshots:
   eventsource@2.0.2: {}
 
   expect-type@1.3.0: {}
+
+  extend@3.0.2: {}
 
   fast-base64-decode@1.0.0: {}
 
@@ -11157,6 +11374,30 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   headers-polyfill@5.0.1:
     dependencies:
       '@types/set-cookie-parser': 2.4.10
@@ -11173,6 +11414,8 @@ snapshots:
   html-parse-stringify@3.0.1:
     dependencies:
       void-elements: 3.1.0
+
+  html-url-attributes@3.0.1: {}
 
   http-parser-js@0.5.10: {}
 
@@ -11234,6 +11477,8 @@ snapshots:
   indent-string@4.0.0: {}
 
   ini@6.0.0: {}
+
+  inline-style-parser@0.2.7: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -11503,6 +11748,8 @@ snapshots:
 
   long@5.3.2: {}
 
+  longest-streak@3.1.0: {}
+
   lru-cache@11.5.1: {}
 
   lru-cache@5.1.1:
@@ -11542,6 +11789,8 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
+  markdown-table@3.0.4: {}
+
   markdownlint-cli2-formatter-default@0.0.6(markdownlint-cli2@0.22.1):
     dependencies:
       markdownlint-cli2: 0.22.1
@@ -11575,6 +11824,159 @@ snapshots:
       - supports-color
 
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   mdn-data@2.27.1: {}
 
@@ -11631,12 +12033,44 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
   micromark-extension-gfm-table@2.1.1:
     dependencies:
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-extension-math@3.1.0:
@@ -11703,6 +12137,13 @@ snapshots:
 
   micromark-util-decode-numeric-character-reference@2.0.2:
     dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-symbol: 2.0.1
 
   micromark-util-encode@2.0.1: {}
@@ -11939,6 +12380,8 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  property-information@7.2.0: {}
+
   prosemirror-changeset@2.4.1:
     dependencies:
       prosemirror-transform: 1.12.0
@@ -12084,6 +12527,24 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-markdown@9.1.0(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.17
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.7
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -12121,6 +12582,40 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 
@@ -12276,6 +12771,8 @@ snapshots:
 
   source-map@0.7.6: {}
 
+  space-separated-tokens@2.0.2: {}
+
   stable-hash-x@0.2.0: {}
 
   stackback@0.0.2: {}
@@ -12310,6 +12807,11 @@ snapshots:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -12321,6 +12823,14 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   sucrase@3.35.1:
     dependencies:
@@ -12395,6 +12905,10 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
@@ -12468,6 +12982,39 @@ snapshots:
 
   unicorn-magic@0.4.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@0.2.0: {}
 
   unrs-resolver@1.12.2:
@@ -12540,6 +13087,16 @@ snapshots:
   uuid@11.1.1: {}
 
   vanilla-cookieconsent@3.1.0: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.100.0)(yaml@2.9.0):
     dependencies:
@@ -12745,3 +13302,5 @@ snapshots:
       '@types/react': 19.2.17
       react: 19.2.7
       use-sync-external-store: 1.6.0(react@19.2.7)
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

Bundles two work-streams on `@granit/react-ai-chat` (both landed in commit `b3f9241f`):

### Markdown rendering for assistant messages
- New `ChatMarkdown` component rendering assistant output via **react-markdown + remark-gfm**, **without `rehype-raw`** — raw HTML is escaped to a React element tree, never a live DOM sink (honours `ChatMessage`'s "no HTML sink" rule).
- Styling through the `components` map with **semantic Tailwind tokens** (`bg-muted`, `text-primary`, `border-border`…) — no hard-coded colours. Inline vs fenced code distinguished by the `language-*` class. GFM tables/lists/links supported.
- Links open out-of-document with a safe `rel="noopener noreferrer nofollow"` (untrusted content).
- Wired into `ChatMessage`'s assistant branch (streaming bubble included). **User messages stay verbatim** (plain text / inline chips), not Markdown.
- `ChatMarkdown` + `ChatMarkdownProps` exported from the barrel.
- Deps `react-markdown ^9` + `remark-gfm ^4` added; **THIRD-PARTY-NOTICES** updated.

### Inline chips for composer & user messages
- `composer-content` tokenizer turning chip markers (bold `@…` / slash runs) into inline pills; rendered in user message bubbles via `UserContent`.
- Composer wiring + `message-metrics` duration formatting.

## Test plan
- `pnpm --filter @granit/react-ai-chat exec tsc --noEmit` — clean
- ESLint `--max-warnings 0` on the package — clean
- `vitest run` (package) — **121 passing** (incl. new Markdown cases: bold/code, lists, user-literal, safe link rel, raw-`<img>` escaped)
- `tsup` build — success (react-markdown/remark-gfm external)

## Notes
- Single commit by request; bundles the Markdown feature with the in-flight composer-chips work that shared the same worktree.
- Showcase untouched (it scans `react-*` sources via `@source`, so the new utilities are emitted downstream automatically).
- No Storybook story (Storybook isn't set up in this repo).