### PR TITLE
ci: parallelize lint/typecheck/test + shard the Vitest suite (4-way)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,14 @@
 # =============================================================================
 # GitHub Actions CI/CD - granit-front
 # =============================================================================
-# Pipeline: quality+test → security → analysis → build → publish
+# Pipeline: lint ∥ typecheck ∥ test (4 shards) → coverage merge → security/analysis/build/publish
 #
-# Single quality job (lint + typecheck + test) to avoid node_modules transfer.
+# lint, typecheck and the test suite run as independent parallel jobs so tsc no
+# longer taxes the test budget. The Vitest suite is split into 4 mechanical
+# shards (`--shard=i/4`); each emits a partial coverage blob. A downstream
+# `coverage` job merges the blobs and enforces the 80% thresholds ONCE on the
+# combined report (per-shard coverage is partial, so thresholds are disabled
+# inside the shards). Bump the matrix to add shards as the suite grows.
 #
 # Optional secrets:
 #   SONAR_TOKEN — SonarCloud authentication token
@@ -28,9 +33,9 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # BUILD + TEST (single job — avoids node_modules artifact transfer)
+  # LINT
   # ---------------------------------------------------------------------------
-  build-and-test:
+  lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -55,11 +60,119 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+  # ---------------------------------------------------------------------------
+  # TYPECHECK
+  # ---------------------------------------------------------------------------
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@5b4374b04084dc1f9032b52464284b769ac5059e # v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          HUSKY: "0"
+
       - name: Typecheck
         run: pnpm tsc
 
-      - name: Test with coverage
-        run: pnpm test:coverage --run
+  # ---------------------------------------------------------------------------
+  # TEST — 4 parallel shards, each emitting a partial coverage blob.
+  # Thresholds are disabled per-shard (partial coverage) and enforced on the
+  # merged report in the `coverage` job.
+  # ---------------------------------------------------------------------------
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    name: test (shard ${{ matrix.shard }}/4)
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@5b4374b04084dc1f9032b52464284b769ac5059e # v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          HUSKY: "0"
+
+      - name: Test (shard ${{ matrix.shard }}/4)
+        run: >-
+          pnpm exec vitest run --coverage --reporter=blob
+          --shard=${{ matrix.shard }}/4
+          --coverage.thresholds.lines=0
+          --coverage.thresholds.functions=0
+          --coverage.thresholds.branches=0
+          --coverage.thresholds.statements=0
+
+      - name: Upload coverage blob
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: blob-${{ matrix.shard }}
+          path: .vitest-reports/
+          include-hidden-files: true
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # COVERAGE — merge the shard blobs and enforce the 80% thresholds once on the
+  # combined report; publish lcov for SonarCloud.
+  # ---------------------------------------------------------------------------
+  coverage:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@5b4374b04084dc1f9032b52464284b769ac5059e # v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          HUSKY: "0"
+
+      - name: Download shard coverage blobs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: blob-*
+          path: .vitest-reports
+          merge-multiple: true
+
+      - name: Merge coverage + enforce thresholds
+        run: pnpm exec vitest run --merge-reports --coverage
 
       - name: Upload coverage
         if: always()
@@ -105,7 +218,7 @@ jobs:
   # ANALYSIS
   # ---------------------------------------------------------------------------
   sonarcloud:
-    needs: build-and-test
+    needs: coverage
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     continue-on-error: true
@@ -137,7 +250,7 @@ jobs:
   # This job fails the CI if someone forgot to regenerate after changing exports.
   # ---------------------------------------------------------------------------
   front-index:
-    needs: build-and-test
+    needs: [lint, typecheck, test]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -158,7 +271,7 @@ jobs:
   # BUILD (tsup — develop/main/tags only)
   # ---------------------------------------------------------------------------
   pack:
-    needs: build-and-test
+    needs: [lint, typecheck, coverage]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,15 +121,27 @@ jobs:
           HUSKY: "0"
 
       - name: Test (shard ${{ matrix.shard }}/4)
-        # `dot` keeps the log compact while still printing failing-test details;
-        # `blob` alone suppresses them. `blob` is the merge source for `coverage`.
+        # Reporters: `dot` (compact console) + `github-actions` (inline PR failure
+        # annotations) + `junit` (downloadable test-results artifact) + `blob`
+        # (opaque merge source for the `coverage` job — never read by a human).
+        # The blob alone would hide failures, hence the human-facing reporters.
         run: >-
-          pnpm exec vitest run --coverage --reporter=dot --reporter=blob
+          pnpm exec vitest run --coverage
+          --reporter=dot --reporter=github-actions --reporter=junit --reporter=blob
+          --outputFile.junit=test-results/junit-${{ matrix.shard }}.xml
           --shard=${{ matrix.shard }}/4
           --coverage.thresholds.lines=0
           --coverage.thresholds.functions=0
           --coverage.thresholds.branches=0
           --coverage.thresholds.statements=0
+
+      - name: Upload test results (JUnit)
+        if: always() # publish even when the shard fails — that is when it is needed
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: test-results-${{ matrix.shard }}
+          path: test-results/
+          retention-days: 7
 
       - name: Upload coverage blob
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,10 @@ jobs:
           HUSKY: "0"
 
       - name: Test (shard ${{ matrix.shard }}/4)
+        # `dot` keeps the log compact while still printing failing-test details;
+        # `blob` alone suppresses them. `blob` is the merge source for `coverage`.
         run: >-
-          pnpm exec vitest run --coverage --reporter=blob
+          pnpm exec vitest run --coverage --reporter=dot --reporter=blob
           --shard=${{ matrix.shard }}/4
           --coverage.thresholds.lines=0
           --coverage.thresholds.functions=0


### PR DESCRIPTION
## Problem
`build-and-test` is a single serial 10-min job: lint (16s) → tsc (**2m33s**) → `test:coverage` (**>7min, cancelled**). As the monorepo grows (~170 packages, 700+ test files, ongoing admin-UI backfill) it now **exceeds the 10-min timeout**. Bumping the timeout only delays the wall.

## Change (mirrors granit-dotnet's batched `test` job)
- **lint** / **typecheck** become independent parallel jobs — tsc no longer taxes the test budget.
- **test** runs as a **4-way matrix** (`vitest run --shard=i/4`), each shard emitting a partial coverage blob (`--reporter=blob`). Per-shard 80% thresholds are disabled (coverage is partial).
- **coverage** job merges the blobs (`vitest run --merge-reports --coverage`) and **enforces the 80% thresholds once** on the combined report, then publishes lcov for SonarCloud.
- Downstream `needs` rewired: `sonarcloud → coverage`, `pack → [lint,typecheck,coverage]`, `front-index → [lint,typecheck,test]`.

## Validated locally (Vitest 4.1.9)
- Shards write distinct blobs (`blob-1-4.json` …) and the `--coverage.thresholds.*=0` overrides suppress per-shard failures.
- `--merge-reports --coverage` combines blobs (union of tests) and regenerates lcov.
- The merge **fails (exit 1) below 80%** → the coverage gate is preserved on the merged report.

## Expected
Critical path **>10min → ~4-5min**. Add shards later by extending `matrix.shard`.

## Note
actionlint wasn't available in my sandbox; YAML + the job/needs graph were validated by parser. First run on this PR will confirm the artifact round-trip (`include-hidden-files` upload + `merge-multiple` download into `.vitest-reports/`).