### PR TITLE
feat(react-ui-authorization): backfill the authorization admin UI

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -7804,6 +7804,49 @@
       ]
     },
     {
+      "name": "@granit/react-ui-authorization",
+      "description": "Granit admin UI for the Authorization module — role/permission management panel, permission-grant and role-metadata discovery tables, and the permission-side badge. Composes @granit/react-authorization (headless) with the foundation UI packages.",
+      "exports": [
+        {
+          "name": "PermissionListPage",
+          "kind": "function",
+          "signature": "function PermissionListPage("
+        },
+        {
+          "name": "PermissionListPageProps",
+          "kind": "interface",
+          "signature": "interface PermissionListPageProps",
+          "members": []
+        },
+        {
+          "name": "PermissionGrantsPage",
+          "kind": "function",
+          "signature": "function PermissionGrantsPage()"
+        },
+        {
+          "name": "RoleMetadataPage",
+          "kind": "function",
+          "signature": "function RoleMetadataPage()"
+        },
+        {
+          "name": "RolePermissionsPanel",
+          "kind": "function",
+          "signature": "function RolePermissionsPanel("
+        },
+        {
+          "name": "RolePermissionsPanelProps",
+          "kind": "interface",
+          "signature": "interface RolePermissionsPanelProps",
+          "members": []
+        },
+        {
+          "name": "PermissionSideBadge",
+          "kind": "function",
+          "signature": "function PermissionSideBadge("
+        }
+      ]
+    },
+    {
       "name": "@granit/react-ui-customer-balance",
       "description": "Granit admin UI for the Customer Balance module — balance page, summary card, transaction table and admin credit/debit dialogs. Composes @granit/react-customer-balance (headless) with the foundation UI packages.",
       "exports": [

--- a/packages/@granit/react-ui-authorization/README.md
+++ b/packages/@granit/react-ui-authorization/README.md
@@ -1,0 +1,32 @@
+# @granit/react-ui-authorization
+
+Admin UI for the **Authorization** module — the role / permission management
+panel (toggle permissions per role) plus the permission-grant and role-metadata
+discovery tables and the permission-side (`Host` / `Tenant` / `Both`) badge.
+
+The **visual** layer for authorization: it composes the headless
+[`@granit/react-authorization`](../react-authorization) (provider + hooks, with
+roles from [`@granit/react-identity`](../react-identity)) and the foundation UI
+packages ([`@granit/react-ui`](../react-ui),
+[`@granit/react-ui-admin-kit`](../react-ui-admin-kit) `QueryDataTable`).
+
+## Usage
+
+```tsx
+import { PermissionListPage, authorizationTranslationsEn } from '@granit/react-ui-authorization';
+
+i18n.addResourceBundle('en', 'translation', authorizationTranslationsEn, true, true);
+
+// Host app:   <Route path="/authorization/permissions" element={<PermissionListPage />} />
+// Tenant app: <Route path="/authorization/permissions" element={<PermissionListPage isTenant />} />
+```
+
+## Injection
+
+- **API client** — resolved from a `GranitClientProvider` /
+  `AuthorizationProvider` higher in the tree (the role-metadata page reads the
+  client via `useGranitClient`). No client is baked in.
+- **Scope** — `isTenant` (default `false`) hides Host-only permissions in
+  tenant-scoped admins, instead of an app-level flag.
+- **i18n** — ships its `Permissions.*` / `PermissionGrants.*` / `RoleMetadata.*`
+  strings; the host registers them. `Common.*` keys are app-global.

--- a/packages/@granit/react-ui-authorization/package.json
+++ b/packages/@granit/react-ui-authorization/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@granit/react-ui-authorization",
+  "description": "Granit admin UI for the Authorization module — role/permission management panel, permission-grant and role-metadata discovery tables, and the permission-side badge. Composes @granit/react-authorization (headless) with the foundation UI packages.",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/authorization": "workspace:*",
+    "@granit/query-engine": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-authorization": "workspace:*",
+    "@granit/react-identity": "workspace:*",
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/react-ui-admin-kit": "workspace:*",
+    "@tanstack/react-table": "^8.21.3",
+    "lucide-react": "^1.21.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/authorization": "workspace:*",
+    "@granit/query-engine": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-authorization": "workspace:*",
+    "@granit/react-identity": "workspace:*",
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/react-ui-admin-kit": "workspace:*",
+    "@storybook/react-vite": "^10.4.6",
+    "@tanstack/react-query": "^5.0.0",
+    "@tanstack/react-table": "^8.21.3",
+    "storybook": "^10.4.6"
+  }
+}

--- a/packages/@granit/react-ui-authorization/src/__tests__/permission-grants-page.test.tsx
+++ b/packages/@granit/react-ui-authorization/src/__tests__/permission-grants-page.test.tsx
@@ -1,0 +1,51 @@
+import { screen } from '@testing-library/react';
+
+import { PermissionGrantsPage } from '../permission-grants-page';
+
+import { renderAuthorization } from './test-utils';
+
+const mockUsePermissionGrants = vi.fn();
+const mockUsePermissionGrantMeta = vi.fn();
+
+vi.mock('@granit/react-authorization', () => ({
+  AuthorizationProvider: ({ children }: { children: unknown }) => <>{children}</>,
+  usePermissionGrants: (...args: unknown[]) => mockUsePermissionGrants(...args),
+  usePermissionGrantMeta: (...args: unknown[]) => mockUsePermissionGrantMeta(...args),
+}));
+
+beforeEach(() => {
+  mockUsePermissionGrantMeta.mockReturnValue({ data: undefined, isLoading: false });
+  mockUsePermissionGrants.mockReturnValue({
+    data: {
+      items: [
+        {
+          id: '1',
+          name: 'Showcase.Users.Manage',
+          providerName: 'R',
+          providerKey: 'admin',
+          tenantId: null,
+          createdAt: '2026-01-01T00:00:00Z',
+          createdBy: 'system',
+          modifiedAt: null,
+          modifiedBy: null,
+        },
+      ],
+      totalCount: 1,
+      hasMore: false,
+      nextCursor: null,
+    },
+    isLoading: false,
+  });
+});
+
+describe('PermissionGrantsPage', () => {
+  it('should render the title', () => {
+    renderAuthorization(<PermissionGrantsPage />);
+    expect(screen.getByText('Permission grants')).toBeInTheDocument();
+  });
+
+  it('should render a grant row', () => {
+    renderAuthorization(<PermissionGrantsPage />);
+    expect(screen.getByText('Showcase.Users.Manage')).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-authorization/src/__tests__/permission-list-page.test.tsx
+++ b/packages/@granit/react-ui-authorization/src/__tests__/permission-list-page.test.tsx
@@ -1,0 +1,44 @@
+import { screen } from '@testing-library/react';
+
+import { PermissionListPage } from '../permission-list-page';
+
+import { renderAuthorization } from './test-utils';
+
+const mockUsePermissionDefinitions = vi.fn();
+const mockUseRolePermissions = vi.fn();
+const mockUsePermissionGrant = vi.fn();
+
+vi.mock('@granit/react-authorization', () => ({
+  AuthorizationProvider: ({ children }: { children: unknown }) => <>{children}</>,
+  usePermissionDefinitions: (...args: unknown[]) => mockUsePermissionDefinitions(...args),
+  useRolePermissions: (...args: unknown[]) => mockUseRolePermissions(...args),
+  usePermissionGrant: (...args: unknown[]) => mockUsePermissionGrant(...args),
+}));
+
+vi.mock('@granit/react-identity', () => ({
+  useRoles: () => ({ data: [], isLoading: false }),
+}));
+
+beforeEach(() => {
+  mockUsePermissionDefinitions.mockReturnValue({ data: [], isLoading: false });
+  mockUseRolePermissions.mockReturnValue({
+    data: { roleName: 'admin', permissions: [] },
+    isLoading: false,
+  });
+  mockUsePermissionGrant.mockReturnValue({
+    grant: { mutate: vi.fn(), isPending: false },
+    revoke: { mutate: vi.fn(), isPending: false },
+  });
+});
+
+describe('PermissionListPage', () => {
+  it('should render page title', () => {
+    renderAuthorization(<PermissionListPage />);
+    expect(screen.getByText('Permissions')).toBeInTheDocument();
+  });
+
+  it('should render subtitle', () => {
+    renderAuthorization(<PermissionListPage />);
+    expect(screen.getByText(/permission definitions and role assignments/i)).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-authorization/src/__tests__/role-metadata-page.test.tsx
+++ b/packages/@granit/react-ui-authorization/src/__tests__/role-metadata-page.test.tsx
@@ -1,0 +1,56 @@
+import { screen } from '@testing-library/react';
+
+import { RoleMetadataPage } from '../role-metadata-page';
+
+import { renderAuthorization } from './test-utils';
+
+const mockUseRoleMetadata = vi.fn();
+const mockUseRoleMetadataMeta = vi.fn();
+
+vi.mock('@granit/react-authorization', () => ({
+  AuthorizationProvider: ({ children }: { children: unknown }) => <>{children}</>,
+  useRoleMetadata: (...args: unknown[]) => mockUseRoleMetadata(...args),
+  useRoleMetadataMeta: (...args: unknown[]) => mockUseRoleMetadataMeta(...args),
+}));
+
+beforeEach(() => {
+  mockUseRoleMetadataMeta.mockReturnValue({ data: undefined, isLoading: false });
+  mockUseRoleMetadata.mockReturnValue({
+    data: {
+      items: [
+        {
+          id: 'a1',
+          name: 'admin',
+          tenantId: null,
+          clientId: null,
+          multiTenancySides: 'Both',
+          description: 'Full administrative access',
+          isSystem: true,
+          isOrphaned: false,
+          orphanedAt: null,
+          concurrencyStamp: 'stamp',
+          createdAt: '2026-01-01T00:00:00Z',
+          createdBy: 'system',
+          modifiedAt: null,
+          modifiedBy: null,
+        },
+      ],
+      totalCount: 1,
+      hasMore: false,
+      nextCursor: null,
+    },
+    isLoading: false,
+  });
+});
+
+describe('RoleMetadataPage', () => {
+  it('should render the title', () => {
+    renderAuthorization(<RoleMetadataPage />);
+    expect(screen.getByText('Role metadata')).toBeInTheDocument();
+  });
+
+  it('should render a role row', () => {
+    renderAuthorization(<RoleMetadataPage />);
+    expect(screen.getByText('admin')).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-authorization/src/__tests__/role-permissions-panel.test.tsx
+++ b/packages/@granit/react-ui-authorization/src/__tests__/role-permissions-panel.test.tsx
@@ -1,0 +1,155 @@
+import { screen } from '@testing-library/react';
+
+import { RolePermissionsPanel } from '../components/role-permissions-panel';
+
+import { renderAuthorization } from './test-utils';
+
+import type { PermissionGroupResponse } from '@granit/authorization';
+
+const mockUsePermissionDefinitions = vi.fn();
+const mockUseRolePermissions = vi.fn();
+const mockGrantMutate = vi.fn();
+const mockRevokeMutate = vi.fn();
+const mockUsePermissionGrant = vi.fn();
+
+vi.mock('@granit/react-authorization', () => ({
+  AuthorizationProvider: ({ children }: { children: unknown }) => <>{children}</>,
+  usePermissionDefinitions: (...args: unknown[]) => mockUsePermissionDefinitions(...args),
+  useRolePermissions: (...args: unknown[]) => mockUseRolePermissions(...args),
+  usePermissionGrant: (...args: unknown[]) => mockUsePermissionGrant(...args),
+}));
+
+vi.mock('@granit/react-identity', () => ({
+  useRoles: () => ({
+    data: [
+      { id: '1', name: 'admin' },
+      { id: '2', name: 'user' },
+    ],
+    isLoading: false,
+  }),
+}));
+
+const sampleGroups: PermissionGroupResponse[] = [
+  {
+    name: 'Showcase',
+    displayName: 'Showcase',
+    permissions: [
+      {
+        name: 'Showcase.Users.Read',
+        displayName: 'View users',
+        multiTenancySides: 'Tenant',
+      },
+      {
+        name: 'Showcase.Users.Manage',
+        displayName: 'Manage users',
+        multiTenancySides: 'Both',
+      },
+    ],
+  },
+];
+
+beforeEach(() => {
+  mockGrantMutate.mockClear();
+  mockRevokeMutate.mockClear();
+  mockUsePermissionGrant.mockReturnValue({
+    grant: { mutate: mockGrantMutate, isPending: false },
+    revoke: { mutate: mockRevokeMutate, isPending: false },
+  });
+});
+
+describe('RolePermissionsPanel', () => {
+  it('should show spinner when loading definitions', () => {
+    mockUsePermissionDefinitions.mockReturnValue({ isLoading: true });
+    mockUseRolePermissions.mockReturnValue({ isLoading: false, data: null });
+    const { container } = renderAuthorization(<RolePermissionsPanel />);
+    expect(
+      container.querySelector('[data-slot="spinner"]') ?? container.querySelector('.animate-spin')
+    ).toBeTruthy();
+  });
+
+  it('should show spinner when loading role permissions', () => {
+    mockUsePermissionDefinitions.mockReturnValue({ isLoading: false, data: sampleGroups });
+    mockUseRolePermissions.mockReturnValue({ isLoading: true, data: null });
+    const { container } = renderAuthorization(<RolePermissionsPanel />);
+    expect(
+      container.querySelector('[data-slot="spinner"]') ?? container.querySelector('.animate-spin')
+    ).toBeTruthy();
+  });
+
+  it('should render role selector with default value admin', () => {
+    mockUsePermissionDefinitions.mockReturnValue({ isLoading: false, data: sampleGroups });
+    mockUseRolePermissions.mockReturnValue({
+      isLoading: false,
+      data: { roleName: 'admin', permissions: [] },
+    });
+    renderAuthorization(<RolePermissionsPanel />);
+    const trigger = screen.getByLabelText(/role/i);
+    expect(trigger).toHaveTextContent('admin');
+  });
+
+  it('should render permission display names', () => {
+    mockUsePermissionDefinitions.mockReturnValue({ isLoading: false, data: sampleGroups });
+    mockUseRolePermissions.mockReturnValue({
+      isLoading: false,
+      data: { roleName: 'admin', permissions: ['Showcase.Users.Read'] },
+    });
+    renderAuthorization(<RolePermissionsPanel />);
+    expect(screen.getByText('View users')).toBeInTheDocument();
+    expect(screen.getByText('Manage users')).toBeInTheDocument();
+  });
+
+  it('should render switches for each permission', () => {
+    mockUsePermissionDefinitions.mockReturnValue({ isLoading: false, data: sampleGroups });
+    mockUseRolePermissions.mockReturnValue({
+      isLoading: false,
+      data: { roleName: 'admin', permissions: ['Showcase.Users.Read'] },
+    });
+    renderAuthorization(<RolePermissionsPanel />);
+    const switches = screen.getAllByRole('switch');
+    expect(switches).toHaveLength(2);
+  });
+
+  it('should show granted permission as checked', () => {
+    mockUsePermissionDefinitions.mockReturnValue({ isLoading: false, data: sampleGroups });
+    mockUseRolePermissions.mockReturnValue({
+      isLoading: false,
+      data: { roleName: 'admin', permissions: ['Showcase.Users.Read'] },
+    });
+    renderAuthorization(<RolePermissionsPanel />);
+    const switches = screen.getAllByRole('switch');
+    expect(switches[0]).toHaveAttribute('data-state', 'checked');
+    expect(switches[1]).toHaveAttribute('data-state', 'unchecked');
+  });
+
+  it('should call revoke when toggling off a granted permission', async () => {
+    mockUsePermissionDefinitions.mockReturnValue({ isLoading: false, data: sampleGroups });
+    mockUseRolePermissions.mockReturnValue({
+      isLoading: false,
+      data: { roleName: 'admin', permissions: ['Showcase.Users.Read'] },
+    });
+    const { user } = renderAuthorization(<RolePermissionsPanel />);
+    const switches = screen.getAllByRole('switch');
+
+    await user.click(switches[0]);
+    expect(mockRevokeMutate).toHaveBeenCalledWith({
+      roleName: 'admin',
+      permissionName: 'Showcase.Users.Read',
+    });
+  });
+
+  it('should call grant when toggling on a non-granted permission', async () => {
+    mockUsePermissionDefinitions.mockReturnValue({ isLoading: false, data: sampleGroups });
+    mockUseRolePermissions.mockReturnValue({
+      isLoading: false,
+      data: { roleName: 'admin', permissions: [] },
+    });
+    const { user } = renderAuthorization(<RolePermissionsPanel />);
+    const switches = screen.getAllByRole('switch');
+
+    await user.click(switches[0]);
+    expect(mockGrantMutate).toHaveBeenCalledWith({
+      roleName: 'admin',
+      permissionName: 'Showcase.Users.Read',
+    });
+  });
+});

--- a/packages/@granit/react-ui-authorization/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-ui-authorization/src/__tests__/test-utils.tsx
@@ -1,0 +1,54 @@
+import { createApiClient } from '@granit/api-client';
+import { GranitClientProvider } from '@granit/react-api-client';
+import { TooltipProvider } from '@granit/react-ui';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import i18next from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+
+import { authorizationTranslationsEn } from '../locales';
+
+import type { ReactElement, ReactNode } from 'react';
+
+// Local UI render helper. Tests stub the data layer (vi.mock
+// @granit/react-authorization / @granit/react-identity in-workspace); the
+// role-metadata page additionally resolves an Axios client via useGranitClient,
+// so a GranitClientProvider is supplied. i18n uses the package's own flat bundle
+// plus the app-global Common.* keys the pages render.
+const testI18n = i18next.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  ns: ['translation'],
+  defaultNS: 'translation',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: {
+    en: {
+      translation: {
+        ...authorizationTranslationsEn,
+        'Common.Yes': 'Yes',
+        'Common.No': 'No',
+        'Common.SearchPlaceholder': 'Search…',
+      },
+    },
+  },
+  interpolation: { escapeValue: false },
+});
+
+const client = createApiClient({ baseURL: '' });
+
+export function renderAuthorization(ui: ReactElement) {
+  return {
+    ...render(ui, {
+      wrapper: ({ children }: { readonly children: ReactNode }) => (
+        <I18nextProvider i18n={testI18n}>
+          <GranitClientProvider client={client}>
+            <TooltipProvider>{children}</TooltipProvider>
+          </GranitClientProvider>
+        </I18nextProvider>
+      ),
+    }),
+    user: userEvent.setup(),
+  };
+}

--- a/packages/@granit/react-ui-authorization/src/components/permission-side-badge.stories.tsx
+++ b/packages/@granit/react-ui-authorization/src/components/permission-side-badge.stories.tsx
@@ -1,0 +1,32 @@
+import { PermissionSideBadge } from './permission-side-badge';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof PermissionSideBadge> = {
+  title: 'Authorization/PermissionSideBadge',
+  component: PermissionSideBadge,
+  tags: ['autodocs'],
+  argTypes: {
+    side: {
+      control: 'select',
+      options: ['Host', 'Tenant', 'Both'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Host: Story = { args: { side: 'Host' } };
+export const Tenant: Story = { args: { side: 'Tenant' } };
+export const Both: Story = { args: { side: 'Both' } };
+
+export const All: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <PermissionSideBadge side="Host" />
+      <PermissionSideBadge side="Tenant" />
+      <PermissionSideBadge side="Both" />
+    </div>
+  ),
+};

--- a/packages/@granit/react-ui-authorization/src/components/permission-side-badge.tsx
+++ b/packages/@granit/react-ui-authorization/src/components/permission-side-badge.tsx
@@ -1,0 +1,19 @@
+import { useTranslation } from '@granit/react-localization';
+import { Badge } from '@granit/react-ui';
+
+import type { PermissionMultiTenancySide } from '@granit/authorization';
+
+const VARIANT_BY_SIDE: Record<PermissionMultiTenancySide, 'default' | 'secondary' | 'outline'> = {
+  Host: 'secondary',
+  Tenant: 'default',
+  Both: 'outline',
+};
+
+export function PermissionSideBadge({ side }: { readonly side: PermissionMultiTenancySide }) {
+  const { t } = useTranslation();
+  return (
+    <Badge variant={VARIANT_BY_SIDE[side]} className="text-[10px]">
+      {t(`Permissions.Side.${side}`)}
+    </Badge>
+  );
+}

--- a/packages/@granit/react-ui-authorization/src/components/role-permissions-panel.stories.tsx
+++ b/packages/@granit/react-ui-authorization/src/components/role-permissions-panel.stories.tsx
@@ -1,0 +1,44 @@
+import { createApiClient } from '@granit/api-client';
+import { AuthorizationProvider } from '@granit/react-authorization';
+import { createAuthorizationHandlers } from '@granit/react-authorization/testing';
+import { IdentityProvider } from '@granit/react-identity';
+import { createIdentityHandlers } from '@granit/react-identity/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { RolePermissionsPanel } from './role-permissions-panel';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const client = createApiClient({ baseURL: '' });
+
+const meta: Meta<typeof RolePermissionsPanel> = {
+  title: 'Authorization/RolePermissionsPanel',
+  component: RolePermissionsPanel,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    msw: {
+      handlers: [...createAuthorizationHandlers(), ...createIdentityHandlers()],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <AuthorizationProvider config={{ client, basePath: '/api/v1/authorization' }}>
+          <IdentityProvider config={{ client, providerBasePath: '/api/v1/identity/provider' }}>
+            <Story />
+          </IdentityProvider>
+        </AuthorizationProvider>
+      </QueryClientProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof RolePermissionsPanel>;
+
+export const Default: Story = {};

--- a/packages/@granit/react-ui-authorization/src/components/role-permissions-panel.tsx
+++ b/packages/@granit/react-ui-authorization/src/components/role-permissions-panel.tsx
@@ -1,0 +1,145 @@
+import {
+  usePermissionDefinitions,
+  usePermissionGrant,
+  useRolePermissions,
+} from '@granit/react-authorization';
+import { useRoles } from '@granit/react-identity';
+import { useTranslation } from '@granit/react-localization';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Spinner,
+  Switch,
+} from '@granit/react-ui';
+import * as React from 'react';
+
+import { PermissionSideBadge } from './permission-side-badge';
+
+import type { PermissionGroupResponse } from '@granit/authorization';
+
+const DEFAULT_ROLE = 'admin';
+
+export interface RolePermissionsPanelProps {
+  /**
+   * Tenant-scoped admin: Host-only permissions cannot be granted at the tenant
+   * level (the backend rejects them), so they are hidden. Host apps pass `false`
+   * (default), tenant apps pass `true`.
+   */
+  readonly isTenant?: boolean;
+}
+
+export function RolePermissionsPanel({ isTenant = false }: RolePermissionsPanelProps = {}) {
+  const { t } = useTranslation();
+  const [roleName, setRoleName] = React.useState(DEFAULT_ROLE);
+
+  const { data: availableRoles, isLoading: isLoadingRoles } = useRoles();
+  const { data: groups, isLoading: isLoadingDefinitions } = usePermissionDefinitions();
+  const { data: roleGrants, isLoading: isLoadingGrants } = useRolePermissions({
+    roleName,
+    enabled: !!roleName,
+  });
+  const { grant, revoke } = usePermissionGrant();
+
+  const grantedSet = React.useMemo(
+    () => new Set(roleGrants?.permissions ?? []),
+    [roleGrants?.permissions]
+  );
+
+  // In a tenant-scoped admin, Host-only permissions cannot be granted at the
+  // tenant level — the backend rejects them. Hide them to avoid confusion.
+  const visibleGroups = React.useMemo<PermissionGroupResponse[]>(() => {
+    if (!groups || !isTenant) return groups ?? [];
+    return groups
+      .map((group) => ({
+        ...group,
+        permissions: group.permissions.filter((p) => p.multiTenancySides !== 'Host'),
+      }))
+      .filter((group) => group.permissions.length > 0);
+  }, [groups, isTenant]);
+
+  const isLoading = isLoadingDefinitions || isLoadingGrants;
+  const isMutating = grant.isPending || revoke.isPending;
+
+  const roleOptions = React.useMemo(() => {
+    const names = new Set<string>(availableRoles?.map((r) => r.name) ?? []);
+    if (roleName) names.add(roleName);
+    return Array.from(names).sort((a, b) => a.localeCompare(b));
+  }, [availableRoles, roleName]);
+
+  const handleToggle = (permissionName: string, currentlyGranted: boolean) => {
+    const mutation = currentlyGranted ? revoke : grant;
+    mutation.mutate({ roleName, permissionName });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Role selector */}
+      <div className="flex items-center gap-3">
+        <label htmlFor="role-select" className="text-sm font-medium text-muted-foreground">
+          {t('Permissions.Roles.SelectRole')}
+        </label>
+        <Select value={roleName} onValueChange={setRoleName} disabled={isLoadingRoles}>
+          <SelectTrigger id="role-select" className="w-64">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {roleOptions.map((name) => (
+              <SelectItem key={name} value={name}>
+                {name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Permission groups */}
+      {visibleGroups.map((group) => (
+        <Card key={group.name}>
+          <CardHeader>
+            <CardTitle className="text-base">{group.displayName ?? group.name}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {group.permissions.map((perm) => {
+                const isGranted = grantedSet.has(perm.name);
+                return (
+                  <div key={perm.name} className="flex items-center justify-between">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm font-medium text-foreground">
+                          {perm.displayName ?? perm.name}
+                        </p>
+                        <PermissionSideBadge side={perm.multiTenancySides} />
+                      </div>
+                      <p className="text-xs font-mono text-muted-foreground">{perm.name}</p>
+                    </div>
+                    <Switch
+                      checked={isGranted}
+                      onCheckedChange={() => handleToggle(perm.name, isGranted)}
+                      disabled={isMutating}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-authorization/src/hooks/use-debounce.ts
+++ b/packages/@granit/react-ui-authorization/src/hooks/use-debounce.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+
+/** Debounce a fast-changing value (e.g. a search input) by `delay` ms. */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/packages/@granit/react-ui-authorization/src/index.ts
+++ b/packages/@granit/react-ui-authorization/src/index.ts
@@ -1,0 +1,16 @@
+// @granit/react-ui-authorization — admin UI for the Granit.Authorization module.
+// Composes the headless @granit/react-authorization (provider + hooks) with the
+// foundation UI packages. The Axios client resolves from a GranitClientProvider
+// in the host tree (role-metadata page); the host/tenant divergence is injected.
+
+export { PermissionListPage } from './permission-list-page';
+export type { PermissionListPageProps } from './permission-list-page';
+export { PermissionGrantsPage } from './permission-grants-page';
+export { RoleMetadataPage } from './role-metadata-page';
+export { RolePermissionsPanel } from './components/role-permissions-panel';
+export type { RolePermissionsPanelProps } from './components/role-permissions-panel';
+export { PermissionSideBadge } from './components/permission-side-badge';
+
+// i18next resource bundles (flat keys, "translation" ns)
+export { authorizationTranslationsEn, authorizationTranslationsFr } from './locales/index';
+export type { AuthorizationTranslations } from './locales/index';

--- a/packages/@granit/react-ui-authorization/src/locales/en.ts
+++ b/packages/@granit/react-ui-authorization/src/locales/en.ts
@@ -1,0 +1,33 @@
+// @granit/react-ui-authorization — i18next resource bundle (flat keys, "translation" ns).
+// Register in the host app:
+//   import { authorizationTranslationsEn } from "@granit/react-ui-authorization";
+//   i18n.addResourceBundle("en", "translation", authorizationTranslationsEn, true, true);
+
+export const authorizationTranslationsEn = {
+  'PermissionGrants.Columns.Created': 'Created',
+  'PermissionGrants.Columns.Permission': 'Permission',
+  'PermissionGrants.Columns.Provider': 'Provider',
+  'PermissionGrants.Columns.Role': 'Role',
+  'PermissionGrants.Empty': 'No permission grants found',
+  'PermissionGrants.Subtitle':
+    'Browse every role → permission grant recorded by the authorization store',
+  'PermissionGrants.Title': 'Permission grants',
+  'Permissions.Roles.GrantSuccess': 'Permission granted',
+  'Permissions.Roles.RevokeSuccess': 'Permission revoked',
+  'Permissions.Roles.SelectRole': 'Role:',
+  'Permissions.Side.Both': 'Both',
+  'Permissions.Side.Host': 'Host',
+  'Permissions.Side.Tenant': 'Tenant',
+  'Permissions.Subtitle': 'Manage permission definitions and role assignments',
+  'Permissions.Title': 'Permissions',
+  'RoleMetadata.Columns.Created': 'Created',
+  'RoleMetadata.Columns.Description': 'Description',
+  'RoleMetadata.Columns.Role': 'Role',
+  'RoleMetadata.Columns.Scope': 'Scope',
+  'RoleMetadata.Columns.System': 'System',
+  'RoleMetadata.Empty': 'No roles found',
+  'RoleMetadata.Subtitle': 'Inspect role definitions, tenancy scope and lifecycle flags',
+  'RoleMetadata.Title': 'Role metadata',
+} as const;
+
+export type AuthorizationTranslations = typeof authorizationTranslationsEn;

--- a/packages/@granit/react-ui-authorization/src/locales/fr.ts
+++ b/packages/@granit/react-ui-authorization/src/locales/fr.ts
@@ -1,0 +1,29 @@
+// @granit/react-ui-authorization — French resource bundle (flat keys, "translation" ns).
+
+export const authorizationTranslationsFr = {
+  'PermissionGrants.Columns.Created': 'Créé le',
+  'PermissionGrants.Columns.Permission': 'Permission',
+  'PermissionGrants.Columns.Provider': 'Fournisseur',
+  'PermissionGrants.Columns.Role': 'Rôle',
+  'PermissionGrants.Empty': 'Aucune attribution de permission trouvée',
+  'PermissionGrants.Subtitle':
+    "Parcourir chaque attribution rôle → permission enregistrée par le magasin d'autorisation",
+  'PermissionGrants.Title': 'Attributions de permissions',
+  'Permissions.Roles.GrantSuccess': 'Permission accordée',
+  'Permissions.Roles.RevokeSuccess': 'Permission révoquée',
+  'Permissions.Roles.SelectRole': 'Rôle :',
+  'Permissions.Side.Both': 'Hôte et tenant',
+  'Permissions.Side.Host': 'Hôte',
+  'Permissions.Side.Tenant': 'Tenant',
+  'Permissions.Subtitle': 'Gérer les définitions de permissions et les attributions par rôle',
+  'Permissions.Title': 'Permissions',
+  'RoleMetadata.Columns.Created': 'Créé le',
+  'RoleMetadata.Columns.Description': 'Description',
+  'RoleMetadata.Columns.Role': 'Rôle',
+  'RoleMetadata.Columns.Scope': 'Portée',
+  'RoleMetadata.Columns.System': 'Système',
+  'RoleMetadata.Empty': 'Aucun rôle trouvé',
+  'RoleMetadata.Subtitle':
+    'Inspecter les définitions de rôles, leur portée de location et leurs indicateurs de cycle de vie',
+  'RoleMetadata.Title': 'Métadonnées de rôles',
+} as const;

--- a/packages/@granit/react-ui-authorization/src/locales/index.ts
+++ b/packages/@granit/react-ui-authorization/src/locales/index.ts
@@ -1,0 +1,3 @@
+export { authorizationTranslationsEn } from './en';
+export type { AuthorizationTranslations } from './en';
+export { authorizationTranslationsFr } from './fr';

--- a/packages/@granit/react-ui-authorization/src/permission-grants-page.tsx
+++ b/packages/@granit/react-ui-authorization/src/permission-grants-page.tsx
@@ -1,0 +1,128 @@
+import { usePermissionGrantMeta, usePermissionGrants } from '@granit/react-authorization';
+import { useDateFormatter, useTranslation } from '@granit/react-localization';
+import { Input, Spinner } from '@granit/react-ui';
+import { QueryDataTable } from '@granit/react-ui-admin-kit';
+import { Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { useDebounce } from './hooks/use-debounce';
+
+import type { PermissionGrant } from '@granit/authorization';
+import type { SortEntry } from '@granit/query-engine';
+import type { ColumnDef } from '@tanstack/react-table';
+
+const DEFAULT_PAGE_SIZE = 20;
+
+function GrantNameCell({ row }: { readonly row: { readonly original: PermissionGrant } }) {
+  return <span className="font-medium">{row.original.name}</span>;
+}
+
+function GrantProviderCell({ row }: { readonly row: { readonly original: PermissionGrant } }) {
+  return <span className="font-mono text-xs">{row.original.providerName}</span>;
+}
+
+/**
+ * Admin discovery surface for the `GET /authorization/grants` query endpoint.
+ *
+ * Exercises `usePermissionGrants` + `usePermissionGrantMeta` from
+ * `@granit/react-authorization`.
+ */
+export function PermissionGrantsPage() {
+  const { t } = useTranslation();
+  const { formatDate } = useDateFormatter();
+
+  const [search, setSearch] = useState('');
+  const debouncedSearch = useDebounce(search, 300);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [sort, setSort] = useState<SortEntry[]>([{ field: 'name', direction: 'asc' }]);
+
+  const meta = usePermissionGrantMeta();
+  const { data, isLoading } = usePermissionGrants(
+    {},
+    { page, pageSize, sort, search: debouncedSearch || undefined }
+  );
+
+  const toggleSort = (field: string) => {
+    setSort((prev) => {
+      const current = prev[0];
+      const direction = current?.field === field && current.direction === 'asc' ? 'desc' : 'asc';
+      return [{ field, direction }];
+    });
+  };
+
+  const columns = useMemo<ColumnDef<PermissionGrant>[]>(
+    () => [
+      {
+        accessorKey: 'name',
+        header: t('PermissionGrants.Columns.Permission'),
+        cell: GrantNameCell,
+      },
+      {
+        accessorKey: 'providerName',
+        header: t('PermissionGrants.Columns.Provider'),
+        enableSorting: false,
+        cell: GrantProviderCell,
+      },
+      {
+        accessorKey: 'providerKey',
+        header: t('PermissionGrants.Columns.Role'),
+        enableSorting: false,
+        cell: ({ row }) => row.original.providerKey,
+      },
+      {
+        accessorKey: 'createdAt',
+        header: t('PermissionGrants.Columns.Created'),
+        cell: ({ row }) => formatDate(row.original.createdAt),
+      },
+    ],
+    [t, formatDate]
+  );
+
+  if (meta.isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div data-slot="permission-grants-page" className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-foreground">{t('PermissionGrants.Title')}</h2>
+        <p className="mt-1 text-sm text-muted-foreground">{t('PermissionGrants.Subtitle')}</p>
+      </div>
+
+      <div className="relative max-w-sm">
+        <Search className="absolute left-2.5 top-2.5 size-4 text-muted-foreground" />
+        <Input
+          placeholder={t('Common.SearchPlaceholder')}
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setPage(1);
+          }}
+          className="pl-8"
+        />
+      </div>
+
+      <QueryDataTable
+        columns={columns}
+        data={data?.items ?? []}
+        totalCount={data?.totalCount ?? 0}
+        isLoading={isLoading}
+        page={page}
+        pageSize={pageSize}
+        sort={sort}
+        onPageChange={setPage}
+        onPageSizeChange={(size) => {
+          setPageSize(size);
+          setPage(1);
+        }}
+        onToggleSort={toggleSort}
+        emptyMessage={t('PermissionGrants.Empty')}
+      />
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-authorization/src/permission-list-page.tsx
+++ b/packages/@granit/react-ui-authorization/src/permission-list-page.tsx
@@ -1,0 +1,23 @@
+import { useTranslation } from '@granit/react-localization';
+
+import { RolePermissionsPanel } from './components/role-permissions-panel';
+
+export interface PermissionListPageProps {
+  /** Tenant-scoped admin — hides Host-only permissions. Defaults to `false`. */
+  readonly isTenant?: boolean;
+}
+
+export function PermissionListPage({ isTenant = false }: PermissionListPageProps = {}) {
+  const { t } = useTranslation();
+
+  return (
+    <div data-slot="permission-list-page" className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-foreground">{t('Permissions.Title')}</h2>
+        <p className="mt-1 text-sm text-muted-foreground">{t('Permissions.Subtitle')}</p>
+      </div>
+
+      <RolePermissionsPanel isTenant={isTenant} />
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-authorization/src/role-metadata-page.tsx
+++ b/packages/@granit/react-ui-authorization/src/role-metadata-page.tsx
@@ -1,0 +1,147 @@
+import { useGranitClient } from '@granit/react-api-client';
+import { useRoleMetadata, useRoleMetadataMeta } from '@granit/react-authorization';
+import { useDateFormatter, useTranslation } from '@granit/react-localization';
+import { Badge, Input, Spinner } from '@granit/react-ui';
+import { QueryDataTable } from '@granit/react-ui-admin-kit';
+import { Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { PermissionSideBadge } from './components/permission-side-badge';
+import { useDebounce } from './hooks/use-debounce';
+
+import type { RoleMetadata } from '@granit/authorization';
+import type { SortEntry } from '@granit/query-engine';
+import type { ColumnDef } from '@tanstack/react-table';
+
+const DEFAULT_PAGE_SIZE = 20;
+
+function RoleNameCell({ row }: { readonly row: { readonly original: RoleMetadata } }) {
+  return <span className="font-medium">{row.original.name}</span>;
+}
+
+function RoleScopeCell({ row }: { readonly row: { readonly original: RoleMetadata } }) {
+  return <PermissionSideBadge side={row.original.multiTenancySides} />;
+}
+
+function RoleIsSystemBadgeCell({ row }: { readonly row: { readonly original: RoleMetadata } }) {
+  const { t } = useTranslation();
+  return (
+    <Badge variant={row.original.isSystem ? 'secondary' : 'outline'} className="text-[10px]">
+      {row.original.isSystem ? t('Common.Yes') : t('Common.No')}
+    </Badge>
+  );
+}
+
+/**
+ * Admin discovery surface for the `GET /authorization/role-metadata` query endpoint.
+ *
+ * Exercises `useRoleMetadata` + `useRoleMetadataMeta` from
+ * `@granit/react-authorization`. The Axios client is resolved from a
+ * `GranitClientProvider` in the host tree.
+ */
+export function RoleMetadataPage() {
+  const { t } = useTranslation();
+  const { formatDate } = useDateFormatter();
+  const client = useGranitClient();
+
+  const [search, setSearch] = useState('');
+  const debouncedSearch = useDebounce(search, 300);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [sort, setSort] = useState<SortEntry[]>([{ field: 'name', direction: 'asc' }]);
+
+  const meta = useRoleMetadataMeta({ client });
+  const { data, isLoading } = useRoleMetadata(
+    { client },
+    { page, pageSize, sort, search: debouncedSearch || undefined }
+  );
+
+  const toggleSort = (field: string) => {
+    setSort((prev) => {
+      const current = prev[0];
+      const direction = current?.field === field && current.direction === 'asc' ? 'desc' : 'asc';
+      return [{ field, direction }];
+    });
+  };
+
+  const columns = useMemo<ColumnDef<RoleMetadata>[]>(
+    () => [
+      {
+        accessorKey: 'name',
+        header: t('RoleMetadata.Columns.Role'),
+        cell: RoleNameCell,
+      },
+      {
+        accessorKey: 'multiTenancySides',
+        header: t('RoleMetadata.Columns.Scope'),
+        enableSorting: false,
+        cell: RoleScopeCell,
+      },
+      {
+        accessorKey: 'description',
+        header: t('RoleMetadata.Columns.Description'),
+        enableSorting: false,
+        cell: ({ row }) => row.original.description ?? '—',
+      },
+      {
+        accessorKey: 'isSystem',
+        header: t('RoleMetadata.Columns.System'),
+        enableSorting: false,
+        cell: RoleIsSystemBadgeCell,
+      },
+      {
+        accessorKey: 'createdAt',
+        header: t('RoleMetadata.Columns.Created'),
+        cell: ({ row }) => formatDate(row.original.createdAt),
+      },
+    ],
+    [t, formatDate]
+  );
+
+  if (meta.isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div data-slot="role-metadata-page" className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-foreground">{t('RoleMetadata.Title')}</h2>
+        <p className="mt-1 text-sm text-muted-foreground">{t('RoleMetadata.Subtitle')}</p>
+      </div>
+
+      <div className="relative max-w-sm">
+        <Search className="absolute left-2.5 top-2.5 size-4 text-muted-foreground" />
+        <Input
+          placeholder={t('Common.SearchPlaceholder')}
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setPage(1);
+          }}
+          className="pl-8"
+        />
+      </div>
+
+      <QueryDataTable
+        columns={columns}
+        data={data?.items ?? []}
+        totalCount={data?.totalCount ?? 0}
+        isLoading={isLoading}
+        page={page}
+        pageSize={pageSize}
+        sort={sort}
+        onPageChange={setPage}
+        onPageSizeChange={(size) => {
+          setPageSize(size);
+          setPage(1);
+        }}
+        onToggleSort={toggleSort}
+        emptyMessage={t('RoleMetadata.Empty')}
+      />
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-authorization/tsconfig.json
+++ b/packages/@granit/react-ui-authorization/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**", "src/**/*.stories.ts", "src/**/*.stories.tsx"]
+}

--- a/packages/@granit/react-ui-authorization/tsup.config.ts
+++ b/packages/@granit/react-ui-authorization/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3544,6 +3544,58 @@ importers:
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
+  packages/@granit/react-ui-authorization:
+    dependencies:
+      lucide-react:
+        specifier: ^1.21.0
+        version: 1.21.0(react@19.2.7)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/authorization':
+        specifier: workspace:*
+        version: link:../authorization
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-authorization':
+        specifier: workspace:*
+        version: link:../react-authorization
+      '@granit/react-identity':
+        specifier: workspace:*
+        version: link:../react-identity
+      '@granit/react-localization':
+        specifier: workspace:*
+        version: link:../react-localization
+      '@granit/react-ui':
+        specifier: workspace:*
+        version: link:../react-ui
+      '@granit/react-ui-admin-kit':
+        specifier: workspace:*
+        version: link:../react-ui-admin-kit
+      '@storybook/react-vite':
+        specifier: ^10.4.6
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(yaml@2.9.0))
+      '@tanstack/react-query':
+        specifier: 5.101.0
+        version: 5.101.0(react@19.2.7)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook:
+        specifier: ^10.4.6
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
   packages/@granit/react-ui-customer-balance:
     dependencies:
       lucide-react:


### PR DESCRIPTION
## What

Fifth domain-UI backfill module. Extracts the showcase `permissions` feature into the canonical **authorization** UI package.

### `@granit/react-ui-authorization` (new)
- `PermissionListPage` (role/permission toggle panel), `PermissionGrantsPage` + `RoleMetadataPage` (discovery tables), `RolePermissionsPanel`, `PermissionSideBadge`.
- Composes headless `@granit/react-authorization` (+ roles from `@granit/react-identity`) with the foundation UI packages.
- **Decoupling**: `useDebounce` shipped in-package; role-metadata page resolves the client via `useGranitClient` (was `@/lib/api`); host/tenant divergence injected as an `isTenant` prop (was `isTenantApp`). Ships `Permissions.*` / `PermissionGrants.*` / `RoleMetadata.*` i18n bundle.

## Verification
- typecheck 0 · lint clean · tsup build · Storybook build
- **14 in-package tests** · arch-tests green (75)

## Notes
- Follows the backfill pattern. Companion showcase MR consumes it (host = all 3 pages; tenant = PermissionListPage `isTenant`) and removes `src/features/permissions`.