### PR TITLE
test(arch-tests-kit): scanner fixtures, structure scanner, import-regex fix

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -520,6 +520,28 @@
           "name": "scanUseClientDirective",
           "kind": "function",
           "signature": "function scanUseClientDirective(opts: AllowlistedScanContext): Violation[]"
+        },
+        {
+          "name": "scanForbiddenStructure",
+          "kind": "function",
+          "signature": "function scanForbiddenStructure(opts: ForbiddenStructureOptions): Violation[]"
+        },
+        {
+          "name": "ForbiddenStructureOptions",
+          "kind": "interface",
+          "signature": "interface ForbiddenStructureOptions extends ScanContext",
+          "members": [
+            {
+              "name": "coreForbidden",
+              "kind": "property",
+              "signature": "coreForbidden?: ReadonlyArray<string>"
+            },
+            {
+              "name": "reactForbidden",
+              "kind": "property",
+              "signature": "reactForbidden?: ReadonlyArray<string>"
+            }
+          ]
         }
       ]
     },

--- a/packages/@granit/arch-tests-kit/README.md
+++ b/packages/@granit/arch-tests-kit/README.md
@@ -26,7 +26,12 @@ app's `package.json`:
 }
 ```
 
-Add a TypeScript path mapping in your test `tsconfig`:
+Vite-based apps with the `@granit/*` auto-alias plugin (or a root Vitest alias)
+pick the `link:` symlink up for free — `moduleResolution: bundler` resolves the
+package's `exports` to `src/index.ts`, so no extra TypeScript config is needed.
+
+Only if your test `tsconfig` runs without that alias (plain `tsc`, no bundler
+resolution), add a path mapping:
 
 ```jsonc
 {
@@ -39,8 +44,6 @@ Add a TypeScript path mapping in your test `tsconfig`:
   },
 }
 ```
-
-Vite-based apps with the `@granit/*` auto-alias plugin pick it up for free.
 
 ## Quick start
 
@@ -112,24 +115,33 @@ A complete reference setup lives in
 
 ## Available scanners
 
-| Scanner                    | Rule                                                                                     |
-| -------------------------- | ---------------------------------------------------------------------------------------- |
-| `scanKebabCase`            | Source files use kebab-case (allows `.stories.tsx`, `.d.ts`)                             |
-| `scanHookNaming`           | Every `hooks/use-*.ts` exports a `useXxx` symbol                                         |
-| `scanComponentNaming`      | Every `components/*.tsx` exports a PascalCase / `createX` / `useX` symbol                |
-| `scanFetchVerbInApi`       | `api/` functions never use the `fetch*` verb                                             |
-| `scanConsole`              | No `console.*` in runtime code                                                           |
-| `scanFetch`                | No native `fetch()` calls                                                                |
-| `scanAxiosImports`         | No direct `axios` imports                                                                |
-| `scanOnlySkip`             | No committed `.only` / `.skip` in tests                                                  |
-| `scanBarrelDefaultExports` | No `export default` in module barrels                                                    |
-| `scanLeakedInternals`      | No underscore-prefixed exports leaked from barrels                                       |
-| `scanLocaleParity`         | `locales/` ships `en.ts` + `fr.ts` + `index.ts` + matching `TranslationsEn/Fr` constants |
-| `scanDomScriptSinks`       | Any package writing to a DOM-script sink ships a `<pkg>/csp` subpath (Trusted Types)     |
-| `scanUndeclaredDeps`       | Every bare import is declared in the package's own `package.json` (no phantom deps)      |
-| `scanUseClientDirective`   | RSC-consumed modules mark every client-hook file with `'use client'` (opt-in)            |
+| Scanner                       | Rule                                                                                     |
+| ----------------------------- | ---------------------------------------------------------------------------------------- |
+| `scanKebabCase`               | Source files use kebab-case (allows `.stories.tsx`, `.d.ts`)                             |
+| `scanHookNaming`              | Every `hooks/use-*.ts` exports a `useXxx` symbol                                         |
+| `scanComponentNaming`         | Every `components/*.tsx` exports a PascalCase / `createX` / `useX` symbol                |
+| `scanFetchVerbInApi`          | `api/` functions never use the `fetch*` verb                                             |
+| `scanConsole`                 | No `console.*` in runtime code                                                           |
+| `scanFetch`                   | No native `fetch()` calls                                                                |
+| `scanAxiosImports`            | No direct `axios` imports                                                                |
+| `scanOnlySkip`                | No committed `.only` / `.skip` in tests                                                  |
+| `scanBarrelDefaultExports`    | No `export default` in module barrels                                                    |
+| `scanLeakedInternals`         | No underscore-prefixed exports leaked from barrels                                       |
+| `scanLocaleParity`            | `locales/` ships `en.ts` + `fr.ts` + `index.ts` + matching `TranslationsEn/Fr` constants |
+| `scanDomScriptSinks`          | Any package writing to a DOM-script sink ships a `<pkg>/csp` subpath (Trusted Types)     |
+| `scanUndeclaredDeps`          | Every bare import is declared in the package's own `package.json` (no phantom deps)      |
+| `scanUseClientDirective`      | RSC-consumed modules mark every client-hook file with `'use client'` (opt-in)            |
+| `scanForbiddenStructure`      | Core modules carry no `hooks/components/providers/`; React modules carry no `api/`       |
+| `scanAnonymousDefaultExports` | No anonymous `export default` (breaks DevTools labels & stack traces)                    |
+| `scanWallClockInApi`          | `api/` helpers never read the wall clock (`Date.now()` / `new Date()`)                   |
+| `scanUseFormResolver`         | Every `useForm()` call pairs with a `resolver:` (no silent validation skips)             |
+| `scanEmptyCatch`              | No empty `catch {}` blocks (errors must be logged, rethrown, or handled)                 |
+| `scanReadmePresence`          | Every module ships a `README.md` whose H1 matches the module name                        |
+| `scanSharedDepVersions`       | Curated shared deps use one version constraint across every package                      |
 
 All scanners return `Violation[]`. Empty array means the rule passes.
+`collectImports` (specifier extraction) and `hasBannedConsole` (pure predicate)
+are also exported for building custom checks.
 
 ## Customizing
 

--- a/packages/@granit/arch-tests-kit/package.json
+++ b/packages/@granit/arch-tests-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/arch-tests-kit",
   "description": "Reusable architecture-test primitives — pure scanner functions returning violations. Consumed by `@granit/arch-tests` (framework) and by downstream app test suites (showcase, future DD apps).",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/arch-tests-kit/src/__tests__/scanners.test.ts
+++ b/packages/@granit/arch-tests-kit/src/__tests__/scanners.test.ts
@@ -1,0 +1,417 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  collectImports,
+  hasBannedConsole,
+  isTestFile,
+  isTestingDir,
+  scanAnonymousDefaultExports,
+  scanAxiosImports,
+  scanBarrelDefaultExports,
+  scanComponentNaming,
+  scanConsole,
+  scanDomScriptSinks,
+  scanEmptyCatch,
+  scanFetch,
+  scanFetchVerbInApi,
+  scanForbiddenStructure,
+  scanHookNaming,
+  scanKebabCase,
+  scanLeakedInternals,
+  scanLocaleParity,
+  scanOnlySkip,
+  scanReadmePresence,
+  scanSharedDepVersions,
+  scanUndeclaredDeps,
+  scanUseClientDirective,
+  scanUseFormResolver,
+  scanWallClockInApi,
+  stripComments,
+  walkSourceFiles,
+} from '../index';
+
+import type { Module } from '../types';
+
+// These scanners are negative assertions in the framework suite (run against a
+// clean monorepo: `expect(scan(ctx)).toEqual([])`). That proves they DON'T
+// false-positive, but a scanner whose regex silently matches nothing would also
+// pass — the classic always-green trap. The fixtures below feed each scanner a
+// crafted violation and assert it IS caught, then a clean counterpart and assert
+// it is NOT. Together they pin the scanner's real behaviour.
+
+let root: string;
+let seq = 0;
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-kit-fixtures-'));
+});
+
+afterAll(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function writeFiles(baseDir: string, files: Record<string, string>): void {
+  for (const [relPath, content] of Object.entries(files)) {
+    const full = path.join(baseDir, relPath);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+}
+
+interface FixtureOptions {
+  /** Files written under the module's `src/`. */
+  src?: Record<string, string>;
+  /** Files written at the module root (package.json, README.md, …). */
+  rootFiles?: Record<string, string>;
+  isReact?: boolean;
+  name?: string;
+}
+
+function makeModule(opts: FixtureOptions): Module {
+  const dir = path.join(root, `m${seq++}`);
+  const srcDir = path.join(dir, 'src');
+  fs.mkdirSync(srcDir, { recursive: true });
+  if (opts.src) writeFiles(srcDir, opts.src);
+  if (opts.rootFiles) writeFiles(dir, opts.rootFiles);
+  return { name: opts.name ?? 'fixture', dir, srcDir, isReact: opts.isReact };
+}
+
+function ctxFor(...modules: Module[]) {
+  return { modules, repoRoot: root };
+}
+
+describe('naming scanners', () => {
+  it('scanKebabCase flags PascalCase file names, accepts kebab-case + qualifiers', () => {
+    const dirty = ctxFor(makeModule({ src: { 'BadName.ts': 'export const x = 1;' } }));
+    expect(scanKebabCase(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(
+      makeModule({
+        src: { 'good-name.ts': 'export const x = 1;', 'widget.stories.tsx': 'export const S = 1;' },
+      })
+    );
+    expect(scanKebabCase(clean)).toEqual([]);
+  });
+
+  it('scanHookNaming flags a hooks/use-*.ts that exports no useXxx symbol', () => {
+    const dirty = ctxFor(makeModule({ src: { 'hooks/use-foo.ts': 'export const value = 1;' } }));
+    expect(scanHookNaming(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(
+      makeModule({ src: { 'hooks/use-foo.ts': 'export function useFoo() { return 1; }' } })
+    );
+    expect(scanHookNaming(clean)).toEqual([]);
+  });
+
+  it('scanComponentNaming flags a components/*.tsx with no PascalCase export', () => {
+    const dirty = ctxFor(makeModule({ src: { 'components/widget.tsx': 'export const x = 1;' } }));
+    expect(scanComponentNaming(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(
+      makeModule({ src: { 'components/widget.tsx': 'export function Widget() { return null; }' } })
+    );
+    expect(scanComponentNaming(clean)).toEqual([]);
+  });
+
+  it('scanFetchVerbInApi flags api/ functions named fetch*, accepts get*/list*', () => {
+    const dirty = ctxFor(
+      makeModule({ src: { 'api/things.ts': 'export function fetchThings() { return []; }' } })
+    );
+    expect(scanFetchVerbInApi(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(
+      makeModule({ src: { 'api/things.ts': 'export function listThings() { return []; }' } })
+    );
+    expect(scanFetchVerbInApi(clean)).toEqual([]);
+  });
+});
+
+describe('import scanners', () => {
+  it('scanConsole flags console.* and the globalThis.console bypass', () => {
+    const direct = ctxFor(makeModule({ src: { 'a.ts': 'console.log("x");' } }));
+    expect(scanConsole(direct)).not.toHaveLength(0);
+
+    const bypass = ctxFor(makeModule({ src: { 'a.ts': 'globalThis.console.error("x");' } }));
+    expect(scanConsole(bypass)).not.toHaveLength(0);
+
+    const clean = ctxFor(makeModule({ src: { 'a.ts': 'export const log = (m: string) => m;' } }));
+    expect(scanConsole(clean)).toEqual([]);
+  });
+
+  it('scanConsole honours the per-module allowlist', () => {
+    const mod = makeModule({ name: 'logger', src: { 'a.ts': 'console.log("x");' } });
+    expect(scanConsole({ ...ctxFor(mod), allowedModules: ['logger'] })).toEqual([]);
+  });
+
+  it('scanFetch flags native fetch(), allowlist exempts infra modules', () => {
+    const dirty = ctxFor(makeModule({ src: { 'a.ts': 'const r = fetch("/api");' } }));
+    expect(scanFetch(dirty)).not.toHaveLength(0);
+
+    const bff = makeModule({ name: 'bff', src: { 'a.ts': 'const r = fetch("/api");' } });
+    expect(scanFetch({ ...ctxFor(bff), allowedModules: ['bff'] })).toEqual([]);
+  });
+
+  it('scanAxiosImports flags a direct axios import', () => {
+    const dirty = ctxFor(makeModule({ src: { 'a.ts': 'import axios from "axios";' } }));
+    expect(scanAxiosImports(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(
+      makeModule({ src: { 'a.ts': 'import { client } from "@granit/api-client";' } })
+    );
+    expect(scanAxiosImports(clean)).toEqual([]);
+  });
+
+  it('scanOnlySkip flags committed .only / .skip', () => {
+    const only = ctxFor(makeModule({ src: { 'a.test.ts': 'it.only("x", () => {});' } }));
+    expect(scanOnlySkip(only)).not.toHaveLength(0);
+
+    const skip = ctxFor(makeModule({ src: { 'a.test.ts': 'describe.skip("x", () => {});' } }));
+    expect(scanOnlySkip(skip)).not.toHaveLength(0);
+
+    const clean = ctxFor(makeModule({ src: { 'a.test.ts': 'it("x", () => {});' } }));
+    expect(scanOnlySkip(clean)).toEqual([]);
+  });
+
+  it('hasBannedConsole is a pure predicate over already-stripped source', () => {
+    expect(hasBannedConsole('console.log(x)')).toBe(true);
+    expect(hasBannedConsole("globalThis['console'].info(x)")).toBe(true);
+    expect(hasBannedConsole('myconsole.log(x)')).toBe(false);
+  });
+
+  it('collectImports extracts real specifiers, ignoring comments and string literals', () => {
+    const f = path.join(makeModule({ src: { 'a.ts': '' } }).srcDir, 'a.ts');
+    fs.writeFileSync(
+      f,
+      [
+        'import { a } from "real";',
+        'export { b } from "./local";',
+        '// import x from "commented";',
+        'const msg = \'Delete redirect from "{{path}}"?\';', // not an import
+        'const where = `select from "table"`;', // not an import
+      ].join('\n')
+    );
+    expect(collectImports(f)).toEqual(['real', './local']);
+  });
+});
+
+describe('barrel scanners', () => {
+  it('scanBarrelDefaultExports flags `export default` in index.ts', () => {
+    const dirty = ctxFor(makeModule({ src: { 'index.ts': 'export default {};' } }));
+    expect(scanBarrelDefaultExports(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(makeModule({ src: { 'index.ts': 'export const api = {};' } }));
+    expect(scanBarrelDefaultExports(clean)).toEqual([]);
+  });
+
+  it('scanLeakedInternals flags underscore-prefixed exports in the barrel', () => {
+    const dirty = ctxFor(makeModule({ src: { 'index.ts': 'export const _internal = 1;' } }));
+    expect(scanLeakedInternals(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(makeModule({ src: { 'index.ts': 'export const publicApi = 1;' } }));
+    expect(scanLeakedInternals(clean)).toEqual([]);
+  });
+});
+
+describe('i18n scanner', () => {
+  it('scanLocaleParity flags a locales/ missing files or the TranslationsEn/Fr export', () => {
+    const dirty = ctxFor(makeModule({ src: { 'locales/en.ts': 'export const wrongName = {};' } }));
+    expect(scanLocaleParity(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(
+      makeModule({
+        src: {
+          'locales/en.ts': 'export const fooTranslationsEn = {};',
+          'locales/fr.ts': 'export const fooTranslationsFr = {};',
+          'locales/index.ts': 'export {};',
+        },
+      })
+    );
+    expect(scanLocaleParity(clean)).toEqual([]);
+  });
+});
+
+describe('pattern scanners', () => {
+  it('scanAnonymousDefaultExports flags `export default () => …`, accepts named', () => {
+    const dirty = ctxFor(makeModule({ src: { 'a.ts': 'export default () => 1;' } }));
+    expect(scanAnonymousDefaultExports(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(
+      makeModule({ src: { 'a.ts': 'function Foo() { return 1; }\nexport default Foo;' } })
+    );
+    expect(scanAnonymousDefaultExports(clean)).toEqual([]);
+  });
+
+  it('scanWallClockInApi flags Date.now()/new Date() inside api/', () => {
+    const dirty = ctxFor(makeModule({ src: { 'api/a.ts': 'export const t = Date.now();' } }));
+    expect(scanWallClockInApi(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(
+      makeModule({ src: { 'api/a.ts': 'export const at = (t: number) => t;' } })
+    );
+    expect(scanWallClockInApi(clean)).toEqual([]);
+  });
+
+  it('scanUseFormResolver flags useForm() without a resolver', () => {
+    const dirty = ctxFor(makeModule({ src: { 'a.ts': 'const form = useForm();' } }));
+    expect(scanUseFormResolver(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(
+      makeModule({ src: { 'a.ts': 'const form = useForm({ resolver: zodResolver(schema) });' } })
+    );
+    expect(scanUseFormResolver(clean)).toEqual([]);
+  });
+
+  it('scanEmptyCatch flags an empty catch block', () => {
+    const dirty = ctxFor(makeModule({ src: { 'a.ts': 'try { run(); } catch {}' } }));
+    expect(scanEmptyCatch(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(makeModule({ src: { 'a.ts': 'try { run(); } catch (e) { log(e); }' } }));
+    expect(scanEmptyCatch(clean)).toEqual([]);
+  });
+});
+
+describe('uniformity scanners', () => {
+  it('scanReadmePresence flags a missing README and a mismatched H1', () => {
+    const missing = ctxFor(makeModule({ name: 'fixture', src: { 'index.ts': 'export {};' } }));
+    expect(scanReadmePresence(missing)).not.toHaveLength(0);
+
+    const clean = ctxFor(
+      makeModule({ name: 'fixture', rootFiles: { 'README.md': '# fixture\n\nhello' } })
+    );
+    expect(scanReadmePresence(clean)).toEqual([]);
+  });
+
+  it('scanSharedDepVersions flags version drift across packages', () => {
+    const a = makeModule({
+      name: 'a',
+      rootFiles: { 'package.json': '{"dependencies":{"react":"^1.0.0"}}' },
+    });
+    const b = makeModule({
+      name: 'b',
+      rootFiles: { 'package.json': '{"dependencies":{"react":"^2.0.0"}}' },
+    });
+    expect(scanSharedDepVersions({ ...ctxFor(a, b), deps: ['react'] })).not.toHaveLength(0);
+
+    const c = makeModule({
+      name: 'c',
+      rootFiles: { 'package.json': '{"dependencies":{"react":"^2.0.0"}}' },
+    });
+    const d = makeModule({
+      name: 'd',
+      rootFiles: { 'package.json': '{"dependencies":{"react":"^2.0.0"}}' },
+    });
+    expect(scanSharedDepVersions({ ...ctxFor(c, d), deps: ['react'] })).toEqual([]);
+  });
+});
+
+describe('csp scanner', () => {
+  it('scanDomScriptSinks flags a sink writer with no csp/index.ts subpath', () => {
+    const dirty = ctxFor(makeModule({ src: { 'render.ts': 'node.innerHTML = html;' } }));
+    expect(scanDomScriptSinks(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(
+      makeModule({
+        src: {
+          'render.ts': 'node.innerHTML = html;',
+          'csp/index.ts': 'export function installPolicy() {}',
+        },
+      })
+    );
+    expect(scanDomScriptSinks(clean)).toEqual([]);
+  });
+});
+
+describe('deps scanner', () => {
+  it('scanUndeclaredDeps flags a bare import absent from package.json', () => {
+    const dirty = ctxFor(
+      makeModule({
+        src: { 'a.ts': 'import _ from "lodash";' },
+        rootFiles: { 'package.json': '{"name":"@granit/fixture"}' },
+      })
+    );
+    expect(scanUndeclaredDeps(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(
+      makeModule({
+        src: { 'a.ts': 'import _ from "lodash";' },
+        rootFiles: { 'package.json': '{"name":"@granit/fixture","dependencies":{"lodash":"^4"}}' },
+      })
+    );
+    expect(scanUndeclaredDeps(clean)).toEqual([]);
+  });
+});
+
+describe('react scanner', () => {
+  it("scanUseClientDirective flags a client hook without 'use client'", () => {
+    const dirty = ctxFor(makeModule({ src: { 'widget.tsx': 'const x = useState(0);' } }));
+    expect(scanUseClientDirective(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(
+      makeModule({ src: { 'widget.tsx': "'use client';\nconst x = useState(0);" } })
+    );
+    expect(scanUseClientDirective(clean)).toEqual([]);
+  });
+});
+
+describe('structure scanner', () => {
+  it('scanForbiddenStructure flags React dirs in a core module', () => {
+    const dirty = ctxFor(
+      makeModule({ name: 'core', isReact: false, src: { 'hooks/use-x.ts': 'export const x = 1;' } })
+    );
+    expect(scanForbiddenStructure(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(
+      makeModule({ name: 'core', isReact: false, src: { 'types/index.ts': 'export type X = 1;' } })
+    );
+    expect(scanForbiddenStructure(clean)).toEqual([]);
+  });
+
+  it('scanForbiddenStructure flags an api/ dir in a React module', () => {
+    const dirty = ctxFor(
+      makeModule({ name: 'react-x', isReact: true, src: { 'api/x.ts': 'export const x = 1;' } })
+    );
+    expect(scanForbiddenStructure(dirty)).not.toHaveLength(0);
+
+    const clean = ctxFor(
+      makeModule({
+        name: 'react-x',
+        isReact: true,
+        src: { 'hooks/use-x.ts': 'export const x = 1;' },
+      })
+    );
+    expect(scanForbiddenStructure(clean)).toEqual([]);
+  });
+});
+
+describe('fs helpers', () => {
+  it('walkSourceFiles collects .ts/.tsx and skips node_modules', () => {
+    const mod = makeModule({
+      src: { 'a.ts': '', 'sub/b.tsx': '', 'node_modules/dep/c.ts': '', 'readme.md': '' },
+    });
+    const files = walkSourceFiles(mod.srcDir)
+      .map((f) => path.basename(f))
+      .sort();
+    expect(files).toEqual(['a.ts', 'b.tsx']);
+  });
+
+  it('isTestFile / isTestingDir recognise the conventional paths', () => {
+    expect(isTestFile('src/a.test.ts')).toBe(true);
+    expect(isTestFile('src/__tests__/a.ts')).toBe(true);
+    expect(isTestFile('src/a.ts')).toBe(false);
+    expect(isTestingDir('src/testing/handlers.ts')).toBe(true);
+    expect(isTestingDir('src/api/a.ts')).toBe(false);
+  });
+
+  it('stripComments removes line, block and JSDoc comments', () => {
+    const out = stripComments('const a = 1; // x\n/* y */\n/** z */\nconst b = 2;');
+    expect(out).not.toContain('x');
+    expect(out).not.toContain('y');
+    expect(out).not.toContain('z');
+    expect(out).toContain('const a = 1;');
+    expect(out).toContain('const b = 2;');
+  });
+});

--- a/packages/@granit/arch-tests-kit/src/index.ts
+++ b/packages/@granit/arch-tests-kit/src/index.ts
@@ -42,3 +42,6 @@ export { scanUndeclaredDeps } from './scanners/deps';
 export type { UndeclaredDepsOptions } from './scanners/deps';
 
 export { scanUseClientDirective } from './scanners/react';
+
+export { scanForbiddenStructure } from './scanners/structure';
+export type { ForbiddenStructureOptions } from './scanners/structure';

--- a/packages/@granit/arch-tests-kit/src/scanners/imports.ts
+++ b/packages/@granit/arch-tests-kit/src/scanners/imports.ts
@@ -2,7 +2,13 @@ import { isTestFile, isTestingDir, readFile, rel, stripComments, walkSourceFiles
 
 import type { AllowlistedScanContext, ScanContext, Violation } from '../types';
 
-const IMPORT_RE = /from\s+['"]([^'"\n]+)['"]/g;
+// Anchored to a real `import`/`export … from '<spec>'` statement. The leading
+// `\b(?:import|export)\b[^;'"]*?` requirement keeps a `from "…"` substring that
+// merely lives inside a string literal (e.g. an i18n message
+// `'Delete from "{{path}}"'`) from being miscounted as a dependency — the
+// quote-excluding run can't bridge the keyword to such a `from`.
+// NOSONAR: bounded developer source files only — no user input, no ReDoS risk.
+const IMPORT_RE = /\b(?:import|export)\b[^;'"]*?\bfrom\s+['"]([^'"\n]+)['"]/g;
 
 export function collectImports(file: string): string[] {
   // Strip comments first — JSDoc examples often quote `import … from '@granit/x'`

--- a/packages/@granit/arch-tests-kit/src/scanners/structure.ts
+++ b/packages/@granit/arch-tests-kit/src/scanners/structure.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { rel } from '../fs';
+
+import type { ScanContext, Violation } from '../types';
+
+export interface ForbiddenStructureOptions extends ScanContext {
+  /**
+   * Directory names that must NOT appear directly under a non-React (core)
+   * module's `srcDir`. Defaults to the React-only layers — a core package keeps
+   * to types/api, its React siblings own the UI.
+   */
+  coreForbidden?: ReadonlyArray<string>;
+  /**
+   * Directory names that must NOT appear directly under a React module's
+   * `srcDir`. Defaults to `api` — HTTP calls live in the core package; the
+   * React package consumes them through hooks.
+   */
+  reactForbidden?: ReadonlyArray<string>;
+}
+
+const DEFAULT_CORE_FORBIDDEN = ['hooks', 'components', 'providers', 'field-components'] as const;
+const DEFAULT_REACT_FORBIDDEN = ['api'] as const;
+
+/**
+ * Enforces the core/React layering seam: a core `@granit/{module}` carries no
+ * React-only directories (`hooks/`, `components/`, `providers/`,
+ * `field-components/`), and a `react-{module}` carries no server-side `api/`
+ * directory (its hooks call the core package's API functions). Mirrors the
+ * "Forbidden" structure rules in the framework CLAUDE.md, extracted here so any
+ * app slicing code into core/React module pairs can enforce the same seam.
+ *
+ * The React/core split is read from {@link Module.isReact}.
+ */
+export function scanForbiddenStructure(opts: ForbiddenStructureOptions): Violation[] {
+  const coreForbidden = opts.coreForbidden ?? DEFAULT_CORE_FORBIDDEN;
+  const reactForbidden = opts.reactForbidden ?? DEFAULT_REACT_FORBIDDEN;
+  const out: Violation[] = [];
+
+  for (const m of opts.modules) {
+    const forbidden = m.isReact ? reactForbidden : coreForbidden;
+    const layer = m.isReact ? 'react' : 'core';
+    for (const dir of forbidden) {
+      const full = path.join(m.srcDir, dir);
+      if (fs.existsSync(full)) {
+        out.push({
+          rule: 'forbidden-structure',
+          module: m.name,
+          file: rel(full, opts.repoRoot),
+          message: `${layer} package must not contain src/${dir}/ (wrong layer for this module kind)`,
+        });
+      }
+    }
+  }
+
+  return out;
+}

--- a/packages/@granit/arch-tests/README.md
+++ b/packages/@granit/arch-tests/README.md
@@ -1,3 +1,59 @@
 # @granit/arch-tests
 
-Architecture tests — enforce framework-wide structural, naming, and dependency conventions.
+Architecture tests — enforce framework-wide structural, naming, and dependency
+conventions across every `@granit/*` package.
+
+This package is the framework's **self-check**: a Vitest suite that runs the pure
+scanners from [`@granit/arch-tests-kit`](../arch-tests-kit) against all 130+
+packages on every CI run. Linters catch per-file style; these tests catch
+cross-package drift — a core package growing a `hooks/` dir, a `fetch*` API
+function, a `console.log`, a phantom dependency, a locale missing its French
+translation.
+
+It is also the kit's **reference user**: any new scanner is wired here first,
+because running against the whole monorepo is the strongest test for
+false-positives.
+
+## Layout
+
+```text
+src/__tests__/
+  helpers.ts           listPackages() — the package inventory + allowlists
+  naming.test.ts       kebab-case, hook/component naming, fetch-verb-in-api
+  imports.test.ts      console / fetch / axios bans, barrel-bypass, acyclic graph
+  barrels.test.ts      no default export / no leaked internals / no .only-.skip
+  structure.test.ts    single barrel, no flat types.ts, core/react layering seam
+  package-json.test.ts source-direct package.json invariants (exports, peers, …)
+  deps.test.ts         no undeclared deps, react-* declares its core sibling
+  i18n.test.ts         locales/ parity (en.ts + fr.ts + index.ts + exports)
+  csp.test.ts          DOM-script sinks ship a <pkg>/csp subpath
+  patterns.test.ts     anonymous default export, wall-clock in api, empty catch…
+  uniformity.test.ts   README presence, shared-dep version drift
+  use-client.test.ts   'use client' on RSC-consumed client-hook files
+```
+
+Most files delegate to a kit scanner (`expect(scanX(ctx)).toEqual([])`).
+`structure` and `package-json` keep a few **source-direct-specific** checks
+inline (e.g. `exports["."] === ./src/index.ts`, `workspace:*` protocol) that
+only apply to framework packages, not to downstream apps.
+
+## Run
+
+```bash
+pnpm --filter @granit/arch-tests test        # this suite only
+pnpm test                                     # whole workspace (includes it)
+```
+
+## Adding a rule
+
+1. Add a pure scanner in
+   [`@granit/arch-tests-kit`](../arch-tests-kit/src/scanners) returning
+   `Violation[]`, and re-export it from the kit barrel.
+2. Wire it here — usually a one-liner delegating to the scanner. Add per-module
+   or per-file exemptions through the scanner's allowlist options, never by
+   weakening the rule.
+3. Reserve inline (non-kit) checks for conventions specific to this monorepo's
+   source-direct packaging that have no reuse value downstream.
+
+The arch test packages exclude themselves from the scan (see `EXCLUDED_DIRS` in
+`helpers.ts`).

--- a/packages/@granit/arch-tests/src/__tests__/structure.test.ts
+++ b/packages/@granit/arch-tests/src/__tests__/structure.test.ts
@@ -1,9 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { scanForbiddenStructure } from '@granit/arch-tests-kit';
 import { describe, expect, it } from 'vitest';
 
-import { listPackages } from './helpers';
+import { REPO_ROOT, listPackages, toModules } from './helpers';
 
 const packages = listPackages();
 
@@ -29,22 +30,13 @@ describe('structure: no endpoints/ directory', () => {
   });
 });
 
-describe('structure: core packages do not contain React-only directories', () => {
-  const cores = packages.filter((p) => !p.isReact);
-  it.each(cores.map((p) => [p.name, p]))('%s has no hooks/ components/ providers/', (_n, pkg) => {
-    for (const dir of ['hooks', 'components', 'providers', 'field-components']) {
-      expect(
-        fs.existsSync(path.join(pkg.srcDir, dir)),
-        `core package ${pkg.name} must not contain src/${dir}/`
-      ).toBe(false);
-    }
-  });
-});
-
-describe('structure: react packages do not contain server-only api/ dir', () => {
-  const reacts = packages.filter((p) => p.isReact);
-  it.each(reacts.map((p) => [p.name, p]))('%s has no src/api/ (use hooks/)', (_n, pkg) => {
-    expect(fs.existsSync(path.join(pkg.srcDir, 'api'))).toBe(false);
+describe('structure: core/react layering seam (delegated to kit)', () => {
+  it('core packages carry no React dirs; react packages carry no api/', () => {
+    // scanForbiddenStructure reads the seam from Module.isReact: core →
+    // no hooks/components/providers/field-components, react → no api/.
+    expect(scanForbiddenStructure({ modules: toModules(packages), repoRoot: REPO_ROOT })).toEqual(
+      []
+    );
   });
 });
 


### PR DESCRIPTION
## Why

Audit of `@granit/arch-tests` + `@granit/arch-tests-kit` found that every kit
scanner had **only negative assertions** — the framework suite runs them against
a clean monorepo (`expect(scan(ctx)).toEqual([])`). That proves they don't
false-positive, but a scanner whose regex silently matched nothing would pass
too: the classic always-green trap. The kit (a *published* package) shipped with
no positive coverage of its own.

## Changes

- **Fixture tests** — `arch-tests-kit/src/__tests__/scanners.test.ts`: every
  scanner gets a crafted violation (asserted **caught**) + a clean counterpart
  (asserted **clean**), in a hermetic temp dir. Closes the always-green gap.
- **New `scanForbiddenStructure` scanner** — extracts the core/React layering
  rule (core packages: no `hooks/components/providers/`; React packages: no
  `api/`) out of `@granit/arch-tests` into the reusable kit. `structure.test.ts`
  now delegates to it.
- **`collectImports` regex fix** — `IMPORT_RE` now anchors to a real
  `import`/`export … from` statement, so a `from "..."` inside a string literal
  (e.g. an i18n message `'Delete from "{{path}}"'`) is no longer miscounted as a
  dependency. Removes a false positive in `scanUndeclaredDeps`. The whole
  framework suite (dependency-graph + barrel-bypass checks rely on this) still
  passes.
- **Docs** — document the 7 previously-undocumented scanners in the kit README,
  mark the tsconfig path-mapping as optional (bundler resolution covers the
  linked setup), and expand the `@granit/arch-tests` README.
- **Version** — bump `@granit/arch-tests-kit` 0.2.0 → 0.3.0 (new public export).

## Verification

- `vitest run` — **2178 tests pass** (12 files, incl. the new fixtures and the
  rewired structure suite)
- `tsc --noEmit` + ESLint (`--max-warnings 0`) + markdownlint — all clean
- kit `tsup` build succeeds, `dist/` exports `scanForbiddenStructure`

## Downstream

Unblocks granit-showcase-react MR
[!126](https://gitlab.digitaldynamics.be/digital-dynamics/granit-fx/granit-showcase-react/-/merge_requests/126)
(Draft), whose `scanUndeclaredDeps` adoption depends on the `collectImports`
fix here. **Merge this first.**