### PR TITLE
feat(background-jobs): add @granit/react-ui-background-jobs

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -7852,6 +7852,47 @@
       ]
     },
     {
+      "name": "@granit/react-ui-background-jobs",
+      "description": "Granit admin UI for the Background Jobs module — the recurring-jobs monitoring page (list + kanban), status badge, per-job actions and cron-expression rendering. Composes @granit/react-background-jobs (headless) with the foundation UI packages.",
+      "exports": [
+        {
+          "name": "BackgroundJobListPage",
+          "kind": "function",
+          "signature": "function BackgroundJobListPage()"
+        },
+        {
+          "name": "JobCard",
+          "kind": "function",
+          "signature": "function JobCard("
+        },
+        {
+          "name": "JobActions",
+          "kind": "function",
+          "signature": "function JobActions("
+        },
+        {
+          "name": "JobStatusBadge",
+          "kind": "function",
+          "signature": "function JobStatusBadge("
+        },
+        {
+          "name": "createBackgroundJobColumns",
+          "kind": "function",
+          "signature": "function createBackgroundJobColumns("
+        },
+        {
+          "name": "getCronstrueLocale",
+          "kind": "function",
+          "signature": "function getCronstrueLocale(language: string): string"
+        },
+        {
+          "name": "loadCronstrueLocale",
+          "kind": "function",
+          "signature": "async function loadCronstrueLocale(language: string): Promise<void>"
+        }
+      ]
+    },
+    {
       "name": "@granit/react-ui-customer-balance",
       "description": "Granit admin UI for the Customer Balance module — balance page, summary card, transaction table and admin credit/debit dialogs. Composes @granit/react-customer-balance (headless) with the foundation UI packages.",
       "exports": [

--- a/packages/@granit/react-ui-background-jobs/README.md
+++ b/packages/@granit/react-ui-background-jobs/README.md
@@ -1,0 +1,40 @@
+# @granit/react-ui-background-jobs
+
+Admin UI for the **Background Jobs** module — the recurring-jobs monitoring page
+(a sortable list plus a kanban view of job cards), a status badge, per-job
+actions (pause / resume / trigger) and human-readable cron-expression rendering.
+
+The **visual** layer for background jobs: it composes the headless
+[`@granit/react-background-jobs`](../react-background-jobs) (data hooks +
+provider) with the foundation UI packages ([`@granit/react-ui`](../react-ui),
+[`@granit/react-ui-admin-kit`](../react-ui-admin-kit)).
+
+## Usage
+
+```tsx
+import {
+  BackgroundJobListPage,
+  backgroundJobsTranslationsEn,
+  loadCronstrueLocale,
+} from '@granit/react-ui-background-jobs';
+
+i18n.addResourceBundle('en', 'translation', backgroundJobsTranslationsEn, true, true);
+
+// Load the cronstrue locale data on language change (the module is the only
+// cronstrue consumer, so it owns the mapping).
+i18n.on('languageChanged', (lng) => void loadCronstrueLocale(lng));
+
+<Route path="/background-jobs" element={<BackgroundJobListPage />} />;
+```
+
+## Injection
+
+- **API client** — resolved from a `GranitClientProvider`
+  (`@granit/react-api-client`) higher in the tree (`useGranitClient`), then handed
+  to the headless `BackgroundJobsProvider`. No client is baked in.
+- **i18n** — ships its `BackgroundJobs.*` strings
+  (`backgroundJobsTranslationsEn/Fr`); the host registers them. `Common.*` keys
+  are app-global.
+- **Cron rendering** — `getCronstrueLocale` / `loadCronstrueLocale` map BCP 47
+  tags to cronstrue locale files; the host wires `loadCronstrueLocale` to its
+  `languageChanged` event.

--- a/packages/@granit/react-ui-background-jobs/package.json
+++ b/packages/@granit/react-ui-background-jobs/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@granit/react-ui-background-jobs",
+  "description": "Granit admin UI for the Background Jobs module — the recurring-jobs monitoring page (list + kanban), status badge, per-job actions and cron-expression rendering. Composes @granit/react-background-jobs (headless) with the foundation UI packages.",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/background-jobs": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-background-jobs": "workspace:*",
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/react-ui-admin-kit": "workspace:*",
+    "@granit/utils": "workspace:*",
+    "@tanstack/react-table": "^8.21.3",
+    "cronstrue": "^3.20.0",
+    "lucide-react": "^1.21.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/background-jobs": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-background-jobs": "workspace:*",
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/react-ui-admin-kit": "workspace:*",
+    "@granit/types": "workspace:*",
+    "@granit/utils": "workspace:*",
+    "@storybook/react-vite": "^10.4.6",
+    "@tanstack/react-query": "^5.0.0",
+    "@tanstack/react-table": "^8.21.3",
+    "cronstrue": "^3.20.0",
+    "storybook": "^10.4.6"
+  }
+}

--- a/packages/@granit/react-ui-background-jobs/src/__tests__/background-job-list-page.test.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/__tests__/background-job-list-page.test.tsx
@@ -1,0 +1,72 @@
+import { toISODateString } from '@granit/types';
+import { screen } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { BackgroundJobListPage } from '../background-job-list-page';
+
+import { renderBackgroundJobs } from './test-utils';
+
+import type { BackgroundJobStatus } from '@granit/background-jobs';
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+const mockJobs: BackgroundJobStatus[] = [
+  {
+    jobName: 'NotificationDigestJob',
+    cronExpression: '0 */5 * * * ?',
+    isEnabled: true,
+    lastExecutedAt: toISODateString('2026-04-02T12:00:00Z'),
+    nextExecutionAt: toISODateString('2026-04-02T12:05:00Z'),
+    consecutiveFailures: 0,
+    deadLetterCount: 0,
+    lastError: null,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Mocks — the page consumes the @granit/react-background-jobs hooks directly
+// (simple pagination, no query-engine). BackgroundJobsProvider is stubbed to a
+// passthrough; useGranitClient still resolves from the real GranitClientProvider.
+// ---------------------------------------------------------------------------
+
+vi.mock('@granit/react-background-jobs', () => ({
+  BackgroundJobsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useBackgroundJobs: () => ({
+    data: { items: mockJobs, totalCount: mockJobs.length },
+    isLoading: false,
+    isFetching: false,
+    refetch: vi.fn(),
+  }),
+  usePauseJob: () => ({ mutate: vi.fn(), isPending: false }),
+  useResumeJob: () => ({ mutate: vi.fn(), isPending: false }),
+  useTriggerJob: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('BackgroundJobListPage', () => {
+  it('should render the page title', () => {
+    renderBackgroundJobs(<BackgroundJobListPage />);
+    expect(screen.getByText('Background Jobs')).toBeInTheDocument();
+  });
+
+  it('should render the subtitle', () => {
+    renderBackgroundJobs(<BackgroundJobListPage />);
+    expect(screen.getByText('Monitor and manage recurring system tasks')).toBeInTheDocument();
+  });
+
+  it('should render refresh button', () => {
+    renderBackgroundJobs(<BackgroundJobListPage />);
+    expect(screen.getByText('Refresh')).toBeInTheDocument();
+  });
+
+  it('should have data-slot attribute', () => {
+    renderBackgroundJobs(<BackgroundJobListPage />);
+    expect(document.querySelector('[data-slot="background-job-list-page"]')).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-background-jobs/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/__tests__/test-utils.tsx
@@ -1,0 +1,53 @@
+import { createApiClient } from '@granit/api-client';
+import { GranitClientProvider } from '@granit/react-api-client';
+import { TooltipProvider } from '@granit/react-ui';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import i18next from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+
+import { backgroundJobsTranslationsEn } from '../locales';
+
+import type { ReactElement, ReactNode } from 'react';
+
+// Local UI render helper. The page test stubs the data layer (vi.mock
+// @granit/react-background-jobs in-workspace); the page resolves an Axios client
+// via useGranitClient, so a GranitClientProvider is supplied. i18n uses the
+// package's own flat bundle plus the few app-global Common.* keys the page renders.
+const testI18n = i18next.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  ns: ['translation'],
+  defaultNS: 'translation',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: {
+    en: {
+      translation: {
+        ...backgroundJobsTranslationsEn,
+        'Common.Refresh': 'Refresh',
+        'Common.ViewList': 'List',
+        'Common.ViewKanban': 'Kanban',
+      },
+    },
+  },
+  interpolation: { escapeValue: false },
+});
+
+const client = createApiClient({ baseURL: '' });
+
+export function renderBackgroundJobs(ui: ReactElement) {
+  return {
+    ...render(ui, {
+      wrapper: ({ children }: { readonly children: ReactNode }) => (
+        <I18nextProvider i18n={testI18n}>
+          <GranitClientProvider client={client}>
+            <TooltipProvider>{children}</TooltipProvider>
+          </GranitClientProvider>
+        </I18nextProvider>
+      ),
+    }),
+    user: userEvent.setup(),
+  };
+}

--- a/packages/@granit/react-ui-background-jobs/src/background-job-list-page.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/background-job-list-page.tsx
@@ -1,0 +1,158 @@
+import { useGranitClient } from '@granit/react-api-client';
+import {
+  BackgroundJobsProvider,
+  useBackgroundJobs,
+  usePauseJob,
+  useResumeJob,
+  useTriggerJob,
+} from '@granit/react-background-jobs';
+import { useDateFormatter, useTranslation } from '@granit/react-localization';
+import { Button, Card, CardContent, Spinner } from '@granit/react-ui';
+import { ManualDataTable, ViewSwitcher } from '@granit/react-ui-admin-kit';
+import { RotateCw } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+
+import { createBackgroundJobColumns } from './components/background-job-columns';
+import { JobCard } from './components/job-card';
+
+import type { BackgroundJobStatus } from '@granit/background-jobs';
+import type { ViewMode } from '@granit/react-ui-admin-kit';
+
+// ---------------------------------------------------------------------------
+// Kanban view
+// ---------------------------------------------------------------------------
+
+function JobKanbanView({ jobs }: Readonly<{ jobs: readonly BackgroundJobStatus[] }>) {
+  return (
+    <div data-slot="job-kanban-view" className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {jobs.map((job) => (
+        <JobCard key={job.jobName} job={job} />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
+export function BackgroundJobListPage() {
+  // The Axios client is resolved from the GranitClientProvider in the host tree
+  // and handed to the headless data provider — no `@/lib/api` coupling.
+  const client = useGranitClient();
+  return (
+    <BackgroundJobsProvider config={{ client }}>
+      <BackgroundJobListPageContent />
+    </BackgroundJobsProvider>
+  );
+}
+
+function BackgroundJobListPageContent() {
+  const { t, i18n } = useTranslation();
+  const { formatDateTime, formatTimeAgo } = useDateFormatter();
+  const [view, setView] = useState<ViewMode>('list');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
+  const { data, isLoading, isFetching, refetch } = useBackgroundJobs({ page, pageSize });
+
+  // Mutations
+  const pauseJob = usePauseJob();
+  const resumeJob = useResumeJob();
+  const triggerJob = useTriggerJob();
+  const isMutating = pauseJob.isPending || resumeJob.isPending || triggerJob.isPending;
+
+  const handlePause = useCallback(
+    (job: BackgroundJobStatus) => pauseJob.mutate(job.jobName),
+    [pauseJob]
+  );
+  const handleResume = useCallback(
+    (job: BackgroundJobStatus) => resumeJob.mutate(job.jobName),
+    [resumeJob]
+  );
+  const handleTrigger = useCallback(
+    (job: BackgroundJobStatus) => triggerJob.mutate(job.jobName),
+    [triggerJob]
+  );
+
+  const columns = useMemo(
+    () =>
+      createBackgroundJobColumns({
+        t,
+        locale: i18n.language,
+        formatDateTime,
+        formatTimeAgo,
+        onPause: handlePause,
+        onResume: handleResume,
+        onTrigger: handleTrigger,
+        isMutating,
+      }),
+    [
+      t,
+      i18n.language,
+      formatDateTime,
+      formatTimeAgo,
+      handlePause,
+      handleResume,
+      handleTrigger,
+      isMutating,
+    ]
+  );
+
+  const jobs = data?.items ?? [];
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div data-slot="background-job-list-page" className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold text-foreground">{t('BackgroundJobs.Title')}</h2>
+          <p className="mt-1 text-sm text-muted-foreground">{t('BackgroundJobs.Subtitle')}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <ViewSwitcher view={view} onViewChange={setView} />
+          <Button variant="outline" size="sm" disabled={isFetching} onClick={() => refetch()}>
+            <RotateCw className={`size-4 ${isFetching ? 'animate-spin' : ''}`} />
+            {t('Common.Refresh')}
+          </Button>
+        </div>
+      </div>
+
+      {/* Kanban view */}
+      {view === 'kanban' && jobs.length > 0 && <JobKanbanView jobs={jobs} />}
+      {view === 'kanban' && jobs.length === 0 && (
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            {t('BackgroundJobs.NoJobs')}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* List view */}
+      {view !== 'kanban' && (
+        <ManualDataTable
+          columns={columns}
+          data={jobs}
+          totalCount={data?.totalCount ?? 0}
+          page={page}
+          pageSize={pageSize}
+          pageSizes={[10, 20, 50]}
+          onPageChange={setPage}
+          onPageSizeChange={(size) => {
+            setPageSize(size);
+            setPage(1);
+          }}
+          hidePaginationOnSinglePage
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-background-jobs/src/components/background-job-columns.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/components/background-job-columns.tsx
@@ -1,0 +1,224 @@
+import {
+  Badge,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@granit/react-ui';
+import { cn } from '@granit/utils';
+import cronstrue from 'cronstrue';
+import { AlertTriangle, Clock, MoreHorizontal, Pause, Play, Zap } from 'lucide-react';
+
+import { getCronstrueLocale } from '../cronstrue-locale';
+
+import type { BackgroundJobStatus } from '@granit/background-jobs';
+import type { useTranslation } from '@granit/react-localization';
+import type { ColumnDef } from '@tanstack/react-table';
+
+// Derive the translate function type from the localization hook rather than
+// importing `TFunction` from i18next directly — keeps the column factory immune
+// to i18next major-version skew between linked workspace packages.
+type TranslateFn = ReturnType<typeof useTranslation>['t'];
+
+interface BackgroundJobColumnOptions {
+  readonly t: TranslateFn;
+  readonly locale: string;
+  readonly formatDateTime: (date: string | Date) => string;
+  readonly formatTimeAgo: (date: string | Date) => string;
+  readonly onPause: (job: BackgroundJobStatus) => void;
+  readonly onResume: (job: BackgroundJobStatus) => void;
+  readonly onTrigger: (job: BackgroundJobStatus) => void;
+  readonly isMutating?: boolean;
+}
+
+function getStatusVariant(job: BackgroundJobStatus) {
+  if (!job.isEnabled) return 'secondary' as const;
+  if (job.consecutiveFailures > 0) return 'destructive' as const;
+  return 'default' as const;
+}
+
+export function createBackgroundJobColumns({
+  t,
+  locale,
+  formatDateTime,
+  formatTimeAgo,
+  onPause,
+  onResume,
+  onTrigger,
+  isMutating,
+}: BackgroundJobColumnOptions): ColumnDef<BackgroundJobStatus, unknown>[] {
+  return [
+    {
+      id: 'jobName',
+      accessorKey: 'jobName',
+      header: t('BackgroundJobs.Columns.JobName'),
+      enableSorting: true,
+      cell: ({ row }) => (
+        <span className="font-mono text-sm font-medium text-foreground">
+          {row.original.jobName}
+        </span>
+      ),
+    },
+    {
+      id: 'cronExpression',
+      accessorKey: 'cronExpression',
+      header: t('BackgroundJobs.Columns.CronExpression'),
+      enableSorting: false,
+      cell: ({ row }) => {
+        const expr = row.original.cronExpression;
+        const human = cronstrue.toString(expr, {
+          locale: getCronstrueLocale(locale),
+          throwExceptionOnParseError: false,
+        });
+        return (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="flex cursor-default items-center gap-1.5 text-sm text-muted-foreground">
+                <Clock className="size-3.5 shrink-0" />
+                {human}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <span className="font-mono">{expr}</span>
+            </TooltipContent>
+          </Tooltip>
+        );
+      },
+    },
+    {
+      id: 'isEnabled',
+      accessorKey: 'isEnabled',
+      header: t('BackgroundJobs.Columns.Status'),
+      enableSorting: false,
+      cell: ({ row }) => {
+        const job = row.original;
+        const variant = getStatusVariant(job);
+        let label: string;
+        if (job.isEnabled) {
+          label =
+            job.consecutiveFailures > 0
+              ? t('BackgroundJobs.Status.Failing')
+              : t('BackgroundJobs.Status.Active');
+        } else {
+          label = t('BackgroundJobs.Status.Paused');
+        }
+        return (
+          <Badge
+            variant={variant}
+            className={cn(
+              'text-xs',
+              variant === 'default' &&
+                'bg-success-500/15 text-success-600 dark:text-success-500 border-success-500/25'
+            )}
+          >
+            {label}
+          </Badge>
+        );
+      },
+    },
+    {
+      id: 'lastExecutedAt',
+      accessorKey: 'lastExecutedAt',
+      header: t('BackgroundJobs.Columns.LastExecution'),
+      enableSorting: true,
+      cell: ({ row }) => (
+        <span className="text-sm text-muted-foreground">
+          {row.original.lastExecutedAt
+            ? formatTimeAgo(row.original.lastExecutedAt)
+            : t('BackgroundJobs.Never')}
+        </span>
+      ),
+    },
+    {
+      id: 'nextExecutionAt',
+      accessorKey: 'nextExecutionAt',
+      header: t('BackgroundJobs.Columns.NextExecution'),
+      enableSorting: true,
+      cell: ({ row }) => (
+        <span className="text-sm text-muted-foreground">
+          {row.original.nextExecutionAt
+            ? formatDateTime(row.original.nextExecutionAt)
+            : t('BackgroundJobs.NotScheduled')}
+        </span>
+      ),
+    },
+    {
+      id: 'consecutiveFailures',
+      accessorKey: 'consecutiveFailures',
+      header: t('BackgroundJobs.Columns.Failures'),
+      enableSorting: true,
+      cell: ({ row }) => {
+        const job = row.original;
+        if (job.consecutiveFailures === 0 && job.deadLetterCount === 0) return null;
+        return (
+          <div className="space-y-0.5">
+            {job.consecutiveFailures > 0 && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="flex items-center gap-1 text-destructive">
+                    <AlertTriangle className="size-3.5" />
+                    {job.consecutiveFailures}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {job.lastError ?? t('BackgroundJobs.Status.Failing')}
+                </TooltipContent>
+              </Tooltip>
+            )}
+            {job.deadLetterCount > 0 && (
+              <span className="text-xs text-orange-700 dark:text-orange-400">
+                {t('BackgroundJobs.DeadLetters', { count: job.deadLetterCount })}
+              </span>
+            )}
+          </div>
+        );
+      },
+    },
+    {
+      id: 'actions',
+      header: '',
+      enableSorting: false,
+      cell: ({ row }) => {
+        const job = row.original;
+        return (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                aria-label={`Actions for ${job.jobName}`}
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {job.isEnabled ? (
+                <DropdownMenuItem disabled={isMutating} onClick={() => onPause(job)}>
+                  <Pause className="mr-2 size-4" />
+                  {t('BackgroundJobs.Actions.Pause')}
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem disabled={isMutating} onClick={() => onResume(job)}>
+                  <Play className="mr-2 size-4" />
+                  {t('BackgroundJobs.Actions.Resume')}
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuItem
+                disabled={isMutating || !job.isEnabled}
+                onClick={() => onTrigger(job)}
+              >
+                <Zap className="mr-2 size-4" />
+                {t('BackgroundJobs.Actions.Trigger')}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        );
+      },
+    },
+  ];
+}

--- a/packages/@granit/react-ui-background-jobs/src/components/job-actions.stories.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/components/job-actions.stories.tsx
@@ -1,0 +1,42 @@
+import { createApiClient } from '@granit/api-client';
+import { BackgroundJobsProvider } from '@granit/react-background-jobs';
+import { mockBackgroundJobs } from '@granit/react-background-jobs/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { JobActions } from './job-actions';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const client = createApiClient({ baseURL: '' });
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const meta: Meta<typeof JobActions> = {
+  title: 'BackgroundJobs/JobActions',
+  component: JobActions,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <BackgroundJobsProvider config={{ client }}>
+          <Story />
+        </BackgroundJobsProvider>
+      </QueryClientProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** An enabled job exposes Pause + Trigger. */
+export const Enabled: Story = {
+  args: { job: mockBackgroundJobs[0] },
+};
+
+/** A disabled job exposes Resume; Trigger is disabled until re-enabled. */
+export const Disabled: Story = {
+  args: { job: { ...mockBackgroundJobs[0], isEnabled: false } },
+};

--- a/packages/@granit/react-ui-background-jobs/src/components/job-actions.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/components/job-actions.tsx
@@ -1,0 +1,63 @@
+import { usePauseJob, useResumeJob, useTriggerJob } from '@granit/react-background-jobs';
+import { useTranslation } from '@granit/react-localization';
+import { Button, Tooltip, TooltipContent, TooltipTrigger } from '@granit/react-ui';
+import { Pause, Play, Zap } from 'lucide-react';
+
+import type { BackgroundJobStatus } from '@granit/background-jobs';
+
+export function JobActions({ job }: Readonly<{ job: BackgroundJobStatus }>) {
+  const { t } = useTranslation();
+  const pauseJob = usePauseJob();
+  const resumeJob = useResumeJob();
+  const triggerJob = useTriggerJob();
+
+  const isMutating = pauseJob.isPending || resumeJob.isPending || triggerJob.isPending;
+
+  return (
+    <div data-slot="job-actions" className="flex gap-1">
+      {job.isEnabled ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={isMutating}
+              onClick={() => pauseJob.mutate(job.jobName)}
+            >
+              <Pause className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('BackgroundJobs.Actions.Pause')}</TooltipContent>
+        </Tooltip>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={isMutating}
+              onClick={() => resumeJob.mutate(job.jobName)}
+            >
+              <Play className="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('BackgroundJobs.Actions.Resume')}</TooltipContent>
+        </Tooltip>
+      )}
+
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={isMutating || !job.isEnabled}
+            onClick={() => triggerJob.mutate(job.jobName)}
+          >
+            <Zap className="size-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{t('BackgroundJobs.Actions.Trigger')}</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-background-jobs/src/components/job-card.stories.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/components/job-card.stories.tsx
@@ -1,0 +1,49 @@
+import { createApiClient } from '@granit/api-client';
+import { BackgroundJobsProvider } from '@granit/react-background-jobs';
+import { mockBackgroundJobs } from '@granit/react-background-jobs/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { JobCard } from './job-card';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const client = createApiClient({ baseURL: '' });
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const meta: Meta<typeof JobCard> = {
+  title: 'BackgroundJobs/JobCard',
+  component: JobCard,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <BackgroundJobsProvider config={{ client }}>
+          <div className="w-96">
+            <Story />
+          </div>
+        </BackgroundJobsProvider>
+      </QueryClientProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A healthy, scheduled job. */
+export const Healthy: Story = {
+  args: { job: mockBackgroundJobs[0] },
+};
+
+/** A failing job — consecutive failures and a dead-letter count surface inline. */
+export const Failing: Story = {
+  args: { job: mockBackgroundJobs[2] },
+};
+
+/** A disabled job renders dimmed with no next execution. */
+export const Disabled: Story = {
+  args: { job: mockBackgroundJobs[3] },
+};

--- a/packages/@granit/react-ui-background-jobs/src/components/job-card.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/components/job-card.tsx
@@ -1,0 +1,103 @@
+import { useDateFormatter, useTranslation } from '@granit/react-localization';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@granit/react-ui';
+import { cn } from '@granit/utils';
+import cronstrue from 'cronstrue';
+import { AlertTriangle, Clock } from 'lucide-react';
+
+import { getCronstrueLocale } from '../cronstrue-locale';
+
+import { JobActions } from './job-actions';
+import { JobStatusBadge } from './job-status-badge';
+
+import type { BackgroundJobStatus } from '@granit/background-jobs';
+
+export function JobCard({ job }: Readonly<{ job: BackgroundJobStatus }>) {
+  const { t, i18n } = useTranslation();
+  const { formatDateTime, formatTimeAgo } = useDateFormatter();
+  const cronHuman = cronstrue.toString(job.cronExpression, {
+    locale: getCronstrueLocale(i18n.language),
+    throwExceptionOnParseError: false,
+  });
+
+  return (
+    <Card
+      data-slot="job-card"
+      className={cn(
+        job.consecutiveFailures > 0 && 'border-destructive/50',
+        job.isEnabled || 'opacity-70'
+      )}
+    >
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between">
+          <div className="space-y-1">
+            <CardTitle className="font-mono text-sm">{job.jobName}</CardTitle>
+            <CardDescription className="flex items-center gap-1.5">
+              <Clock className="size-3.5 shrink-0" />
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="cursor-default">{cronHuman}</span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <span className="font-mono">{job.cronExpression}</span>
+                </TooltipContent>
+              </Tooltip>
+            </CardDescription>
+          </div>
+          <JobStatusBadge job={job} />
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-3">
+        <div className="grid grid-cols-2 gap-2 text-sm">
+          <div>
+            <p className="text-muted-foreground">{t('BackgroundJobs.LastExecution')}</p>
+            <p className="font-medium">
+              {job.lastExecutedAt ? formatTimeAgo(job.lastExecutedAt) : t('BackgroundJobs.Never')}
+            </p>
+          </div>
+          <div>
+            <p className="text-muted-foreground">{t('BackgroundJobs.NextExecution')}</p>
+            <p className="font-medium">
+              {job.nextExecutionAt
+                ? formatDateTime(job.nextExecutionAt)
+                : t('BackgroundJobs.NotScheduled')}
+            </p>
+          </div>
+        </div>
+
+        {job.consecutiveFailures > 0 && (
+          <div className="rounded-md bg-destructive/10 p-2 text-sm">
+            <div className="flex items-center gap-1.5 font-medium text-destructive">
+              <AlertTriangle className="size-3.5" />
+              {t('BackgroundJobs.Failures', { count: job.consecutiveFailures })}
+            </div>
+            {job.lastError && (
+              <p className="mt-1 truncate font-mono text-xs text-destructive/80">{job.lastError}</p>
+            )}
+          </div>
+        )}
+
+        {job.deadLetterCount > 0 && (
+          <div className="rounded-md bg-warning-500/10 p-2 text-sm">
+            <p className="font-medium text-warning-600 dark:text-warning-500">
+              {t('BackgroundJobs.DeadLetters', { count: job.deadLetterCount })}
+            </p>
+          </div>
+        )}
+
+        <div className="pt-1">
+          <JobActions job={job} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/@granit/react-ui-background-jobs/src/components/job-status-badge.stories.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/components/job-status-badge.stories.tsx
@@ -1,0 +1,61 @@
+import { JobStatusBadge } from './job-status-badge';
+
+import type { BackgroundJobStatus } from '@granit/background-jobs';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const baseJob: BackgroundJobStatus = {
+  jobName: 'invoice-reminder-dispatch',
+  cronExpression: '0 */15 * * * *',
+  isEnabled: true,
+  lastExecutedAt: '2026-06-21T09:45:00Z',
+  nextExecutionAt: '2026-06-21T10:00:00Z',
+  consecutiveFailures: 0,
+  deadLetterCount: 0,
+  lastError: null,
+};
+
+const activeJob: BackgroundJobStatus = baseJob;
+
+const failingJob: BackgroundJobStatus = {
+  ...baseJob,
+  jobName: 'webhook-delivery-retry',
+  consecutiveFailures: 3,
+  deadLetterCount: 2,
+  lastError: 'Connection timed out after 30s',
+};
+
+const pausedJob: BackgroundJobStatus = {
+  ...baseJob,
+  jobName: 'nightly-data-export',
+  cronExpression: '0 0 2 * * *',
+  isEnabled: false,
+  nextExecutionAt: null,
+};
+
+const meta: Meta<typeof JobStatusBadge> = {
+  title: 'BackgroundJobs/JobStatusBadge',
+  component: JobStatusBadge,
+  tags: ['autodocs'],
+  argTypes: {
+    job: {
+      control: 'object',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Active: Story = { args: { job: activeJob } };
+export const Failing: Story = { args: { job: failingJob } };
+export const Paused: Story = { args: { job: pausedJob } };
+
+export const All: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <JobStatusBadge job={activeJob} />
+      <JobStatusBadge job={failingJob} />
+      <JobStatusBadge job={pausedJob} />
+    </div>
+  ),
+};

--- a/packages/@granit/react-ui-background-jobs/src/components/job-status-badge.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/components/job-status-badge.tsx
@@ -1,0 +1,32 @@
+import { useTranslation } from '@granit/react-localization';
+import { Badge } from '@granit/react-ui';
+
+import type { BackgroundJobStatus } from '@granit/background-jobs';
+
+export function JobStatusBadge({ job }: Readonly<{ job: BackgroundJobStatus }>) {
+  const { t } = useTranslation();
+
+  if (!job.isEnabled) {
+    return (
+      <Badge data-slot="job-status-badge" variant="secondary">
+        {t('BackgroundJobs.Status.Paused')}
+      </Badge>
+    );
+  }
+  if (job.consecutiveFailures > 0) {
+    return (
+      <Badge data-slot="job-status-badge" variant="destructive">
+        {t('BackgroundJobs.Status.Failing')}
+      </Badge>
+    );
+  }
+  return (
+    <Badge
+      data-slot="job-status-badge"
+      variant="default"
+      className="border-success-500/25 bg-success-500/15 text-success-600 hover:bg-success-500/25 dark:text-success-500"
+    >
+      {t('BackgroundJobs.Status.Active')}
+    </Badge>
+  );
+}

--- a/packages/@granit/react-ui-background-jobs/src/cronstrue-locale.ts
+++ b/packages/@granit/react-ui-background-jobs/src/cronstrue-locale.ts
@@ -1,5 +1,3 @@
-/// <reference path="./cronstrue-locales.d.ts" />
-
 /**
  * Maps BCP 47 language tags to cronstrue locale file names.
  * cronstrue uses underscores for regional variants (pt_BR, zh_CN, zh_TW).

--- a/packages/@granit/react-ui-background-jobs/src/cronstrue-locale.ts
+++ b/packages/@granit/react-ui-background-jobs/src/cronstrue-locale.ts
@@ -1,3 +1,5 @@
+/// <reference path="./cronstrue-locales.d.ts" />
+
 /**
  * Maps BCP 47 language tags to cronstrue locale file names.
  * cronstrue uses underscores for regional variants (pt_BR, zh_CN, zh_TW).

--- a/packages/@granit/react-ui-background-jobs/src/cronstrue-locale.ts
+++ b/packages/@granit/react-ui-background-jobs/src/cronstrue-locale.ts
@@ -1,0 +1,185 @@
+/**
+ * Maps BCP 47 language tags to cronstrue locale file names.
+ * cronstrue uses underscores for regional variants (pt_BR, zh_CN, zh_TW).
+ * Tags without a dedicated cronstrue file fall back to their base language (es-MX → es).
+ * hi (Hindi) has no cronstrue locale — falls back to 'en' via the ?? 'en' default.
+ */
+const LOCALE_MAP: Record<string, string> = {
+  af: 'af',
+  ar: 'ar',
+  be: 'be',
+  bg: 'bg',
+  ca: 'ca',
+  cs: 'cs',
+  da: 'da',
+  de: 'de',
+  en: 'en',
+  'en-GB': 'en',
+  es: 'es',
+  'es-MX': 'es',
+  fa: 'fa',
+  fi: 'fi',
+  fr: 'fr',
+  'fr-CA': 'fr',
+  he: 'he',
+  hr: 'hr',
+  hu: 'hu',
+  id: 'id',
+  it: 'it',
+  ja: 'ja',
+  ko: 'ko',
+  my: 'my',
+  nb: 'nb',
+  nl: 'nl',
+  pl: 'pl',
+  pt: 'pt_PT',
+  'pt-BR': 'pt_BR',
+  ro: 'ro',
+  ru: 'ru',
+  sk: 'sk',
+  sl: 'sl',
+  sr: 'sr',
+  sv: 'sv',
+  sw: 'sw',
+  th: 'th',
+  tr: 'tr',
+  uk: 'uk',
+  vi: 'vi',
+  zh: 'zh_CN',
+  'zh-TW': 'zh_TW',
+};
+
+const loaded = new Set<string>();
+
+/** Returns the cronstrue locale name for a given BCP 47 language tag. */
+export function getCronstrueLocale(language: string): string {
+  const base = language.split('-')[0] ?? language;
+  return LOCALE_MAP[language] ?? LOCALE_MAP[base] ?? 'en';
+}
+
+/** Lazily imports a cronstrue locale file. No-ops if already loaded. */
+export async function loadCronstrueLocale(language: string): Promise<void> {
+  const locale = getCronstrueLocale(language);
+  if (loaded.has(locale)) return;
+  loaded.add(locale);
+  // Explicit static imports so Vite can resolve bare specifiers at build time.
+  switch (locale) {
+    case 'af':
+      await import('cronstrue/locales/af');
+      break;
+    case 'ar':
+      await import('cronstrue/locales/ar');
+      break;
+    case 'be':
+      await import('cronstrue/locales/be');
+      break;
+    case 'bg':
+      await import('cronstrue/locales/bg');
+      break;
+    case 'ca':
+      await import('cronstrue/locales/ca');
+      break;
+    case 'cs':
+      await import('cronstrue/locales/cs');
+      break;
+    case 'da':
+      await import('cronstrue/locales/da');
+      break;
+    case 'de':
+      await import('cronstrue/locales/de');
+      break;
+    case 'en':
+      await import('cronstrue/locales/en');
+      break;
+    case 'es':
+      await import('cronstrue/locales/es');
+      break;
+    case 'fa':
+      await import('cronstrue/locales/fa');
+      break;
+    case 'fi':
+      await import('cronstrue/locales/fi');
+      break;
+    case 'fr':
+      await import('cronstrue/locales/fr');
+      break;
+    case 'he':
+      await import('cronstrue/locales/he');
+      break;
+    case 'hr':
+      await import('cronstrue/locales/hr');
+      break;
+    case 'hu':
+      await import('cronstrue/locales/hu');
+      break;
+    case 'id':
+      await import('cronstrue/locales/id');
+      break;
+    case 'it':
+      await import('cronstrue/locales/it');
+      break;
+    case 'ja':
+      await import('cronstrue/locales/ja');
+      break;
+    case 'ko':
+      await import('cronstrue/locales/ko');
+      break;
+    case 'my':
+      await import('cronstrue/locales/my');
+      break;
+    case 'nb':
+      await import('cronstrue/locales/nb');
+      break;
+    case 'nl':
+      await import('cronstrue/locales/nl');
+      break;
+    case 'pl':
+      await import('cronstrue/locales/pl');
+      break;
+    case 'pt_PT':
+      await import('cronstrue/locales/pt_PT');
+      break;
+    case 'pt_BR':
+      await import('cronstrue/locales/pt_BR');
+      break;
+    case 'ro':
+      await import('cronstrue/locales/ro');
+      break;
+    case 'ru':
+      await import('cronstrue/locales/ru');
+      break;
+    case 'sk':
+      await import('cronstrue/locales/sk');
+      break;
+    case 'sl':
+      await import('cronstrue/locales/sl');
+      break;
+    case 'sr':
+      await import('cronstrue/locales/sr');
+      break;
+    case 'sv':
+      await import('cronstrue/locales/sv');
+      break;
+    case 'sw':
+      await import('cronstrue/locales/sw');
+      break;
+    case 'th':
+      await import('cronstrue/locales/th');
+      break;
+    case 'tr':
+      await import('cronstrue/locales/tr');
+      break;
+    case 'uk':
+      await import('cronstrue/locales/uk');
+      break;
+    case 'vi':
+      await import('cronstrue/locales/vi');
+      break;
+    case 'zh_CN':
+      await import('cronstrue/locales/zh_CN');
+      break;
+    case 'zh_TW':
+      await import('cronstrue/locales/zh_TW');
+      break;
+  }
+}

--- a/packages/@granit/react-ui-background-jobs/src/cronstrue-locales.d.ts
+++ b/packages/@granit/react-ui-background-jobs/src/cronstrue-locales.d.ts
@@ -1,0 +1,4 @@
+// cronstrue ships its locale files under `cronstrue/locales/*` (e.g. `cronstrue/locales/fr`)
+// without bundled type declarations. `loadCronstrueLocale` dynamic-imports them for their
+// registration side effect only, so a wildcard ambient module declaration is enough.
+declare module 'cronstrue/locales/*';

--- a/packages/@granit/react-ui-background-jobs/src/index.ts
+++ b/packages/@granit/react-ui-background-jobs/src/index.ts
@@ -1,0 +1,18 @@
+// @granit/react-ui-background-jobs — admin UI for the Granit.BackgroundJobs module.
+// Composes the headless @granit/react-background-jobs (data hooks + provider) with
+// the foundation UI packages. The Axios client resolves from a GranitClientProvider
+// in the host tree.
+
+export { BackgroundJobListPage } from './background-job-list-page';
+export { JobCard } from './components/job-card';
+export { JobActions } from './components/job-actions';
+export { JobStatusBadge } from './components/job-status-badge';
+export { createBackgroundJobColumns } from './components/background-job-columns';
+
+// Cron-expression rendering helpers. The module is the only cronstrue consumer, so
+// it owns the locale mapping; the host calls `loadCronstrueLocale` on language change.
+export { getCronstrueLocale, loadCronstrueLocale } from './cronstrue-locale';
+
+// i18next resource bundles (flat keys, "translation" ns)
+export { backgroundJobsTranslationsEn, backgroundJobsTranslationsFr } from './locales/index';
+export type { BackgroundJobsTranslations } from './locales/index';

--- a/packages/@granit/react-ui-background-jobs/src/locales/en.ts
+++ b/packages/@granit/react-ui-background-jobs/src/locales/en.ts
@@ -1,0 +1,34 @@
+// @granit/react-ui-background-jobs — i18next resource bundle (flat keys, "translation" ns).
+// Register in the host app:
+//   import { backgroundJobsTranslationsEn } from "@granit/react-ui-background-jobs";
+//   i18n.addResourceBundle("en", "translation", backgroundJobsTranslationsEn, true, true);
+
+export const backgroundJobsTranslationsEn = {
+  'BackgroundJobs.Actions.Pause': 'Pause',
+  'BackgroundJobs.Actions.Resume': 'Resume',
+  'BackgroundJobs.Actions.Trigger': 'Trigger now',
+  'BackgroundJobs.Columns.CronExpression': 'Schedule',
+  'BackgroundJobs.Columns.Failures': 'Failures',
+  'BackgroundJobs.Columns.JobName': 'Job name',
+  'BackgroundJobs.Columns.LastExecution': 'Last execution',
+  'BackgroundJobs.Columns.NextExecution': 'Next execution',
+  'BackgroundJobs.Columns.Status': 'Status',
+  'BackgroundJobs.DeadLetters': '{{count}} dead-letter message',
+  'BackgroundJobs.DeadLetters_other': '{{count}} dead-letter messages',
+  'BackgroundJobs.Failures': '{{count}} consecutive failure',
+  'BackgroundJobs.Failures_other': '{{count}} consecutive failures',
+  'BackgroundJobs.LastExecution': 'Last execution',
+  'BackgroundJobs.Never': 'Never',
+  'BackgroundJobs.NextExecution': 'Next execution',
+  'BackgroundJobs.NoJobs': 'No background jobs registered',
+  'BackgroundJobs.NotScheduled': 'Not scheduled',
+  'BackgroundJobs.Status.Active': 'Active',
+  'BackgroundJobs.Status.Failing': 'Failing',
+  'BackgroundJobs.Status.Paused': 'Paused',
+  'BackgroundJobs.Subtitle': 'Monitor and manage recurring system tasks',
+  'BackgroundJobs.Title': 'Background Jobs',
+  'BackgroundJobs.View.Kanban': 'Card view',
+  'BackgroundJobs.View.List': 'List view',
+} as const;
+
+export type BackgroundJobsTranslations = typeof backgroundJobsTranslationsEn;

--- a/packages/@granit/react-ui-background-jobs/src/locales/fr.ts
+++ b/packages/@granit/react-ui-background-jobs/src/locales/fr.ts
@@ -1,0 +1,32 @@
+// @granit/react-ui-background-jobs — i18next resource bundle (flat keys, "translation" ns).
+// Register in the host app:
+//   import { backgroundJobsTranslationsFr } from "@granit/react-ui-background-jobs";
+//   i18n.addResourceBundle("fr", "translation", backgroundJobsTranslationsFr, true, true);
+
+export const backgroundJobsTranslationsFr = {
+  'BackgroundJobs.Actions.Pause': 'Mettre en pause',
+  'BackgroundJobs.Actions.Resume': 'Reprendre',
+  'BackgroundJobs.Actions.Trigger': 'Exécuter maintenant',
+  'BackgroundJobs.Columns.CronExpression': 'Planification',
+  'BackgroundJobs.Columns.Failures': 'Échecs',
+  'BackgroundJobs.Columns.JobName': 'Nom de la tâche',
+  'BackgroundJobs.Columns.LastExecution': 'Dernière exécution',
+  'BackgroundJobs.Columns.NextExecution': 'Prochaine exécution',
+  'BackgroundJobs.Columns.Status': 'Statut',
+  'BackgroundJobs.DeadLetters': '{{count}} message en dead-letter',
+  'BackgroundJobs.DeadLetters_other': '{{count}} messages en dead-letter',
+  'BackgroundJobs.Failures': '{{count}} échec consécutif',
+  'BackgroundJobs.Failures_other': '{{count}} échecs consécutifs',
+  'BackgroundJobs.LastExecution': 'Dernière exécution',
+  'BackgroundJobs.Never': 'Jamais',
+  'BackgroundJobs.NextExecution': 'Prochaine exécution',
+  'BackgroundJobs.NoJobs': 'Aucune tâche planifiée enregistrée',
+  'BackgroundJobs.NotScheduled': 'Non planifiée',
+  'BackgroundJobs.Status.Active': 'Actif',
+  'BackgroundJobs.Status.Failing': 'En erreur',
+  'BackgroundJobs.Status.Paused': 'En pause',
+  'BackgroundJobs.Subtitle': 'Surveiller et gérer les tâches récurrentes du système',
+  'BackgroundJobs.Title': 'Tâches planifiées',
+  'BackgroundJobs.View.Kanban': 'Vue en cartes',
+  'BackgroundJobs.View.List': 'Vue en liste',
+} as const;

--- a/packages/@granit/react-ui-background-jobs/src/locales/index.ts
+++ b/packages/@granit/react-ui-background-jobs/src/locales/index.ts
@@ -1,0 +1,3 @@
+export { backgroundJobsTranslationsEn } from './en';
+export type { BackgroundJobsTranslations } from './en';
+export { backgroundJobsTranslationsFr } from './fr';

--- a/packages/@granit/react-ui-background-jobs/tsconfig.json
+++ b/packages/@granit/react-ui-background-jobs/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**", "src/**/*.stories.ts", "src/**/*.stories.tsx"]
+}

--- a/packages/@granit/react-ui-background-jobs/tsup.config.ts
+++ b/packages/@granit/react-ui-background-jobs/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3599,6 +3599,61 @@ importers:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
+  packages/@granit/react-ui-background-jobs:
+    dependencies:
+      lucide-react:
+        specifier: ^1.21.0
+        version: 1.21.0(react@19.2.7)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/background-jobs':
+        specifier: workspace:*
+        version: link:../background-jobs
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-background-jobs':
+        specifier: workspace:*
+        version: link:../react-background-jobs
+      '@granit/react-localization':
+        specifier: workspace:*
+        version: link:../react-localization
+      '@granit/react-ui':
+        specifier: workspace:*
+        version: link:../react-ui
+      '@granit/react-ui-admin-kit':
+        specifier: workspace:*
+        version: link:../react-ui-admin-kit
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
+      '@granit/utils':
+        specifier: workspace:*
+        version: link:../utils
+      '@storybook/react-vite':
+        specifier: ^10.4.6
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(yaml@2.9.0))
+      '@tanstack/react-query':
+        specifier: 5.101.0
+        version: 5.101.0(react@19.2.7)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      cronstrue:
+        specifier: ^3.20.0
+        version: 3.20.0
+      storybook:
+        specifier: ^10.4.6
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
   packages/@granit/react-ui-customer-balance:
     dependencies:
       lucide-react:
@@ -7654,6 +7709,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  cronstrue@3.20.0:
+    resolution: {integrity: sha512-2VOOE8DSemXhqEtlU23GBMoeowHnhcto+HPelhtCfM5cP+PB59UOuoeOIBQATzKSW+RfOGF7OJjcwfaUxRW6QQ==}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -13487,6 +13546,8 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
+
+  cronstrue@3.20.0: {}
 
   cross-spawn@7.0.6:
     dependencies:


### PR DESCRIPTION
## Summary

Backfill the **Background Jobs** admin UI from `granit-showcase-react` into a dedicated foundation package `@granit/react-ui-background-jobs`, so a second admin app gets it without duplication. Composes the headless `@granit/react-background-jobs` (data hooks + provider) with `@granit/react-ui` and `@granit/react-ui-admin-kit`.

Follows the established domain-UI backfill pattern (auditing, diagnostics, customer-balance, settings, authorization, hostnames).

## What's in the package

- `BackgroundJobListPage` — monitoring page with list (sortable `ManualDataTable`) + kanban (`JobCard`) views via `ViewSwitcher`
- `JobStatusBadge`, `JobActions`, `createBackgroundJobColumns`
- Colocated stories (`BackgroundJobs/*`) + an in-package test
- Flat i18n bundles `backgroundJobsTranslationsEn/Fr` (`BackgroundJobs.*`, `translation` ns)

## Decoupling

- **API client** resolved via `useGranitClient()` (`GranitClientProvider`) and handed to `BackgroundJobsProvider` — no `@/lib/api`.
- `cn` from `@granit/utils`; column `t` typed off `useTranslation` (no direct i18next `TFunction` import).
- **Cron rendering** owns its locale map: `getCronstrueLocale` / `loadCronstrueLocale` ship with the package (the host wires `loadCronstrueLocale` to `languageChanged`).

## Verification

- `tsc` clean, `eslint --max-warnings 0` clean
- Package tests pass (4)
- **Full** `@granit/arch-tests` pass (2348, incl. `patterns.test`)
- Stories auto-discovered by the granit-front Storybook glob + i18n bundle glob

The showcase consumption MR (router re-point + i18n register + feature deletion) follows on GitLab once this merges into `develop`.