### PR TITLE
feat(react-ai-chat): unified @ mention picker via /conversations/mentions

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2891,6 +2891,11 @@
           "members": []
         },
         {
+          "name": "useDefaultMentionSearch",
+          "kind": "function",
+          "signature": "function useDefaultMentionSearch( limit: number = DEFAULT_MENTION_SEARCH_LIMIT ): SearchMentions | undefined"
+        },
+        {
           "name": "useChatStream",
           "kind": "function",
           "signature": "function useChatStream(): UseChatStreamReturn"

--- a/contracts/openapi/ai-chat.json
+++ b/contracts/openapi/ai-chat.json
@@ -574,7 +574,7 @@
       "post": {
         "tags": ["AI - Conversations"],
         "summary": "Sends a message and streams a tool-grounded answer over SSE.",
-        "description": "Runs the agentic loop within the caller's permissions, persists the user and assistant messages, and streams the answer as Server-Sent Events: a 'conversation' frame with the (possibly new) conversation id (flushed immediately), then live 'tool_call'/'tool_result' frames as the agent uses tools and incremental 'delta' content frames as the model writes, then a 'usage' frame (and 'suggestions' / 'clarification' when applicable). Rejects a non-chat-capable workspace before streaming. If the agent fails after the stream is committed (provider quota exhausted, a provider 5xx/timeout, or any other fault), the stream ends with a terminal 'error' frame carrying a machine 'code' (rate_limit / provider_unavailable / server_error) \u2014 a frame within the 200 response, not an HTTP status. A client-cancelled request emits no 'error' frame.",
+        "description": "Runs the agentic loop within the caller's permissions, persists the user and assistant messages, and streams the answer as Server-Sent Events: a 'conversation' frame with the (possibly new) conversation id (flushed immediately), then live 'tool_call'/'tool_result' frames as the agent uses tools and incremental 'delta' content frames as the model writes, then a 'usage' frame (and 'suggestions' / 'clarification' when applicable). Rejects a non-chat-capable workspace before streaming. If the agent fails after the stream is committed (provider quota exhausted, a provider 5xx/timeout, or any other fault), the stream ends with a terminal 'error' frame carrying a machine 'code' (rate_limit / provider_unavailable / server_error) — a frame within the 200 response, not an HTTP status. A client-cancelled request emits no 'error' frame.",
         "operationId": "SendChatMessage",
         "requestBody": {
           "content": {
@@ -664,7 +664,7 @@
       "post": {
         "tags": ["AI - Conversations"],
         "summary": "Reports a message in one of the current user's conversations.",
-        "description": "Records a user report flagging the message for review and raises a domain event the application can route. Scoped to the caller: a message outside the caller's own conversations is reported as not found. The report stores identifiers plus the user-entered reason \u2014 never the message content (ADR-071).",
+        "description": "Records a user report flagging the message for review and raises a domain event the application can route. Scoped to the caller: a message outside the caller's own conversations is reported as not found. The report stores identifiers plus the user-entered reason — never the message content (ADR-071).",
         "operationId": "ReportChatMessage",
         "parameters": [
           {
@@ -734,6 +734,81 @@
           },
           "422": {
             "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/conversations/mentions": {
+      "get": {
+        "tags": ["AI - Conversations"],
+        "summary": "Searches mentionable entities for the @ picker.",
+        "description": "Returns the entities the caller may @-mention that match the query, resolved under the caller's ACLs across the application's opted-in mention resolvers. Optionally narrowed to a single type. Entities the caller cannot see never appear.",
+        "operationId": "SearchChatMentions",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Filter by type discriminator value.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MentionSearchResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1043,6 +1118,36 @@
           },
           "id": {
             "type": "string"
+          }
+        }
+      },
+      "MentionSearchResponse": {
+        "required": ["items"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MentionSuggestionResponse"
+            }
+          }
+        }
+      },
+      "MentionSuggestionResponse": {
+        "required": ["type", "id", "label", "description"],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
           }
         }
       },

--- a/packages/@granit/ai-chat/src/__tests__/conversations-api.test.ts
+++ b/packages/@granit/ai-chat/src/__tests__/conversations-api.test.ts
@@ -10,6 +10,7 @@ import {
   listConversations,
   renameConversation,
   reportConversationMessage,
+  searchConversationMentions,
   setConversationFavorite,
 } from '../api/conversations-api';
 import { MESSAGE_REPORT_CATEGORIES } from '../types/index';
@@ -143,6 +144,33 @@ describe('conversations-api', () => {
     expect(client.post).toHaveBeenCalledWith(`${BASE}/messages/${MESSAGE_ID}/report`, {
       reason: 'Inaccurate answer',
       category: 'Inaccurate',
+    });
+  });
+
+  it('searchConversationMentions GETs {basePath}/mentions with q + limit and returns the items', async () => {
+    const client = createMockClient();
+    const items = [
+      { type: 'contact', id: 'c-42', label: 'Acme Corp', description: 'Customer' },
+      { type: 'invoice', id: 'inv-1', label: 'Invoice #1', description: null },
+    ];
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items }));
+
+    const result = await searchConversationMentions(client, BASE, 'ac', { limit: 8 });
+
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/mentions`, {
+      params: { q: 'ac', limit: 8 },
+    });
+    expect(result).toEqual(items);
+  });
+
+  it('searchConversationMentions forwards the type filter and sends an empty q verbatim', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [] }));
+
+    await searchConversationMentions(client, BASE, '', { type: 'invoice' });
+
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/mentions`, {
+      params: { q: '', type: 'invoice' },
     });
   });
 

--- a/packages/@granit/ai-chat/src/api/conversations-api.ts
+++ b/packages/@granit/ai-chat/src/api/conversations-api.ts
@@ -13,6 +13,7 @@ import type {
   ConversationResponse,
   ConversationSummaryResponse,
   CreateConversationRequest,
+  MentionSuggestionResponse,
   MessageId,
   MessageResponse,
   RenameConversationRequest,
@@ -174,6 +175,34 @@ export async function listChatWorkspaces(
 ): Promise<ChatWorkspacesResponse> {
   const response = await client.get<ChatWorkspacesResponse>(`${basePath}/workspaces`);
   return response.data;
+}
+
+/**
+ * Search `@` mention candidates across the entities the caller may reference,
+ * via the unified, ACL-bound picker endpoint (one route for every entity type —
+ * there is no per-entity mention endpoint). Empty `q` returns the backend's top
+ * default set; `options.type` narrows to a single resolver; `options.limit`
+ * caps the result count (server default 8, hard cap 25).
+ *
+ * Requires the `AIChat.Conversations.Send` permission — the same gate as sending
+ * a message, so the picker never surfaces entities the user could not mention.
+ *
+ * `GET {basePath}/mentions?q={query}&type={type}&limit={n}`
+ */
+export async function searchConversationMentions(
+  client: AxiosInstance,
+  basePath: string,
+  query: string,
+  options: { limit?: number; type?: string } = {}
+): Promise<readonly MentionSuggestionResponse[]> {
+  const params: Record<string, string | number> = { q: query };
+  if (options.type != null) params.type = options.type;
+  if (options.limit != null) params.limit = options.limit;
+  const response = await client.get<{ items: readonly MentionSuggestionResponse[] }>(
+    `${basePath}/mentions`,
+    { params }
+  );
+  return response.data.items;
 }
 
 /** Parse one raw SSE line into a {@link ChatStreamEvent}, or `null` to skip it. */

--- a/packages/@granit/ai-chat/src/index.ts
+++ b/packages/@granit/ai-chat/src/index.ts
@@ -13,6 +13,7 @@ export type {
   ConversationSummaryResponse,
   CreateConversationRequest,
   MentionRequest,
+  MentionSuggestionResponse,
   MessageId,
   MessageReportCategory,
   MessageResponse,
@@ -45,6 +46,7 @@ export {
   listConversations,
   renameConversation,
   reportConversationMessage,
+  searchConversationMentions,
   setConversationFavorite,
   streamConversationMessage,
 } from './api/conversations-api';

--- a/packages/@granit/ai-chat/src/types/index.ts
+++ b/packages/@granit/ai-chat/src/types/index.ts
@@ -137,6 +137,22 @@ export interface MentionRequest {
 }
 
 /**
+ * One `@` mention candidate from the unified picker
+ * (`GET /conversations/mentions`). Maps 1:1 onto the composer's `MentionOption`;
+ * the selected suggestion's `{ type, id }` becomes the {@link MentionRequest}
+ * sent with the turn.
+ */
+export interface MentionSuggestionResponse {
+  /** Resolver discriminator (e.g. `contact`, `invoice`) — opaque to the front. */
+  readonly type: string;
+  readonly id: string;
+  /** Display label shown in the picker and the inserted chip. */
+  readonly label: string;
+  /** Optional secondary line in the picker; `null` when the entity has none. */
+  readonly description: string | null;
+}
+
+/**
  * An app-uploaded attachment. The front uploads the blob to the app's own
  * store, then sends this opaque reference; the backend reads the bytes back.
  */

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -191,6 +191,7 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'ReportMessageRequest',
       'SendMessageRequest',
       'MentionRequest',
+      'MentionSuggestionResponse',
       'AttachmentRequest',
       'ChatStreamEvent',
       'SuggestedActionResponse',

--- a/packages/@granit/react-ai-chat/src/__tests__/chat-composer.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/chat-composer.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -6,7 +6,7 @@ import { ChatComposer } from '../components/chat-composer';
 import { createChipElement } from '../components/composer-content';
 
 import type { ChipSpec } from '../components/composer-content';
-import type { PromptOption } from '../components/composer-types';
+import type { MentionOption, PromptOption } from '../components/composer-types';
 import type { PromptId, SendMessageRequest } from '@granit/ai-chat';
 
 const PROMPTS: PromptOption[] = [
@@ -67,6 +67,31 @@ describe('ChatComposer', () => {
     // The picker is open and filtered to the matching prompt.
     expect(await screen.findByText('Summarize')).toBeInTheDocument();
     expect(screen.queryByText('Daily brief')).not.toBeInTheDocument();
+  });
+
+  it('renders the resolved @ mention suggestions in the picker', async () => {
+    const searchMentions = vi.fn<(query: string) => Promise<MentionOption[]>>(async () => [
+      { type: 'contact', id: 'c-42', label: 'Acme Corp', description: 'Customer' },
+    ]);
+    render(<ChatComposer onSubmit={vi.fn()} searchMentions={searchMentions} />);
+
+    await userEvent.type(getEditor(), '@ac');
+
+    expect(await screen.findByText('Acme Corp')).toBeInTheDocument();
+    expect(screen.getByText('Customer')).toBeInTheDocument();
+    expect(searchMentions).toHaveBeenLastCalledWith('ac');
+  });
+
+  it('coalesces fast @ typing into a single debounced search for the final query', async () => {
+    const searchMentions = vi.fn<(query: string) => Promise<MentionOption[]>>(async () => []);
+    render(<ChatComposer onSubmit={vi.fn()} searchMentions={searchMentions} />);
+
+    // Five keystrokes land well within the 200 ms window, so the debounce fires
+    // exactly once — for the final query, not each intermediate prefix.
+    await userEvent.type(getEditor(), '@acme');
+
+    await waitFor(() => expect(searchMentions).toHaveBeenCalledTimes(1));
+    expect(searchMentions).toHaveBeenLastCalledWith('acme');
   });
 
   it('submits on Enter and stays put on Shift+Enter', async () => {

--- a/packages/@granit/react-ai-chat/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-ai-chat/src/__tests__/testing-handlers.test.ts
@@ -48,6 +48,22 @@ describe('createAIChatHandlers', () => {
     expect(body.workspaces[0]).toBe('Auto');
   });
 
+  it('searches mentions by query and filters by type (not swallowed by /:id)', async () => {
+    server.use(...createAIChatHandlers(BASE));
+
+    const byQuery = (await (await fetch(`${BASE}/mentions?q=acme&limit=8`)).json()) as {
+      items: { label: string }[];
+    };
+    expect(byQuery.items).toHaveLength(1);
+    expect(byQuery.items[0]?.label).toBe('Acme Corp');
+
+    const byType = (await (await fetch(`${BASE}/mentions?q=&type=invoice`)).json()) as {
+      items: { type: string }[];
+    };
+    expect(byType.items.length).toBeGreaterThan(0);
+    expect(byType.items.every((item) => item.type === 'invoice')).toBe(true);
+  });
+
   it('create then list reflects the new conversation', async () => {
     server.use(...createAIChatHandlers(BASE));
     const created = await fetch(BASE, {

--- a/packages/@granit/react-ai-chat/src/__tests__/use-default-mention-search.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/use-default-mention-search.test.tsx
@@ -1,0 +1,58 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useDefaultMentionSearch } from '../hooks/use-default-mention-search';
+
+import { createWrapper, TEST_BASE_PATH } from './test-utils';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useDefaultMentionSearch', () => {
+  it('searches /mentions and maps the response 1:1 to MentionOption (description preserved, null kept)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse({
+        items: [
+          { type: 'contact', id: 'c-42', label: 'Acme Corp', description: 'Customer' },
+          { type: 'document', id: 'doc-7', label: 'Q2 Contract.pdf', description: null },
+        ],
+      })
+    );
+
+    const { result } = renderHook(() => useDefaultMentionSearch(), {
+      wrapper: createWrapper(client),
+    });
+
+    const options = await result.current!('ac');
+
+    expect(client.get).toHaveBeenCalledWith(`${TEST_BASE_PATH}/mentions`, {
+      params: { q: 'ac', limit: 8 },
+    });
+    expect(options).toEqual([
+      { type: 'contact', id: 'c-42', label: 'Acme Corp', description: 'Customer' },
+      { type: 'document', id: 'doc-7', label: 'Q2 Contract.pdf', description: null },
+    ]);
+  });
+
+  it('honours a custom limit', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [] }));
+
+    const { result } = renderHook(() => useDefaultMentionSearch(3), {
+      wrapper: createWrapper(client),
+    });
+    await result.current!('');
+
+    expect(client.get).toHaveBeenCalledWith(`${TEST_BASE_PATH}/mentions`, {
+      params: { q: '', limit: 3 },
+    });
+  });
+
+  it('returns undefined outside an AIChatProvider (picker stays disabled)', () => {
+    const { result } = renderHook(() => useDefaultMentionSearch());
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
@@ -2,8 +2,10 @@ import { SEND_MESSAGE_LIMITS } from '@granit/ai-chat';
 import { createLogger } from '@granit/logger';
 import { cn } from '@granit/utils';
 import { ArrowUp, Paperclip, Sparkles, Square } from 'lucide-react';
-import { useCallback, useId, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 
+import { MENTION_SEARCH_DEBOUNCE_MS } from '../constants';
+import { useDefaultMentionSearch } from '../hooks/use-default-mention-search';
 import { defaultChatLabels } from '../locales/index';
 
 import { AttachmentChips } from './attachment-chips';
@@ -47,7 +49,11 @@ export interface ChatComposerProps {
   readonly onStop?: () => void;
   /** Prompt options for the `/` picker (filtered client-side by the query). */
   readonly prompts?: readonly PromptOption[];
-  /** App-specific `@` mention search. Omit to disable the mention picker. */
+  /**
+   * Override the `@` mention search. Defaults to the provider-backed generic
+   * search (`GET /conversations/mentions`) when rendered inside an
+   * `AIChatProvider`; omit it outside a provider to disable the mention picker.
+   */
   readonly searchMentions?: SearchMentions;
   /** App-specific attachment upload. Omit to hide the attach button. */
   readonly uploadAttachment?: UploadAttachment;
@@ -110,11 +116,19 @@ export function ChatComposer({
   const [mentionResults, setMentionResults] = useState<readonly MentionOption[]>([]);
   const [mentionLoading, setMentionLoading] = useState(false);
 
+  // The picker resolves mentions through the host's adapter when supplied, else
+  // the provider-backed generic search (`GET /conversations/mentions`); `null`
+  // outside a provider keeps the picker disabled.
+  const defaultSearchMentions = useDefaultMentionSearch();
+  const effectiveSearchMentions = searchMentions ?? defaultSearchMentions;
+
   const editorRef = useRef<HTMLDivElement>(null);
   // The trigger token's location, captured so a picked chip can replace it even
   // after the picker click moved focus out of the editor.
   const triggerLocRef = useRef<{ node: Text; start: number; end: number } | null>(null);
   const searchSeq = useRef(0);
+  // Pending debounce timer for the `@` mention search, cleared on every re-eval.
+  const mentionDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const attachmentSeq = useRef(0);
 
   const baseId = useId();
@@ -129,30 +143,50 @@ export function ChatComposer({
 
   const suggestionItems = trigger?.kind === '@' ? mentionResults : promptMatches;
   const showSuggestions =
-    trigger !== null && (trigger.kind === '/' || searchMentions !== undefined);
+    trigger !== null && (trigger.kind === '/' || effectiveSearchMentions !== undefined);
 
+  /** Cancel any pending debounced mention search. */
+  const clearMentionDebounce = useCallback(() => {
+    if (mentionDebounceRef.current !== null) {
+      clearTimeout(mentionDebounceRef.current);
+      mentionDebounceRef.current = null;
+    }
+  }, []);
+
+  /**
+   * Resolve `@` mention candidates for the live query, debounced so fast typing
+   * fires a single request. The picker shows its loading state immediately;
+   * stale responses are dropped via the bumped {@link searchSeq}.
+   */
   const runMentionSearch = useCallback(
     (query: string) => {
-      if (!searchMentions) return;
+      if (!effectiveSearchMentions) return;
+      clearMentionDebounce();
       const seq = ++searchSeq.current;
       setMentionLoading(true);
-      searchMentions(query)
-        .then((results) => {
-          if (seq === searchSeq.current) {
-            setMentionResults(results);
-            setMentionLoading(false);
-          }
-        })
-        .catch((err: unknown) => {
-          logger.warn('Mention search failed; cleared results', { err });
-          if (seq === searchSeq.current) {
-            setMentionResults([]);
-            setMentionLoading(false);
-          }
-        });
+      mentionDebounceRef.current = setTimeout(() => {
+        mentionDebounceRef.current = null;
+        effectiveSearchMentions(query)
+          .then((results) => {
+            if (seq === searchSeq.current) {
+              setMentionResults(results);
+              setMentionLoading(false);
+            }
+          })
+          .catch((err: unknown) => {
+            logger.warn('Mention search failed; cleared results', { err });
+            if (seq === searchSeq.current) {
+              setMentionResults([]);
+              setMentionLoading(false);
+            }
+          });
+      }, MENTION_SEARCH_DEBOUNCE_MS);
     },
-    [searchMentions]
+    [effectiveSearchMentions, clearMentionDebounce]
   );
+
+  // Drop a pending search if the composer unmounts mid-debounce.
+  useEffect(() => clearMentionDebounce, [clearMentionDebounce]);
 
   /**
    * Re-evaluate the `/` `@` trigger from the live caret. A trigger is only valid
@@ -161,6 +195,9 @@ export function ChatComposer({
    * span for {@link insertChip}.
    */
   const refreshTrigger = useCallback(() => {
+    // Any re-evaluation supersedes a pending search; the @-branch below schedules
+    // a fresh one when the caret is still inside a mention token.
+    clearMentionDebounce();
     const editor = editorRef.current;
     const selection = typeof window !== 'undefined' ? window.getSelection() : null;
     const node = selection?.anchorNode ?? null;
@@ -187,7 +224,7 @@ export function ChatComposer({
     setActiveIndex(0);
     if (active.kind === '@') runMentionSearch(active.query);
     else setMentionResults([]);
-  }, [runMentionSearch]);
+  }, [runMentionSearch, clearMentionDebounce]);
 
   const handleInput = useCallback(
     (event: FormEvent<HTMLDivElement>) => {
@@ -215,37 +252,41 @@ export function ChatComposer({
   }, []);
 
   /** Replace the active trigger token with a chip + trailing space; re-focus. */
-  const insertChip = useCallback((spec: ChipSpec, iconColor?: string | null) => {
-    const editor = editorRef.current;
-    const loc = triggerLocRef.current;
-    if (!editor || !loc) return;
-    const doc = editor.ownerDocument;
-    const length = loc.node.textContent?.length ?? 0;
-    const range = doc.createRange();
-    range.setStart(loc.node, Math.min(loc.start, length));
-    range.setEnd(loc.node, Math.min(loc.end, length));
-    range.deleteContents();
+  const insertChip = useCallback(
+    (spec: ChipSpec, iconColor?: string | null) => {
+      const editor = editorRef.current;
+      const loc = triggerLocRef.current;
+      if (!editor || !loc) return;
+      const doc = editor.ownerDocument;
+      const length = loc.node.textContent?.length ?? 0;
+      const range = doc.createRange();
+      range.setStart(loc.node, Math.min(loc.start, length));
+      range.setEnd(loc.node, Math.min(loc.end, length));
+      range.deleteContents();
 
-    const chip = createChipElement(doc, spec, iconColor);
-    range.insertNode(chip);
-    // A non-breaking space keeps the caret off the non-editable chip and gives a
-    // visible gap; serialization collapses it back to a normal space.
-    const spacer = doc.createTextNode(' ');
-    chip.after(spacer);
+      const chip = createChipElement(doc, spec, iconColor);
+      range.insertNode(chip);
+      // A non-breaking space keeps the caret off the non-editable chip and gives a
+      // visible gap; serialization collapses it back to a normal space.
+      const spacer = doc.createTextNode(' ');
+      chip.after(spacer);
 
-    editor.focus();
-    const after = doc.createRange();
-    after.setStartAfter(spacer);
-    after.collapse(true);
-    const selection = doc.defaultView?.getSelection();
-    selection?.removeAllRanges();
-    selection?.addRange(after);
+      editor.focus();
+      const after = doc.createRange();
+      after.setStartAfter(spacer);
+      after.collapse(true);
+      const selection = doc.defaultView?.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(after);
 
-    triggerLocRef.current = null;
-    setTrigger(null);
-    setMentionResults([]);
-    setIsEmpty(isEditorEmpty(editor));
-  }, []);
+      triggerLocRef.current = null;
+      setTrigger(null);
+      setMentionResults([]);
+      clearMentionDebounce();
+      setIsEmpty(isEditorEmpty(editor));
+    },
+    [clearMentionDebounce]
+  );
 
   const selectPrompt = useCallback(
     (option: PromptOption) => {
@@ -315,7 +356,8 @@ export function ChatComposer({
     setAttachments([]);
     setTrigger(null);
     setMentionResults([]);
-  }, [hasUploading, disabled, workspace, attachments, onSubmit]);
+    clearMentionDebounce();
+  }, [hasUploading, disabled, workspace, attachments, onSubmit, clearMentionDebounce]);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {

--- a/packages/@granit/react-ai-chat/src/components/composer-types.ts
+++ b/packages/@granit/react-ai-chat/src/components/composer-types.ts
@@ -32,7 +32,11 @@ export interface PromptOption {
   readonly iconColor?: string | null;
 }
 
-/** An `@` mention option resolved by the app-specific `searchMentions` adapter. */
+/**
+ * An `@` mention option resolved by `searchMentions` — the provider-backed
+ * generic search by default, or a host-supplied adapter. Mirrors the backend's
+ * `MentionSuggestionResponse` 1:1.
+ */
 export interface MentionOption {
   readonly type: string;
   readonly id: string;
@@ -46,8 +50,10 @@ export interface StagedMention extends MentionRequest {
 }
 
 /**
- * App-specific search for `@` mention candidates. There is no generic
- * mention-search endpoint — the host implements this against its entity APIs.
+ * Search for `@` mention candidates. The composer defaults to the unified,
+ * ACL-bound `GET /conversations/mentions` endpoint (via `useDefaultMentionSearch`);
+ * a host may pass its own adapter to override it (e.g. to scope or decorate
+ * results). Empty `query` should return the top default suggestions.
  */
 export type SearchMentions = (query: string) => Promise<readonly MentionOption[]>;
 

--- a/packages/@granit/react-ai-chat/src/constants.ts
+++ b/packages/@granit/react-ai-chat/src/constants.ts
@@ -8,3 +8,9 @@ export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;
 
 /** Default React Query key prefix for chat queries. */
 export const DEFAULT_QUERY_KEY_PREFIX = ['ai-chat'] as const;
+
+/** Default `@`-mention suggestions the composer requests per query (server cap: 25). */
+export const DEFAULT_MENTION_SEARCH_LIMIT = 8;
+
+/** Debounce applied to `@`-mention search before hitting the network, in ms. */
+export const MENTION_SEARCH_DEBOUNCE_MS = 200;

--- a/packages/@granit/react-ai-chat/src/hooks/use-default-mention-search.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-default-mention-search.ts
@@ -1,0 +1,40 @@
+import { searchConversationMentions } from '@granit/ai-chat';
+import { useMemo } from 'react';
+
+import { DEFAULT_MENTION_SEARCH_LIMIT } from '../constants';
+import { useOptionalAIChatConfig } from '../providers/ai-chat-provider';
+
+import type { MentionOption, SearchMentions } from '../components/composer-types';
+
+/**
+ * The provider-backed default `@`-mention search: binds the unified
+ * `GET /conversations/mentions` endpoint to the {@link AIChatProvider}'s client +
+ * base path and maps each {@link MentionSuggestionResponse} 1:1 onto a
+ * {@link MentionOption}. {@link ChatComposer} uses it whenever the host does not
+ * pass its own `searchMentions` adapter.
+ *
+ * Returns `undefined` outside an {@link AIChatProvider} (e.g. a standalone
+ * composer in tests/Storybook), which leaves the mention picker disabled until a
+ * `searchMentions` prop is supplied.
+ *
+ * @param limit - Maximum suggestions per query (server cap: 25). Defaults to
+ *   {@link DEFAULT_MENTION_SEARCH_LIMIT}.
+ */
+export function useDefaultMentionSearch(
+  limit: number = DEFAULT_MENTION_SEARCH_LIMIT
+): SearchMentions | undefined {
+  const config = useOptionalAIChatConfig();
+  return useMemo<SearchMentions | undefined>(() => {
+    if (!config) return undefined;
+    const { client, basePath } = config;
+    return async (query) => {
+      const items = await searchConversationMentions(client, basePath, query, { limit });
+      return items.map<MentionOption>((item) => ({
+        type: item.type,
+        id: item.id,
+        label: item.label,
+        description: item.description,
+      }));
+    };
+  }, [config, limit]);
+}

--- a/packages/@granit/react-ai-chat/src/index.ts
+++ b/packages/@granit/react-ai-chat/src/index.ts
@@ -40,6 +40,9 @@ export type {
 export { useReportMessage } from './hooks/use-report-message';
 export type { ReportMessageVariables, UseReportMessageReturn } from './hooks/use-report-message';
 
+// Hooks — mentions
+export { useDefaultMentionSearch } from './hooks/use-default-mention-search';
+
 // Re-exports from @granit/ai-chat — the report contract the showcase dialog needs.
 export { MESSAGE_REPORT_CATEGORIES } from '@granit/ai-chat';
 export type { MessageReportCategory, ReportMessageRequest } from '@granit/ai-chat';

--- a/packages/@granit/react-ai-chat/src/testing/data.ts
+++ b/packages/@granit/react-ai-chat/src/testing/data.ts
@@ -3,6 +3,7 @@ import { toEntityId, toISODateString } from '@granit/types';
 import type {
   ConversationResponse,
   ConversationSummaryResponse,
+  MentionSuggestionResponse,
   MessageResponse,
 } from '@granit/ai-chat';
 
@@ -90,3 +91,15 @@ export const mockConversationSummaries: ConversationSummaryResponse[] = [
 
 /** Selectable default workspaces returned by `GET /conversations/workspaces`. */
 export const mockChatWorkspaces: readonly string[] = ['Auto', 'default', 'support'];
+
+/**
+ * `@`-mention candidates returned by `GET /conversations/mentions`. A mix of
+ * resolver types so the unified picker can be exercised (and the `type` filter
+ * validated). One entry carries a `null` description to cover that branch.
+ */
+export const mockMentionSuggestions: readonly MentionSuggestionResponse[] = [
+  { type: 'contact', id: 'c-42', label: 'Acme Corp', description: 'Customer' },
+  { type: 'contact', id: 'c-43', label: 'Globex', description: 'Customer' },
+  { type: 'invoice', id: 'inv-1001', label: 'Invoice #1001', description: '€1,350 · due Jun 30' },
+  { type: 'document', id: 'doc-7', label: 'Q2 Contract.pdf', description: null },
+];

--- a/packages/@granit/react-ai-chat/src/testing/handlers.ts
+++ b/packages/@granit/react-ai-chat/src/testing/handlers.ts
@@ -9,12 +9,14 @@ import {
   mockConversationSummaries,
   mockLongConversationId,
   mockLongConversationMessages,
+  mockMentionSuggestions,
 } from './data';
 
 import type {
   ConversationResponse,
   ConversationSummaryResponse,
   CreateConversationRequest,
+  MentionSuggestionResponse,
   MessageResponse,
   RenameConversationRequest,
   SetConversationFavoriteRequest,
@@ -41,6 +43,21 @@ export function createAIChatHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
     // GET /conversations/workspaces — before /:id so it is not swallowed.
     http.get(`${baseUrl}/workspaces`, () => HttpResponse.json({ workspaces: mockChatWorkspaces })),
+
+    // GET /conversations/mentions — unified @-mention search. Filters the fixture
+    // by `q` (label, case-insensitive) and optional `type`, capped by `limit`
+    // (default 8). Declared before /:id so it is not shadowed.
+    http.get(`${baseUrl}/mentions`, ({ request }) => {
+      const url = new URL(request.url);
+      const q = (url.searchParams.get('q') ?? '').trim().toLowerCase();
+      const type = url.searchParams.get('type');
+      const limit = Math.min(Math.max(Number(url.searchParams.get('limit')) || 8, 1), 25);
+      const items: MentionSuggestionResponse[] = mockMentionSuggestions
+        .filter((item) => (type ? item.type === type : true))
+        .filter((item) => (q ? item.label.toLowerCase().includes(q) : true))
+        .slice(0, limit);
+      return HttpResponse.json({ items });
+    }),
 
     // GET /conversations — list summaries, newest first.
     http.get(baseUrl, () => HttpResponse.json(summaries)),

--- a/packages/@granit/react-ai-chat/src/testing/index.ts
+++ b/packages/@granit/react-ai-chat/src/testing/index.ts
@@ -9,5 +9,6 @@ export {
   mockConversationSummaries,
   mockLongConversationId,
   mockLongConversationMessages,
+  mockMentionSuggestions,
 } from './data';
 export { createAIChatHandlers } from './handlers';


### PR DESCRIPTION
## Context

The backend (granit-dotnet #2823, ADR-067) now exposes a single, ACL-bound mention-search endpoint for the chat `@` picker. This rebranches the front onto it and removes the per-app/per-entity workaround.

`GET /conversations/mentions?q=<query>&type=<optional>&limit=<optional>` — auth `AIChat.Conversations.Send`, `limit` default 8 / cap 25, empty `q` allowed. Response `{ items: [{ type, id, label, description }] }`, mapping 1:1 onto the composer's `MentionOption`.

## Changes

**`@granit/ai-chat`**
- `searchConversationMentions(client, basePath, query, { limit?, type? })` → `GET /conversations/mentions`, returns `items`.
- `MentionSuggestionResponse` DTO (mirrors the backend 1:1).

**`@granit/react-ai-chat`**
- `useDefaultMentionSearch()` binds the endpoint to the `AIChatProvider` config and maps `items → MentionOption[]`.
- `ChatComposer` uses it as the **default** `searchMentions` implementation — the prop is now an override (omit outside a provider to disable the picker).
- The mention search is **debounced 200 ms**; selecting a suggestion still emits `MentionRequest { type, id }` in `POST /conversations/messages` (unchanged).
- MSW handler + fixture for the new endpoint.

**Contracts**
- Vendored `/conversations/mentions` + `MentionSearchResponse`/`MentionSuggestionResponse` from the authoritative backend artifact (scoped to the new endpoint — the rest of the snapshot is unchanged); registered `MentionSuggestionResponse` in the conformance manifest.

## Notes
- The wholesale OpenAPI sync also surfaced an unrelated backend drift (`workspaceKey` moved earlier in `Conversation*Response`/`MessageResponse`). Per @jf.meyers that ordering will be fixed **backend-side** in granit-dotnet, so the front DTOs are left as-is and this PR only vendors the mention additions.
- The showcase rewire (drop `searchDemoMentions`, delete `demo-mentions.ts`) ships as a separate MR, opened as Draft until this merges.

## Tests
- api: search + type filter + empty `q`.
- hook: mapping, `null` description, custom limit, undefined outside provider.
- composer: 200 ms debounce coalescing + suggestion rendering.
- MSW handler: query + type filter.
- Contract conformance green against the vendored spec.