### PR TITLE
feat(react-ui-diagnostics): backfill the diagnostics admin UI

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -7883,6 +7883,27 @@
       ]
     },
     {
+      "name": "@granit/react-ui-diagnostics",
+      "description": "Granit admin UI for the Diagnostics module — the monitoring/health page, service-health cards and auto-refresh indicator. Composes @granit/react-diagnostics (headless) with the foundation UI packages.",
+      "exports": [
+        {
+          "name": "DiagnosticListPage",
+          "kind": "function",
+          "signature": "function DiagnosticListPage()"
+        },
+        {
+          "name": "ServiceHealthCard",
+          "kind": "function",
+          "signature": "function ServiceHealthCard("
+        },
+        {
+          "name": "AutoRefreshIndicator",
+          "kind": "function",
+          "signature": "function AutoRefreshIndicator("
+        }
+      ]
+    },
+    {
       "name": "@granit/react-ui-hostnames",
       "description": "Granit admin UI for the managed Hostnames module — owner-scoped hostname list, DNS details, status/certificate badges, row actions and add-hostname dialog. Composes @granit/react-hostnames (headless) with the foundation UI packages.",
       "exports": [

--- a/packages/@granit/react-ui-diagnostics/README.md
+++ b/packages/@granit/react-ui-diagnostics/README.md
@@ -1,0 +1,26 @@
+# @granit/react-ui-diagnostics
+
+Admin UI for the **Diagnostics** module — the monitoring page (a grid of
+service-health cards with an auto-refresh indicator).
+
+The **visual** layer for diagnostics: it composes the headless
+[`@granit/react-diagnostics`](../react-diagnostics) (`useMonitoringHealth`) with
+the foundation UI packages ([`@granit/react-ui`](../react-ui)).
+
+## Usage
+
+```tsx
+import { DiagnosticListPage, diagnosticsTranslationsEn } from '@granit/react-ui-diagnostics';
+
+i18n.addResourceBundle('en', 'translation', diagnosticsTranslationsEn, true, true);
+
+<Route path="/diagnostics" element={<DiagnosticListPage />} />;
+```
+
+## Injection
+
+- **API client** — resolved from a `GranitClientProvider`
+  (`@granit/react-api-client`) higher in the tree (`useGranitClient`). No client
+  is baked in.
+- **i18n** — ships its `Diagnostics.*` strings (`diagnosticsTranslationsEn/Fr`);
+  the host registers them. `Common.*` keys are app-global.

--- a/packages/@granit/react-ui-diagnostics/package.json
+++ b/packages/@granit/react-ui-diagnostics/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@granit/react-ui-diagnostics",
+  "description": "Granit admin UI for the Diagnostics module — the monitoring/health page, service-health cards and auto-refresh indicator. Composes @granit/react-diagnostics (headless) with the foundation UI packages.",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/diagnostics": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-diagnostics": "workspace:*",
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/utils": "workspace:*",
+    "lucide-react": "^1.21.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/diagnostics": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-diagnostics": "workspace:*",
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/utils": "workspace:*",
+    "@storybook/react-vite": "^10.4.6",
+    "storybook": "^10.4.6"
+  }
+}

--- a/packages/@granit/react-ui-diagnostics/src/__tests__/auto-refresh-indicator.test.tsx
+++ b/packages/@granit/react-ui-diagnostics/src/__tests__/auto-refresh-indicator.test.tsx
@@ -1,0 +1,49 @@
+import { act, screen } from '@testing-library/react';
+
+import { AutoRefreshIndicator } from '../components/auto-refresh-indicator';
+
+import { renderDiagnostics } from './test-utils';
+
+describe('AutoRefreshIndicator', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should render countdown text', () => {
+    renderDiagnostics(<AutoRefreshIndicator onRefresh={vi.fn()} />);
+    expect(screen.getByText(/30s/)).toBeInTheDocument();
+  });
+
+  it('should render refresh button', () => {
+    renderDiagnostics(<AutoRefreshIndicator onRefresh={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
+  });
+
+  it('should call onRefresh when button is clicked', async () => {
+    const onRefresh = vi.fn();
+    const { user } = renderDiagnostics(<AutoRefreshIndicator onRefresh={onRefresh} />);
+
+    await user.click(screen.getByRole('button', { name: /refresh/i }));
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it('should disable button when refreshing', () => {
+    renderDiagnostics(<AutoRefreshIndicator onRefresh={vi.fn()} isRefreshing={true} />);
+    expect(screen.getByRole('button', { name: /refresh/i })).toBeDisabled();
+  });
+
+  it('should decrement countdown over time', async () => {
+    vi.useFakeTimers();
+    renderDiagnostics(<AutoRefreshIndicator onRefresh={vi.fn()} />);
+    expect(screen.getByText(/30s/)).toBeInTheDocument();
+    await act(() => vi.advanceTimersByTime(3000));
+    expect(screen.getByText(/27s/)).toBeInTheDocument();
+  });
+
+  it('should reset countdown after reaching zero', async () => {
+    vi.useFakeTimers();
+    renderDiagnostics(<AutoRefreshIndicator onRefresh={vi.fn()} />);
+    await act(() => vi.advanceTimersByTime(30000));
+    expect(screen.getByText(/30s/)).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-diagnostics/src/__tests__/diagnostic-list-page.test.tsx
+++ b/packages/@granit/react-ui-diagnostics/src/__tests__/diagnostic-list-page.test.tsx
@@ -1,0 +1,89 @@
+import { screen } from '@testing-library/react';
+
+import { DiagnosticListPage } from '../diagnostic-list-page';
+
+import { renderDiagnostics } from './test-utils';
+
+import type { ServiceHealthResponse } from '@granit/diagnostics';
+
+const { mockUseMonitoringHealth } = vi.hoisted(() => ({ mockUseMonitoringHealth: vi.fn() }));
+
+vi.mock('@granit/react-diagnostics', () => ({
+  useMonitoringHealth: () => mockUseMonitoringHealth(),
+}));
+
+const services: ServiceHealthResponse[] = [
+  {
+    id: 'api',
+    name: 'API Gateway',
+    description: null,
+    status: 'healthy',
+    responseTimeMs: 42,
+    tags: [],
+  },
+  {
+    id: 'iam',
+    name: 'Keycloak (IAM)',
+    description: null,
+    status: 'degraded',
+    responseTimeMs: 850,
+    tags: [],
+  },
+  {
+    id: 'fhir',
+    name: 'FHIR Server',
+    description: null,
+    status: 'down',
+    responseTimeMs: null,
+    tags: [],
+  },
+];
+
+beforeEach(() => {
+  mockUseMonitoringHealth.mockReturnValue({
+    data: { services, checkedAt: '2026-06-01T10:00:00Z' },
+    isLoading: false,
+    isFetching: false,
+    refetch: vi.fn(),
+  });
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe('DiagnosticListPage', () => {
+  it('should render page title', () => {
+    renderDiagnostics(<DiagnosticListPage />);
+    expect(screen.getByText('Monitoring')).toBeInTheDocument();
+  });
+
+  it('should render the auto-refresh button', () => {
+    renderDiagnostics(<DiagnosticListPage />);
+    expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
+  });
+
+  it('should render a card for each service', () => {
+    renderDiagnostics(<DiagnosticListPage />);
+    expect(screen.getByText('API Gateway')).toBeInTheDocument();
+    expect(screen.getByText('Keycloak (IAM)')).toBeInTheDocument();
+    expect(screen.getByText('FHIR Server')).toBeInTheDocument();
+  });
+
+  it('should render translated status labels (not raw i18n keys)', () => {
+    renderDiagnostics(<DiagnosticListPage />);
+    expect(screen.getAllByText('Healthy').length).toBeGreaterThan(0);
+    expect(screen.getByText('Degraded')).toBeInTheDocument();
+    expect(screen.getByText('Down')).toBeInTheDocument();
+    expect(screen.queryByText(/Diagnostics\.Status\./)).not.toBeInTheDocument();
+  });
+
+  it('should show the loading skeletons while loading', () => {
+    mockUseMonitoringHealth.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      refetch: vi.fn(),
+    });
+    renderDiagnostics(<DiagnosticListPage />);
+    expect(screen.queryByText('API Gateway')).not.toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-diagnostics/src/__tests__/service-health-card.test.tsx
+++ b/packages/@granit/react-ui-diagnostics/src/__tests__/service-health-card.test.tsx
@@ -1,0 +1,101 @@
+import { screen, within } from '@testing-library/react';
+
+import { ServiceHealthCard } from '../components/service-health-card';
+
+import { renderDiagnostics } from './test-utils';
+
+import type { ServiceHealthResponse } from '@granit/diagnostics';
+
+const checkedAt = '2026-03-12T10:00:00Z';
+
+function makeService(overrides: Partial<ServiceHealthResponse> = {}): ServiceHealthResponse {
+  return {
+    id: 'postgresql',
+    name: 'PostgreSQL',
+    status: 'healthy',
+    responseTimeMs: 42,
+    description: 'Primary database cluster',
+    tags: ['readiness', 'startup'],
+    ...overrides,
+  };
+}
+
+describe('ServiceHealthCard', () => {
+  it('should render the service name', () => {
+    renderDiagnostics(<ServiceHealthCard service={makeService()} checkedAt={checkedAt} />);
+    expect(screen.getByText('PostgreSQL')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['healthy', 'Healthy'],
+    ['degraded', 'Degraded'],
+    ['down', 'Down'],
+  ] as const)('should render the translated label for status "%s"', (status, label) => {
+    const { container } = renderDiagnostics(
+      <ServiceHealthCard service={makeService({ status })} checkedAt={checkedAt} />
+    );
+
+    expect(screen.getByText(label)).toBeInTheDocument();
+    expect(screen.queryByText(/Diagnostics\.Status\./)).not.toBeInTheDocument();
+    expect(container.querySelector('[data-slot="service-health-card"]')).toHaveAttribute(
+      'data-status',
+      status
+    );
+  });
+
+  it('should render the response time when present', () => {
+    renderDiagnostics(
+      <ServiceHealthCard service={makeService({ responseTimeMs: 42 })} checkedAt={checkedAt} />
+    );
+    expect(screen.getByText('42ms')).toBeInTheDocument();
+  });
+
+  it('should render an em dash when responseTimeMs is null', () => {
+    renderDiagnostics(
+      <ServiceHealthCard service={makeService({ responseTimeMs: null })} checkedAt={checkedAt} />
+    );
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(screen.queryByText(/ms$/)).not.toBeInTheDocument();
+  });
+
+  it('should render the description when present', () => {
+    renderDiagnostics(
+      <ServiceHealthCard
+        service={makeService({ description: 'Primary database cluster' })}
+        checkedAt={checkedAt}
+      />
+    );
+    expect(screen.getByText('Primary database cluster')).toBeInTheDocument();
+  });
+
+  it('should omit the description when null', () => {
+    renderDiagnostics(
+      <ServiceHealthCard service={makeService({ description: null })} checkedAt={checkedAt} />
+    );
+    expect(screen.queryByText('Primary database cluster')).not.toBeInTheDocument();
+  });
+
+  it('should render each tag', () => {
+    renderDiagnostics(
+      <ServiceHealthCard
+        service={makeService({ tags: ['readiness', 'startup'] })}
+        checkedAt={checkedAt}
+      />
+    );
+    expect(screen.getByText('readiness')).toBeInTheDocument();
+    expect(screen.getByText('startup')).toBeInTheDocument();
+  });
+
+  it('should show an unreachable alert only when the service is down', () => {
+    const { rerender } = renderDiagnostics(
+      <ServiceHealthCard service={makeService({ status: 'healthy' })} checkedAt={checkedAt} />
+    );
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    rerender(<ServiceHealthCard service={makeService({ status: 'down' })} checkedAt={checkedAt} />);
+
+    const alert = screen.getByRole('alert');
+    expect(within(alert).getByText('Service unreachable')).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-diagnostics/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-ui-diagnostics/src/__tests__/test-utils.tsx
@@ -1,0 +1,41 @@
+import { createApiClient } from '@granit/api-client';
+import { GranitClientProvider } from '@granit/react-api-client';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import i18next from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+
+import { diagnosticsTranslationsEn } from '../locales';
+
+import type { ReactElement, ReactNode } from 'react';
+
+// Local UI render helper. Tests stub the data layer (vi.mock
+// @granit/react-diagnostics in-workspace); the page resolves an Axios client via
+// useGranitClient, so a GranitClientProvider is supplied. i18n uses the package's
+// own flat bundle plus the app-global Common.Refresh key the indicator renders.
+const testI18n = i18next.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  ns: ['translation'],
+  defaultNS: 'translation',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: { ...diagnosticsTranslationsEn, 'Common.Refresh': 'Refresh' } } },
+  interpolation: { escapeValue: false },
+});
+
+const client = createApiClient({ baseURL: '' });
+
+export function renderDiagnostics(ui: ReactElement) {
+  return {
+    ...render(ui, {
+      wrapper: ({ children }: { readonly children: ReactNode }) => (
+        <I18nextProvider i18n={testI18n}>
+          <GranitClientProvider client={client}>{children}</GranitClientProvider>
+        </I18nextProvider>
+      ),
+    }),
+    user: userEvent.setup(),
+  };
+}

--- a/packages/@granit/react-ui-diagnostics/src/components/auto-refresh-indicator.stories.tsx
+++ b/packages/@granit/react-ui-diagnostics/src/components/auto-refresh-indicator.stories.tsx
@@ -1,0 +1,35 @@
+import { fn } from 'storybook/test';
+
+import { AutoRefreshIndicator } from './auto-refresh-indicator';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof AutoRefreshIndicator> = {
+  title: 'Diagnostics/AutoRefreshIndicator',
+  component: AutoRefreshIndicator,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+  },
+  argTypes: {
+    onRefresh: { action: 'onRefresh' },
+    isRefreshing: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AutoRefreshIndicator>;
+
+export const Default: Story = {
+  args: {
+    onRefresh: fn(),
+    isRefreshing: false,
+  },
+};
+
+export const Refreshing: Story = {
+  args: {
+    onRefresh: fn(),
+    isRefreshing: true,
+  },
+};

--- a/packages/@granit/react-ui-diagnostics/src/components/auto-refresh-indicator.tsx
+++ b/packages/@granit/react-ui-diagnostics/src/components/auto-refresh-indicator.tsx
@@ -1,0 +1,56 @@
+import { useTranslation } from '@granit/react-localization';
+import { Button } from '@granit/react-ui';
+import { cn } from '@granit/utils';
+import { RefreshCw } from 'lucide-react';
+import * as React from 'react';
+
+const REFRESH_INTERVAL_SECONDS = 30;
+
+interface AutoRefreshIndicatorProps {
+  onRefresh: () => void;
+  isRefreshing?: boolean;
+}
+
+export function AutoRefreshIndicator({
+  onRefresh,
+  isRefreshing = false,
+}: Readonly<AutoRefreshIndicatorProps>) {
+  const { t } = useTranslation();
+  const [countdown, setCountdown] = React.useState(REFRESH_INTERVAL_SECONDS);
+
+  React.useEffect(() => {
+    setCountdown(REFRESH_INTERVAL_SECONDS);
+
+    const interval = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          return REFRESH_INTERVAL_SECONDS;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [isRefreshing]);
+
+  return (
+    <div data-slot="auto-refresh-indicator" className="flex items-center gap-3">
+      <span className="text-sm text-muted-foreground">
+        {t('Diagnostics.AutoRefresh', { seconds: countdown })}
+      </span>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onRefresh}
+        disabled={isRefreshing}
+        aria-label={t('Diagnostics.RefreshAriaLabel')}
+      >
+        <RefreshCw
+          className={cn('mr-1.5 h-3.5 w-3.5', isRefreshing && 'animate-spin')}
+          aria-hidden="true"
+        />
+        {t('Common.Refresh')}
+      </Button>
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-diagnostics/src/components/service-health-card.stories.tsx
+++ b/packages/@granit/react-ui-diagnostics/src/components/service-health-card.stories.tsx
@@ -1,0 +1,106 @@
+import { ServiceHealthCard } from './service-health-card';
+
+import type { ServiceHealthResponse } from '@granit/diagnostics';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof ServiceHealthCard> = {
+  title: 'Diagnostics/ServiceHealthCard',
+  component: ServiceHealthCard,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+  },
+  argTypes: {
+    service: { control: 'object' },
+    checkedAt: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ServiceHealthCard>;
+
+const checkedAt = '2026-06-20T14:30:00Z';
+
+const baseService: ServiceHealthResponse = {
+  id: 'api-gateway',
+  name: 'API Gateway',
+  description: 'Main entry point of the Granit REST API',
+  status: 'healthy',
+  responseTimeMs: 42,
+  tags: ['readiness'],
+};
+
+export const Healthy: Story = {
+  args: { service: { ...baseService, status: 'healthy', responseTimeMs: 42 }, checkedAt },
+};
+
+export const Degraded: Story = {
+  args: {
+    service: {
+      ...baseService,
+      id: 'fhir-server',
+      name: 'FHIR R4 Server',
+      description: 'FHIR server for structured health data',
+      status: 'degraded',
+      responseTimeMs: 850,
+      tags: ['readiness', 'startup'],
+    },
+    checkedAt,
+  },
+};
+
+export const Down: Story = {
+  args: {
+    service: {
+      ...baseService,
+      id: 'notification-service',
+      name: 'Notification Service',
+      description: 'Push and email notification delivery',
+      status: 'down',
+      responseTimeMs: null,
+      tags: ['readiness'],
+    },
+    checkedAt,
+  },
+};
+
+export const NoResponseTime: Story = {
+  args: {
+    service: { ...baseService, status: 'degraded', responseTimeMs: null, tags: ['readiness'] },
+    checkedAt,
+  },
+};
+
+export const Grid: Story = {
+  render: () => (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <ServiceHealthCard
+        service={{ ...baseService, status: 'healthy', responseTimeMs: 42 }}
+        checkedAt={checkedAt}
+      />
+      <ServiceHealthCard
+        service={{
+          ...baseService,
+          id: 'fhir',
+          name: 'FHIR R4 Server',
+          status: 'degraded',
+          responseTimeMs: 920,
+          tags: ['readiness', 'startup'],
+        }}
+        checkedAt={checkedAt}
+      />
+      <ServiceHealthCard
+        service={{
+          ...baseService,
+          id: 'notif',
+          name: 'Notification Service',
+          status: 'down',
+          responseTimeMs: null,
+          tags: ['readiness'],
+        }}
+        checkedAt={checkedAt}
+      />
+    </div>
+  ),
+  parameters: { layout: 'padded' },
+};

--- a/packages/@granit/react-ui-diagnostics/src/components/service-health-card.tsx
+++ b/packages/@granit/react-ui-diagnostics/src/components/service-health-card.tsx
@@ -1,0 +1,102 @@
+import { useDateFormatter, useTranslation } from '@granit/react-localization';
+import { Badge, Card, CardContent, CardHeader, CardTitle } from '@granit/react-ui';
+import { cn } from '@granit/utils';
+import { Activity, CheckCircle2, WifiOff, XCircle } from 'lucide-react';
+
+import type { ServiceHealthResponse, ServiceStatus } from '@granit/diagnostics';
+
+const statusConfig: Record<
+  ServiceStatus,
+  { icon: React.ElementType; colorClass: string; badgeClass: string }
+> = {
+  healthy: {
+    icon: CheckCircle2,
+    colorClass: 'text-success-600',
+    badgeClass: 'border-success-500/25 bg-success-500/15 text-success-600 dark:text-success-500',
+  },
+  degraded: {
+    icon: Activity,
+    colorClass: 'text-warning-600',
+    badgeClass: 'border-warning-500/25 bg-warning-500/15 text-warning-600 dark:text-warning-500',
+  },
+  down: {
+    icon: XCircle,
+    colorClass: 'text-alert-600',
+    badgeClass: 'border-alert-500/25 bg-alert-500/15 text-alert-600 dark:text-alert-500',
+  },
+};
+
+interface ServiceHealthCardProps {
+  service: ServiceHealthResponse;
+  checkedAt: string;
+}
+
+export function ServiceHealthCard({ service, checkedAt }: Readonly<ServiceHealthCardProps>) {
+  const { t } = useTranslation();
+  const { formatTimeAgo } = useDateFormatter();
+  const config = statusConfig[service.status];
+  const StatusIcon = config.icon;
+
+  return (
+    <Card
+      data-slot="service-health-card"
+      data-status={service.status}
+      className={cn(
+        'card-shadow transition-all',
+        service.status === 'down' && 'border-alert-500/40',
+        service.status === 'degraded' && 'border-warning-500/40'
+      )}
+    >
+      <CardHeader className="pb-2">
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="text-sm font-semibold text-foreground">{service.name}</CardTitle>
+          <div className="flex items-center gap-1.5 flex-shrink-0">
+            <StatusIcon className={cn('h-4 w-4', config.colorClass)} aria-hidden="true" />
+            <Badge variant="outline" className={cn('text-xs', config.badgeClass)}>
+              {t(`Diagnostics.Status.${service.status}`)}
+            </Badge>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {service.description && (
+          <p className="text-xs text-muted-foreground">{service.description}</p>
+        )}
+
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>
+            {service.responseTimeMs === null
+              ? '—'
+              : t('Diagnostics.ResponseTime', { ms: service.responseTimeMs })}
+          </span>
+          {service.tags.length > 0 && (
+            <div className="flex gap-1">
+              {service.tags.map((tag) => (
+                <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <p className="text-xs text-muted-foreground/70">
+          {t('Diagnostics.LastChecked', { time: formatTimeAgo(checkedAt) })}
+        </p>
+
+        {service.status === 'down' && (
+          <div
+            className="flex items-center gap-1.5 rounded bg-alert-500/10 px-2 py-1.5"
+            role="alert"
+            aria-live="polite"
+          >
+            <WifiOff className="h-3.5 w-3.5 text-alert-600" aria-hidden="true" />
+            <span className="text-xs font-medium text-alert-600 dark:text-alert-500">
+              {t('Diagnostics.ServiceUnreachable', 'Service unreachable')}
+            </span>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/@granit/react-ui-diagnostics/src/diagnostic-list-page.tsx
+++ b/packages/@granit/react-ui-diagnostics/src/diagnostic-list-page.tsx
@@ -1,0 +1,49 @@
+import { useGranitClient } from '@granit/react-api-client';
+import { useMonitoringHealth } from '@granit/react-diagnostics';
+import { useTranslation } from '@granit/react-localization';
+import { Skeleton } from '@granit/react-ui';
+
+import { AutoRefreshIndicator } from './components/auto-refresh-indicator';
+import { ServiceHealthCard } from './components/service-health-card';
+
+export function DiagnosticListPage() {
+  const { t } = useTranslation();
+  const client = useGranitClient();
+  const { data, isLoading, isFetching, refetch } = useMonitoringHealth({
+    client,
+    refetchInterval: 30_000,
+  });
+
+  return (
+    <div data-slot="diagnostic-list-page" className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold text-foreground">{t('Diagnostics.Title')}</h2>
+          <p className="mt-1 text-sm text-muted-foreground">{t('Diagnostics.Subtitle')}</p>
+        </div>
+        <AutoRefreshIndicator
+          onRefresh={() => {
+            refetch();
+          }}
+          isRefreshing={isFetching}
+        />
+      </div>
+
+      {/* Service health grid */}
+      {isLoading ? (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }, (_, i) => (
+            <Skeleton key={`skeleton-${i}`} className="h-40 w-full rounded-lg" />
+          ))}
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {data?.services.map((service) => (
+            <ServiceHealthCard key={service.id} service={service} checkedAt={data.checkedAt} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-diagnostics/src/index.ts
+++ b/packages/@granit/react-ui-diagnostics/src/index.ts
@@ -1,0 +1,12 @@
+// @granit/react-ui-diagnostics — admin UI for the Granit.Diagnostics module.
+// Composes the headless @granit/react-diagnostics (useMonitoringHealth) with the
+// foundation UI packages. The Axios client resolves from a GranitClientProvider
+// in the host tree.
+
+export { DiagnosticListPage } from './diagnostic-list-page';
+export { ServiceHealthCard } from './components/service-health-card';
+export { AutoRefreshIndicator } from './components/auto-refresh-indicator';
+
+// i18next resource bundles (flat keys, "translation" ns)
+export { diagnosticsTranslationsEn, diagnosticsTranslationsFr } from './locales/index';
+export type { DiagnosticsTranslations } from './locales/index';

--- a/packages/@granit/react-ui-diagnostics/src/locales/en.ts
+++ b/packages/@granit/react-ui-diagnostics/src/locales/en.ts
@@ -1,0 +1,19 @@
+// @granit/react-ui-diagnostics — i18next resource bundle (flat keys, "translation" ns).
+// Register in the host app:
+//   import { diagnosticsTranslationsEn } from "@granit/react-ui-diagnostics";
+//   i18n.addResourceBundle("en", "translation", diagnosticsTranslationsEn, true, true);
+
+export const diagnosticsTranslationsEn = {
+  'Diagnostics.AutoRefresh': 'Auto-refreshes in {{seconds}}s',
+  'Diagnostics.LastChecked': 'Last checked {{time}}',
+  'Diagnostics.RefreshAriaLabel': 'Refresh diagnostics data',
+  'Diagnostics.ResponseTime': '{{ms}}ms',
+  'Diagnostics.ServiceUnreachable': 'Service unreachable',
+  'Diagnostics.Status.degraded': 'Degraded',
+  'Diagnostics.Status.down': 'Down',
+  'Diagnostics.Status.healthy': 'Healthy',
+  'Diagnostics.Subtitle': 'System health and service status overview',
+  'Diagnostics.Title': 'Monitoring',
+} as const;
+
+export type DiagnosticsTranslations = typeof diagnosticsTranslationsEn;

--- a/packages/@granit/react-ui-diagnostics/src/locales/fr.ts
+++ b/packages/@granit/react-ui-diagnostics/src/locales/fr.ts
@@ -1,0 +1,14 @@
+// @granit/react-ui-diagnostics — French resource bundle (flat keys, "translation" ns).
+
+export const diagnosticsTranslationsFr = {
+  'Diagnostics.AutoRefresh': 'Actualisation dans {{seconds}}s',
+  'Diagnostics.LastChecked': 'Vérifié {{time}}',
+  'Diagnostics.RefreshAriaLabel': 'Actualiser les données de diagnostic',
+  'Diagnostics.ResponseTime': '{{ms}}ms',
+  'Diagnostics.ServiceUnreachable': 'Service injoignable',
+  'Diagnostics.Status.degraded': 'Dégradé',
+  'Diagnostics.Status.down': 'Hors service',
+  'Diagnostics.Status.healthy': 'Opérationnel',
+  'Diagnostics.Subtitle': "Santé des services et vue d'ensemble du système",
+  'Diagnostics.Title': 'Supervision',
+} as const;

--- a/packages/@granit/react-ui-diagnostics/src/locales/index.ts
+++ b/packages/@granit/react-ui-diagnostics/src/locales/index.ts
@@ -1,0 +1,3 @@
+export { diagnosticsTranslationsEn } from './en';
+export type { DiagnosticsTranslations } from './en';
+export { diagnosticsTranslationsFr } from './fr';

--- a/packages/@granit/react-ui-diagnostics/tsconfig.json
+++ b/packages/@granit/react-ui-diagnostics/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**", "src/**/*.stories.ts", "src/**/*.stories.tsx"]
+}

--- a/packages/@granit/react-ui-diagnostics/tsup.config.ts
+++ b/packages/@granit/react-ui-diagnostics/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3651,6 +3651,46 @@ importers:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
+  packages/@granit/react-ui-diagnostics:
+    dependencies:
+      lucide-react:
+        specifier: ^1.21.0
+        version: 1.21.0(react@19.2.7)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/diagnostics':
+        specifier: workspace:*
+        version: link:../diagnostics
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-diagnostics':
+        specifier: workspace:*
+        version: link:../react-diagnostics
+      '@granit/react-localization':
+        specifier: workspace:*
+        version: link:../react-localization
+      '@granit/react-ui':
+        specifier: workspace:*
+        version: link:../react-ui
+      '@granit/utils':
+        specifier: workspace:*
+        version: link:../utils
+      '@storybook/react-vite':
+        specifier: ^10.4.6
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(yaml@2.9.0))
+      storybook:
+        specifier: ^10.4.6
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
   packages/@granit/react-ui-hostnames:
     dependencies:
       lucide-react:


### PR DESCRIPTION
## What

Sixth domain-UI backfill module. Extracts the diagnostics (monitoring) admin UI from `granit-showcase-react`.

### `@granit/react-ui-diagnostics` (new)
- `DiagnosticListPage` (service-health card grid + auto-refresh indicator), `ServiceHealthCard`, `AutoRefreshIndicator`.
- Composes headless `@granit/react-diagnostics` (`useMonitoringHealth`) with the foundation UI packages.
- **Decoupling**: client resolves from `GranitClientProvider` (was `@/lib/api`); `cn` from `@granit/utils`. Ships `Diagnostics.*` i18n bundle.

## Verification
- typecheck 0 · lint clean · tsup build · Storybook build
- **21 in-package tests** · arch-tests green (75)

## Notes
- Follows the backfill pattern. Companion showcase MR consumes it (host router) and removes `src/features/diagnostics`.