### PR TITLE
feat(react-ui-settings): backfill the settings admin UI

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -7804,6 +7804,34 @@
       ]
     },
     {
+      "name": "@granit/react-ui-settings",
+      "description": "Granit admin UI for the Settings module — the application-settings edit page and dynamic settings panel (typed fields, encrypted-secret handling, bulk save). Composes @granit/react-settings (headless) with the foundation UI packages.",
+      "exports": [
+        {
+          "name": "AppSettingsEditPage",
+          "kind": "function",
+          "signature": "function AppSettingsEditPage("
+        },
+        {
+          "name": "AppSettingsEditPageProps",
+          "kind": "interface",
+          "signature": "interface AppSettingsEditPageProps",
+          "members": []
+        },
+        {
+          "name": "AppSettingsPanel",
+          "kind": "function",
+          "signature": "function AppSettingsPanel("
+        },
+        {
+          "name": "AppSettingsPanelProps",
+          "kind": "interface",
+          "signature": "interface AppSettingsPanelProps",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/react-ui-shell-admin",
       "description": "Granit admin app shell (chrome): the AppShell layout (sidebar + topbar + content + right rail), AppSidebar with workspace-driven navigation, user menu, command palette and header. App-specific data (auth, navigation, languages, logger) is injected via ShellChromeProvider; feature widgets are passed as header slots.",
       "exports": []

--- a/packages/@granit/react-ui-settings/README.md
+++ b/packages/@granit/react-ui-settings/README.md
@@ -1,0 +1,31 @@
+# @granit/react-ui-settings
+
+Admin UI for the **Granit.Settings** module — the application-settings edit page
+and the dynamic settings panel (typed fields per `ValueKind`, allowed-value
+dropdowns, encrypted-secret masking, bulk save with per-row outcomes).
+
+The **visual** layer for settings: it composes the headless
+[`@granit/react-settings`](../react-settings) (provider + hooks) with the
+foundation UI packages ([`@granit/react-ui`](../react-ui)).
+
+## Usage
+
+```tsx
+import { AppSettingsEditPage, settingsTranslationsEn } from '@granit/react-ui-settings';
+
+i18n.addResourceBundle('en', 'translation', settingsTranslationsEn, true, true);
+
+// Host app:   <Route path="/settings/config" element={<AppSettingsEditPage scope="global" />} />
+// Tenant app: <Route path="/settings/config" element={<AppSettingsEditPage scope="tenant" />} />
+```
+
+## Injection
+
+- **API client** — resolved from a `GranitClientProvider`
+  (`@granit/react-api-client`) higher in the tree (via the `@granit/react-settings`
+  hooks). No client is baked in.
+- **Scope** — `scope` (`'global'` | `'tenant'`, default `'global'`) is injected,
+  so the package never depends on an app's host/tenant flag.
+- **i18n** — ships its `Config.AppSettings.*` strings
+  (`settingsTranslationsEn/Fr`); the host registers them. `Common.*` and dynamic
+  `Setting:*` keys are app/backend-provided.

--- a/packages/@granit/react-ui-settings/package.json
+++ b/packages/@granit/react-ui-settings/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@granit/react-ui-settings",
+  "description": "Granit admin UI for the Settings module — the application-settings edit page and dynamic settings panel (typed fields, encrypted-secret handling, bulk save). Composes @granit/react-settings (headless) with the foundation UI packages.",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-settings": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/settings": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "sonner": "^2.0.7"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-settings": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/settings": "workspace:*",
+    "@storybook/react-vite": "^10.4.6",
+    "@tanstack/react-query": "^5.0.0"
+  }
+}

--- a/packages/@granit/react-ui-settings/src/__tests__/app-settings-edit-page.test.tsx
+++ b/packages/@granit/react-ui-settings/src/__tests__/app-settings-edit-page.test.tsx
@@ -1,0 +1,29 @@
+import { mockAppSettings } from '@granit/react-settings/testing';
+import { screen } from '@testing-library/react';
+
+import { AppSettingsEditPage } from '../app-settings-edit-page';
+
+import { renderSettings } from './test-utils';
+
+import type { AdminAppSettingResponse } from '@granit/settings';
+
+const stableSettings = mockAppSettings.map((s: AdminAppSettingResponse) => ({ ...s }));
+
+vi.mock('@granit/react-settings', () => ({
+  useAdminAppSettings: () => ({ data: stableSettings, isLoading: false }),
+  useBulkUpdateSettings: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useSettings: () => ({ data: {}, isLoading: false }),
+  useUpdateSetting: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+}));
+
+describe('AppSettingsEditPage', () => {
+  it('should render page title', () => {
+    renderSettings(<AppSettingsEditPage />);
+    expect(screen.getByRole('heading', { name: 'Application Settings' })).toBeInTheDocument();
+  });
+
+  it('should have data-slot attribute', () => {
+    renderSettings(<AppSettingsEditPage />);
+    expect(document.querySelector('[data-slot="app-settings-edit-page"]')).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-settings/src/__tests__/app-settings-panel.test.tsx
+++ b/packages/@granit/react-ui-settings/src/__tests__/app-settings-panel.test.tsx
@@ -1,0 +1,199 @@
+import { screen, waitFor } from '@testing-library/react';
+import { toast } from 'sonner';
+
+import { AppSettingsPanel } from '../components/app-settings-panel';
+
+import { renderSettings } from './test-utils';
+
+import type {
+  AdminAppSettingResponse,
+  BulkSettingEntry,
+  BulkUpdateSettingsResponse,
+} from '@granit/settings';
+
+const mockSaveAsync =
+  vi.fn<(entries: readonly BulkSettingEntry[]) => Promise<BulkUpdateSettingsResponse>>();
+
+const mockSettings: AdminAppSettingResponse[] = [
+  {
+    key: 'audit.retention_days',
+    label: 'Audit Log Retention',
+    description: 'Days to retain audit logs',
+    defaultValue: '365',
+    value: '1095',
+    valueKind: 'Int',
+    allowedValues: null,
+    isEncrypted: false,
+  },
+  {
+    key: 'notifications.email_enabled',
+    label: 'Email Notifications',
+    description: null,
+    defaultValue: 'false',
+    value: 'true',
+    valueKind: 'Bool',
+    allowedValues: null,
+    isEncrypted: false,
+  },
+  {
+    key: 'ui.theme',
+    label: 'Theme',
+    description: null,
+    defaultValue: 'system',
+    value: 'light',
+    valueKind: 'String',
+    allowedValues: ['light', 'dark', 'system'],
+    isEncrypted: false,
+  },
+  {
+    key: 'integrations.stripe_secret_key',
+    label: 'Stripe Secret',
+    description: null,
+    defaultValue: null,
+    value: '***',
+    valueKind: 'String',
+    allowedValues: null,
+    isEncrypted: true,
+  },
+];
+
+vi.mock('@granit/react-settings', () => ({
+  useAdminAppSettings: () => ({ data: mockSettings, isLoading: false }),
+  useBulkUpdateSettings: () => ({ mutateAsync: mockSaveAsync, isPending: false }),
+  useSettings: () => ({ data: {}, isLoading: false }),
+  useUpdateSetting: () => ({
+    update: vi.fn(),
+    updateAsync: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSaveAsync.mockResolvedValue({
+    results: mockSettings.map((s) => ({ key: s.key, outcome: 'Updated', errorCode: null })),
+  });
+});
+
+describe('AppSettingsPanel', () => {
+  it('should render title', () => {
+    renderSettings(<AppSettingsPanel />);
+    expect(screen.getByText('Application Settings')).toBeInTheDocument();
+  });
+
+  it('should render a label for each setting', async () => {
+    renderSettings(<AppSettingsPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Audit Log Retention')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Email Notifications')).toBeInTheDocument();
+    expect(screen.getByText('Theme')).toBeInTheDocument();
+    expect(screen.getByText('Stripe Secret')).toBeInTheDocument();
+  });
+
+  it('should render a number input for Int kind', async () => {
+    renderSettings(<AppSettingsPanel />);
+    await waitFor(() => expect(screen.getByDisplayValue('1095')).toBeInTheDocument());
+    expect(screen.getByDisplayValue('1095')).toHaveAttribute('type', 'number');
+  });
+
+  it('should render a switch for Bool kind', async () => {
+    renderSettings(<AppSettingsPanel />);
+    await waitFor(() => expect(screen.getByText('Email Notifications')).toBeInTheDocument());
+    const switches = screen.getAllByRole('switch');
+    expect(switches).toHaveLength(1);
+    expect(switches[0]).toHaveAttribute('data-state', 'checked');
+  });
+
+  it('should render a dropdown when allowedValues is present', async () => {
+    renderSettings(<AppSettingsPanel />);
+    await waitFor(() => expect(screen.getByText('Theme')).toBeInTheDocument());
+    const combobox = screen.getByRole('combobox');
+    expect(combobox).toBeInTheDocument();
+    expect(combobox).toHaveTextContent('light');
+  });
+
+  it('should mask encrypted fields until Change is clicked', async () => {
+    const { user } = renderSettings(<AppSettingsPanel />);
+    await waitFor(() => expect(screen.getByText('Stripe Secret')).toBeInTheDocument());
+
+    const masked = screen.getByDisplayValue('••••••••');
+    expect(masked).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: /change/i }));
+    expect(screen.queryByDisplayValue('••••••••')).not.toBeInTheDocument();
+  });
+
+  it('should send only changed entries and show success when all Updated', async () => {
+    const { user } = renderSettings(<AppSettingsPanel />);
+    await waitFor(() => expect(screen.getByDisplayValue('1095')).toBeInTheDocument());
+
+    const retentionInput = screen.getByDisplayValue('1095');
+    await user.clear(retentionInput);
+    await user.type(retentionInput, '2000');
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(mockSaveAsync).toHaveBeenCalled());
+    expect(mockSaveAsync).toHaveBeenCalledWith([{ key: 'audit.retention_days', value: '2000' }]);
+    expect(toast.success).toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('should surface per-row errors when outcome !== Updated', async () => {
+    mockSaveAsync.mockResolvedValue({
+      results: [
+        {
+          key: 'audit.retention_days',
+          outcome: 'ValidationFailed',
+          errorCode: 'Granit:Settings:ValidationFailed',
+        },
+      ],
+    });
+
+    const { user } = renderSettings(<AppSettingsPanel />);
+    await waitFor(() => expect(screen.getByDisplayValue('1095')).toBeInTheDocument());
+
+    const retentionInput = screen.getByDisplayValue('1095');
+    await user.clear(retentionInput);
+    await user.type(retentionInput, '-1');
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('should show "no changes" info when nothing is modified', async () => {
+    const { user } = renderSettings(<AppSettingsPanel />);
+    await waitFor(() => expect(screen.getByDisplayValue('1095')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(toast.info).toHaveBeenCalled());
+    expect(mockSaveAsync).not.toHaveBeenCalled();
+  });
+
+  it('should reset form to original values', async () => {
+    const { user } = renderSettings(<AppSettingsPanel />);
+    await waitFor(() => expect(screen.getByDisplayValue('1095')).toBeInTheDocument());
+
+    const retentionInput = screen.getByDisplayValue('1095');
+    await user.clear(retentionInput);
+    await user.type(retentionInput, '9999');
+    expect(retentionInput).toHaveValue(9999);
+
+    await user.click(screen.getByRole('button', { name: /reset/i }));
+    await waitFor(() => expect(retentionInput).toHaveValue(1095));
+  });
+});

--- a/packages/@granit/react-ui-settings/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-ui-settings/src/__tests__/test-utils.tsx
@@ -1,0 +1,44 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import i18next from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+
+import { settingsTranslationsEn } from '../locales';
+
+import type { ReactElement, ReactNode } from 'react';
+
+// Local UI render helper. The settings tests stub the data layer (vi.mock
+// @granit/react-settings in-workspace), so only i18n is needed: the package's
+// own flat bundle plus the few app-global Common.* keys the panel renders
+// (Save/Reset/Saving). No router/client/QueryClient required.
+const testI18n = i18next.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  ns: ['translation'],
+  defaultNS: 'translation',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: {
+    en: {
+      translation: {
+        ...settingsTranslationsEn,
+        'Common.Save': 'Save',
+        'Common.Reset': 'Reset',
+        'Common.Saving': 'Saving',
+      },
+    },
+  },
+  interpolation: { escapeValue: false },
+});
+
+export function renderSettings(ui: ReactElement) {
+  return {
+    ...render(ui, {
+      wrapper: ({ children }: { readonly children: ReactNode }) => (
+        <I18nextProvider i18n={testI18n}>{children}</I18nextProvider>
+      ),
+    }),
+    user: userEvent.setup(),
+  };
+}

--- a/packages/@granit/react-ui-settings/src/app-settings-edit-page.tsx
+++ b/packages/@granit/react-ui-settings/src/app-settings-edit-page.tsx
@@ -1,0 +1,25 @@
+import { useTranslation } from '@granit/react-localization';
+
+import { AppSettingsPanel } from './components/app-settings-panel';
+
+import type { AdminSettingsScope } from '@granit/settings';
+
+export interface AppSettingsEditPageProps {
+  /** Settings scope — host apps pass `'global'`, tenant apps `'tenant'`. Defaults to `'global'`. */
+  readonly scope?: AdminSettingsScope;
+}
+
+export function AppSettingsEditPage({ scope = 'global' }: AppSettingsEditPageProps = {}) {
+  const { t } = useTranslation();
+
+  return (
+    <div data-slot="app-settings-edit-page" className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-foreground">{t('Config.AppSettings.Title')}</h2>
+        <p className="mt-1 text-sm text-muted-foreground">{t('Config.AppSettings.Subtitle')}</p>
+      </div>
+
+      <AppSettingsPanel scope={scope} />
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-settings/src/components/app-settings-panel.stories.tsx
+++ b/packages/@granit/react-ui-settings/src/components/app-settings-panel.stories.tsx
@@ -1,0 +1,40 @@
+import { createApiClient } from '@granit/api-client';
+import { SettingsProvider } from '@granit/react-settings';
+import { createSettingsHandlers } from '@granit/react-settings/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { AppSettingsPanel } from './app-settings-panel';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const client = createApiClient({ baseURL: '' });
+
+const meta: Meta<typeof AppSettingsPanel> = {
+  title: 'Settings/AppSettingsPanel',
+  component: AppSettingsPanel,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    msw: {
+      handlers: createSettingsHandlers(),
+    },
+  },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <SettingsProvider config={{ client, basePath: '/api/v1' }}>
+          <Story />
+        </SettingsProvider>
+      </QueryClientProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof AppSettingsPanel>;
+
+export const Default: Story = {};

--- a/packages/@granit/react-ui-settings/src/components/app-settings-panel.tsx
+++ b/packages/@granit/react-ui-settings/src/components/app-settings-panel.tsx
@@ -1,0 +1,330 @@
+import { useTranslation } from '@granit/react-localization';
+import { useAdminAppSettings, useBulkUpdateSettings } from '@granit/react-settings';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Skeleton,
+  Switch,
+} from '@granit/react-ui';
+import * as React from 'react';
+import { toast } from 'sonner';
+
+import type {
+  AdminAppSettingResponse,
+  AdminSettingsScope,
+  BulkSettingEntry,
+  ValueKind,
+} from '@granit/settings';
+
+/** Sentinel used when an encrypted field is in its masked (unedited) state. */
+const ENCRYPTED_UNCHANGED = '__GRANIT_ENCRYPTED_UNCHANGED__';
+
+type FormValues = Record<string, string>;
+
+export interface AppSettingsPanelProps {
+  /**
+   * Settings scope to read/write. Host apps pass `'global'`, tenant apps pass
+   * `'tenant'`. Defaults to `'global'` so the package never depends on an app's
+   * host/tenant flag.
+   */
+  readonly scope?: AdminSettingsScope;
+}
+
+/** Format initial value for the form (encrypted → sentinel, null → default/''). */
+function toFormValue(setting: AdminAppSettingResponse): string {
+  if (setting.isEncrypted) return ENCRYPTED_UNCHANGED;
+  return setting.value ?? setting.defaultValue ?? '';
+}
+
+export function AppSettingsPanel({ scope = 'global' }: AppSettingsPanelProps = {}) {
+  const { t } = useTranslation();
+  const { data: settings, isLoading } = useAdminAppSettings(scope);
+  const saveMutation = useBulkUpdateSettings(scope);
+
+  const defaults = React.useMemo<FormValues>(
+    () => Object.fromEntries((settings ?? []).map((s) => [s.key, toFormValue(s)])),
+    [settings]
+  );
+
+  const [values, setValues] = React.useState<FormValues>(() => defaults);
+  const [editingEncrypted, setEditingEncrypted] = React.useState<ReadonlySet<string>>(new Set());
+  const lastAppliedDefaults = React.useRef<FormValues>(defaults);
+
+  React.useEffect(() => {
+    // Only reset when the definitions catalog itself changed (new ref from the
+    // query) — otherwise user edits during a re-render would be silently
+    // clobbered by a defaults-from-props re-sync.
+    if (lastAppliedDefaults.current !== defaults) {
+      lastAppliedDefaults.current = defaults;
+      setValues(defaults);
+      setEditingEncrypted(new Set());
+    }
+  }, [defaults]);
+
+  const setFieldValue = React.useCallback((key: string, value: string) => {
+    setValues((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const onReset = () => {
+    setValues(defaults);
+    setEditingEncrypted(new Set());
+  };
+
+  const collectChangedEntries = (): BulkSettingEntry[] => {
+    if (!settings) return [];
+    const changed: BulkSettingEntry[] = [];
+    for (const setting of settings) {
+      const current = values[setting.key] ?? '';
+      const baseline = defaults[setting.key] ?? '';
+      if (current === baseline) continue;
+      if (setting.isEncrypted && current === ENCRYPTED_UNCHANGED) continue;
+      changed.push({ key: setting.key, value: current === '' ? null : current });
+    }
+    return changed;
+  };
+
+  const reportSaveOutcome = (
+    failures: ReadonlyArray<{ readonly key: string; readonly errorCode?: string | null }>
+  ) => {
+    if (failures.length === 0) {
+      toast.success(t('Config.AppSettings.SaveSuccess'));
+      return;
+    }
+    for (const failure of failures) {
+      const message = failure.errorCode
+        ? t(failure.errorCode, { key: failure.key })
+        : t('Config.AppSettings.SaveErrorRow', { key: failure.key });
+      toast.error(message);
+    }
+  };
+
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!settings) return;
+
+    const changed = collectChangedEntries();
+    if (changed.length === 0) {
+      toast.info(t('Config.AppSettings.NoChanges'));
+      return;
+    }
+
+    try {
+      const response = await saveMutation.mutateAsync(changed);
+      const failures = response.results.filter((r) => r.outcome !== 'Updated');
+      reportSaveOutcome(failures);
+    } catch {
+      // API errors are surfaced by the global MutationCache.onError toast.
+    }
+  };
+
+  return (
+    <Card data-slot="app-settings-panel">
+      <CardHeader>
+        <CardTitle className="text-base">{t('Config.AppSettings.Title')}</CardTitle>
+        <CardDescription>{t('Config.AppSettings.Subtitle')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="space-y-4">
+            {Array.from({ length: 4 }, (_, i) => (
+              <Skeleton key={`skeleton-${i}`} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
+        )}
+
+        {settings && settings.length > 0 && (
+          <form onSubmit={onSubmit} className="space-y-4">
+            {settings.map((setting) => (
+              <SettingField
+                key={setting.key}
+                setting={setting}
+                value={values[setting.key] ?? ''}
+                onChange={(v) => setFieldValue(setting.key, v)}
+                isEditingEncrypted={editingEncrypted.has(setting.key)}
+                onStartEditingEncrypted={() => {
+                  setEditingEncrypted((prev) => new Set(prev).add(setting.key));
+                  setFieldValue(setting.key, '');
+                }}
+              />
+            ))}
+
+            <div className="flex gap-2 pt-2">
+              <Button type="submit" disabled={saveMutation.isPending}>
+                {saveMutation.isPending ? t('Common.Saving') : t('Common.Save')}
+              </Button>
+              <Button type="button" variant="outline" onClick={onReset}>
+                {t('Common.Reset')}
+              </Button>
+            </div>
+          </form>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Field renderer
+// ---------------------------------------------------------------------------
+
+type SettingFieldProps = {
+  readonly setting: AdminAppSettingResponse;
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+  readonly isEditingEncrypted: boolean;
+  readonly onStartEditingEncrypted: () => void;
+};
+
+function SettingField({
+  setting,
+  value,
+  onChange,
+  isEditingEncrypted,
+  onStartEditingEncrypted,
+}: SettingFieldProps) {
+  const { t } = useTranslation();
+
+  const label = setting.label ?? t(`Setting:${setting.key}`, { defaultValue: setting.key });
+  const description =
+    setting.description ?? t(`Setting:${setting.key}:Description`, { defaultValue: '' });
+
+  const inputId = `setting-${setting.key}`;
+  const isBool = setting.valueKind === 'Bool';
+
+  return (
+    <div
+      className={
+        isBool ? 'flex items-center justify-between gap-4 rounded-lg border p-4' : 'space-y-2'
+      }
+      data-slot="setting-field"
+      data-setting-key={setting.key}
+    >
+      <div className="space-y-0.5">
+        <Label htmlFor={inputId}>{label}</Label>
+        {description && <p className="text-xs text-muted-foreground">{description}</p>}
+      </div>
+      {renderControl(setting, value, onChange, {
+        inputId,
+        isEditingEncrypted,
+        onStartEditingEncrypted,
+        t,
+      })}
+    </div>
+  );
+}
+
+function renderControl(
+  setting: AdminAppSettingResponse,
+  value: string,
+  onChange: (value: string) => void,
+  ctx: {
+    readonly inputId: string;
+    readonly isEditingEncrypted: boolean;
+    readonly onStartEditingEncrypted: () => void;
+    readonly t: (key: string, options?: Record<string, unknown>) => string;
+  }
+) {
+  if (setting.isEncrypted && !ctx.isEditingEncrypted && value === ENCRYPTED_UNCHANGED) {
+    return (
+      <div className="flex items-center gap-2">
+        <Input id={ctx.inputId} value="••••••••" disabled className="font-mono" readOnly />
+        <Button type="button" variant="outline" size="sm" onClick={ctx.onStartEditingEncrypted}>
+          {ctx.t('Config.AppSettings.ChangeSecret')}
+        </Button>
+      </div>
+    );
+  }
+
+  if (setting.allowedValues && setting.allowedValues.length > 0) {
+    return (
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger id={ctx.inputId}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {setting.allowedValues.map((option) => (
+            <SelectItem key={option} value={option}>
+              {ctx.t(`Setting:${setting.key}:Option:${option}`, { defaultValue: option })}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  return renderByKind(setting.valueKind, value, onChange, ctx.inputId, setting.isEncrypted);
+}
+
+function renderByKind(
+  kind: ValueKind,
+  value: string,
+  onChange: (value: string) => void,
+  inputId: string,
+  isEncrypted: boolean
+): React.ReactNode {
+  switch (kind) {
+    case 'Bool':
+      return (
+        <Switch
+          id={inputId}
+          checked={value === 'true'}
+          onCheckedChange={(checked) => onChange(String(checked))}
+        />
+      );
+    case 'Int':
+      return (
+        <Input
+          id={inputId}
+          type="number"
+          step="1"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="font-mono"
+        />
+      );
+    case 'Double':
+      return (
+        <Input
+          id={inputId}
+          type="number"
+          step="any"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="font-mono"
+        />
+      );
+    case 'Json':
+      return (
+        <textarea
+          id={inputId}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          rows={4}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs"
+          spellCheck={false}
+        />
+      );
+    case 'String':
+    default:
+      return (
+        <Input
+          id={inputId}
+          type={isEncrypted ? 'password' : 'text'}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="font-mono"
+        />
+      );
+  }
+}

--- a/packages/@granit/react-ui-settings/src/index.ts
+++ b/packages/@granit/react-ui-settings/src/index.ts
@@ -1,0 +1,13 @@
+// @granit/react-ui-settings — admin UI for the Granit.Settings module.
+// Composes the headless @granit/react-settings (provider + hooks) with the
+// foundation UI packages. The Axios client resolves from a GranitClientProvider
+// in the host tree; the settings scope (global/tenant) is injected.
+
+export { AppSettingsEditPage } from './app-settings-edit-page';
+export type { AppSettingsEditPageProps } from './app-settings-edit-page';
+export { AppSettingsPanel } from './components/app-settings-panel';
+export type { AppSettingsPanelProps } from './components/app-settings-panel';
+
+// i18next resource bundles (flat keys, "translation" ns)
+export { settingsTranslationsEn, settingsTranslationsFr } from './locales/index';
+export type { SettingsTranslations } from './locales/index';

--- a/packages/@granit/react-ui-settings/src/locales/en.ts
+++ b/packages/@granit/react-ui-settings/src/locales/en.ts
@@ -1,0 +1,18 @@
+// @granit/react-ui-settings — i18next resource bundle (flat keys, "translation" ns).
+// Register in the host app:
+//   import { settingsTranslationsEn } from "@granit/react-ui-settings";
+//   i18n.addResourceBundle("en", "translation", settingsTranslationsEn, true, true);
+
+export const settingsTranslationsEn = {
+  'Config.AppSettings.ChangeSecret': 'Change',
+  'Config.AppSettings.ConfirmReset': 'Reset all settings to defaults?',
+  'Config.AppSettings.NoChanges': 'No changes to save',
+  'Config.AppSettings.SaveError': 'Failed to save settings',
+  'Config.AppSettings.SaveErrorRow': 'Failed to save {{key}}',
+  'Config.AppSettings.SaveSuccess': 'Settings saved successfully',
+  'Config.AppSettings.Subtitle': 'Core configuration parameters',
+  'Config.AppSettings.Title': 'Application Settings',
+  'Config.AppSettings.UnsavedChanges': 'You have unsaved changes',
+} as const;
+
+export type SettingsTranslations = typeof settingsTranslationsEn;

--- a/packages/@granit/react-ui-settings/src/locales/fr.ts
+++ b/packages/@granit/react-ui-settings/src/locales/fr.ts
@@ -1,0 +1,13 @@
+// @granit/react-ui-settings — French resource bundle (flat keys, "translation" ns).
+
+export const settingsTranslationsFr = {
+  'Config.AppSettings.ChangeSecret': 'Modifier',
+  'Config.AppSettings.ConfirmReset': 'Réinitialiser tous les paramètres aux valeurs par défaut ?',
+  'Config.AppSettings.NoChanges': 'Aucune modification à enregistrer',
+  'Config.AppSettings.SaveError': "Échec de l'enregistrement",
+  'Config.AppSettings.SaveErrorRow': "Échec de l'enregistrement de {{key}}",
+  'Config.AppSettings.SaveSuccess': 'Paramètres enregistrés avec succès',
+  'Config.AppSettings.Subtitle': 'Paramètres de configuration principaux',
+  'Config.AppSettings.Title': "Paramètres de l'application",
+  'Config.AppSettings.UnsavedChanges': 'Vous avez des modifications non enregistrées',
+} as const;

--- a/packages/@granit/react-ui-settings/src/locales/index.ts
+++ b/packages/@granit/react-ui-settings/src/locales/index.ts
@@ -1,0 +1,3 @@
+export { settingsTranslationsEn } from './en';
+export type { SettingsTranslations } from './en';
+export { settingsTranslationsFr } from './fr';

--- a/packages/@granit/react-ui-settings/tsconfig.json
+++ b/packages/@granit/react-ui-settings/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**", "src/**/*.stories.ts", "src/**/*.stories.tsx"]
+}

--- a/packages/@granit/react-ui-settings/tsup.config.ts
+++ b/packages/@granit/react-ui-settings/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3544,6 +3544,40 @@ importers:
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
+  packages/@granit/react-ui-settings:
+    dependencies:
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-localization':
+        specifier: workspace:*
+        version: link:../react-localization
+      '@granit/react-settings':
+        specifier: workspace:*
+        version: link:../react-settings
+      '@granit/react-ui':
+        specifier: workspace:*
+        version: link:../react-ui
+      '@granit/settings':
+        specifier: workspace:*
+        version: link:../settings
+      '@storybook/react-vite':
+        specifier: ^10.4.6
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(yaml@2.9.0))
+      '@tanstack/react-query':
+        specifier: 5.101.0
+        version: 5.101.0(react@19.2.7)
+
   packages/@granit/react-ui-shell-admin:
     dependencies:
       lucide-react:


### PR DESCRIPTION
## What

Second domain-UI backfill module (after `react-ui-auditing`). Extracts the settings admin UI from `granit-showcase-react`.

### `@granit/react-ui-settings` (new)
- `AppSettingsEditPage` + `AppSettingsPanel`: typed fields per `ValueKind` (Int/Bool/Double/Json/String), allowed-value dropdowns, encrypted-secret masking + "Change", bulk save with per-row outcomes & toasts.
- Composes headless `@granit/react-settings` with the foundation UI packages.
- **Injection**: Axios client from `GranitClientProvider`; host/tenant divergence via a **`scope`** prop (`'global'` | `'tenant'`, default `'global'`) — no app-level `isHostApp`. Ships `Config.AppSettings.*` i18n bundle.

## Verification
- typecheck 0 · lint clean · tsup build · Storybook build
- **12 tests** in-package (panel interactions incl. Radix Select / Switch / encrypted / save-reset) · arch-tests green

## Notes
- Follows the auditing pilot pattern (tests-in-package, local render helper, i18n auto-discovery).
- Companion showcase MR consumes it (host + tenant routers pass `scope`) and removes `src/features/settings`.