### PR TITLE
feat(mentions): route @ picker through generic /lookups/mentions

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2010,6 +2010,18 @@
       ]
     },
     {
+      "name": "@granit/mentions",
+      "description": "Framework-agnostic client for the Granit @-mention picker — a thin facade over @granit/data-lookup binding the 'mentions' source (GET /lookups/mentions) and the composite type:id value convention",
+      "exports": [
+        {
+          "name": "MentionItem",
+          "kind": "interface",
+          "signature": "interface MentionItem",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/metering",
       "description": "Usage metering — meter definitions, events, and quota types and API functions",
       "exports": [
@@ -2893,7 +2905,12 @@
         {
           "name": "useDefaultMentionSearch",
           "kind": "function",
-          "signature": "function useDefaultMentionSearch( limit: number = DEFAULT_MENTION_SEARCH_LIMIT ): SearchMentions | undefined"
+          "signature": "function useDefaultMentionSearch(): SearchMentions | undefined"
+        },
+        {
+          "name": "useDefaultMentionResolve",
+          "kind": "function",
+          "signature": "function useDefaultMentionResolve(): ResolveMention | undefined"
         },
         {
           "name": "useChatStream",

--- a/contracts/openapi/ai-chat.json
+++ b/contracts/openapi/ai-chat.json
@@ -165,8 +165,8 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -175,8 +175,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -228,16 +228,6 @@
           "204": {
             "description": "No Content"
           },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -248,107 +238,8 @@
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/conversations/{id}/messages": {
-      "get": {
-        "tags": ["AI - Conversations"],
-        "summary": "Returns a page of a conversation's messages, newest first (keyset pagination).",
-        "description": "Returns the newest page when no cursor is given, then older pages via the returned nextCursor (an opaque keyset over createdAt+id; null at the start of history). Scoped to the caller: another user's conversation is reported as not found.",
-        "operationId": "GetConversationMessages",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Resource identifier (UUID).",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "cursor",
-            "in": "query",
-            "description": "Opaque keyset cursor for the next older page; omit for the newest page.",
-            "required": false,
-            "schema": {
-              "type": ["null", "string"]
-            }
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Messages per page (default 30, max 100).",
-            "required": false,
-            "schema": {
-              "type": ["null", "integer"],
-              "format": "int32"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "items": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/MessageResponse"
-                      }
-                    },
-                    "totalCount": {
-                      "type": ["null", "integer"],
-                      "format": "int32"
-                    },
-                    "hasMore": {
-                      "type": "boolean"
-                    },
-                    "nextCursor": {
-                      "type": ["null", "string"]
-                    }
-                  }
-                }
-              }
-            }
-          },
           "401": {
             "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -422,8 +313,8 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -432,8 +323,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -517,8 +408,8 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -527,8 +418,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -570,11 +461,100 @@
         }
       }
     },
+    "/conversations/{id}/messages": {
+      "get": {
+        "tags": ["AI - Conversations"],
+        "summary": "Returns a backwards-paginated page of a conversation's messages.",
+        "description": "Returns the newest page of messages first, sorted newest-first. Pass the returned nextCursor to load the page of older messages; nextCursor is null at the start of history. Scoped to the caller: another user's conversation is reported as not found.",
+        "operationId": "GetConversationMessages",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedResultOfMessageResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/conversations/messages": {
       "post": {
         "tags": ["AI - Conversations"],
         "summary": "Sends a message and streams a tool-grounded answer over SSE.",
-        "description": "Runs the agentic loop within the caller's permissions, persists the user and assistant messages, and streams the answer as Server-Sent Events: a 'conversation' frame with the (possibly new) conversation id (flushed immediately), then live 'tool_call'/'tool_result' frames as the agent uses tools and incremental 'delta' content frames as the model writes, then a 'usage' frame (and 'suggestions' / 'clarification' when applicable). Rejects a non-chat-capable workspace before streaming. If the agent fails after the stream is committed (provider quota exhausted, a provider 5xx/timeout, or any other fault), the stream ends with a terminal 'error' frame carrying a machine 'code' (rate_limit / provider_unavailable / server_error) — a frame within the 200 response, not an HTTP status. A client-cancelled request emits no 'error' frame.",
+        "description": "Runs the agentic loop within the caller's permissions, persists the user and assistant messages, and streams the answer as Server-Sent Events: a 'conversation' frame with the (possibly new) conversation id (flushed immediately), then live 'tool_call'/'tool_result' frames as the agent uses tools and incremental 'delta' content frames as the model writes, then (on a successful turn) a 'persisted' frame carrying the turn's saved user and assistant messages with their real ids and server timestamps, then a 'usage' frame (and 'suggestions' / 'clarification' when applicable). Rejects a non-chat-capable workspace before streaming. If the agent fails after the stream is committed (provider quota exhausted, a provider 5xx/timeout, or any other fault), the stream ends with a terminal 'error' frame carrying a machine 'code' (rate_limit / provider_unavailable / server_error) — a frame within the 200 response, not an HTTP status. A client-cancelled request emits no 'error' frame.",
         "operationId": "SendChatMessage",
         "requestBody": {
           "content": {
@@ -617,6 +597,16 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "403": {
             "description": "Forbidden",
             "content": {
@@ -629,16 +619,6 @@
           },
           "422": {
             "description": "Unprocessable Entity",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -702,8 +682,8 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
+          "404": {
+            "description": "Not Found",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -712,8 +692,8 @@
               }
             }
           },
-          "404": {
-            "description": "Not Found",
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -734,81 +714,6 @@
           },
           "422": {
             "description": "Unprocessable Entity",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/conversations/mentions": {
-      "get": {
-        "tags": ["AI - Conversations"],
-        "summary": "Searches mentionable entities for the @ picker.",
-        "description": "Returns the entities the caller may @-mention that match the query, resolved under the caller's ACLs across the application's opted-in mention resolvers. Optionally narrowed to a single type. Entities the caller cannot see never appear.",
-        "operationId": "SearchChatMentions",
-        "parameters": [
-          {
-            "name": "q",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "type",
-            "in": "query",
-            "description": "Filter by type discriminator value.",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MentionSearchResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1009,9 +914,9 @@
           "title",
           "ownerId",
           "isFavorite",
+          "workspaceKey",
           "createdAt",
-          "modifiedAt",
-          "workspaceKey"
+          "modifiedAt"
         ],
         "type": "object",
         "properties": {
@@ -1029,6 +934,9 @@
           "isFavorite": {
             "type": "boolean"
           },
+          "workspaceKey": {
+            "type": ["null", "string"]
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time"
@@ -1036,14 +944,11 @@
           "modifiedAt": {
             "type": ["null", "string"],
             "format": "date-time"
-          },
-          "workspaceKey": {
-            "type": ["null", "string"]
           }
         }
       },
       "ConversationSummaryResponse": {
-        "required": ["id", "title", "isFavorite", "createdAt", "modifiedAt", "workspaceKey"],
+        "required": ["id", "title", "isFavorite", "workspaceKey", "createdAt", "modifiedAt"],
         "type": "object",
         "properties": {
           "id": {
@@ -1056,6 +961,9 @@
           "isFavorite": {
             "type": "boolean"
           },
+          "workspaceKey": {
+            "type": ["null", "string"]
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time"
@@ -1063,9 +971,6 @@
           "modifiedAt": {
             "type": ["null", "string"],
             "format": "date-time"
-          },
-          "workspaceKey": {
-            "type": ["null", "string"]
           }
         }
       },
@@ -1121,41 +1026,11 @@
           }
         }
       },
-      "MentionSearchResponse": {
-        "required": ["items"],
-        "type": "object",
-        "properties": {
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MentionSuggestionResponse"
-            }
-          }
-        }
-      },
-      "MentionSuggestionResponse": {
-        "required": ["type", "id", "label", "description"],
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "label": {
-            "type": "string"
-          },
-          "description": {
-            "type": ["null", "string"]
-          }
-        }
-      },
       "MessageReportCategory": {
         "enum": ["Inaccurate", "Harmful", "Other", null]
       },
       "MessageResponse": {
-        "required": ["id", "role", "content", "createdAt", "workspaceKey"],
+        "required": ["id", "role", "content", "workspaceKey", "createdAt"],
         "type": "object",
         "properties": {
           "id": {
@@ -1174,6 +1049,28 @@
           "createdAt": {
             "type": "string",
             "format": "date-time"
+          }
+        }
+      },
+      "PagedResultOfMessageResponse": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MessageResponse"
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
           }
         }
       },

--- a/packages/@granit/ai-chat/src/__tests__/conversations-api.test.ts
+++ b/packages/@granit/ai-chat/src/__tests__/conversations-api.test.ts
@@ -10,7 +10,6 @@ import {
   listConversations,
   renameConversation,
   reportConversationMessage,
-  searchConversationMentions,
   setConversationFavorite,
 } from '../api/conversations-api';
 import { MESSAGE_REPORT_CATEGORIES } from '../types/index';
@@ -144,33 +143,6 @@ describe('conversations-api', () => {
     expect(client.post).toHaveBeenCalledWith(`${BASE}/messages/${MESSAGE_ID}/report`, {
       reason: 'Inaccurate answer',
       category: 'Inaccurate',
-    });
-  });
-
-  it('searchConversationMentions GETs {basePath}/mentions with q + limit and returns the items', async () => {
-    const client = createMockClient();
-    const items = [
-      { type: 'contact', id: 'c-42', label: 'Acme Corp', description: 'Customer' },
-      { type: 'invoice', id: 'inv-1', label: 'Invoice #1', description: null },
-    ];
-    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items }));
-
-    const result = await searchConversationMentions(client, BASE, 'ac', { limit: 8 });
-
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/mentions`, {
-      params: { q: 'ac', limit: 8 },
-    });
-    expect(result).toEqual(items);
-  });
-
-  it('searchConversationMentions forwards the type filter and sends an empty q verbatim', async () => {
-    const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [] }));
-
-    await searchConversationMentions(client, BASE, '', { type: 'invoice' });
-
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/mentions`, {
-      params: { q: '', type: 'invoice' },
     });
   });
 

--- a/packages/@granit/ai-chat/src/api/conversations-api.ts
+++ b/packages/@granit/ai-chat/src/api/conversations-api.ts
@@ -13,7 +13,6 @@ import type {
   ConversationResponse,
   ConversationSummaryResponse,
   CreateConversationRequest,
-  MentionSuggestionResponse,
   MessageId,
   MessageResponse,
   RenameConversationRequest,
@@ -175,34 +174,6 @@ export async function listChatWorkspaces(
 ): Promise<ChatWorkspacesResponse> {
   const response = await client.get<ChatWorkspacesResponse>(`${basePath}/workspaces`);
   return response.data;
-}
-
-/**
- * Search `@` mention candidates across the entities the caller may reference,
- * via the unified, ACL-bound picker endpoint (one route for every entity type —
- * there is no per-entity mention endpoint). Empty `q` returns the backend's top
- * default set; `options.type` narrows to a single resolver; `options.limit`
- * caps the result count (server default 8, hard cap 25).
- *
- * Requires the `AIChat.Conversations.Send` permission — the same gate as sending
- * a message, so the picker never surfaces entities the user could not mention.
- *
- * `GET {basePath}/mentions?q={query}&type={type}&limit={n}`
- */
-export async function searchConversationMentions(
-  client: AxiosInstance,
-  basePath: string,
-  query: string,
-  options: { limit?: number; type?: string } = {}
-): Promise<readonly MentionSuggestionResponse[]> {
-  const params: Record<string, string | number> = { q: query };
-  if (options.type != null) params.type = options.type;
-  if (options.limit != null) params.limit = options.limit;
-  const response = await client.get<{ items: readonly MentionSuggestionResponse[] }>(
-    `${basePath}/mentions`,
-    { params }
-  );
-  return response.data.items;
 }
 
 /** Parse one raw SSE line into a {@link ChatStreamEvent}, or `null` to skip it. */

--- a/packages/@granit/ai-chat/src/index.ts
+++ b/packages/@granit/ai-chat/src/index.ts
@@ -13,7 +13,6 @@ export type {
   ConversationSummaryResponse,
   CreateConversationRequest,
   MentionRequest,
-  MentionSuggestionResponse,
   MessageId,
   MessageReportCategory,
   MessageResponse,
@@ -46,7 +45,6 @@ export {
   listConversations,
   renameConversation,
   reportConversationMessage,
-  searchConversationMentions,
   setConversationFavorite,
   streamConversationMessage,
 } from './api/conversations-api';

--- a/packages/@granit/ai-chat/src/types/index.ts
+++ b/packages/@granit/ai-chat/src/types/index.ts
@@ -130,26 +130,14 @@ export type MessageReportCategory =
 
 // -- Composer inputs ---------------------------------------------------------
 
-/** An `@` mention the server resolves to grounded, untrusted context. */
+/**
+ * An `@` mention the server resolves to grounded, untrusted context. The picker
+ * candidates come from `@granit/mentions` (`GET /lookups/mentions`); the selected
+ * item's `{ type, id }` becomes this request, sent with the turn.
+ */
 export interface MentionRequest {
   readonly type: string;
   readonly id: string;
-}
-
-/**
- * One `@` mention candidate from the unified picker
- * (`GET /conversations/mentions`). Maps 1:1 onto the composer's `MentionOption`;
- * the selected suggestion's `{ type, id }` becomes the {@link MentionRequest}
- * sent with the turn.
- */
-export interface MentionSuggestionResponse {
-  /** Resolver discriminator (e.g. `contact`, `invoice`) — opaque to the front. */
-  readonly type: string;
-  readonly id: string;
-  /** Display label shown in the picker and the inserted chip. */
-  readonly label: string;
-  /** Optional secondary line in the picker; `null` when the entity has none. */
-  readonly description: string | null;
 }
 
 /**
@@ -265,10 +253,10 @@ export interface ConversationResponse {
   readonly title: string;
   readonly ownerId: UserId;
   readonly isFavorite: boolean;
-  readonly createdAt: ISODateString;
-  readonly modifiedAt: ISODateString | null;
   /** Workspace key frozen at creation (null for pre-workspace conversations). */
   readonly workspaceKey: string | null;
+  readonly createdAt: ISODateString;
+  readonly modifiedAt: ISODateString | null;
 }
 
 /** A conversation list item, without its messages. */
@@ -276,10 +264,10 @@ export interface ConversationSummaryResponse {
   readonly id: ConversationId;
   readonly title: string;
   readonly isFavorite: boolean;
-  readonly createdAt: ISODateString;
-  readonly modifiedAt: ISODateString | null;
   /** Workspace key frozen at creation (null for pre-workspace conversations). */
   readonly workspaceKey: string | null;
+  readonly createdAt: ISODateString;
+  readonly modifiedAt: ISODateString | null;
 }
 
 /** Body of `POST /conversations`. */

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -191,7 +191,6 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'ReportMessageRequest',
       'SendMessageRequest',
       'MentionRequest',
-      'MentionSuggestionResponse',
       'AttachmentRequest',
       'ChatStreamEvent',
       'SuggestedActionResponse',

--- a/packages/@granit/mentions/README.md
+++ b/packages/@granit/mentions/README.md
@@ -1,0 +1,21 @@
+# @granit/mentions
+
+Framework-agnostic client for the Granit **`@` mention picker**.
+
+A mention has **no dedicated wire contract**: the backend (`Granit.Mentions`) exposes a
+single facade lookup source — `GET /lookups/mentions` — built on `Granit.DataLookup` and
+fanned across every source tagged mentionable. This package is the matching thin front
+facade over [`@granit/data-lookup`](../data-lookup): it binds the `mentions` source and the
+composite `"<type>:<id>"` value convention so every consumer (AI chat, timeline, …) shares
+one home instead of re-deriving it.
+
+## Contents
+
+- `MentionItem` — normalized picker item (`{ type, id, label, extra }`).
+- `searchMentions(client, { search, type? })` — multi-type typeahead over
+  `GET /lookups/mentions` (`type` ⇒ `scope.type`).
+- `resolveMention(client, value)` — rehydrate a composite value via
+  `GET /lookups/mentions/resolve`.
+- `parseMentionValue("user:42")` ⇒ `{ type: "user", id: "42" }`, and `MENTIONS_SOURCE`.
+
+See the backend documentation at `/dotnet/business/mentions/` for the full contract.

--- a/packages/@granit/mentions/package.json
+++ b/packages/@granit/mentions/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@granit/mentions",
+  "description": "Framework-agnostic client for the Granit @-mention picker — a thin facade over @granit/data-lookup binding the 'mentions' source (GET /lookups/mentions) and the composite type:id value convention",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/data-lookup": "workspace:*",
+    "@granit/testing": "workspace:*"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/data-lookup": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/mentions/src/__tests__/mentions-client.test.ts
+++ b/packages/@granit/mentions/src/__tests__/mentions-client.test.ts
@@ -1,0 +1,109 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MENTIONS_SOURCE, parseMentionValue, resolveMention, searchMentions } from '../api/index';
+
+import type { LookupItemResponse, LookupResultResponse } from '@granit/data-lookup';
+
+const ADA: LookupItemResponse = {
+  value: 'user:42',
+  label: 'Ada Lovelace',
+  extra: { type: 'user', email: 'ada@x.io' },
+};
+
+const INVOICE: LookupItemResponse = {
+  value: 'invoice:inv-1',
+  label: 'Invoice #1',
+  extra: { type: 'invoice' },
+};
+
+function result(items: readonly LookupItemResponse[]): LookupResultResponse {
+  return { items, totalCount: null, continuationToken: null };
+}
+
+describe('MENTIONS_SOURCE', () => {
+  it('is the facade source name "mentions"', () => {
+    expect(MENTIONS_SOURCE).toBe('mentions');
+  });
+});
+
+describe('parseMentionValue', () => {
+  it('splits on the first colon only', () => {
+    expect(parseMentionValue('user:42')).toEqual({ type: 'user', id: '42' });
+    expect(parseMentionValue('doc:a:b')).toEqual({ type: 'doc', id: 'a:b' });
+  });
+
+  it('treats a value without a colon as a bare id', () => {
+    expect(parseMentionValue('42')).toEqual({ type: '', id: '42' });
+  });
+});
+
+describe('searchMentions', () => {
+  it('GETs /lookups/mentions with the search term and maps items (id from value, type/extra from item)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(result([ADA, INVOICE])));
+
+    const items = await searchMentions(client, { search: 'a' });
+
+    expect(client.get).toHaveBeenCalledWith('/lookups/mentions', {
+      params: { search: 'a' },
+      signal: undefined,
+    });
+    expect(items).toEqual([
+      { type: 'user', id: '42', label: 'Ada Lovelace', extra: { type: 'user', email: 'ada@x.io' } },
+      { type: 'invoice', id: 'inv-1', label: 'Invoice #1', extra: { type: 'invoice' } },
+    ]);
+  });
+
+  it('forwards the type filter as scope.type and an empty search verbatim (omitted by the query builder)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(result([])));
+
+    await searchMentions(client, { search: '', type: 'user' });
+
+    expect(client.get).toHaveBeenCalledWith('/lookups/mentions', {
+      params: { 'scope.type': 'user' },
+      signal: undefined,
+    });
+  });
+
+  it('forwards the abort signal', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(result([])));
+    const controller = new AbortController();
+
+    await searchMentions(client, { search: 'x' }, { signal: controller.signal });
+
+    expect(client.get).toHaveBeenCalledWith('/lookups/mentions', {
+      params: { search: 'x' },
+      signal: controller.signal,
+    });
+  });
+});
+
+describe('resolveMention', () => {
+  it('GETs /lookups/mentions/resolve?value=… and maps the item', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(ADA));
+
+    const item = await resolveMention(client, 'user:42');
+
+    expect(client.get).toHaveBeenCalledWith('/lookups/mentions/resolve', {
+      params: { value: 'user:42' },
+      signal: undefined,
+    });
+    expect(item).toEqual({
+      type: 'user',
+      id: '42',
+      label: 'Ada Lovelace',
+      extra: { type: 'user', email: 'ada@x.io' },
+    });
+  });
+
+  it('returns null when the value is unknown (HTTP 404)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue({ response: { status: 404 } });
+
+    await expect(resolveMention(client, 'user:does-not-exist')).resolves.toBeNull();
+  });
+});

--- a/packages/@granit/mentions/src/api/index.ts
+++ b/packages/@granit/mentions/src/api/index.ts
@@ -1,0 +1,7 @@
+export {
+  MENTIONS_SOURCE,
+  parseMentionValue,
+  resolveMention,
+  searchMentions,
+} from './mentions-client';
+export type { MentionClientOptions, SearchMentionsParams } from './mentions-client';

--- a/packages/@granit/mentions/src/api/mentions-client.ts
+++ b/packages/@granit/mentions/src/api/mentions-client.ts
@@ -1,0 +1,82 @@
+import {
+  DEFAULT_LOOKUP_BASE_PATH,
+  resolveLookup,
+  searchLookup,
+  stringifyLookupValue,
+} from '@granit/data-lookup';
+
+import type { MentionItem } from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+import type { LookupItemResponse } from '@granit/data-lookup';
+
+/**
+ * Registry name of the single facade lookup source that fans the `@`-mention picker
+ * across every source tagged mentionable on the backend (`Granit.Mentions`).
+ */
+export const MENTIONS_SOURCE = 'mentions';
+
+/** Parameters for {@link searchMentions}. */
+export interface SearchMentionsParams {
+  /** Free-text query; an empty string returns the backend's top default set. */
+  readonly search: string;
+  /** Narrow to a single mention type (`scope.type=<type>`); omit for all types. */
+  readonly type?: string;
+}
+
+/** Shared options for the mention client calls. */
+export interface MentionClientOptions {
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Searches the `@`-mention picker via the unified `GET /lookups/mentions` facade source.
+ * Multi-type by default; pass `type` to restrict to one source (`scope.type`).
+ */
+export async function searchMentions(
+  client: AxiosInstance,
+  params: SearchMentionsParams,
+  options: MentionClientOptions = {}
+): Promise<readonly MentionItem[]> {
+  const result = await searchLookup(
+    { name: MENTIONS_SOURCE },
+    { search: params.search, scope: params.type ? { type: params.type } : undefined },
+    { client, basePath: DEFAULT_LOOKUP_BASE_PATH, signal: options.signal }
+  );
+  return result.items.map(toMentionItem);
+}
+
+/**
+ * Resolves a previously selected composite value (`"<type>:<id>"`) back to a
+ * {@link MentionItem} for rehydration. Returns `null` when the value is unknown (HTTP 404).
+ */
+export async function resolveMention(
+  client: AxiosInstance,
+  value: string,
+  options: MentionClientOptions = {}
+): Promise<MentionItem | null> {
+  const item = await resolveLookup({ name: MENTIONS_SOURCE }, value, {
+    client,
+    basePath: DEFAULT_LOOKUP_BASE_PATH,
+    signal: options.signal,
+  });
+  return item ? toMentionItem(item) : null;
+}
+
+/**
+ * Splits a composite mention value (`"<type>:<id>"`) into its parts. When no `:` is
+ * present the whole value is treated as the id and `type` is empty.
+ */
+export function parseMentionValue(value: string): { type: string; id: string } {
+  const sep = value.indexOf(':');
+  return sep >= 0
+    ? { type: value.slice(0, sep), id: value.slice(sep + 1) }
+    : { type: '', id: value };
+}
+
+/** Normalizes a raw lookup item into a {@link MentionItem}. */
+function toMentionItem(item: LookupItemResponse): MentionItem {
+  const value = stringifyLookupValue(item.value);
+  const parsed = parseMentionValue(value);
+  const type = typeof item.extra?.type === 'string' ? item.extra.type : parsed.type;
+  return { type, id: parsed.id, label: item.label, extra: item.extra };
+}

--- a/packages/@granit/mentions/src/index.ts
+++ b/packages/@granit/mentions/src/index.ts
@@ -1,0 +1,14 @@
+// ---------------------------------------------------------------------------
+// @granit/mentions — public API (framework-agnostic)
+// ---------------------------------------------------------------------------
+//
+// The @-mention picker client: a thin facade over @granit/data-lookup that binds the
+// 'mentions' source (GET /lookups/mentions) and the composite `type:id` value convention.
+// Mirrors the backend `Granit.Mentions` boundary — there is no mention-specific wire DTO.
+
+// Types
+export type { MentionItem } from './types/index';
+
+// HTTP client
+export { MENTIONS_SOURCE, parseMentionValue, resolveMention, searchMentions } from './api/index';
+export type { MentionClientOptions, SearchMentionsParams } from './api/index';

--- a/packages/@granit/mentions/src/types/index.ts
+++ b/packages/@granit/mentions/src/types/index.ts
@@ -1,0 +1,16 @@
+/**
+ * A resolved `@`-mention candidate from the Granit mention picker
+ * (`GET /lookups/mentions`). A mention has **no dedicated wire contract** — it is a
+ * `Granit.DataLookup` item whose composite `value` (`"<type>:<id>"`) and source-specific
+ * `extra` are normalized here. Consumers project this onto their own option shape.
+ */
+export interface MentionItem {
+  /** Mention type discriminator (e.g. `user`), from the item's `extra.type` or value prefix. */
+  readonly type: string;
+  /** Opaque entity id — the part of the composite value after the first `:`. */
+  readonly id: string;
+  /** Already-localized display label, rendered verbatim. */
+  readonly label: string;
+  /** Source-specific secondary attributes (e.g. `{ email }`), or `null` when none. */
+  readonly extra: Readonly<Record<string, unknown>> | null;
+}

--- a/packages/@granit/mentions/tsconfig.json
+++ b/packages/@granit/mentions/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/mentions/tsup.config.ts
+++ b/packages/@granit/mentions/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-ai-chat/package.json
+++ b/packages/@granit/react-ai-chat/package.json
@@ -22,6 +22,7 @@
     "@granit/ai-chat": "workspace:*",
     "@granit/api-client": "workspace:*",
     "@granit/logger": "workspace:*",
+    "@granit/mentions": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
@@ -53,7 +54,9 @@
   "devDependencies": {
     "@granit/ai-chat": "workspace:*",
     "@granit/api-client": "workspace:*",
+    "@granit/data-lookup": "workspace:*",
     "@granit/logger": "workspace:*",
+    "@granit/mentions": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",

--- a/packages/@granit/react-ai-chat/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-ai-chat/src/__tests__/testing-handlers.test.ts
@@ -1,7 +1,7 @@
 import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
-import { createAIChatHandlers } from '../testing/index';
+import { createAIChatHandlers, createMentionLookupHandlers } from '../testing/index';
 
 import type { ChatStreamEvent, ConversationSummaryResponse } from '@granit/ai-chat';
 import type { PagedResult } from '@granit/query-engine';
@@ -9,6 +9,7 @@ import type { PagedResult } from '@granit/query-engine';
 const LONG_ID = 'a1111111-1111-1111-1111-1111111110ff';
 
 const BASE = 'http://api.test/api/v1/conversations';
+const LOOKUP_BASE = 'http://api.test/lookups';
 const server = createMswServer();
 
 /** Read an SSE response body into parsed ChatStreamEvent frames. */
@@ -46,22 +47,6 @@ describe('createAIChatHandlers', () => {
     const response = await fetch(`${BASE}/workspaces`);
     const body = (await response.json()) as { workspaces: string[] };
     expect(body.workspaces[0]).toBe('Auto');
-  });
-
-  it('searches mentions by query and filters by type (not swallowed by /:id)', async () => {
-    server.use(...createAIChatHandlers(BASE));
-
-    const byQuery = (await (await fetch(`${BASE}/mentions?q=acme&limit=8`)).json()) as {
-      items: { label: string }[];
-    };
-    expect(byQuery.items).toHaveLength(1);
-    expect(byQuery.items[0]?.label).toBe('Acme Corp');
-
-    const byType = (await (await fetch(`${BASE}/mentions?q=&type=invoice`)).json()) as {
-      items: { type: string }[];
-    };
-    expect(byType.items.length).toBeGreaterThan(0);
-    expect(byType.items.every((item) => item.type === 'invoice')).toBe(true);
   });
 
   it('create then list reflects the new conversation', async () => {
@@ -164,5 +149,39 @@ describe('createAIChatHandlers', () => {
     const events = await readEvents(response.body);
     expect(events.map((e) => e.type)).toEqual(['conversation', 'delta', 'delta', 'usage']);
     expect(events.at(-1)).toMatchObject({ type: 'usage', inputTokens: 12, outputTokens: 8 });
+  });
+});
+
+describe('createMentionLookupHandlers', () => {
+  it('searches /lookups/mentions by query', async () => {
+    server.use(...createMentionLookupHandlers(LOOKUP_BASE));
+
+    const byQuery = (await (await fetch(`${LOOKUP_BASE}/mentions?search=ada`)).json()) as {
+      items: { label: string }[];
+    };
+    expect(byQuery.items).toHaveLength(1);
+    expect(byQuery.items[0]?.label).toBe('Ada Lovelace');
+  });
+
+  it('filters by scope.type', async () => {
+    server.use(...createMentionLookupHandlers(LOOKUP_BASE));
+
+    const byType = (await (await fetch(`${LOOKUP_BASE}/mentions?scope.type=invoice`)).json()) as {
+      items: { value: string }[];
+    };
+    expect(byType.items.length).toBeGreaterThan(0);
+    expect(byType.items.every((item) => item.value.startsWith('invoice:'))).toBe(true);
+  });
+
+  it('resolves a composite value, and returns null for an unknown one', async () => {
+    server.use(...createMentionLookupHandlers(LOOKUP_BASE));
+
+    const resolved = (await (
+      await fetch(`${LOOKUP_BASE}/mentions/resolve?value=user:u-42`)
+    ).json()) as { label: string } | null;
+    expect(resolved?.label).toBe('Ada Lovelace');
+
+    const missing = await (await fetch(`${LOOKUP_BASE}/mentions/resolve?value=user:nope`)).json();
+    expect(missing).toBeNull();
   });
 });

--- a/packages/@granit/react-ai-chat/src/__tests__/use-default-mention-resolve.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/use-default-mention-resolve.test.tsx
@@ -1,0 +1,57 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useDefaultMentionResolve } from '../hooks/use-default-mention-resolve';
+
+import { createWrapper } from './test-utils';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useDefaultMentionResolve', () => {
+  it('rehydrates a composite value via /lookups/mentions/resolve and maps it onto MentionOption', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse({
+        value: 'user:u-42',
+        label: 'Ada Lovelace',
+        extra: { type: 'user', email: 'ada@x.io' },
+      })
+    );
+
+    const { result } = renderHook(() => useDefaultMentionResolve(), {
+      wrapper: createWrapper(client),
+    });
+
+    const option = await result.current!('user:u-42');
+
+    expect(client.get).toHaveBeenCalledWith('/lookups/mentions/resolve', {
+      params: { value: 'user:u-42' },
+      signal: undefined,
+    });
+    expect(option).toEqual({
+      type: 'user',
+      id: 'u-42',
+      label: 'Ada Lovelace',
+      description: 'ada@x.io',
+    });
+  });
+
+  it('returns null when the value is unknown (HTTP 404)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue({ response: { status: 404 } });
+
+    const { result } = renderHook(() => useDefaultMentionResolve(), {
+      wrapper: createWrapper(client),
+    });
+
+    await expect(result.current!('user:nope')).resolves.toBeNull();
+  });
+
+  it('returns undefined outside an AIChatProvider', () => {
+    const { result } = renderHook(() => useDefaultMentionResolve());
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/packages/@granit/react-ai-chat/src/__tests__/use-default-mention-search.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/use-default-mention-search.test.tsx
@@ -4,50 +4,59 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { useDefaultMentionSearch } from '../hooks/use-default-mention-search';
 
-import { createWrapper, TEST_BASE_PATH } from './test-utils';
+import { createWrapper } from './test-utils';
+
+import type { LookupResultResponse } from '@granit/data-lookup';
+
+function lookupResult(items: LookupResultResponse['items']): LookupResultResponse {
+  return { items, totalCount: null, continuationToken: null };
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
 describe('useDefaultMentionSearch', () => {
-  it('searches /mentions and maps the response 1:1 to MentionOption (description preserved, null kept)', async () => {
+  it('searches /lookups/mentions and maps items onto MentionOption (email→description, null otherwise)', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue(
-      axiosResponse({
-        items: [
-          { type: 'contact', id: 'c-42', label: 'Acme Corp', description: 'Customer' },
-          { type: 'document', id: 'doc-7', label: 'Q2 Contract.pdf', description: null },
-        ],
-      })
+      axiosResponse(
+        lookupResult([
+          { value: 'user:u-42', label: 'Ada Lovelace', extra: { type: 'user', email: 'ada@x.io' } },
+          { value: 'invoice:inv-1', label: 'Invoice #1', extra: { type: 'invoice' } },
+        ])
+      )
     );
 
     const { result } = renderHook(() => useDefaultMentionSearch(), {
       wrapper: createWrapper(client),
     });
 
-    const options = await result.current!('ac');
+    const options = await result.current!('ad');
 
-    expect(client.get).toHaveBeenCalledWith(`${TEST_BASE_PATH}/mentions`, {
-      params: { q: 'ac', limit: 8 },
+    // The picker hits the unified lookup base path, not the conversations base path.
+    expect(client.get).toHaveBeenCalledWith('/lookups/mentions', {
+      params: { search: 'ad' },
+      signal: undefined,
     });
     expect(options).toEqual([
-      { type: 'contact', id: 'c-42', label: 'Acme Corp', description: 'Customer' },
-      { type: 'document', id: 'doc-7', label: 'Q2 Contract.pdf', description: null },
+      { type: 'user', id: 'u-42', label: 'Ada Lovelace', description: 'ada@x.io' },
+      { type: 'invoice', id: 'inv-1', label: 'Invoice #1', description: null },
     ]);
   });
 
-  it('honours a custom limit', async () => {
+  it('forwards an empty query verbatim (omitted by the lookup query builder) for the default set', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [] }));
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(lookupResult([])));
 
-    const { result } = renderHook(() => useDefaultMentionSearch(3), {
+    const { result } = renderHook(() => useDefaultMentionSearch(), {
       wrapper: createWrapper(client),
     });
     await result.current!('');
 
-    expect(client.get).toHaveBeenCalledWith(`${TEST_BASE_PATH}/mentions`, {
-      params: { q: '', limit: 3 },
+    expect(client.get).toHaveBeenCalledWith('/lookups/mentions', {
+      params: {},
+      signal: undefined,
     });
   });
 

--- a/packages/@granit/react-ai-chat/src/components/composer-types.ts
+++ b/packages/@granit/react-ai-chat/src/components/composer-types.ts
@@ -34,8 +34,8 @@ export interface PromptOption {
 
 /**
  * An `@` mention option resolved by `searchMentions` — the provider-backed
- * generic search by default, or a host-supplied adapter. Mirrors the backend's
- * `MentionSuggestionResponse` 1:1.
+ * generic search by default, or a host-supplied adapter. Projected from a
+ * `@granit/mentions` `MentionItem` (`GET /lookups/mentions`).
  */
 export interface MentionOption {
   readonly type: string;
@@ -51,11 +51,18 @@ export interface StagedMention extends MentionRequest {
 
 /**
  * Search for `@` mention candidates. The composer defaults to the unified,
- * ACL-bound `GET /conversations/mentions` endpoint (via `useDefaultMentionSearch`);
+ * ACL-bound `GET /lookups/mentions` picker (via `useDefaultMentionSearch`);
  * a host may pass its own adapter to override it (e.g. to scope or decorate
  * results). Empty `query` should return the top default suggestions.
  */
 export type SearchMentions = (query: string) => Promise<readonly MentionOption[]>;
+
+/**
+ * Rehydrate a composite mention value (`"<type>:<id>"`) into a {@link MentionOption},
+ * or `null` when the value is unknown. Backed by `GET /lookups/mentions/resolve`
+ * via `useDefaultMentionResolve`.
+ */
+export type ResolveMention = (value: string) => Promise<MentionOption | null>;
 
 /**
  * App-specific attachment upload: push the file to the app's blob store and

--- a/packages/@granit/react-ai-chat/src/constants.ts
+++ b/packages/@granit/react-ai-chat/src/constants.ts
@@ -9,8 +9,5 @@ export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;
 /** Default React Query key prefix for chat queries. */
 export const DEFAULT_QUERY_KEY_PREFIX = ['ai-chat'] as const;
 
-/** Default `@`-mention suggestions the composer requests per query (server cap: 25). */
-export const DEFAULT_MENTION_SEARCH_LIMIT = 8;
-
 /** Debounce applied to `@`-mention search before hitting the network, in ms. */
 export const MENTION_SEARCH_DEBOUNCE_MS = 200;

--- a/packages/@granit/react-ai-chat/src/hooks/map-mention-option.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/map-mention-option.ts
@@ -1,0 +1,16 @@
+import type { MentionOption } from '../components/composer-types';
+import type { MentionItem } from '@granit/mentions';
+
+/**
+ * Projects a generic {@link MentionItem} from `@granit/mentions` onto the composer's
+ * {@link MentionOption}: the item's `email` (when present in `extra`) becomes the
+ * secondary description line; other mention types render with no description.
+ */
+export function toMentionOption(item: MentionItem): MentionOption {
+  return {
+    type: item.type,
+    id: item.id,
+    label: item.label,
+    description: typeof item.extra?.email === 'string' ? item.extra.email : null,
+  };
+}

--- a/packages/@granit/react-ai-chat/src/hooks/use-default-mention-resolve.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-default-mention-resolve.ts
@@ -1,0 +1,29 @@
+import { resolveMention } from '@granit/mentions';
+import { useMemo } from 'react';
+
+import { useOptionalAIChatConfig } from '../providers/ai-chat-provider';
+
+import { toMentionOption } from './map-mention-option';
+
+import type { ResolveMention } from '../components/composer-types';
+
+/**
+ * The provider-backed default `@`-mention resolver: rehydrates a composite
+ * `"<type>:<id>"` value into a {@link MentionOption} via `@granit/mentions`
+ * (`GET /lookups/mentions/resolve`), or `null` when the value is unknown. Useful
+ * when restoring a draft that persisted only mention ids — the live picker keeps
+ * the label inline, so the composer itself never needs it.
+ *
+ * Returns `undefined` outside an {@link AIChatProvider}.
+ */
+export function useDefaultMentionResolve(): ResolveMention | undefined {
+  const config = useOptionalAIChatConfig();
+  return useMemo<ResolveMention | undefined>(() => {
+    if (!config) return undefined;
+    const { client } = config;
+    return async (value) => {
+      const item = await resolveMention(client, value);
+      return item ? toMentionOption(item) : null;
+    };
+  }, [config]);
+}

--- a/packages/@granit/react-ai-chat/src/hooks/use-default-mention-search.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-default-mention-search.ts
@@ -1,40 +1,31 @@
-import { searchConversationMentions } from '@granit/ai-chat';
+import { searchMentions } from '@granit/mentions';
 import { useMemo } from 'react';
 
-import { DEFAULT_MENTION_SEARCH_LIMIT } from '../constants';
 import { useOptionalAIChatConfig } from '../providers/ai-chat-provider';
 
-import type { MentionOption, SearchMentions } from '../components/composer-types';
+import { toMentionOption } from './map-mention-option';
+
+import type { SearchMentions } from '../components/composer-types';
 
 /**
  * The provider-backed default `@`-mention search: binds the unified
- * `GET /conversations/mentions` endpoint to the {@link AIChatProvider}'s client +
- * base path and maps each {@link MentionSuggestionResponse} 1:1 onto a
+ * `GET /lookups/mentions` picker (via `@granit/mentions`) to the
+ * {@link AIChatProvider}'s client and maps each `MentionItem` onto a
  * {@link MentionOption}. {@link ChatComposer} uses it whenever the host does not
  * pass its own `searchMentions` adapter.
  *
  * Returns `undefined` outside an {@link AIChatProvider} (e.g. a standalone
  * composer in tests/Storybook), which leaves the mention picker disabled until a
  * `searchMentions` prop is supplied.
- *
- * @param limit - Maximum suggestions per query (server cap: 25). Defaults to
- *   {@link DEFAULT_MENTION_SEARCH_LIMIT}.
  */
-export function useDefaultMentionSearch(
-  limit: number = DEFAULT_MENTION_SEARCH_LIMIT
-): SearchMentions | undefined {
+export function useDefaultMentionSearch(): SearchMentions | undefined {
   const config = useOptionalAIChatConfig();
   return useMemo<SearchMentions | undefined>(() => {
     if (!config) return undefined;
-    const { client, basePath } = config;
+    const { client } = config;
     return async (query) => {
-      const items = await searchConversationMentions(client, basePath, query, { limit });
-      return items.map<MentionOption>((item) => ({
-        type: item.type,
-        id: item.id,
-        label: item.label,
-        description: item.description,
-      }));
+      const items = await searchMentions(client, { search: query });
+      return items.map(toMentionOption);
     };
-  }, [config, limit]);
+  }, [config]);
 }

--- a/packages/@granit/react-ai-chat/src/index.ts
+++ b/packages/@granit/react-ai-chat/src/index.ts
@@ -42,6 +42,7 @@ export type { ReportMessageVariables, UseReportMessageReturn } from './hooks/use
 
 // Hooks — mentions
 export { useDefaultMentionSearch } from './hooks/use-default-mention-search';
+export { useDefaultMentionResolve } from './hooks/use-default-mention-resolve';
 
 // Re-exports from @granit/ai-chat — the report contract the showcase dialog needs.
 export { MESSAGE_REPORT_CATEGORIES } from '@granit/ai-chat';
@@ -102,6 +103,7 @@ export type { ActiveTrigger } from './components/detect-trigger';
 export type {
   MentionOption,
   PromptOption,
+  ResolveMention,
   SearchMentions,
   StagedMention,
   UploadAttachment,

--- a/packages/@granit/react-ai-chat/src/testing/data.ts
+++ b/packages/@granit/react-ai-chat/src/testing/data.ts
@@ -3,9 +3,9 @@ import { toEntityId, toISODateString } from '@granit/types';
 import type {
   ConversationResponse,
   ConversationSummaryResponse,
-  MentionSuggestionResponse,
   MessageResponse,
 } from '@granit/ai-chat';
+import type { LookupItemResponse } from '@granit/data-lookup';
 
 const OWNER = toEntityId<'User'>('b2222222-2222-2222-2222-222222222222');
 
@@ -93,13 +93,14 @@ export const mockConversationSummaries: ConversationSummaryResponse[] = [
 export const mockChatWorkspaces: readonly string[] = ['Auto', 'default', 'support'];
 
 /**
- * `@`-mention candidates returned by `GET /conversations/mentions`. A mix of
- * resolver types so the unified picker can be exercised (and the `type` filter
- * validated). One entry carries a `null` description to cover that branch.
+ * `@`-mention candidates returned by the unified picker (`GET /lookups/mentions`),
+ * in the raw `Granit.DataLookup` item shape (`{ value: "<type>:<id>", label, extra }`).
+ * A mix of types so multi-type search and the `scope.type` filter can be exercised;
+ * the non-`user` entries carry no `email`, covering the `description: null` branch.
  */
-export const mockMentionSuggestions: readonly MentionSuggestionResponse[] = [
-  { type: 'contact', id: 'c-42', label: 'Acme Corp', description: 'Customer' },
-  { type: 'contact', id: 'c-43', label: 'Globex', description: 'Customer' },
-  { type: 'invoice', id: 'inv-1001', label: 'Invoice #1001', description: '€1,350 · due Jun 30' },
-  { type: 'document', id: 'doc-7', label: 'Q2 Contract.pdf', description: null },
+export const mockMentionLookupItems: readonly LookupItemResponse[] = [
+  { value: 'user:u-42', label: 'Ada Lovelace', extra: { type: 'user', email: 'ada@x.io' } },
+  { value: 'user:u-43', label: 'Grace Hopper', extra: { type: 'user', email: 'grace@x.io' } },
+  { value: 'invoice:inv-1001', label: 'Invoice #1001', extra: { type: 'invoice' } },
+  { value: 'document:doc-7', label: 'Q2 Contract.pdf', extra: { type: 'document' } },
 ];

--- a/packages/@granit/react-ai-chat/src/testing/handlers.ts
+++ b/packages/@granit/react-ai-chat/src/testing/handlers.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_LOOKUP_BASE_PATH } from '@granit/data-lookup';
 import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants';
@@ -9,18 +10,18 @@ import {
   mockConversationSummaries,
   mockLongConversationId,
   mockLongConversationMessages,
-  mockMentionSuggestions,
+  mockMentionLookupItems,
 } from './data';
 
 import type {
   ConversationResponse,
   ConversationSummaryResponse,
   CreateConversationRequest,
-  MentionSuggestionResponse,
   MessageResponse,
   RenameConversationRequest,
   SetConversationFavoriteRequest,
 } from '@granit/ai-chat';
+import type { LookupItemResponse, LookupResultResponse } from '@granit/data-lookup';
 import type { PagedResult } from '@granit/query-engine';
 import type { Mutable } from '@granit/testing';
 
@@ -43,21 +44,6 @@ export function createAIChatHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
     // GET /conversations/workspaces — before /:id so it is not swallowed.
     http.get(`${baseUrl}/workspaces`, () => HttpResponse.json({ workspaces: mockChatWorkspaces })),
-
-    // GET /conversations/mentions — unified @-mention search. Filters the fixture
-    // by `q` (label, case-insensitive) and optional `type`, capped by `limit`
-    // (default 8). Declared before /:id so it is not shadowed.
-    http.get(`${baseUrl}/mentions`, ({ request }) => {
-      const url = new URL(request.url);
-      const q = (url.searchParams.get('q') ?? '').trim().toLowerCase();
-      const type = url.searchParams.get('type');
-      const limit = Math.min(Math.max(Number(url.searchParams.get('limit')) || 8, 1), 25);
-      const items: MentionSuggestionResponse[] = mockMentionSuggestions
-        .filter((item) => (type ? item.type === type : true))
-        .filter((item) => (q ? item.label.toLowerCase().includes(q) : true))
-        .slice(0, limit);
-      return HttpResponse.json({ items });
-    }),
 
     // GET /conversations — list summaries, newest first.
     http.get(baseUrl, () => HttpResponse.json(summaries)),
@@ -181,6 +167,52 @@ export function createAIChatHandlers(baseUrl = DEFAULT_BASE_PATH) {
       });
 
       return new HttpResponse(stream, { headers: { 'Content-Type': 'text/event-stream' } });
+    }),
+  ];
+}
+
+/**
+ * MSW handlers for the unified `@`-mention picker, served by `Granit.DataLookup`'s
+ * `mentions` facade source (NOT the conversations base path). Mirrors the live
+ * contract:
+ *   - `GET {baseUrl}/mentions?search=&scope.type=` — multi-type typeahead over the
+ *     fixture (filters by `label`/`value`, case-insensitive; optional `scope.type`).
+ *   - `GET {baseUrl}/mentions/resolve?value=<type>:<id>` — single-item rehydration,
+ *     or `null` when unknown.
+ *
+ * Compose alongside {@link createAIChatHandlers} when exercising the composer picker.
+ *
+ * @param baseUrl - Lookup base path (default: `/lookups`).
+ * @param items - Fixture served by the source (default: {@link mockMentionLookupItems}).
+ */
+export function createMentionLookupHandlers(
+  baseUrl: string = DEFAULT_LOOKUP_BASE_PATH,
+  items: readonly LookupItemResponse[] = mockMentionLookupItems
+) {
+  return [
+    http.get(`${baseUrl}/mentions/resolve`, ({ request }) => {
+      const value = new URL(request.url).searchParams.get('value') ?? '';
+      const item = items.find((i) => String(i.value) === value) ?? null;
+      return HttpResponse.json(item);
+    }),
+
+    http.get(`${baseUrl}/mentions`, ({ request }) => {
+      const url = new URL(request.url);
+      const search = (url.searchParams.get('search') ?? '').trim().toLowerCase();
+      const type = url.searchParams.get('scope.type');
+      const matched = items
+        .filter((i) => (type ? i.extra?.type === type : true))
+        .filter((i) =>
+          search
+            ? i.label.toLowerCase().includes(search) ||
+              String(i.value).toLowerCase().includes(search)
+            : true
+        );
+      return HttpResponse.json<LookupResultResponse>({
+        items: matched,
+        totalCount: null,
+        continuationToken: null,
+      });
     }),
   ];
 }

--- a/packages/@granit/react-ai-chat/src/testing/index.ts
+++ b/packages/@granit/react-ai-chat/src/testing/index.ts
@@ -9,6 +9,6 @@ export {
   mockConversationSummaries,
   mockLongConversationId,
   mockLongConversationMessages,
-  mockMentionSuggestions,
+  mockMentionLookupItems,
 } from './data';
-export { createAIChatHandlers } from './handlers';
+export { createAIChatHandlers, createMentionLookupHandlers } from './handlers';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -803,6 +803,18 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/mentions:
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/data-lookup':
+        specifier: workspace:*
+        version: link:../data-lookup
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/metering:
     devDependencies:
       '@granit/api-client':
@@ -1139,9 +1151,15 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/data-lookup':
+        specifier: workspace:*
+        version: link:../data-lookup
       '@granit/logger':
         specifier: workspace:*
         version: link:../logger
+      '@granit/mentions':
+        specifier: workspace:*
+        version: link:../mentions
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine


### PR DESCRIPTION
## Context

Backend PR granit-dotnet#2828 **removed** the AI-chat-specific `GET /conversations/mentions` endpoint. A mention is now a `Granit.DataLookup` source *tagged mentionable* (`Granit.Mentions` facade), served by the generic **`GET /lookups/mentions`** — there is **no mention-specific wire DTO** (the wire is the plain `LookupItemResponse {value,label,extra}`). This rebranches the front onto that contract.

## What changed

### New package `@granit/mentions` (core, framework-agnostic)
Thin facade over `@granit/data-lookup`, mirroring the backend `Granit.Mentions` boundary. Binds the `mentions` source + the composite `"<type>:<id>"` value convention so every consumer (AI chat, timeline, …) shares one home instead of re-deriving it:
- `searchMentions(client, { search, type? })` → `GET /lookups/mentions` (`type` ⇒ `scope.type`)
- `resolveMention(client, value)` → `GET /lookups/mentions/resolve`
- `parseMentionValue`, `MentionItem { type, id, label, extra }`, `MENTIONS_SOURCE`

### `@granit/react-ai-chat`
- `useDefaultMentionSearch` rewritten on `@granit/mentions`; new `useDefaultMentionResolve` (rehydration). 200 ms debounce unchanged. `email`→`description` projection lives in the chat consumer.
- testing: dropped the `/conversations/mentions` MSW handler; added `createMentionLookupHandlers` over `/lookups/mentions`.

### `@granit/ai-chat`
- Removed dead `searchConversationMentions` + `MentionSuggestionResponse` (endpoint deleted). `MentionRequest` (send contract) unchanged.

### `@granit/contract-tests`
- Dropped `MentionSuggestionResponse` from the manifest; re-vendored the `ai-chat` OpenAPI snapshot. The re-sync also surfaced an unrelated backend reorder — `ConversationResponse`/`ConversationSummaryResponse.workspaceKey` moved before `createdAt` to match the spec (field order only, no API break).

## Verification
- `pnpm tsc` ✅ · ESLint `--max-warnings 0` ✅ · 673 tests ✅ (incl. `@granit/mentions` unit tests, both default-mention hooks, MSW handler).

## Notes
- The **showcase host** wiring (`AddMentionSource` registering the `mentions` source) is backend/host scope, not in this PR.
- The showcase-react front rewire (timeline `@` picker → `/lookups/mentions`) ships as a separate MR on GitLab.