### PR TITLE
refactor(ai-chat): audit follow-ups for data-lookup/mentions/ai-chat

### DIFF
--- a/packages/@granit/ai-chat/src/api/conversations-api.ts
+++ b/packages/@granit/ai-chat/src/api/conversations-api.ts
@@ -18,6 +18,7 @@ import type {
   RenameConversationRequest,
   ReportMessageRequest,
   SendMessageRequest,
+  SetConversationFavoriteRequest,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 import type { PagedResult } from '@granit/query-engine';
@@ -127,7 +128,8 @@ export async function setConversationFavorite(
   id: ConversationId,
   isFavorite: boolean
 ): Promise<void> {
-  await client.put(`${basePath}/${encodeURIComponent(id)}/favorite`, { isFavorite });
+  const body: SetConversationFavoriteRequest = { isFavorite };
+  await client.put(`${basePath}/${encodeURIComponent(id)}/favorite`, body);
 }
 
 /**

--- a/packages/@granit/ai-chat/src/types/index.ts
+++ b/packages/@granit/ai-chat/src/types/index.ts
@@ -89,7 +89,15 @@ export const CHAT_STREAM_ERROR_CODES = {
 export type ChatStreamErrorCode =
   (typeof CHAT_STREAM_ERROR_CODES)[keyof typeof CHAT_STREAM_ERROR_CODES];
 
-/** Role of a persisted chat message. */
+/**
+ * Role of a persisted chat message. The conversation thread
+ * (`GET /{id}/messages`) only ever carries `user`/`assistant` rows — the backend
+ * never persists `system` or `tool` messages (system prompts are composed
+ * per-turn by the orchestrator; tool activity stays in the stream as
+ * `tool_call`/`tool_result` frames). `'system'` is kept for forward
+ * compatibility; `'tool'` is intentionally excluded as unreachable on this
+ * contract.
+ */
 export type ChatMessageRole = 'user' | 'assistant' | 'system';
 
 /** Server-enforced limits for a single `SendMessageRequest` turn. */
@@ -148,8 +156,11 @@ export interface AttachmentRequest {
   readonly reference: string;
   readonly fileName: string;
   readonly contentType: string;
-  /** int64 — surfaces as `number | string` in generated clients. */
-  readonly sizeBytes: number | string;
+  /**
+   * Byte size of the uploaded blob (.NET `long`, serialized as a JSON number).
+   * Attachments are capped server-side well within the JS safe-integer range.
+   */
+  readonly sizeBytes: number;
 }
 
 /** Body of `POST /conversations/messages`. */

--- a/packages/@granit/react-ai-chat/package.json
+++ b/packages/@granit/react-ai-chat/package.json
@@ -21,6 +21,7 @@
   "peerDependencies": {
     "@granit/ai-chat": "workspace:*",
     "@granit/api-client": "workspace:*",
+    "@granit/data-lookup": "workspace:*",
     "@granit/logger": "workspace:*",
     "@granit/mentions": "workspace:*",
     "@granit/query-engine": "workspace:*",
@@ -34,6 +35,9 @@
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/data-lookup": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-ai-chat/src/components/attachment-chips.tsx
+++ b/packages/@granit/react-ai-chat/src/components/attachment-chips.tsx
@@ -25,9 +25,9 @@ export interface AttachmentChipsProps {
 
 const UNITS = ['B', 'KB', 'MB', 'GB'] as const;
 
-/** Human-readable byte size; accepts the int64 `number | string` shape. */
-function formatBytes(sizeBytes: number | string): string {
-  let size = typeof sizeBytes === 'string' ? Number(sizeBytes) : sizeBytes;
+/** Human-readable byte size. */
+function formatBytes(sizeBytes: number): string {
+  let size = sizeBytes;
   if (!Number.isFinite(size) || size <= 0) return '0 B';
   let unit = 0;
   while (size >= 1024 && unit < UNITS.length - 1) {

--- a/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
@@ -51,7 +51,7 @@ export interface ChatComposerProps {
   readonly prompts?: readonly PromptOption[];
   /**
    * Override the `@` mention search. Defaults to the provider-backed generic
-   * search (`GET /conversations/mentions`) when rendered inside an
+   * search (`GET /lookups/mentions`) when rendered inside an
    * `AIChatProvider`; omit it outside a provider to disable the mention picker.
    */
   readonly searchMentions?: SearchMentions;
@@ -117,7 +117,7 @@ export function ChatComposer({
   const [mentionLoading, setMentionLoading] = useState(false);
 
   // The picker resolves mentions through the host's adapter when supplied, else
-  // the provider-backed generic search (`GET /conversations/mentions`); `null`
+  // the provider-backed generic search (`GET /lookups/mentions`); `null`
   // outside a provider keeps the picker disabled.
   const defaultSearchMentions = useDefaultMentionSearch();
   const effectiveSearchMentions = searchMentions ?? defaultSearchMentions;

--- a/packages/@granit/react-ai-chat/src/components/composer-types.ts
+++ b/packages/@granit/react-ai-chat/src/components/composer-types.ts
@@ -73,5 +73,5 @@ export type UploadAttachment = (file: File) => Promise<{
   readonly reference: string;
   readonly fileName: string;
   readonly contentType: string;
-  readonly sizeBytes: number | string;
+  readonly sizeBytes: number;
 }>;


### PR DESCRIPTION
## Context

Follow-up to #712. Framework-conformity fixes surfaced by an `/audit` of the `mentions`, `data-lookup`, `ai-chat`, `react-data-lookup`, `react-ai-chat`, and `react-ai-chat-blob-storage` modules against their `Granit.DataLookup` / `Granit.Mentions` / `Granit.AI.Chat` backend contracts.

The audit found **0 BREAKING** issues — endpoint coverage is 100%, type names mirror the .NET DTOs, the HTTP-client rules hold, and the markdown renderer is correctly hardened. These are the minor cleanups. **No behaviour change.**

## Changes

- **docs(react-ai-chat):** correct stale `GET /conversations/mentions` references in `ChatComposer` to the actual `GET /lookups/mentions` route introduced by #712.
- **refactor(ai-chat):** narrow `AttachmentRequest.sizeBytes` to `number` — the backend serializes the .NET `long` as a JSON number, so the `string` branch was unreachable. Cascades to `UploadAttachment` and `formatBytes`.
- **refactor(ai-chat):** `setConversationFavorite` now sends a typed `SetConversationFavoriteRequest` body instead of an inline object literal.
- **chore(react-ai-chat):** declare `@granit/data-lookup` as an *optional* peer — it is consumed by the published `./testing` entry's MSW handlers (previously dev-only).
- **docs(ai-chat):** document the `ChatMessageRole` persistence invariant. Backend verification confirmed the thread only ever persists `user`/`assistant` rows (`system`/`tool` are never written), so `'tool'` is intentionally excluded rather than added.

## Verification

- `tsc --noEmit`: PASS (ai-chat, react-ai-chat, react-ai-chat-blob-storage, data-lookup, mentions, react-data-lookup)
- ESLint (`--max-warnings 0`): PASS
- Vitest: 151/151 pass (ai-chat + react-ai-chat)

No exported-symbol break: `UploadAttachment` / `AttachmentRequest` have no consumers in showcase-admin-react or cms-renderer.