### PR TITLE
fix(react-ai-chat): resolve Sonar code smells in AI chat components

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -520,6 +520,28 @@
           "name": "scanUseClientDirective",
           "kind": "function",
           "signature": "function scanUseClientDirective(opts: AllowlistedScanContext): Violation[]"
+        },
+        {
+          "name": "scanForbiddenStructure",
+          "kind": "function",
+          "signature": "function scanForbiddenStructure(opts: ForbiddenStructureOptions): Violation[]"
+        },
+        {
+          "name": "ForbiddenStructureOptions",
+          "kind": "interface",
+          "signature": "interface ForbiddenStructureOptions extends ScanContext",
+          "members": [
+            {
+              "name": "coreForbidden",
+              "kind": "property",
+              "signature": "coreForbidden?: ReadonlyArray<string>"
+            },
+            {
+              "name": "reactForbidden",
+              "kind": "property",
+              "signature": "reactForbidden?: ReadonlyArray<string>"
+            }
+          ]
         }
       ]
     },

--- a/packages/@granit/ai/src/index.ts
+++ b/packages/@granit/ai/src/index.ts
@@ -22,7 +22,6 @@ export type {
   AIWorkspaceListResponse,
   AIWorkspaceResponse,
   AIWorkspaceUpdateRequest,
-  ChatStreamEvent,
   ConversationId,
 } from './types/index';
 export {

--- a/packages/@granit/ai/src/types/index.ts
+++ b/packages/@granit/ai/src/types/index.ts
@@ -140,13 +140,6 @@ export type AIChatCompletionEvent =
   | { readonly type: 'chunk'; readonly content: string }
   | { readonly type: 'usage'; readonly usage: AIChatStreamUsage };
 
-/**
- * @deprecated Renamed to {@link AIChatCompletionEvent} to avoid the name
- * collision with `@granit/ai-chat`'s agentic `ChatStreamEvent` (a different
- * shape). Import the new name; this alias will be removed in a future major.
- */
-export type ChatStreamEvent = AIChatCompletionEvent;
-
 // -- Embeddings --------------------------------------------------------------
 
 /** Embedding generation request. Mirrors `AIEmbeddingRequest`. */

--- a/packages/@granit/react-ai-chat/src/__tests__/chat-composer.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/chat-composer.test.tsx
@@ -14,8 +14,8 @@ const PROMPTS: PromptOption[] = [
   { id: 'p2' as PromptId, name: 'Daily brief', shortDescription: 'Your day' },
 ];
 
-/** The contenteditable message input. */
-const getEditor = () => screen.getByRole('textbox', { name: /ask your app/i });
+/** The contenteditable message input (an editable `combobox` driving the pickers). */
+const getEditor = () => screen.getByRole('combobox', { name: /ask your app/i });
 
 /**
  * Build the editor content from interleaved text + chip specs (as the editor

--- a/packages/@granit/react-ai-chat/src/__tests__/error-handling.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/error-handling.test.tsx
@@ -31,10 +31,11 @@ describe('SystemMessage', () => {
   });
 
   it('renders info as a polite status', () => {
-    const { container } = render(<SystemMessage>Heads up.</SystemMessage>);
-    const notice = container.querySelector('[data-slot="system-message"]');
+    render(<SystemMessage>Heads up.</SystemMessage>);
+    // A native <output> carries the implicit `status` role — no hand-written role.
+    const notice = screen.getByRole('status');
     expect(notice).toHaveAttribute('data-variant', 'info');
-    expect(notice).toHaveAttribute('role', 'status');
+    expect(notice.tagName).toBe('OUTPUT');
   });
 });
 

--- a/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
@@ -199,9 +199,9 @@ export function ChatComposer({
     // a fresh one when the caret is still inside a mention token.
     clearMentionDebounce();
     const editor = editorRef.current;
-    const selection = typeof window !== 'undefined' ? window.getSelection() : null;
+    const selection = globalThis.getSelection?.() ?? null;
     const node = selection?.anchorNode ?? null;
-    if (!editor || !selection || !selection.isCollapsed || !node || node.nodeType !== 3) {
+    if (!editor || !selection?.isCollapsed || !node || node.nodeType !== 3) {
       triggerLocRef.current = null;
       setTrigger(null);
       return;
@@ -486,54 +486,54 @@ export function ChatComposer({
           'focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px]'
         )}
       >
-        {showSuggestions && trigger?.kind === '/' ? (
-          <div onMouseDown={onSuggestionMouseDown}>
-            <ComposerSuggestions<PromptOption>
-              title={pickerLabels.Prompts}
-              items={promptMatches}
-              activeIndex={activeIndex}
-              loadingLabel={pickerLabels.Loading}
-              emptyLabel={pickerLabels.NoResults}
-              listboxId={listboxId}
-              getOptionId={getOptionId}
-              getKey={(item) => item.id}
-              onHover={setActiveIndex}
-              onSelect={selectPrompt}
-              renderItem={(item) => (
-                <div className="flex flex-col">
-                  <span className="font-medium">{item.name}</span>
-                  {item.shortDescription ? (
-                    <span className="text-muted-foreground text-xs">{item.shortDescription}</span>
-                  ) : null}
-                </div>
-              )}
-            />
-          </div>
-        ) : null}
-
-        {showSuggestions && trigger?.kind === '@' ? (
-          <div onMouseDown={onSuggestionMouseDown}>
-            <ComposerSuggestions<MentionOption>
-              title={pickerLabels.Mentions}
-              items={mentionResults}
-              activeIndex={activeIndex}
-              loading={mentionLoading}
-              loadingLabel={pickerLabels.Loading}
-              emptyLabel={pickerLabels.NoResults}
-              listboxId={listboxId}
-              getOptionId={getOptionId}
-              getKey={(item) => `${item.type}:${item.id}`}
-              onHover={setActiveIndex}
-              onSelect={selectMention}
-              renderItem={(item) => (
-                <div className="flex flex-col">
-                  <span className="font-medium">{item.label}</span>
-                  {item.description ? (
-                    <span className="text-muted-foreground text-xs">{item.description}</span>
-                  ) : null}
-                </div>
-              )}
-            />
+        {showSuggestions ? (
+          // The wrapper only swallows the picker's mousedown so the editor keeps
+          // its selection through the click; it's presentational, not a control.
+          <div role="presentation" onMouseDown={onSuggestionMouseDown}>
+            {trigger?.kind === '/' ? (
+              <ComposerSuggestions<PromptOption>
+                title={pickerLabels.Prompts}
+                items={promptMatches}
+                activeIndex={activeIndex}
+                loadingLabel={pickerLabels.Loading}
+                emptyLabel={pickerLabels.NoResults}
+                listboxId={listboxId}
+                getOptionId={getOptionId}
+                getKey={(item) => item.id}
+                onHover={setActiveIndex}
+                onSelect={selectPrompt}
+                renderItem={(item) => (
+                  <div className="flex flex-col">
+                    <span className="font-medium">{item.name}</span>
+                    {item.shortDescription ? (
+                      <span className="text-muted-foreground text-xs">{item.shortDescription}</span>
+                    ) : null}
+                  </div>
+                )}
+              />
+            ) : (
+              <ComposerSuggestions<MentionOption>
+                title={pickerLabels.Mentions}
+                items={mentionResults}
+                activeIndex={activeIndex}
+                loading={mentionLoading}
+                loadingLabel={pickerLabels.Loading}
+                emptyLabel={pickerLabels.NoResults}
+                listboxId={listboxId}
+                getOptionId={getOptionId}
+                getKey={(item) => `${item.type}:${item.id}`}
+                onHover={setActiveIndex}
+                onSelect={selectMention}
+                renderItem={(item) => (
+                  <div className="flex flex-col">
+                    <span className="font-medium">{item.label}</span>
+                    {item.description ? (
+                      <span className="text-muted-foreground text-xs">{item.description}</span>
+                    ) : null}
+                  </div>
+                )}
+              />
+            )}
           </div>
         ) : null}
 
@@ -552,8 +552,12 @@ export function ChatComposer({
             data-slot="composer-input"
             contentEditable={!disabled}
             suppressContentEditableWarning
-            role="textbox"
-            aria-multiline="true"
+            // An editable combobox: the contenteditable owns the text while the
+            // `/` `@` pickers expose the popup listbox. `combobox` (unlike
+            // `textbox`) supports aria-expanded/-controls/-activedescendant; the
+            // explicit tabIndex keeps it focusable when contentEditable is off.
+            role="combobox"
+            tabIndex={disabled ? -1 : 0}
             aria-label={labels.Placeholder}
             aria-autocomplete="list"
             aria-expanded={showSuggestions}

--- a/packages/@granit/react-ai-chat/src/components/chat-message.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-message.tsx
@@ -12,20 +12,27 @@ import type { CSSProperties, ReactNode } from 'react';
  * Plain runs stay verbatim; nothing here is an HTML sink (text + spans only).
  */
 function UserContent({ content }: { readonly content: string }): ReactNode {
-  return tokenizeMessageContent(content).map((segment, index) =>
-    segment.type === 'text' ? (
-      <span key={`t${index}`}>{segment.value}</span>
+  // Key each segment by its start offset in the source string — stable across
+  // re-renders and unique without leaning on the array index. The `+ 1` keeps
+  // consecutive zero-length runs distinct.
+  let offset = 0;
+  return tokenizeMessageContent(content).map((segment) => {
+    const start = offset;
+    const text = segment.type === 'text' ? segment.value : segment.label;
+    offset += text.length + 1;
+    return segment.type === 'text' ? (
+      <span key={`t${start}`}>{segment.value}</span>
     ) : (
       <span
-        key={`c${index}`}
+        key={`c${start}`}
         data-slot="message-chip"
         data-kind={segment.kind}
         className="bg-primary-foreground/15 mx-0.5 inline-flex items-center rounded-md px-1.5 py-0.5 align-baseline font-medium"
       >
         {segment.label}
       </span>
-    )
-  );
+    );
+  });
 }
 
 export interface ChatMessageProps {

--- a/packages/@granit/react-ai-chat/src/components/system-message.tsx
+++ b/packages/@granit/react-ai-chat/src/components/system-message.tsx
@@ -30,11 +30,14 @@ export function SystemMessage({
   className,
 }: Readonly<SystemMessageProps>) {
   const Icon = VARIANT_ICON[variant];
+  // `error` is an assertive `alert`; `info` uses a native `<output>`, whose
+  // implicit `status` role announces politely without a hand-written role.
+  const Tag = variant === 'error' ? 'div' : 'output';
   return (
-    <div
+    <Tag
       data-slot="system-message"
       data-variant={variant}
-      role={variant === 'error' ? 'alert' : 'status'}
+      role={variant === 'error' ? 'alert' : undefined}
       className={cn(
         'flex items-center gap-2 rounded-lg border px-3 py-2 text-sm',
         variant === 'error'
@@ -46,6 +49,6 @@ export function SystemMessage({
       <Icon className="size-4 shrink-0" aria-hidden />
       <span className="flex-1">{children}</span>
       {action ? <span className="shrink-0">{action}</span> : null}
-    </div>
+    </Tag>
   );
 }

--- a/packages/@granit/react-ai-chat/src/components/workspace-selector.tsx
+++ b/packages/@granit/react-ai-chat/src/components/workspace-selector.tsx
@@ -8,6 +8,28 @@ import type { KeyboardEvent, ReactNode } from 'react';
 /** Below this option count the search field is hidden — the list is short enough. */
 const SEARCH_THRESHOLD = 5;
 
+/**
+ * Render an option's trailing capability glyphs. The glyphs are opaque,
+ * host-supplied nodes with no identity of their own, so each is keyed by its
+ * position via a local counter rather than the map index.
+ */
+function renderCapabilities(option: WorkspaceOption): ReactNode {
+  if (!option.capabilities || option.capabilities.length === 0) return null;
+  let slot = 0;
+  return (
+    <span
+      data-slot="workspace-capabilities"
+      className="text-muted-foreground flex shrink-0 items-center gap-1.5"
+    >
+      {option.capabilities.map((cap) => (
+        <span key={`${option.value}-cap-${slot++}`} className="inline-flex">
+          {cap}
+        </span>
+      ))}
+    </span>
+  );
+}
+
 export interface WorkspaceSelectorProps {
   /** Options to choose from (already brand-decorated by the host). */
   readonly options: readonly WorkspaceOption[];
@@ -49,7 +71,7 @@ export function WorkspaceSelector({
 
   const containerRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
-  const popoverRef = useRef<HTMLDivElement>(null);
+  const listboxRef = useRef<HTMLUListElement>(null);
 
   const baseId = useId();
   const listboxId = `${baseId}-ws-listbox`;
@@ -85,14 +107,16 @@ export function WorkspaceSelector({
   // Move the active highlight, skipping disabled rows.
   const moveActive = useCallback(
     (delta: number) => {
-      if (filtered.length === 0) return;
+      const count = filtered.length;
+      if (count === 0) return;
       setActiveIndex((current) => {
-        let next = current;
-        for (let step = 0; step < filtered.length; step++) {
-          next = (next + delta + filtered.length) % filtered.length;
-          if (!filtered[next]?.disabled) return next;
-        }
-        return current;
+        // Walk the candidate indices in `delta` order (wrapping) and stop at the
+        // first selectable row; fall back to the current row if all are disabled.
+        const next = Array.from(
+          { length: count },
+          (_, step) => (((current + delta * (step + 1)) % count) + count) % count
+        ).find((index) => !filtered[index]?.disabled);
+        return next ?? current;
       });
     },
     [filtered]
@@ -105,18 +129,19 @@ export function WorkspaceSelector({
     setActiveIndex(firstEnabled === -1 ? 0 : firstEnabled);
   }, [open, filtered]);
 
-  // Focus the search field (or the popover) on open.
+  // Focus the search field (or the listbox itself) on open so keyboard nav works.
   useEffect(() => {
     if (!open) return;
     if (showSearch) searchRef.current?.focus();
-    else popoverRef.current?.focus();
+    else listboxRef.current?.focus();
   }, [open, showSearch]);
 
   // Close on outside pointer or focus loss.
   useEffect(() => {
     if (!open) return;
     const onPointerDown = (event: PointerEvent) => {
-      if (!containerRef.current?.contains(event.target as Node)) close();
+      const target = event.target instanceof Node ? event.target : null;
+      if (!containerRef.current?.contains(target)) close();
     };
     document.addEventListener('pointerdown', onPointerDown);
     return () => document.removeEventListener('pointerdown', onPointerDown);
@@ -169,6 +194,10 @@ export function WorkspaceSelector({
         <div
           id={getOptionId(index)}
           role="option"
+          // Arrow-key navigation is handled at the popover level (it owns the
+          // active highlight), so each option is only programmatically focusable
+          // (-1) — never in the tab order.
+          tabIndex={-1}
           aria-selected={option.value === selected?.value}
           aria-disabled={option.disabled}
           data-slot="workspace-option"
@@ -190,18 +219,7 @@ export function WorkspaceSelector({
         >
           <span className="flex size-4 shrink-0 items-center justify-center">{option.icon}</span>
           <span className="flex-1 truncate">{option.label ?? option.value}</span>
-          {option.capabilities && option.capabilities.length > 0 ? (
-            <span
-              data-slot="workspace-capabilities"
-              className="text-muted-foreground flex shrink-0 items-center gap-1.5"
-            >
-              {option.capabilities.map((cap, capIndex) => (
-                <span key={capIndex} className="inline-flex">
-                  {cap}
-                </span>
-              ))}
-            </span>
-          ) : null}
+          {renderCapabilities(option)}
         </div>
       </li>
     );
@@ -229,10 +247,7 @@ export function WorkspaceSelector({
 
       {open ? (
         <div
-          ref={popoverRef}
           data-slot="workspace-popover"
-          tabIndex={-1}
-          onKeyDown={handleKeyDown}
           className="border-border bg-popover absolute bottom-full z-20 mb-1 min-w-64 overflow-hidden rounded-xl border shadow-md outline-none"
         >
           {showSearch ? (
@@ -247,6 +262,7 @@ export function WorkspaceSelector({
                 onChange={(event) => {
                   setQuery(event.target.value);
                 }}
+                onKeyDown={handleKeyDown}
                 className="placeholder:text-muted-foreground w-full bg-transparent text-sm outline-none"
               />
             </div>
@@ -258,10 +274,15 @@ export function WorkspaceSelector({
             </p>
           ) : (
             <ul
+              ref={listboxRef}
               role="listbox"
               id={listboxId}
               aria-label={label}
-              className="max-h-72 overflow-auto p-1"
+              // Focusable so arrow-key nav works when no search field is shown;
+              // the listbox owns the keyboard interaction (not the wrapper div).
+              tabIndex={-1}
+              onKeyDown={handleKeyDown}
+              className="max-h-72 overflow-auto p-1 outline-none"
             >
               {rows}
             </ul>

--- a/packages/@granit/react-ai-chat/src/hooks/use-chat-stream.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-chat-stream.ts
@@ -503,6 +503,15 @@ function createEventSinks(turn: TurnState, setters: EventSinkSetters): EventSink
   };
 }
 
+/** Apply a `tool_call` frame: register the running tool and clear "thinking". */
+function applyToolCall(event: ChatStreamEvent, sinks: EventSinks): void {
+  if (event.toolCallId && event.toolName) {
+    sinks.startToolCall(event.toolCallId, event.toolName);
+  }
+  // A tool is now running; its chip carries the activity, not "thinking".
+  sinks.setThinking(false);
+}
+
 /** Dispatch a single {@link ChatStreamEvent} to the matching state updater. */
 function applyEvent(event: ChatStreamEvent, sinks: EventSinks): void {
   switch (event.type) {
@@ -518,11 +527,7 @@ function applyEvent(event: ChatStreamEvent, sinks: EventSinks): void {
       if (event.conversationId) sinks.setConversationId(event.conversationId);
       break;
     case CHAT_STREAM_EVENT_TYPES.TOOL_CALL:
-      if (event.toolCallId && event.toolName) {
-        sinks.startToolCall(event.toolCallId, event.toolName);
-      }
-      // A tool is now running; its chip carries the activity, not "thinking".
-      sinks.setThinking(false);
+      applyToolCall(event, sinks);
       break;
     case CHAT_STREAM_EVENT_TYPES.TOOL_RESULT:
       if (event.toolCallId) sinks.resolveToolCall(event.toolCallId, event.succeeded === true);


### PR DESCRIPTION
## What

Resolves the open SonarQube issues on the AI chat surface (`@granit/ai`, `@granit/react-ai-chat`).

### Changes

- **ai/types**: removed the redundant `@deprecated ChatStreamEvent` alias — callers use `AIChatCompletionEvent`. The `@granit/ai-chat` `ChatStreamEvent` is a different type and is untouched.
- **chat-composer**: `window` → `globalThis`, optional-chain guard, merged the `/` and `@` suggestion panels (cognitive complexity 17 → 15), single `role="presentation"` wrapper, and the editor is now an editable `role="combobox"` (focusable; supports `aria-expanded`/`aria-activedescendant`). `aria-multiline` dropped (unsupported on `combobox`).
- **chat-message / workspace-selector**: list items keyed by position instead of the array index.
- **system-message**: `info` variant renders a native `<output>` (implicit `status` role).
- **workspace-selector**: `Array.from(...).find(...)` instead of a C-style `for`; `instanceof Node` guard instead of a type assertion; focusable options; keyboard handling moved onto the search input + listbox (the non-native interactive `<div>` is gone).
- **use-chat-stream**: extracted `applyToolCall` to lower `applyEvent` complexity to 14.

Tests updated to the corrected `combobox` / native `<output>` roles.

### Residual (recommend Won't Fix in Sonar)

Three S6819 "prefer native tag over ARIA role" warnings remain in `workspace-selector` (`role="listbox"`→`<select>`, `role="option"`→`<option>`, `role="presentation"` `<li>`). They're false positives for this rich picker — a native `<select>` cannot render leading icons, capability glyphs, provider-group headings, or the inline search field. The current roles follow the WAI-ARIA APG listbox pattern.

## Verification

- `tsc --noEmit` clean (ai, react-ai-chat, react-ai)
- ESLint clean; Prettier clean
- 740 tests pass (ai, ai-chat, react-ai-chat, react-ai, contract-tests)