### PR TITLE
test: raise branch coverage above 80% threshold

### DIFF
--- a/packages/@granit/arch-tests-kit/src/__tests__/scanners.edge.test.ts
+++ b/packages/@granit/arch-tests-kit/src/__tests__/scanners.edge.test.ts
@@ -1,0 +1,550 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { findSubdirs } from '../fs';
+import {
+  scanAnonymousDefaultExports,
+  scanAxiosImports,
+  scanBarrelDefaultExports,
+  scanComponentNaming,
+  scanConsole,
+  scanDomScriptSinks,
+  scanEmptyCatch,
+  scanFetch,
+  scanHookNaming,
+  scanKebabCase,
+  scanLeakedInternals,
+  scanLocaleParity,
+  scanReadmePresence,
+  scanSharedDepVersions,
+  scanUndeclaredDeps,
+  scanUseClientDirective,
+  scanUseFormResolver,
+} from '../index';
+
+import type { Module } from '../types';
+
+// Edge-case coverage for the arch-tests-kit scanners — allowlist branches,
+// empty/absent inputs, custom-option overrides, and the directory-skip paths
+// the behavioural fixture suite does not exercise.
+
+let root: string;
+let seq = 0;
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-kit-edge-'));
+});
+
+afterAll(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function writeFiles(baseDir: string, files: Record<string, string>): void {
+  for (const [relPath, content] of Object.entries(files)) {
+    const full = path.join(baseDir, relPath);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+}
+
+interface FixtureOptions {
+  src?: Record<string, string>;
+  rootFiles?: Record<string, string>;
+  isReact?: boolean;
+  name?: string;
+}
+
+function makeModule(opts: FixtureOptions): Module {
+  const dir = path.join(root, `m${seq++}`);
+  const srcDir = path.join(dir, 'src');
+  fs.mkdirSync(srcDir, { recursive: true });
+  if (opts.src) writeFiles(srcDir, opts.src);
+  if (opts.rootFiles) writeFiles(dir, opts.rootFiles);
+  return { name: opts.name ?? 'fixture', dir, srcDir, isReact: opts.isReact };
+}
+
+function ctxFor(...modules: Module[]) {
+  return { modules, repoRoot: root };
+}
+
+describe('fs.findSubdirs', () => {
+  it('skips node_modules and dist while finding the named directory', () => {
+    const mod = makeModule({
+      src: {
+        'api/x.ts': 'export const x = 1;',
+        'node_modules/api/y.ts': 'export const y = 1;',
+        'dist/api/z.ts': 'export const z = 1;',
+      },
+    });
+    const found = findSubdirs(mod.srcDir, 'api');
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain(`${path.sep}api`);
+    expect(found[0]).not.toContain('node_modules');
+  });
+
+  it('returns an empty list when the root does not exist', () => {
+    expect(findSubdirs(path.join(root, 'does-not-exist'), 'api')).toEqual([]);
+  });
+
+  it('recurses into nested non-matching directories to find deeper matches', () => {
+    const mod = makeModule({ src: { 'feature/widgets/api/x.ts': 'export const x = 1;' } });
+    expect(findSubdirs(mod.srcDir, 'api')).toHaveLength(1);
+  });
+});
+
+describe('scanKebabCase — allowlist', () => {
+  it('exempts a file whose relative path matches an allowedFiles needle', () => {
+    const mod = makeModule({ src: { 'BadName.ts': 'export const x = 1;' } });
+    const relPath = path.relative(root, path.join(mod.srcDir, 'BadName.ts'));
+    expect(scanKebabCase({ ...ctxFor(mod), allowedFiles: [relPath] })).toEqual([]);
+  });
+});
+
+describe('scanHookNaming — non-hook files', () => {
+  it('ignores a hooks/ file not prefixed with use-', () => {
+    const mod = makeModule({ src: { 'hooks/create-store.ts': 'export const value = 1;' } });
+    expect(scanHookNaming(ctxFor(mod))).toEqual([]);
+  });
+
+  it('accepts a use-*.ts that re-exports a useXxx symbol', () => {
+    const mod = makeModule({ src: { 'hooks/use-foo.ts': 'export { useFoo } from "./impl";' } });
+    expect(scanHookNaming(ctxFor(mod))).toEqual([]);
+  });
+});
+
+describe('scanComponentNaming — helper & non-tsx files', () => {
+  it('skips conventional helper files (index.ts, constants.ts, …)', () => {
+    const mod = makeModule({
+      src: {
+        'components/index.ts': 'export const x = 1;',
+        'components/constants.ts': 'export const Y = 1;',
+      },
+    });
+    expect(scanComponentNaming(ctxFor(mod))).toEqual([]);
+  });
+
+  it('skips a non-.tsx file in components/', () => {
+    const mod = makeModule({ src: { 'components/util.ts': 'export const x = 1;' } });
+    expect(scanComponentNaming(ctxFor(mod))).toEqual([]);
+  });
+
+  it('accepts a re-exported PascalCase component', () => {
+    const mod = makeModule({ src: { 'components/widget.tsx': 'export { Widget } from "./w";' } });
+    expect(scanComponentNaming(ctxFor(mod))).toEqual([]);
+  });
+});
+
+describe('scanConsole / scanFetch / scanAxiosImports — file allowlist', () => {
+  it('scanConsole exempts a file matched by allowedFiles', () => {
+    const mod = makeModule({ src: { 'boot.ts': 'console.log("x");' } });
+    const relPath = path.relative(root, path.join(mod.srcDir, 'boot.ts'));
+    expect(scanConsole({ ...ctxFor(mod), allowedFiles: [relPath] })).toEqual([]);
+  });
+
+  it('scanConsole skips test and testing files', () => {
+    const mod = makeModule({
+      src: { 'a.test.ts': 'console.log("x");', 'testing/handlers.ts': 'console.log("y");' },
+    });
+    expect(scanConsole(ctxFor(mod))).toEqual([]);
+  });
+
+  it('scanFetch exempts a file matched by allowedFiles', () => {
+    const mod = makeModule({ src: { 'boot.ts': 'const r = fetch("/api");' } });
+    const relPath = path.relative(root, path.join(mod.srcDir, 'boot.ts'));
+    expect(scanFetch({ ...ctxFor(mod), allowedFiles: [relPath] })).toEqual([]);
+  });
+
+  it('scanAxiosImports exempts a file matched by allowedFiles', () => {
+    const mod = makeModule({ src: { 'boot.ts': 'import axios from "axios";' } });
+    const relPath = path.relative(root, path.join(mod.srcDir, 'boot.ts'));
+    expect(scanAxiosImports({ ...ctxFor(mod), allowedFiles: [relPath] })).toEqual([]);
+  });
+
+  it('scanAxiosImports flags an axios subpath import', () => {
+    const mod = makeModule({ src: { 'a.ts': 'import { x } from "axios/lib";' } });
+    expect(scanAxiosImports(ctxFor(mod))).not.toHaveLength(0);
+  });
+
+  it('scanAxiosImports honours the per-module allowlist', () => {
+    const mod = makeModule({ name: 'api-client', src: { 'a.ts': 'import axios from "axios";' } });
+    expect(scanAxiosImports({ ...ctxFor(mod), allowedModules: ['api-client'] })).toEqual([]);
+  });
+});
+
+describe('scanBarrelDefaultExports / scanLeakedInternals — barrel presence & custom path', () => {
+  it('skips a module with no barrel file', () => {
+    const mod = makeModule({ src: { 'other.ts': 'export default {};' } });
+    expect(scanBarrelDefaultExports(ctxFor(mod))).toEqual([]);
+    expect(scanLeakedInternals(ctxFor(mod))).toEqual([]);
+  });
+
+  it('honours a custom barrelFile path', () => {
+    const mod = makeModule({ src: { 'public.ts': 'export default {};' } });
+    expect(scanBarrelDefaultExports({ ...ctxFor(mod), barrelFile: 'public.ts' })).not.toHaveLength(
+      0
+    );
+  });
+
+  it('scanLeakedInternals honours a custom barrelFile path', () => {
+    const mod = makeModule({ src: { 'public.ts': 'export const _secret = 1;' } });
+    expect(scanLeakedInternals({ ...ctxFor(mod), barrelFile: 'public.ts' })).not.toHaveLength(0);
+  });
+});
+
+describe('scanLocaleParity — fr export & no-locales', () => {
+  it('does nothing when the module has no locales/ directory', () => {
+    const mod = makeModule({ src: { 'index.ts': 'export {};' } });
+    expect(scanLocaleParity(ctxFor(mod))).toEqual([]);
+  });
+
+  it('flags an fr.ts missing the TranslationsFr export but valid en.ts', () => {
+    const mod = makeModule({
+      src: {
+        'locales/en.ts': 'export const fooTranslationsEn = {};',
+        'locales/fr.ts': 'export const wrong = {};',
+        'locales/index.ts': 'export {};',
+      },
+    });
+    const v = scanLocaleParity(ctxFor(mod));
+    expect(v).toContainEqual(
+      expect.objectContaining({ rule: 'locale-export', message: expect.stringContaining('Fr') })
+    );
+    expect(v.some((x) => x.message.includes('En'))).toBe(false);
+  });
+});
+
+describe('scanAnonymousDefaultExports — branch forms', () => {
+  it('skips files with no export default at all', () => {
+    const mod = makeModule({ src: { 'a.ts': 'export const x = 1;' } });
+    expect(scanAnonymousDefaultExports(ctxFor(mod))).toEqual([]);
+  });
+
+  it('accepts a named default class', () => {
+    const mod = makeModule({ src: { 'a.ts': 'export default class Foo {}' } });
+    expect(scanAnonymousDefaultExports(ctxFor(mod))).toEqual([]);
+  });
+
+  it('accepts a named default function', () => {
+    const mod = makeModule({ src: { 'a.ts': 'export default function foo() {}' } });
+    expect(scanAnonymousDefaultExports(ctxFor(mod))).toEqual([]);
+  });
+
+  it('flags an anonymous default object literal', () => {
+    const mod = makeModule({ src: { 'a.ts': 'export default {};' } });
+    expect(scanAnonymousDefaultExports(ctxFor(mod))).not.toHaveLength(0);
+  });
+});
+
+describe('scanUseFormResolver — allowlists', () => {
+  it('honours the per-module allowlist', () => {
+    const mod = makeModule({ name: 'forms', src: { 'a.ts': 'const f = useForm();' } });
+    expect(scanUseFormResolver({ ...ctxFor(mod), allowedModules: ['forms'] })).toEqual([]);
+  });
+
+  it('honours the per-file allowlist', () => {
+    const mod = makeModule({ src: { 'a.ts': 'const f = useForm();' } });
+    const relPath = path.relative(root, path.join(mod.srcDir, 'a.ts'));
+    expect(scanUseFormResolver({ ...ctxFor(mod), allowedFiles: [relPath] })).toEqual([]);
+  });
+
+  it('skips files that never call useForm', () => {
+    const mod = makeModule({ src: { 'a.ts': 'export const x = 1;' } });
+    expect(scanUseFormResolver(ctxFor(mod))).toEqual([]);
+  });
+});
+
+describe('scanEmptyCatch — allowlists', () => {
+  it('honours the per-module allowlist', () => {
+    const mod = makeModule({ name: 'legacy', src: { 'a.ts': 'try { run(); } catch {}' } });
+    expect(scanEmptyCatch({ ...ctxFor(mod), allowedModules: ['legacy'] })).toEqual([]);
+  });
+
+  it('honours the per-file allowlist', () => {
+    const mod = makeModule({ src: { 'a.ts': 'try { run(); } catch {}' } });
+    const relPath = path.relative(root, path.join(mod.srcDir, 'a.ts'));
+    expect(scanEmptyCatch({ ...ctxFor(mod), allowedFiles: [relPath] })).toEqual([]);
+  });
+
+  it('flags an empty catch with a binding parameter (catch (e) {})', () => {
+    const mod = makeModule({ src: { 'a.ts': 'try { run(); } catch (e) {}' } });
+    expect(scanEmptyCatch(ctxFor(mod))).not.toHaveLength(0);
+  });
+});
+
+describe('scanReadmePresence — H1 branches & allowlists', () => {
+  it('flags a README with no H1 heading', () => {
+    const mod = makeModule({
+      name: 'fixture',
+      rootFiles: { 'README.md': 'just prose, no heading' },
+    });
+    expect(scanReadmePresence(ctxFor(mod))).toContainEqual(
+      expect.objectContaining({ rule: 'readme-h1', message: expect.stringContaining('no `# H1`') })
+    );
+  });
+
+  it('flags a README whose H1 does not match the expected heading', () => {
+    const mod = makeModule({ name: 'fixture', rootFiles: { 'README.md': '# Wrong Title\n' } });
+    expect(scanReadmePresence(ctxFor(mod))).toContainEqual(
+      expect.objectContaining({ rule: 'readme-h1', message: expect.stringContaining('expected') })
+    );
+  });
+
+  it('accepts a custom expectedHeading resolver', () => {
+    const mod = makeModule({ name: 'pkg', rootFiles: { 'README.md': '# @scope/pkg\n' } });
+    expect(scanReadmePresence({ ...ctxFor(mod), expectedHeading: (n) => `@scope/${n}` })).toEqual(
+      []
+    );
+  });
+
+  it('honours the per-module allowlist', () => {
+    const mod = makeModule({ name: 'skip-me' });
+    expect(scanReadmePresence({ ...ctxFor(mod), allowedModules: ['skip-me'] })).toEqual([]);
+  });
+
+  it('honours the per-file allowlist', () => {
+    const mod = makeModule({ name: 'fixture' });
+    const relPath = path.relative(root, path.join(mod.dir, 'README.md'));
+    expect(scanReadmePresence({ ...ctxFor(mod), allowedFiles: [relPath] })).toEqual([]);
+  });
+});
+
+describe('scanSharedDepVersions — within-package drift & options', () => {
+  it('flags a dep declared with two versions inside one package', () => {
+    const mod = makeModule({
+      name: 'a',
+      rootFiles: {
+        'package.json': '{"dependencies":{"react":"^1.0.0"},"peerDependencies":{"react":"^2.0.0"}}',
+      },
+    });
+    expect(scanSharedDepVersions({ ...ctxFor(mod), deps: ['react'] })).toContainEqual(
+      expect.objectContaining({ rule: 'shared-dep-version-drift-within-package' })
+    );
+  });
+
+  it('ignores workspace: and * version constraints', () => {
+    const a = makeModule({
+      name: 'a',
+      rootFiles: { 'package.json': '{"dependencies":{"react":"workspace:*"}}' },
+    });
+    const b = makeModule({
+      name: 'b',
+      rootFiles: { 'package.json': '{"dependencies":{"react":"*"}}' },
+    });
+    expect(scanSharedDepVersions({ ...ctxFor(a, b), deps: ['react'] })).toEqual([]);
+  });
+
+  it('skips a module whose package.json is absent', () => {
+    const a = makeModule({ name: 'a' }); // no package.json written
+    expect(scanSharedDepVersions({ ...ctxFor(a), deps: ['react'] })).toEqual([]);
+  });
+
+  it('honours a custom sections list', () => {
+    const a = makeModule({
+      name: 'a',
+      rootFiles: { 'package.json': '{"devDependencies":{"vite":"^1.0.0"}}' },
+    });
+    const b = makeModule({
+      name: 'b',
+      rootFiles: { 'package.json': '{"devDependencies":{"vite":"^2.0.0"}}' },
+    });
+    expect(
+      scanSharedDepVersions({ ...ctxFor(a, b), deps: ['vite'], sections: ['devDependencies'] })
+    ).not.toHaveLength(0);
+  });
+
+  it('attributes cross-workspace drift to the minority modules only', () => {
+    const majority1 = makeModule({
+      name: 'maj1',
+      rootFiles: { 'package.json': '{"dependencies":{"zod":"^3.0.0"}}' },
+    });
+    const majority2 = makeModule({
+      name: 'maj2',
+      rootFiles: { 'package.json': '{"dependencies":{"zod":"^3.0.0"}}' },
+    });
+    const minority = makeModule({
+      name: 'min',
+      rootFiles: { 'package.json': '{"dependencies":{"zod":"^4.0.0"}}' },
+    });
+    const v = scanSharedDepVersions({
+      ...ctxFor(majority1, majority2, minority),
+      deps: ['zod'],
+    });
+    const drift = v.filter((x) => x.rule === 'shared-dep-version-drift');
+    expect(drift).toHaveLength(1);
+    expect(drift[0]?.module).toBe('min');
+  });
+});
+
+describe('scanDomScriptSinks — branches', () => {
+  it('does nothing for a module with no sink writers', () => {
+    const mod = makeModule({ src: { 'a.ts': 'export const x = 1;' } });
+    expect(scanDomScriptSinks(ctxFor(mod))).toEqual([]);
+  });
+
+  it('honours the per-module allowlist', () => {
+    const mod = makeModule({ name: 'renderer', src: { 'r.ts': 'node.innerHTML = html;' } });
+    expect(scanDomScriptSinks({ ...ctxFor(mod), allowedModules: ['renderer'] })).toEqual([]);
+  });
+
+  it('honours the per-file allowlist', () => {
+    const mod = makeModule({ src: { 'r.ts': 'node.innerHTML = html;' } });
+    const relPath = path.relative(root, path.join(mod.srcDir, 'r.ts'));
+    expect(scanDomScriptSinks({ ...ctxFor(mod), allowedFiles: [relPath] })).toEqual([]);
+  });
+
+  it('counts multiple sink files and reports the first', () => {
+    const mod = makeModule({
+      src: {
+        'a.ts': 'node.outerHTML = html;',
+        'b.ts': "el.insertAdjacentHTML('beforeend', html);",
+      },
+    });
+    const v = scanDomScriptSinks(ctxFor(mod));
+    expect(v).toHaveLength(1);
+    expect(v[0]?.message).toContain('2 file(s)');
+  });
+
+  it('honours a custom cspSubpath that satisfies the rule', () => {
+    const mod = makeModule({
+      src: {
+        'r.ts': 'node.innerHTML = html;',
+        'security/policy.ts': 'export function installPolicy() {}',
+      },
+    });
+    expect(
+      scanDomScriptSinks({ ...ctxFor(mod), cspSubpath: path.join('security', 'policy.ts') })
+    ).toEqual([]);
+  });
+
+  it('detects a setAttribute("src", …) sink', () => {
+    const mod = makeModule({ src: { 'r.ts': "iframe.setAttribute('src', url);" } });
+    expect(scanDomScriptSinks(ctxFor(mod))).not.toHaveLength(0);
+  });
+});
+
+describe('scanUndeclaredDeps — branches', () => {
+  it('skips a module with no package.json', () => {
+    const mod = makeModule({ src: { 'a.ts': 'import _ from "lodash";' } });
+    expect(scanUndeclaredDeps(ctxFor(mod))).toEqual([]);
+  });
+
+  it('ignores relative, node:, virtual:, alias and query specifiers', () => {
+    const mod = makeModule({
+      src: {
+        'a.ts': [
+          'import a from "./local";',
+          'import b from "node:fs";',
+          'import c from "virtual:thing";',
+          'import d from "@/lib/x";',
+          'import e from "~/lib/y";',
+          'import f from "thing?worker";',
+        ].join('\n'),
+      },
+      rootFiles: { 'package.json': '{"name":"@granit/fixture"}' },
+    });
+    expect(scanUndeclaredDeps(ctxFor(mod))).toEqual([]);
+  });
+
+  it('resolves a scoped package name and accepts it when declared', () => {
+    const mod = makeModule({
+      src: { 'a.ts': 'import { x } from "@scope/pkg/sub";' },
+      rootFiles: {
+        'package.json': '{"name":"@granit/fixture","dependencies":{"@scope/pkg":"^1"}}',
+      },
+    });
+    expect(scanUndeclaredDeps(ctxFor(mod))).toEqual([]);
+  });
+
+  it('flags a bare scope import with no package segment', () => {
+    const mod = makeModule({
+      src: { 'a.ts': 'import x from "@bare";' },
+      rootFiles: { 'package.json': '{"name":"@granit/fixture"}' },
+    });
+    expect(scanUndeclaredDeps(ctxFor(mod))).toContainEqual(
+      expect.objectContaining({
+        rule: 'no-undeclared-dep',
+        message: expect.stringContaining('@bare'),
+      })
+    );
+  });
+
+  it('does not flag a self-import (the package importing its own name)', () => {
+    const mod = makeModule({
+      src: { 'a.ts': 'import { x } from "@granit/fixture/sub";' },
+      rootFiles: { 'package.json': '{"name":"@granit/fixture"}' },
+    });
+    expect(scanUndeclaredDeps(ctxFor(mod))).toEqual([]);
+  });
+
+  it('honours the ignore list (bare specifier and package name)', () => {
+    const mod = makeModule({
+      src: { 'a.ts': 'import _ from "lodash";' },
+      rootFiles: { 'package.json': '{"name":"@granit/fixture"}' },
+    });
+    expect(scanUndeclaredDeps({ ...ctxFor(mod), ignore: ['lodash'] })).toEqual([]);
+  });
+
+  it('uses the module name as self when package.json has no name', () => {
+    const mod = makeModule({
+      name: 'mypkg',
+      src: { 'a.ts': 'import { x } from "mypkg/sub";' },
+      rootFiles: { 'package.json': '{"dependencies":{}}' },
+    });
+    // self resolves to m.name ("mypkg"), so the self-import is not flagged.
+    expect(scanUndeclaredDeps(ctxFor(mod))).toEqual([]);
+  });
+
+  it('reports each undeclared package only once per module', () => {
+    const mod = makeModule({
+      src: {
+        'a.ts': 'import x from "missingpkg";',
+        'b.ts': 'import y from "missingpkg/sub";',
+      },
+      rootFiles: { 'package.json': '{"name":"@granit/fixture"}' },
+    });
+    expect(
+      scanUndeclaredDeps(ctxFor(mod)).filter((v) => v.rule === 'no-undeclared-dep')
+    ).toHaveLength(1);
+  });
+});
+
+describe('scanUseClientDirective — branches', () => {
+  it('does nothing when no client-only React API is used', () => {
+    const mod = makeModule({ src: { 'a.tsx': 'export const x = 1;' } });
+    expect(scanUseClientDirective(ctxFor(mod))).toEqual([]);
+  });
+
+  it('accepts a directive after a leading blank line (slack before stop)', () => {
+    const mod = makeModule({ src: { 'a.tsx': "\n'use client';\nconst x = useState(0);" } });
+    expect(scanUseClientDirective(ctxFor(mod))).toEqual([]);
+  });
+
+  it('flags a client hook when the directive appears too late', () => {
+    const mod = makeModule({
+      src: {
+        'a.tsx':
+          'import x from "y";\nimport z from "w";\nimport q from "p";\n"use client";\nconst s = useState(0);',
+      },
+    });
+    expect(scanUseClientDirective(ctxFor(mod))).not.toHaveLength(0);
+  });
+
+  it('detects createContext as a client API', () => {
+    const mod = makeModule({ src: { 'a.tsx': 'const C = createContext(null);' } });
+    expect(scanUseClientDirective(ctxFor(mod))).not.toHaveLength(0);
+  });
+
+  it('honours the per-module allowlist', () => {
+    const mod = makeModule({ name: 'server-only', src: { 'a.tsx': 'const x = useState(0);' } });
+    expect(scanUseClientDirective({ ...ctxFor(mod), allowedModules: ['server-only'] })).toEqual([]);
+  });
+
+  it('honours the per-file allowlist', () => {
+    const mod = makeModule({ src: { 'a.tsx': 'const x = useState(0);' } });
+    const relPath = path.relative(root, path.join(mod.srcDir, 'a.tsx'));
+    expect(scanUseClientDirective({ ...ctxFor(mod), allowedFiles: [relPath] })).toEqual([]);
+  });
+});

--- a/packages/@granit/contract-tests/src/__tests__/__fixtures__/dir-import/dto.ts
+++ b/packages/@granit/contract-tests/src/__tests__/__fixtures__/dir-import/dto.ts
@@ -1,0 +1,8 @@
+import type { Kind } from './sub';
+
+// Fixture DTO whose `kind` is typed via an enum re-exported from a sibling
+// directory's index.ts — exercises the directory-index branch of module
+// resolution.
+export interface Sample {
+  readonly kind: Kind;
+}

--- a/packages/@granit/contract-tests/src/__tests__/__fixtures__/dir-import/sub/index.ts
+++ b/packages/@granit/contract-tests/src/__tests__/__fixtures__/dir-import/sub/index.ts
@@ -1,0 +1,3 @@
+// Fixture: a string-union enum reached through a directory import (`./sub`),
+// which resolves via the `<dir>/index.ts` fallback in resolveModuleFile.
+export type Kind = 'Alpha' | 'Beta';

--- a/packages/@granit/contract-tests/src/__tests__/conformance.edge.test.ts
+++ b/packages/@granit/contract-tests/src/__tests__/conformance.edge.test.ts
@@ -1,0 +1,508 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { checkSchemaConformance } from '../conformance';
+
+import type { OpenApiDocument, OpenApiSchema } from '../conformance';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+// Edge-case coverage for the conformance oracle. Each test pins a single
+// normalization / resolution branch the positive-control suite does not exercise.
+
+const file = '/virtual/edge.ts';
+
+/** Run the oracle against one schema declared inline as `Sample`. */
+function check(spec: OpenApiDocument, source: string, typeName = 'Sample') {
+  return checkSchemaConformance({
+    spec,
+    schemaName: 'Sample',
+    sourceText: source,
+    fileName: file,
+    typeName,
+  });
+}
+
+/** Build a single-schema spec with one required property. */
+function oneProp(
+  prop: OpenApiSchema,
+  schemas: Record<string, OpenApiSchema> = {}
+): OpenApiDocument {
+  return {
+    components: {
+      schemas: {
+        Sample: { type: 'object', required: ['value'], properties: { value: prop } },
+        ...schemas,
+      },
+    },
+  };
+}
+
+describe('checkSchemaConformance — schema lookup', () => {
+  it('returns schema-missing when the spec has no such schema', () => {
+    const v = checkSchemaConformance({
+      spec: { components: { schemas: {} } },
+      schemaName: 'Ghost',
+      sourceText: 'export interface Ghost { readonly id: string; }',
+      fileName: file,
+    });
+    expect(v).toEqual([
+      expect.objectContaining({ rule: 'schema-missing', schema: 'Ghost', field: '*' }),
+    ]);
+  });
+
+  it('returns schema-missing when components is entirely absent', () => {
+    const v = checkSchemaConformance({
+      spec: {},
+      schemaName: 'Ghost',
+      sourceText: 'export interface Ghost { readonly id: string; }',
+      fileName: file,
+    });
+    expect(v[0]?.rule).toBe('schema-missing');
+  });
+
+  it('returns type-missing when the front type cannot be flattened', () => {
+    // The TS source declares no `Sample` interface/alias.
+    const v = check(oneProp({ type: 'string' }), 'export const unrelated = 1;');
+    expect(v).toEqual([
+      expect.objectContaining({ rule: 'type-missing', schema: 'Sample', field: '*' }),
+    ]);
+  });
+});
+
+describe('specFamily — type normalization', () => {
+  it('maps integer/number/boolean spec types to their families', () => {
+    expect(
+      check(oneProp({ type: 'number' }), 'export interface Sample { readonly value: number; }')
+    ).toEqual([]);
+    expect(
+      check(oneProp({ type: 'boolean' }), 'export interface Sample { readonly value: boolean; }')
+    ).toEqual([]);
+  });
+
+  it('maps an array spec type to the array family', () => {
+    const src = 'export interface Sample { readonly value: readonly string[]; }';
+    expect(check(oneProp({ type: 'array', items: { type: 'string' } }), src)).toEqual([]);
+  });
+
+  it('maps a bare object spec type to the object family', () => {
+    const src = 'export interface Sample { readonly value: { readonly a: string }; }';
+    expect(check(oneProp({ type: 'object' }), src)).toEqual([]);
+  });
+
+  it('treats a typeless schema as unknown (no type-family drift)', () => {
+    const src = 'export interface Sample { readonly value: number; }';
+    expect(check(oneProp({}), src)).toEqual([]);
+  });
+
+  it('honours nullable: true (object form, not the ["null", T] form)', () => {
+    const src = 'export interface Sample { readonly value: string; }';
+    expect(check(oneProp({ type: 'string', nullable: true }), src)).toContainEqual(
+      expect.objectContaining({ rule: 'nullability', field: 'value' })
+    );
+  });
+
+  it('maps an inline string enum to the string family', () => {
+    const src = "export interface Sample { readonly value: 'A' | 'B'; }";
+    expect(check(oneProp({ enum: ['A', 'B'], type: 'string' }), src)).toEqual([]);
+  });
+});
+
+describe('specFamily — $ref resolution', () => {
+  it('resolves a $ref to the target schema family (string enum reads as string)', () => {
+    const spec = oneProp(
+      { $ref: '#/components/schemas/Kind' },
+      { Kind: { enum: ['A', 'B'], type: 'string' } }
+    );
+    const src = "export interface Sample { readonly value: 'A' | 'B'; }";
+    expect(check(spec, src)).toEqual([]);
+  });
+
+  it('treats a $ref to a missing schema as object', () => {
+    const spec = oneProp({ $ref: '#/components/schemas/Nope' });
+    const src = 'export interface Sample { readonly value: { readonly a: string }; }';
+    expect(check(spec, src)).toEqual([]);
+  });
+
+  it('treats a $ref with no resolvable name (object) gracefully and propagates nullability', () => {
+    // ["null"] on the ref site: the ref target is missing → object family, but
+    // the null in the union must still propagate to nullable.
+    const spec = oneProp({ $ref: '#/components/schemas/Nope', nullable: true });
+    const src = 'export interface Sample { readonly value: { readonly a: string }; }';
+    expect(check(spec, src)).toContainEqual(
+      expect.objectContaining({ rule: 'nullability', field: 'value' })
+    );
+  });
+
+  it('guards against a self-referential $ref cycle (resolves to object)', () => {
+    const spec = oneProp(
+      { $ref: '#/components/schemas/Loop' },
+      { Loop: { $ref: '#/components/schemas/Loop' } }
+    );
+    const src = 'export interface Sample { readonly value: { readonly a: string }; }';
+    // Cycle is broken: target becomes undefined the second time → object family.
+    expect(check(spec, src)).toEqual([]);
+  });
+
+  it('propagates a nullable $ref target up to the referencing field', () => {
+    const spec = oneProp(
+      { $ref: '#/components/schemas/MaybeStr' },
+      { MaybeStr: { type: ['null', 'string'] } }
+    );
+    const src = 'export interface Sample { readonly value: string; }';
+    expect(check(spec, src)).toContainEqual(
+      expect.objectContaining({ rule: 'nullability', field: 'value' })
+    );
+  });
+});
+
+describe('familyOf — TypeScript type-node families', () => {
+  it('resolves Array<T> and ReadonlyArray<T> type references to array', () => {
+    const a = 'export interface Sample { readonly value: Array<string>; }';
+    const ro = 'export interface Sample { readonly value: ReadonlyArray<string>; }';
+    expect(check(oneProp({ type: 'array' }), a)).toEqual([]);
+    expect(check(oneProp({ type: 'array' }), ro)).toEqual([]);
+  });
+
+  it('resolves a known framework brand reference to its primitive family', () => {
+    // ISODateString is a cross-package brand listed in BRAND_FAMILY → string.
+    const src = 'export interface Sample { readonly value: ISODateString; }';
+    expect(check(oneProp({ type: 'string' }), src)).toEqual([]);
+  });
+
+  it('resolves a numeric literal type to number and boolean literals to boolean', () => {
+    expect(
+      check(oneProp({ type: 'number' }), 'export interface Sample { readonly value: 42; }')
+    ).toEqual([]);
+    expect(
+      check(oneProp({ type: 'boolean' }), 'export interface Sample { readonly value: true; }')
+    ).toEqual([]);
+  });
+
+  it('treats a bare `null` literal field as unknown family (no type-family drift)', () => {
+    // `value: null` is a lone LiteralTypeNode (not a union) → familyOfLiteralType
+    // returns unknown, so no type-family drift is raised against any spec family.
+    const src = 'export interface Sample { readonly value: null; }';
+    const v = check(oneProp({ type: 'string' }), src);
+    expect(v.some((x) => x.rule === 'type-family')).toBe(false);
+  });
+
+  it('accepts a `T | null` front union against a nullable spec field', () => {
+    // The union path of tsFamily: null member sets nullable, string is the base;
+    // it satisfies a nullable string spec field with no violation.
+    const src = 'export interface Sample { readonly value: string | null; }';
+    expect(check(oneProp({ type: ['null', 'string'] }), src)).toEqual([]);
+  });
+
+  it('reports a union with only nullish members as unknown base family', () => {
+    // `null | undefined` → both members nullish → bases empty → first undefined →
+    // family 'unknown'; no type-family drift against a string spec.
+    const src = 'export interface Sample { readonly value: null | undefined; }';
+    const v = check(oneProp({ type: 'string' }), src);
+    expect(v.some((x) => x.rule === 'type-family')).toBe(false);
+  });
+
+  it('resolves an intersection (brand pattern) to the primitive member', () => {
+    const src = "export interface Sample { readonly value: string & { readonly __brand: 'x' }; }";
+    expect(check(oneProp({ type: 'string' }), src)).toEqual([]);
+  });
+
+  it('falls back to object for an intersection of only object members', () => {
+    const src = 'export interface Sample { readonly value: { a: string } & { b: number }; }';
+    expect(check(oneProp({ type: 'object' }), src)).toEqual([]);
+  });
+
+  it('resolves a type-literal node to object', () => {
+    const src = 'export interface Sample { readonly value: { readonly a: string }; }';
+    expect(check(oneProp({ type: 'object' }), src)).toEqual([]);
+  });
+
+  it('treats an unresolved type reference as object', () => {
+    const src = 'export interface Sample { readonly value: SomeUnknownType; }';
+    expect(check(oneProp({ type: 'object' }), src)).toEqual([]);
+  });
+
+  it('treats a tuple type as unknown (no type-family false positive)', () => {
+    const src = 'export interface Sample { readonly value: [string, number]; }';
+    expect(check(oneProp({ type: 'string' }), src).some((x) => x.rule === 'type-family')).toBe(
+      false
+    );
+  });
+
+  it('resolves a local string-union enum alias to string', () => {
+    const src = `
+      type Color = 'red' | 'green';
+      export interface Sample { readonly value: Color; }`;
+    expect(check(oneProp({ type: 'string' }), src)).toEqual([]);
+  });
+
+  it('resolves a readonly type operator through to the inner family', () => {
+    const src = 'export interface Sample { readonly value: readonly number[]; }';
+    expect(check(oneProp({ type: 'array' }), src)).toEqual([]);
+  });
+});
+
+describe('tsFamily — union nullability', () => {
+  it('reports a non-nullable front union as non-nullable', () => {
+    // `string | number` — no nullish member, first base wins (string).
+    const src = 'export interface Sample { readonly value: string | number; }';
+    expect(check(oneProp({ type: 'string' }), src).some((x) => x.rule === 'nullability')).toBe(
+      false
+    );
+  });
+
+  it('handles a question-token optional field as nullable', () => {
+    const src = 'export interface Sample { value?: string; }';
+    // spec requires value & non-null → optional front prop is nullable, not missing.
+    const v = check(oneProp({ type: 'string' }), src);
+    expect(v.some((x) => x.rule === 'missing-field')).toBe(false);
+  });
+});
+
+describe('module resolution — directory index fallback', () => {
+  it('follows an import that resolves through <dir>/index.ts', () => {
+    const dtoFile = path.join(here, '__fixtures__/dir-import/dto.ts');
+    const spec: OpenApiDocument = {
+      components: {
+        schemas: {
+          Sample: { type: 'object', required: ['kind'], properties: { kind: { $ref: '#/x' } } },
+          x: { enum: ['Alpha', 'Beta'], type: 'string' },
+        },
+      },
+    };
+    const violations = checkSchemaConformance({
+      spec,
+      schemaName: 'Sample',
+      sourceText: readFileSync(dtoFile, 'utf8'),
+      fileName: dtoFile,
+    });
+    expect(violations).toEqual([]);
+  });
+});
+
+describe('resolveDeclMembers — alias forwarding', () => {
+  it('flattens an alias forwarding to an interface', () => {
+    const src = `
+      interface Base { readonly value: string; }
+      export type Sample = Base;`;
+    expect(check(oneProp({ type: 'string' }), src)).toEqual([]);
+  });
+
+  it('returns type-missing for an alias forwarding to a non-named type', () => {
+    // `type Sample = string | number` — aliasTarget is a union, not a type ref,
+    // so resolveDeclMembers cannot flatten it.
+    const src = 'export type Sample = string | number;';
+    expect(check(oneProp({ type: 'string' }), src)).toContainEqual(
+      expect.objectContaining({ rule: 'type-missing' })
+    );
+  });
+});
+
+describe('compareField — type-family with unknown sides', () => {
+  it('does not flag type-family when the front side is unknown', () => {
+    const src = 'export interface Sample { readonly value: unknown; }';
+    expect(check(oneProp({ type: 'string' }), src).some((x) => x.rule === 'type-family')).toBe(
+      false
+    );
+  });
+});
+
+// Discriminated-union edge branches not covered by the positive controls.
+describe('specDiscriminatedUnion — detection branches', () => {
+  const unionSource = `
+    interface MoveDelta { readonly kind: 'move'; readonly from: string; }
+    interface DropDelta { readonly kind: 'drop'; readonly target: string; }
+    export type Delta = MoveDelta | DropDelta;`;
+
+  const checkDelta = (spec: OpenApiDocument, typeName = 'Delta') =>
+    checkSchemaConformance({
+      spec,
+      schemaName: 'Delta',
+      sourceText: unionSource,
+      fileName: file,
+      typeName,
+    });
+
+  it('treats anyOf + discriminator WITHOUT a mapping as a plain schema (no union path)', () => {
+    // No mapping → specDiscriminatedUnion returns undefined → falls through to the
+    // object oracle, which cannot flatten the union front type → type-missing.
+    const spec: OpenApiDocument = {
+      components: {
+        schemas: {
+          Delta: {
+            type: 'object',
+            required: ['kind'],
+            anyOf: [{ $ref: '#/components/schemas/MoveDelta' }],
+            discriminator: { propertyName: 'kind' },
+          },
+        },
+      },
+    };
+    expect(checkDelta(spec)).toContainEqual(expect.objectContaining({ rule: 'type-missing' }));
+  });
+
+  it('skips a mapping ref pointing at a missing schema', () => {
+    // The `rename` mapping points at a non-existent schema; it is dropped, so the
+    // resolved union has only move+drop and the front matches → no violations.
+    const spec: OpenApiDocument = {
+      components: {
+        schemas: {
+          Delta: {
+            type: 'object',
+            required: ['kind'],
+            oneOf: [
+              { $ref: '#/components/schemas/MoveDelta' },
+              { $ref: '#/components/schemas/DropDelta' },
+            ],
+            discriminator: {
+              propertyName: 'kind',
+              mapping: {
+                move: '#/components/schemas/MoveDelta',
+                drop: '#/components/schemas/DropDelta',
+                rename: '#/components/schemas/Missing',
+              },
+            },
+          },
+          MoveDelta: {
+            type: 'object',
+            required: ['kind', 'from'],
+            properties: { kind: { enum: ['move'], type: 'string' }, from: { type: 'string' } },
+          },
+          DropDelta: {
+            type: 'object',
+            required: ['kind', 'target'],
+            properties: { kind: { enum: ['drop'], type: 'string' }, target: { type: 'string' } },
+          },
+        },
+      },
+    };
+    expect(checkDelta(spec)).toEqual([]);
+  });
+
+  it('reports orphan-variant for a front member whose tag has no spec variant', () => {
+    // Spec maps only `move`; front still has a `drop` member → orphan-variant.
+    const spec: OpenApiDocument = {
+      components: {
+        schemas: {
+          Delta: {
+            type: 'object',
+            required: ['kind'],
+            oneOf: [{ $ref: '#/components/schemas/MoveDelta' }],
+            discriminator: {
+              propertyName: 'kind',
+              mapping: { move: '#/components/schemas/MoveDelta' },
+            },
+          },
+          MoveDelta: {
+            type: 'object',
+            required: ['kind', 'from'],
+            properties: { kind: { enum: ['move'], type: 'string' }, from: { type: 'string' } },
+          },
+        },
+      },
+    };
+    expect(checkDelta(spec)).toContainEqual(
+      expect.objectContaining({ rule: 'orphan-variant', message: expect.stringContaining('drop') })
+    );
+  });
+});
+
+describe('resolveUnionVariants — non-union front types', () => {
+  it('reports type-missing when the union alias mixes non-type-reference members', () => {
+    // `type Delta = MoveDelta | { inline: true }` — the inline member is not a
+    // named type ref; only MoveDelta resolves. Spec demands a drop variant too.
+    const src = `
+      interface MoveDelta { readonly kind: 'move'; readonly from: string; }
+      export type Delta = MoveDelta | { readonly inline: true };`;
+    const spec: OpenApiDocument = {
+      components: {
+        schemas: {
+          Delta: {
+            type: 'object',
+            required: ['kind'],
+            oneOf: [
+              { $ref: '#/components/schemas/MoveDelta' },
+              { $ref: '#/components/schemas/DropDelta' },
+            ],
+            discriminator: {
+              propertyName: 'kind',
+              mapping: {
+                move: '#/components/schemas/MoveDelta',
+                drop: '#/components/schemas/DropDelta',
+              },
+            },
+          },
+          MoveDelta: {
+            type: 'object',
+            required: ['kind', 'from'],
+            properties: { kind: { enum: ['move'], type: 'string' }, from: { type: 'string' } },
+          },
+          DropDelta: {
+            type: 'object',
+            required: ['kind', 'target'],
+            properties: { kind: { enum: ['drop'], type: 'string' }, target: { type: 'string' } },
+          },
+        },
+      },
+    };
+    const v = checkSchemaConformance({
+      spec,
+      schemaName: 'Delta',
+      sourceText: src,
+      fileName: file,
+    });
+    expect(v).toContainEqual(expect.objectContaining({ rule: 'missing-variant' }));
+  });
+
+  it('reports type-missing when a union member lacks the discriminator tag', () => {
+    // DropDelta has no string-literal `kind` → discriminatorValueOf returns
+    // undefined, so it is never registered by tag → spec drop has no front match.
+    const src = `
+      interface MoveDelta { readonly kind: 'move'; readonly from: string; }
+      interface DropDelta { readonly target: string; }
+      export type Delta = MoveDelta | DropDelta;`;
+    const spec: OpenApiDocument = {
+      components: {
+        schemas: {
+          Delta: {
+            type: 'object',
+            required: ['kind'],
+            oneOf: [
+              { $ref: '#/components/schemas/MoveDelta' },
+              { $ref: '#/components/schemas/DropDelta' },
+            ],
+            discriminator: {
+              propertyName: 'kind',
+              mapping: {
+                move: '#/components/schemas/MoveDelta',
+                drop: '#/components/schemas/DropDelta',
+              },
+            },
+          },
+          MoveDelta: {
+            type: 'object',
+            required: ['kind', 'from'],
+            properties: { kind: { enum: ['move'], type: 'string' }, from: { type: 'string' } },
+          },
+          DropDelta: {
+            type: 'object',
+            required: ['target'],
+            properties: { target: { type: 'string' } },
+          },
+        },
+      },
+    };
+    const v = checkSchemaConformance({
+      spec,
+      schemaName: 'Delta',
+      sourceText: src,
+      fileName: file,
+    });
+    expect(v).toContainEqual(
+      expect.objectContaining({ rule: 'missing-variant', message: expect.stringContaining('drop') })
+    );
+  });
+});

--- a/packages/@granit/contract-tests/src/__tests__/endpoints.edge.test.ts
+++ b/packages/@granit/contract-tests/src/__tests__/endpoints.edge.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+
+import { checkEndpointConformance } from '../endpoints';
+
+import type { OpenApiPaths } from '../endpoints';
+
+// Edge-case coverage for the endpoint oracle — route extraction branches and the
+// base-prefix auto-detection that the positive controls do not reach.
+
+const file = '/virtual/api.ts';
+const check = (spec: OpenApiPaths, src: string, opts?: { ignore?: readonly string[] }) =>
+  checkEndpointConformance('mod', spec, [{ file, text: src }], opts);
+
+describe('extractRoute — unparseable call forms', () => {
+  it('ignores a client call whose URL template head is non-empty (not basePath-rooted)', () => {
+    // head !== '' → extractRoute returns undefined → call is counted unparseable,
+    // not pushed as an endpoint. Spec route then has no front match → missing.
+    const spec: OpenApiPaths = { paths: { '/widgets': { get: {} } } };
+    const src = `
+      export async function listWidgets(client, basePath) {
+        return client.get(\`/api\${basePath}/widgets\`);
+      }`;
+    expect(check(spec, src)).toContainEqual(
+      expect.objectContaining({ rule: 'missing-endpoint', method: 'get' })
+    );
+  });
+
+  it('ignores a client call whose first template span is not basePath', () => {
+    const spec: OpenApiPaths = { paths: { '/widgets': { get: {} } } };
+    const src = `
+      export async function listWidgets(client, root) {
+        return client.get(\`\${root}/widgets\`);
+      }`;
+    // No parseable front endpoints → spec route is missing.
+    expect(check(spec, src)).toContainEqual(expect.objectContaining({ rule: 'missing-endpoint' }));
+  });
+
+  it('ignores a client call with a non-template, non-basePath string argument', () => {
+    const spec: OpenApiPaths = { paths: { '/widgets': { get: {} } } };
+    const src = `
+      export async function listWidgets(client) {
+        return client.get('/widgets');
+      }`;
+    expect(check(spec, src)).toContainEqual(expect.objectContaining({ rule: 'missing-endpoint' }));
+  });
+
+  it('ignores a client call with no arguments at all', () => {
+    const spec: OpenApiPaths = { paths: { '/widgets': { get: {} } } };
+    const src = `
+      export async function listWidgets(client) {
+        return client.get();
+      }`;
+    expect(check(spec, src)).toContainEqual(expect.objectContaining({ rule: 'missing-endpoint' }));
+  });
+
+  it('resolves the bare basePath identifier to the empty route', () => {
+    const spec: OpenApiPaths = { paths: { '/widgets': { get: {} } } };
+    const src = `
+      export async function listWidgets(client, basePath) {
+        return client.get(basePath);
+      }`;
+    // Front route '' aligned to the '/widgets' base → empty diff, no violations.
+    expect(check(spec, src)).toEqual([]);
+  });
+
+  it('handles a multi-span template (path param interpolation) producing {} placeholders', () => {
+    const spec: OpenApiPaths = { paths: { '/widgets/{id}/parts/{pid}': { get: {} } } };
+    const src = `
+      export async function getPart(client, basePath, id, pid) {
+        return client.get(\`\${basePath}/widgets/\${id}/parts/\${pid}\`);
+      }`;
+    expect(check(spec, src)).toEqual([]);
+  });
+});
+
+describe('const-url resolution', () => {
+  it('resolves a local const referencing basePath', () => {
+    const spec: OpenApiPaths = { paths: { '/widgets': { get: {} } } };
+    const src = `
+      export async function listWidgets(client, basePath) {
+        const url = \`\${basePath}/widgets\`;
+        return client.get(url);
+      }`;
+    expect(check(spec, src)).toEqual([]);
+  });
+
+  it('leaves an unresolvable const identifier unparseable (no false endpoint)', () => {
+    // `url` is never declared as a const here, so consts.get returns undefined and
+    // the identifier itself is passed through → extractRoute returns undefined.
+    const spec: OpenApiPaths = { paths: { '/widgets': { get: {} } } };
+    const src = `
+      export async function listWidgets(client) {
+        return client.get(url);
+      }`;
+    expect(check(spec, src)).toContainEqual(expect.objectContaining({ rule: 'missing-endpoint' }));
+  });
+});
+
+describe('candidateBases & base auto-detection', () => {
+  it('handles an empty spec with no paths (no violations, only orphans possible)', () => {
+    const src = `
+      export async function listWidgets(client, basePath) {
+        return client.get(\`\${basePath}/widgets\`);
+      }`;
+    // No spec paths → candidateBases([]) === [''] → front call is an orphan.
+    expect(check({}, src)).toContainEqual(
+      expect.objectContaining({ rule: 'orphan-endpoint', route: '/widgets' })
+    );
+  });
+
+  it('stops the shared prefix at a path parameter segment', () => {
+    // All paths share '/widgets' then diverge at a param — base is '/widgets'.
+    const spec: OpenApiPaths = {
+      paths: {
+        '/widgets/{id}': { get: {} },
+        '/widgets/{id}/archive': { post: {} },
+      },
+    };
+    const src = `
+      export async function getWidget(client, basePath, id) {
+        return client.get(\`\${basePath}/\${id}\`);
+      }
+      export async function archiveWidget(client, basePath, id) {
+        return client.post(\`\${basePath}/\${id}/archive\`);
+      }`;
+    expect(check(spec, src)).toEqual([]);
+  });
+
+  it('breaks early when a candidate base yields a zero diff', () => {
+    const spec: OpenApiPaths = {
+      paths: { '/widgets': { get: {}, post: {} } },
+    };
+    const src = `
+      export async function listWidgets(client, basePath) {
+        return client.get(\`\${basePath}/widgets\`);
+      }
+      export async function createWidget(client, basePath, body) {
+        return client.post(\`\${basePath}/widgets\`, body);
+      }`;
+    expect(check(spec, src)).toEqual([]);
+  });
+
+  it('ignores non-HTTP method keys in the spec path object', () => {
+    const spec: OpenApiPaths = {
+      paths: { '/widgets': { get: {}, parameters: {}, summary: {} } },
+    };
+    const src = `
+      export async function listWidgets(client, basePath) {
+        return client.get(\`\${basePath}/widgets\`);
+      }`;
+    expect(check(spec, src)).toEqual([]);
+  });
+});
+
+describe('client-call filtering', () => {
+  it('ignores property-access calls that are not on a `client` identifier', () => {
+    const spec: OpenApiPaths = { paths: { '/widgets': { get: {} } } };
+    const src = `
+      export async function listWidgets(api, basePath) {
+        return api.get(\`\${basePath}/widgets\`);
+      }`;
+    // api.get(...) is not client.* → no front endpoint extracted → spec missing.
+    expect(check(spec, src)).toContainEqual(expect.objectContaining({ rule: 'missing-endpoint' }));
+  });
+
+  it('ignores client methods that are not HTTP verbs', () => {
+    const spec: OpenApiPaths = { paths: {} };
+    const src = `
+      export async function setup(client) {
+        return client.interceptors(\`x\`);
+      }`;
+    expect(check(spec, src)).toEqual([]);
+  });
+
+  it('deduplicates identical missing-endpoint violations', () => {
+    // Two spec entries collapse to the same normalized route+method; the oracle's
+    // `seen` set keeps a single violation.
+    const spec: OpenApiPaths = {
+      paths: {
+        '/widgets/{id}': { get: {} },
+        '/widgets/{name}': { get: {} },
+      },
+    };
+    const src = 'export const noop = 1;';
+    const violations = check(spec, src).filter((v) => v.rule === 'missing-endpoint');
+    expect(violations).toHaveLength(1);
+  });
+});

--- a/packages/@granit/react-entities/src/__tests__/entity-gallery-branches.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-gallery-branches.test.tsx
@@ -1,0 +1,393 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryProvider } from '@granit/react-query-engine';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntityGallery } from '../components/entity-gallery';
+
+import type { EntityManifestResponse } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// Branch-coverage backfill for EntityGallery. The base suite covers the happy
+// card / pagination / actions paths. This file targets: resolveCardActions with
+// a null manifest.actions, the empty-body marker after a load, cards with no
+// title / no id / non-scalar field values, the nextPageParam totalCount path
+// (server omits hasMore), pickGalleryLayout skipping a non-Gallery layout, and
+// the non-intersecting IntersectionObserver branch.
+// ---------------------------------------------------------------------------
+
+const BASE_PATH = '/api/v1/parties';
+const ENTITY_NAME = 'Granit.Parties.Party';
+
+interface FakeObserver {
+  readonly observed: Element[];
+  trigger(intersecting?: boolean): void;
+}
+const observers: FakeObserver[] = [];
+class MockIntersectionObserver implements FakeObserver {
+  readonly observed: Element[] = [];
+  constructor(private readonly cb: IntersectionObserverCallback) {
+    observers.push(this);
+  }
+  observe(node: Element): void {
+    this.observed.push(node);
+  }
+  unobserve(node: Element): void {
+    const idx = this.observed.indexOf(node);
+    if (idx >= 0) this.observed.splice(idx, 1);
+  }
+  disconnect(): void {
+    this.observed.length = 0;
+    const idx = observers.indexOf(this);
+    if (idx >= 0) observers.splice(idx, 1);
+  }
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+  trigger(intersecting = true): void {
+    const entries = this.observed.map(
+      (target) =>
+        ({
+          target,
+          isIntersecting: intersecting,
+          intersectionRatio: intersecting ? 1 : 0,
+          time: Date.now(),
+          rootBounds: null,
+          boundingClientRect: target.getBoundingClientRect(),
+          intersectionRect: target.getBoundingClientRect(),
+        }) as IntersectionObserverEntry
+    );
+    this.cb(entries, this as unknown as IntersectionObserver);
+  }
+}
+
+beforeAll(() => vi.stubGlobal('IntersectionObserver', MockIntersectionObserver));
+beforeEach(() => {
+  observers.length = 0;
+});
+
+function triggerLastObserver(intersecting = true): void {
+  const last = observers[observers.length - 1];
+  if (last) last.trigger(intersecting);
+}
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function manifest(galleryOverrides: Record<string, unknown> = {}): EntityManifestResponse {
+  return {
+    schemaVersion: 1,
+    identity: {
+      name: ENTITY_NAME,
+      entityClrType: 'Granit.Parties.Domain.Party',
+      displayKey: null,
+      icon: null,
+      permissionGroup: null,
+      displayProperty: 'name',
+      subtitleProperty: null,
+    },
+    permissions: null,
+    forms: null,
+    details: null,
+    collections: {
+      query: { name: 'Granit.Parties.PartyQuery', clrTypeName: 'PartyQuery' },
+      export: null,
+      metrics: [],
+      dashboards: [],
+      defaultViewId: null,
+      listLayouts: [
+        {
+          kind: 'Gallery',
+          isDefault: false,
+          kanban: null,
+          calendar: null,
+          gallery: {
+            imagePropertyName: 'avatarBlobId',
+            titlePropertyName: 'name',
+            subtitlePropertyName: 'kind',
+            groupByPropertyName: null,
+            cardSize: 'Medium',
+            actions: [],
+            ...galleryOverrides,
+          },
+        },
+      ],
+      headerActions: [],
+      selectionActions: [],
+    },
+    relations: null,
+    actions: null,
+  };
+}
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>
+        <QueryProvider config={{ basePath: BASE_PATH }}>{children}</QueryProvider>
+      </GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper };
+}
+
+describe('EntityGallery — resolveCardActions with null manifest actions', () => {
+  it('renders cards without an action bar when the layout references actions but the manifest has none', async () => {
+    const m = manifest();
+    (m.collections!.listLayouts[0].gallery as { actions: unknown }).actions = [{ name: 'edit' }];
+    // manifest.actions stays null → resolveCardActions hits the `!actions` arm → [].
+    server.use(
+      http.get(`http://localhost${BASE_PATH}`, () =>
+        HttpResponse.json({
+          items: [{ id: 'a', name: 'ACME', kind: 'Customer', avatarBlobId: null }],
+          totalCount: 1,
+          hasMore: false,
+        })
+      )
+    );
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityGallery manifest={m} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-card]')).not.toBeNull()
+    );
+    expect(container.querySelector('[data-granit-gallery-card-actions]')).toBeNull();
+  });
+});
+
+describe('EntityGallery — empty body after a successful load', () => {
+  it('emits the empty marker when the query returns zero items', async () => {
+    server.use(
+      http.get(`http://localhost${BASE_PATH}`, () =>
+        HttpResponse.json({ items: [], totalCount: 0, hasMore: false })
+      )
+    );
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityGallery manifest={manifest()} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-empty]')).not.toBeNull()
+    );
+    expect(container.querySelector('[data-granit-gallery-card]')).toBeNull();
+  });
+});
+
+describe('EntityGallery — card with no title / no id / non-scalar fields', () => {
+  it('omits the title slot and data-row-id when no title property nor id resolves', async () => {
+    // No title: layout titlePropertyName null AND identity.displayProperty null.
+    const m = manifest({ titlePropertyName: null, subtitlePropertyName: null });
+    m.identity!.displayProperty = null;
+    server.use(
+      http.get(`http://localhost${BASE_PATH}`, () =>
+        HttpResponse.json({
+          // Row carries no id/Id, and avatarBlobId is a non-scalar (object) → readScalar → null.
+          items: [{ name: 'ignored', avatarBlobId: { nested: true } }],
+          totalCount: 1,
+          hasMore: false,
+        })
+      )
+    );
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityGallery manifest={m} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-card]')).not.toBeNull()
+    );
+    const card = container.querySelector('[data-granit-gallery-card]') as HTMLElement;
+    expect(card.hasAttribute('data-row-id')).toBe(false);
+    expect(card.hasAttribute('data-image-blob-id')).toBe(false);
+    expect(container.querySelector('[data-granit-gallery-card-title]')).toBeNull();
+    expect(container.querySelector('[data-granit-gallery-card-subtitle]')).toBeNull();
+  });
+});
+
+describe('EntityGallery — nextPageParam via totalCount (no hasMore)', () => {
+  it('paginates by comparing fetched count to totalCount when the server omits hasMore', async () => {
+    // 3 items, pageSize default 50 — but we force pageSize=2 so page 1 returns 2, page 2 returns 1.
+    const rows = [
+      { id: '1', name: 'A', kind: 'Customer', avatarBlobId: null },
+      { id: '2', name: 'B', kind: 'Supplier', avatarBlobId: null },
+      { id: '3', name: 'C', kind: 'Customer', avatarBlobId: null },
+    ];
+    server.use(
+      http.get(`http://localhost${BASE_PATH}`, ({ request }) => {
+        const url = new URL(request.url);
+        const page = Number(url.searchParams.get('page') ?? '1');
+        const pageSize = Number(url.searchParams.get('pageSize') ?? '50');
+        const start = (page - 1) * pageSize;
+        // Deliberately omit `hasMore` → forces the totalCount fallback in nextPageParam.
+        return HttpResponse.json({
+          items: rows.slice(start, start + pageSize),
+          totalCount: rows.length,
+        });
+      })
+    );
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityGallery manifest={manifest()} pageSize={2} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(2)
+    );
+    // Page 1 returned 2/3 → hasNextPage true → sentinel not exhausted.
+    const sentinel = container.querySelector('[data-granit-gallery-sentinel]') as HTMLElement;
+    expect(sentinel.hasAttribute('data-exhausted')).toBe(false);
+    // Scroll → fetch page 2 → fetched (3) === totalCount (3) → no further pages.
+    triggerLastObserver(true);
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(3)
+    );
+    const after = container.querySelector('[data-granit-gallery-sentinel]') as HTMLElement;
+    expect(after.hasAttribute('data-exhausted')).toBe(true);
+  });
+
+  it('stops after one page when the server gives neither hasMore nor totalCount', async () => {
+    server.use(
+      http.get(`http://localhost${BASE_PATH}`, () =>
+        HttpResponse.json({ items: [{ id: 'x', name: 'X', kind: 'C', avatarBlobId: null }] })
+      )
+    );
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityGallery manifest={manifest()} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-card]')).not.toBeNull()
+    );
+    const sentinel = container.querySelector('[data-granit-gallery-sentinel]') as HTMLElement;
+    // No bound → getNextPageParam returns undefined → exhausted.
+    expect(sentinel.hasAttribute('data-exhausted')).toBe(true);
+  });
+});
+
+describe('EntityGallery — pickGalleryLayout skips non-Gallery layouts', () => {
+  it('returns the empty marker when the only layout is a non-Gallery kind', () => {
+    const m = manifest();
+    // Replace the gallery layout with a Kanban layout (gallery slot null).
+    m.collections!.listLayouts = [
+      { kind: 'Kanban', isDefault: false, kanban: null, calendar: null, gallery: null },
+    ];
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityGallery manifest={m} />
+      </Wrapper>
+    );
+    expect(container.querySelector('[data-granit-entity-gallery-empty]')).not.toBeNull();
+  });
+});
+
+describe('EntityGallery — numeric scalar field values', () => {
+  it('stringifies a numeric title / image / id via readScalar', async () => {
+    server.use(
+      http.get(`http://localhost${BASE_PATH}`, () =>
+        HttpResponse.json({
+          // Numeric id + numeric title + numeric blob exercise readScalar's number arm.
+          items: [{ id: 7, name: 123, kind: 'C', avatarBlobId: 456 }],
+          totalCount: 1,
+          hasMore: false,
+        })
+      )
+    );
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityGallery manifest={manifest()} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-card]')).not.toBeNull()
+    );
+    const card = container.querySelector('[data-granit-gallery-card]') as HTMLElement;
+    expect(card.getAttribute('data-row-id')).toBe('7');
+    expect(card.getAttribute('data-image-blob-id')).toBe('456');
+    expect(container.querySelector('[data-granit-gallery-card-title]')?.textContent).toBe('123');
+  });
+});
+
+describe('EntityGallery — environment without IntersectionObserver', () => {
+  it('renders cards without arming a sentinel observer when IntersectionObserver is absent', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined);
+    server.use(
+      http.get(`http://localhost${BASE_PATH}`, () =>
+        HttpResponse.json({
+          items: [{ id: 'a', name: 'A', kind: 'C', avatarBlobId: null }],
+          totalCount: 5,
+          hasMore: true,
+        })
+      )
+    );
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityGallery manifest={manifest()} pageSize={1} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-card]')).not.toBeNull()
+    );
+    // No observer registered (the `typeof IntersectionObserver === 'undefined'` guard short-circuits).
+    expect(observers.length).toBe(0);
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  });
+});
+
+describe('EntityGallery — non-intersecting sentinel does not fetch', () => {
+  it('does not advance pages when the observer fires with isIntersecting=false', async () => {
+    const rows = Array.from({ length: 4 }, (_, i) => ({
+      id: String(i),
+      name: `R${i}`,
+      kind: 'C',
+      avatarBlobId: null,
+    }));
+    server.use(
+      http.get(`http://localhost${BASE_PATH}`, ({ request }) => {
+        const url = new URL(request.url);
+        const page = Number(url.searchParams.get('page') ?? '1');
+        const pageSize = Number(url.searchParams.get('pageSize') ?? '50');
+        const start = (page - 1) * pageSize;
+        const slice = rows.slice(start, start + pageSize);
+        return HttpResponse.json({
+          items: slice,
+          totalCount: rows.length,
+          hasMore: start + slice.length < rows.length,
+        });
+      })
+    );
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityGallery manifest={manifest()} pageSize={2} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(2)
+    );
+    triggerLastObserver(false); // not intersecting → the `.some()` arm is false → no fetch.
+    // Give any (unexpected) fetch a chance to land, then assert the count is unchanged.
+    await Promise.resolve();
+    expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(2);
+  });
+});

--- a/packages/@granit/react-entities/src/__tests__/entity-list-branches.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-list-branches.test.tsx
@@ -1,0 +1,299 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryProvider } from '@granit/react-query-engine';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { EntityList } from '../components/entity-list';
+import { EntityRendererProvider } from '../providers/index';
+
+import type { EntityManifestResponse } from '@granit/entities';
+import type { QueryMetadata } from '@granit/query-engine';
+import type { ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// Branch-coverage backfill for EntityList. The base suite covers the empty
+// manifest, happy rows, row-click, meta-error and zero-items paths. This file
+// targets the formatCell type switch (null / object / number / fallback), the
+// readRowKey fallback-index arm (rows without an id), the query-error arm with
+// no meta error, and the nullish-coalescing fallbacks in the body.
+// ---------------------------------------------------------------------------
+
+const BASE_PATH = '/api/v1/things';
+const ENTITY_NAME = 'Granit.Things.Thing';
+
+const META: QueryMetadata = {
+  columns: [
+    {
+      name: 'label',
+      label: 'Label',
+      type: 'String',
+      order: 0,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'count',
+      label: 'Count',
+      type: 'Int32',
+      order: 1,
+      isSortable: true,
+      isFilterable: false,
+      isVisible: true,
+    },
+    {
+      name: 'payload',
+      label: 'Payload',
+      type: 'Object',
+      order: 2,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: true,
+    },
+    {
+      name: 'note',
+      label: 'Note',
+      type: 'String',
+      order: 3,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [],
+  sortableFields: [],
+  presets: [],
+  quickFilters: [],
+  defaultSort: [],
+};
+
+function manifest(): EntityManifestResponse {
+  return {
+    schemaVersion: 1,
+    identity: {
+      name: ENTITY_NAME,
+      entityClrType: 'Granit.Things.Domain.Thing',
+      displayKey: null,
+      icon: null,
+      permissionGroup: null,
+      displayProperty: null,
+      subtitleProperty: null,
+    },
+    permissions: null,
+    forms: null,
+    details: null,
+    collections: {
+      query: { name: 'Granit.Things.ThingQuery', clrTypeName: 'ThingQuery' },
+      export: null,
+      metrics: [],
+      dashboards: [],
+      defaultViewId: null,
+      listLayouts: [],
+      headerActions: [],
+      selectionActions: [],
+    },
+    relations: null,
+    actions: null,
+  };
+}
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function metaHandler() {
+  return http.get(`http://localhost${BASE_PATH}/meta`, () => HttpResponse.json(META));
+}
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>
+        <QueryProvider config={{ basePath: BASE_PATH }}>
+          <EntityRendererProvider>{children}</EntityRendererProvider>
+        </QueryProvider>
+      </GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper };
+}
+
+describe('EntityList — formatCell type switch', () => {
+  it('renders dash for null, ✓/✗ for booleans, JSON for objects, and raw for numbers/strings', async () => {
+    server.use(
+      metaHandler(),
+      http.get(`http://localhost${BASE_PATH}`, () =>
+        HttpResponse.json({
+          items: [{ label: null, count: 5, payload: { a: 1 }, note: 'hi' }],
+          totalCount: 1,
+          page: 1,
+          pageSize: 20,
+        })
+      )
+    );
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityList manifest={manifest()} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-entity-list-row]')).not.toBeNull()
+    );
+    const cells = Array.from(container.querySelectorAll('tbody tr td')).map((td) => td.textContent);
+    // label=null → dash, count=5 → '5', payload object → JSON, note string → raw.
+    expect(cells).toEqual(['—', '5', '{"a":1}', 'hi']);
+  });
+
+  it('falls back to dash for an unsupported cell type (undefined)', async () => {
+    server.use(
+      metaHandler(),
+      http.get(`http://localhost${BASE_PATH}`, () =>
+        HttpResponse.json({
+          // `count` absent on the row → row['count'] is undefined → first dash arm.
+          items: [{ label: 'L', payload: {}, note: 'n' }],
+          totalCount: 1,
+          page: 1,
+          pageSize: 20,
+        })
+      )
+    );
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityList manifest={manifest()} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-entity-list-row]')).not.toBeNull()
+    );
+    const countCell = container.querySelector('td[data-column="count"]');
+    expect(countCell?.textContent).toBe('—');
+  });
+});
+
+describe('EntityList — readRowKey fallback index', () => {
+  it('keys rows by their array index when no id/Id is present', async () => {
+    server.use(
+      metaHandler(),
+      http.get(`http://localhost${BASE_PATH}`, () =>
+        HttpResponse.json({
+          items: [
+            { label: 'A', count: 1, payload: {}, note: '' },
+            { label: 'B', count: 2, payload: {}, note: '' },
+          ],
+          totalCount: 2,
+          page: 1,
+          pageSize: 20,
+        })
+      )
+    );
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityList manifest={manifest()} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-entity-list-row]').length).toBe(2)
+    );
+  });
+});
+
+describe('EntityList — query error without meta error', () => {
+  it('surfaces "Failed to load" when the page request fails but meta succeeds', async () => {
+    server.use(
+      metaHandler(),
+      http.get(`http://localhost${BASE_PATH}`, () => HttpResponse.text('', { status: 500 }))
+    );
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityList manifest={manifest()} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-entity-list-error]')).not.toBeNull()
+    );
+    // meta.error is undefined → the `?? query.error` arm surfaces the axios message.
+    expect(container.querySelector('[data-granit-entity-list-error]')?.textContent).toContain(
+      '500'
+    );
+  });
+});
+
+describe('EntityList — pagination navigation', () => {
+  it('advances to the next page when next is clicked (drives setPage)', async () => {
+    const page1 = [{ label: 'A', count: 1, payload: {}, note: '' }];
+    const page2 = [{ label: 'B', count: 2, payload: {}, note: '' }];
+    server.use(
+      metaHandler(),
+      http.get(`http://localhost${BASE_PATH}`, ({ request }) => {
+        const page = Number(new URL(request.url).searchParams.get('page') ?? '1');
+        return HttpResponse.json({
+          items: page === 1 ? page1 : page2,
+          totalCount: 40,
+          page,
+          pageSize: 20,
+        });
+      })
+    );
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityList manifest={manifest()} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('td[data-column="label"]')?.textContent).toBe('A')
+    );
+    const next = container.querySelector('[data-granit-pagination-next]') as HTMLButtonElement;
+    expect(next.disabled).toBe(false);
+    fireEvent.click(next);
+    await waitFor(() =>
+      expect(container.querySelector('td[data-column="label"]')?.textContent).toBe('B')
+    );
+    // Now on page 2, prev becomes enabled — clicking it drives setPage(page - 1).
+    const prev = container.querySelector('[data-granit-pagination-prev]') as HTMLButtonElement;
+    expect(prev.disabled).toBe(false);
+    fireEvent.click(prev);
+    await waitFor(() =>
+      expect(container.querySelector('td[data-column="label"]')?.textContent).toBe('A')
+    );
+  });
+});
+
+describe('EntityList — pagination next disabled on the last page', () => {
+  it('disables next when the current page is the only page', async () => {
+    server.use(
+      metaHandler(),
+      http.get(`http://localhost${BASE_PATH}`, () =>
+        HttpResponse.json({
+          items: [{ label: 'A', count: 1, payload: {}, note: '' }],
+          totalCount: 1,
+          page: 1,
+          pageSize: 20,
+        })
+      )
+    );
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityList manifest={manifest()} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-pagination-next]')).not.toBeNull()
+    );
+    expect(
+      (container.querySelector('[data-granit-pagination-next]') as HTMLButtonElement).disabled
+    ).toBe(true);
+  });
+});

--- a/packages/@granit/react-entities/src/__tests__/lookup-form-component-branches.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/lookup-form-component-branches.test.tsx
@@ -1,0 +1,229 @@
+import { DataLookupProvider } from '@granit/react-data-lookup';
+import { createTestQueryClient } from '@granit/react-testing';
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EntityForm } from '../components/entity-form';
+import { STANDARD_FORM_COMPONENTS } from '../field-components/index';
+import { EntityRendererProvider } from '../providers/index';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { LookupDescriptor, LookupItemResponse } from '@granit/data-lookup';
+import type { EntityFormFieldManifest, EntityFormManifest } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// Branch-coverage backfill for LookupFormComponent. The base suite covers the
+// happy picker / rehydrate / read-only / cascade-scope paths. This file targets
+// the defensive descriptor guard, the scope-coercion arms (string / number /
+// object), the read-only raw-value fallback, the aria-invalid arm, and the
+// keyboard-select branch of the listbox options.
+// ---------------------------------------------------------------------------
+
+const TENANTS: LookupItemResponse[] = [
+  { value: 't-1', label: 'Acme Corp', extra: null },
+  { value: 't-2', label: 'Globex', extra: null },
+];
+
+function lookupField(
+  propertyName: string,
+  lookup: LookupDescriptor | null,
+  overrides: Partial<EntityFormFieldManifest> = {}
+): EntityFormFieldManifest {
+  return {
+    propertyName,
+    clrTypeName: 'Guid',
+    component: 'lookup',
+    config: null,
+    labelKey: null,
+    helpKey: null,
+    order: 0,
+    readOnly: false,
+    visibleIf: null,
+    lookup,
+    ...overrides,
+  };
+}
+
+function variantWith(field: EntityFormFieldManifest): EntityFormManifest {
+  return {
+    name: 'default',
+    customizable: false,
+    sections: [
+      { key: 'main', labelKey: null, order: 0, collapsedByDefault: false, fields: [field] },
+    ],
+  };
+}
+
+function tenantClient(): AxiosInstance {
+  const client = createMockClient();
+  vi.mocked(client.get).mockImplementation((url, config) => {
+    if (String(url).includes('/resolve')) {
+      const v = (config as { params?: { value?: string } }).params?.value;
+      return Promise.resolve(axiosResponse(TENANTS.find((t) => t.value === v) ?? null));
+    }
+    const search = (
+      (config as { params?: { search?: string } }).params?.search ?? ''
+    ).toLowerCase();
+    const items = search ? TENANTS.filter((t) => t.label.toLowerCase().includes(search)) : TENANTS;
+    return Promise.resolve(
+      axiosResponse({ items, totalCount: items.length, continuationToken: null })
+    );
+  });
+  return client;
+}
+
+function Harness({
+  field,
+  client,
+  initial = null,
+  seedValues,
+  onChangeSpy,
+}: {
+  readonly field: EntityFormFieldManifest;
+  readonly client: AxiosInstance;
+  readonly initial?: unknown;
+  readonly seedValues?: Readonly<Record<string, unknown>>;
+  readonly onChangeSpy?: (values: Readonly<Record<string, unknown>>) => void;
+}): ReactNode {
+  const [values, setValues] = useState<Readonly<Record<string, unknown>>>({
+    ...seedValues,
+    ...(initial == null ? {} : { [field.propertyName]: initial }),
+  });
+  return (
+    <QueryClientProvider client={createTestQueryClient()}>
+      <DataLookupProvider config={{ client }}>
+        <EntityRendererProvider components={STANDARD_FORM_COMPONENTS}>
+          <EntityForm
+            variant={variantWith(field)}
+            values={values}
+            onChange={(next) => {
+              setValues(next);
+              onChangeSpy?.(next);
+            }}
+          />
+        </EntityRendererProvider>
+      </DataLookupProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe('LookupFormComponent — defensive descriptor guard', () => {
+  it('renders the misconfigured notice when the field carries no lookup descriptor', () => {
+    const field = lookupField('TenantId', null);
+    const { container } = render(<Harness field={field} client={tenantClient()} />);
+    const notice = container.querySelector('[data-granit-lookup-misconfigured]');
+    expect(notice).not.toBeNull();
+    expect(notice?.getAttribute('data-property')).toBe('TenantId');
+  });
+});
+
+describe('LookupFormComponent — scope coercion arms', () => {
+  it('coerces a numeric sibling value into the scope param (number arm)', async () => {
+    const field = lookupField('MeterId', { name: 'meters', scopeKeys: ['tenantId'] });
+    const client = tenantClient();
+    render(<Harness field={field} client={client} seedValues={{ TenantId: 42 }} />);
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    const scopedCall = vi
+      .mocked(client.get)
+      .mock.calls.find((c) => !String(c[0]).includes('/resolve'));
+    expect((scopedCall?.[1] as { params?: Record<string, unknown> }).params).toMatchObject({
+      'scope.tenantId': '42',
+    });
+  });
+
+  it('JSON-stringifies a non-scalar sibling value into the scope param (object arm)', async () => {
+    const field = lookupField('MeterId', { name: 'meters', scopeKeys: ['tenantId'] });
+    const client = tenantClient();
+    render(<Harness field={field} client={client} seedValues={{ TenantId: { id: 7 } }} />);
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    const scopedCall = vi
+      .mocked(client.get)
+      .mock.calls.find((c) => !String(c[0]).includes('/resolve'));
+    expect((scopedCall?.[1] as { params?: Record<string, unknown> }).params).toMatchObject({
+      'scope.tenantId': JSON.stringify({ id: 7 }),
+    });
+  });
+});
+
+describe('LookupFormComponent — read-only raw-value fallback', () => {
+  it('shows the raw stringified value when read-only and no item resolves', async () => {
+    const field = lookupField('TenantId', { name: 'tenants' }, { readOnly: true });
+    const client = tenantClient();
+    // 'unknown-id' resolves to null → selectedItem is undefined → raw value fallback.
+    vi.mocked(client.get).mockImplementation((url) => {
+      if (String(url).includes('/resolve')) return Promise.resolve(axiosResponse(null));
+      return Promise.resolve(
+        axiosResponse({ items: TENANTS, totalCount: TENANTS.length, continuationToken: null })
+      );
+    });
+    const { container } = render(<Harness field={field} client={client} initial="unknown-id" />);
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-lookup-readonly]')).not.toBeNull()
+    );
+    expect(container.querySelector('[data-granit-lookup-readonly]')?.textContent).toBe(
+      'unknown-id'
+    );
+  });
+
+  it('renders an empty read-only label when the value is null and nothing resolves', () => {
+    const field = lookupField('TenantId', { name: 'tenants' }, { readOnly: true });
+    const { container } = render(<Harness field={field} client={tenantClient()} initial={null} />);
+    const ro = container.querySelector('[data-granit-lookup-readonly]');
+    expect(ro).not.toBeNull();
+    expect(ro?.textContent).toBe('');
+  });
+});
+
+describe('LookupFormComponent — combobox arms', () => {
+  it('sets aria-invalid on the input when an error message is present', async () => {
+    const field = lookupField('TenantId', { name: 'tenants' });
+    const { container } = render(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <DataLookupProvider config={{ client: tenantClient() }}>
+          <EntityRendererProvider components={STANDARD_FORM_COMPONENTS}>
+            <EntityForm
+              variant={variantWith(field)}
+              values={{ TenantId: null }}
+              onChange={() => undefined}
+              errors={{ TenantId: 'Required' }}
+            />
+          </EntityRendererProvider>
+        </DataLookupProvider>
+      </QueryClientProvider>
+    );
+    await waitFor(() => expect(container.querySelector('[role="combobox"]')).not.toBeNull());
+    expect(container.querySelector('[role="combobox"]')?.getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('commits an option via the keyboard (Enter) as well as click', async () => {
+    const field = lookupField('TenantId', { name: 'tenants' });
+    const onChangeSpy = vi.fn();
+    const { container } = render(
+      <Harness field={field} client={tenantClient()} onChangeSpy={onChangeSpy} />
+    );
+    await waitFor(() =>
+      expect(container.querySelectorAll('[role="option"]').length).toBeGreaterThan(0)
+    );
+    const option = container.querySelector('[role="option"][data-value="t-2"]')!;
+    fireEvent.keyDown(option, { key: 'Enter' });
+    expect(onChangeSpy).toHaveBeenLastCalledWith({ TenantId: 't-2' });
+  });
+
+  it('ignores non-activation keys on an option', async () => {
+    const field = lookupField('TenantId', { name: 'tenants' });
+    const onChangeSpy = vi.fn();
+    const { container } = render(
+      <Harness field={field} client={tenantClient()} onChangeSpy={onChangeSpy} />
+    );
+    await waitFor(() =>
+      expect(container.querySelectorAll('[role="option"]').length).toBeGreaterThan(0)
+    );
+    const option = container.querySelector('[role="option"][data-value="t-2"]')!;
+    fireEvent.keyDown(option, { key: 'ArrowDown' });
+    expect(onChangeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@granit/react-entities/src/__tests__/standard-detail-components-branches.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/standard-detail-components-branches.test.tsx
@@ -1,0 +1,160 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import axios from 'axios';
+import { describe, expect, it } from 'vitest';
+
+import { EntityDetail } from '../components/entity-detail';
+import {
+  STANDARD_DETAIL_COMPONENTS,
+  defaultDetailFormat,
+} from '../field-components/standard-detail-components';
+import { EntityRendererProvider } from '../providers/index';
+
+import type { EntityDetailManifest } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// Branch-coverage backfill for STANDARD_DETAIL_COMPONENTS. The base catalog
+// suite covers the url / email / tel happy paths. This file targets the
+// boolean formatter arms, the unsafe-URL rejection, the formatText type
+// switch (boolean / object / number / fallback), and the readScalarString
+// number→string coercion + null fallback.
+// ---------------------------------------------------------------------------
+
+function withProvider(children: ReactNode) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>
+        <EntityRendererProvider
+          components={{ form: {}, detail: STANDARD_DETAIL_COMPONENTS.detail }}
+        >
+          {children}
+        </EntityRendererProvider>
+      </GranitClientProvider>
+    </QueryClientProvider>
+  );
+}
+
+function freeForm(...fields: string[]): EntityDetailManifest {
+  return {
+    name: 'default',
+    sections: [{ key: 'main', labelKey: null, order: 0, inheritsFromFormVariant: null, fields }],
+    sidePanels: [],
+  };
+}
+
+function renderDetail(property: string, component: string, value: unknown) {
+  const { container } = render(
+    withProvider(
+      <EntityDetail
+        variant={freeForm(property)}
+        values={{ [property]: value }}
+        propertyComponents={{ [property]: component }}
+      />
+    )
+  );
+  return container.querySelector(`[data-property="${property}"] dd`);
+}
+
+describe('STANDARD_DETAIL_COMPONENTS — boolean formatter', () => {
+  it('renders a check for true', () => {
+    expect(renderDetail('Active', 'boolean', true)?.textContent).toBe('✓');
+  });
+
+  it('renders a cross for false', () => {
+    expect(renderDetail('Active', 'boolean', false)?.textContent).toBe('✗');
+  });
+
+  it('renders an em-dash for null', () => {
+    expect(renderDetail('Active', 'boolean', null)?.textContent).toBe('—');
+  });
+
+  it('renders an em-dash for undefined (missing value)', () => {
+    const { container } = render(
+      withProvider(
+        <EntityDetail
+          variant={freeForm('Active')}
+          values={{}}
+          propertyComponents={{ Active: 'boolean' }}
+        />
+      )
+    );
+    expect(container.querySelector('[data-property="Active"] dd')?.textContent).toBe('—');
+  });
+});
+
+describe('STANDARD_DETAIL_COMPONENTS — url rejection', () => {
+  it('renders an unsafe scheme as plain text marked data-invalid-url', () => {
+    const { container } = render(
+      withProvider(
+        <EntityDetail
+          variant={freeForm('Website')}
+          values={{ Website: 'javascript:alert(1)' }}
+          propertyComponents={{ Website: 'url' }}
+        />
+      )
+    );
+    const span = container.querySelector('[data-property="Website"] [data-invalid-url]');
+    expect(span).not.toBeNull();
+    expect(span?.tagName).toBe('SPAN');
+    expect(container.querySelector('[data-property="Website"] a')).toBeNull();
+  });
+
+  it('coerces a numeric url value to a string before validating (renders the digits)', () => {
+    const dd = renderDetail('Website', 'url', 12345);
+    // readScalarString turns the number into '12345', a relative path → safe → <a>.
+    expect(dd?.querySelector('a')?.getAttribute('href')).toBe('12345');
+  });
+});
+
+describe('STANDARD_DETAIL_COMPONENTS — email / tel null arms', () => {
+  it('email renders em-dash for a null value', () => {
+    expect(renderDetail('Email', 'email', null)?.textContent).toBe('—');
+  });
+
+  it('email renders em-dash for an empty string', () => {
+    expect(renderDetail('Email', 'email', '')?.textContent).toBe('—');
+  });
+
+  it('tel renders em-dash for a null value', () => {
+    expect(renderDetail('Phone', 'tel', null)?.textContent).toBe('—');
+  });
+
+  it('tel coerces a numeric value to a string href', () => {
+    const dd = renderDetail('Phone', 'tel', 3204712345);
+    expect(dd?.querySelector('a')?.getAttribute('href')).toBe('tel:3204712345');
+  });
+});
+
+describe('STANDARD_DETAIL_COMPONENTS — text formatter type switch', () => {
+  it('renders a check/cross for a boolean value through the text formatter', () => {
+    expect(renderDetail('Flag', 'text', true)?.textContent).toBe('✓');
+    expect(renderDetail('Flag', 'text', false)?.textContent).toBe('✗');
+  });
+
+  it('JSON-stringifies an object value', () => {
+    expect(renderDetail('Meta', 'text', { a: 1 })?.textContent).toBe('{"a":1}');
+  });
+
+  it('stringifies a numeric value', () => {
+    expect(renderDetail('Count', 'integer', 7)?.textContent).toBe('7');
+  });
+
+  it('em-dash for a null value', () => {
+    expect(renderDetail('Notes', 'text', null)?.textContent).toBe('—');
+  });
+});
+
+describe('defaultDetailFormat (exported fallback)', () => {
+  it('formats primitives and falls back to em-dash for unsupported types', () => {
+    expect(defaultDetailFormat('hello')).toBe('hello');
+    expect(defaultDetailFormat(42)).toBe('42');
+    expect(defaultDetailFormat(true)).toBe('✓');
+    expect(defaultDetailFormat(null)).toBe('—');
+    // A symbol hits neither string/number/object/boolean → final em-dash arm.
+    expect(defaultDetailFormat(Symbol('x'))).toBe('—');
+  });
+});

--- a/packages/@granit/react-entities/src/__tests__/standard-form-components-branches.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/standard-form-components-branches.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EntityForm } from '../components/entity-form';
+import { STANDARD_FORM_COMPONENTS } from '../field-components/index';
+import { EntityRendererProvider } from '../providers/index';
+
+import type { EntityFormFieldManifest, EntityFormManifest } from '@granit/entities';
+
+// ---------------------------------------------------------------------------
+// Branch-coverage backfill for STANDARD_FORM_COMPONENTS. The base test suite
+// drives the happy paths (correct value type, empty → null). This file targets
+// the *defensive* branches: a value whose runtime type does not match the
+// component's expectation (the `typeof value === X ? … : ''` false arm), the
+// NaN parse fallbacks, and the `readOptions` validation guards.
+// ---------------------------------------------------------------------------
+
+function singleFieldVariant(field: EntityFormFieldManifest): EntityFormManifest {
+  return {
+    name: 'default',
+    customizable: false,
+    sections: [
+      { key: 'main', labelKey: null, order: 0, collapsedByDefault: false, fields: [field] },
+    ],
+  };
+}
+
+function field(
+  component: string,
+  overrides: Partial<EntityFormFieldManifest> = {}
+): EntityFormFieldManifest {
+  return {
+    propertyName: 'X',
+    clrTypeName: 'String',
+    component,
+    config: null,
+    labelKey: null,
+    helpKey: null,
+    order: 0,
+    readOnly: false,
+    visibleIf: null,
+    lookup: null,
+    ...overrides,
+  };
+}
+
+function harness(variant: EntityFormManifest, value: unknown) {
+  const onChange = vi.fn();
+  const utils = render(
+    <EntityRendererProvider components={STANDARD_FORM_COMPONENTS}>
+      <EntityForm variant={variant} values={{ X: value }} onChange={onChange} />
+    </EntityRendererProvider>
+  );
+  return { ...utils, onChange };
+}
+
+describe('STANDARD_FORM_COMPONENTS — defensive value-type branches', () => {
+  it('text — falls back to empty string when value is not a string', () => {
+    const { container } = harness(singleFieldVariant(field('text')), 42);
+    expect((container.querySelector('input[type="text"]') as HTMLInputElement).value).toBe('');
+  });
+
+  it('textarea — falls back to empty string when value is not a string', () => {
+    const { container } = harness(singleFieldVariant(field('textarea')), { not: 'a string' });
+    expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe('');
+  });
+
+  it('integer — empty input when value is not a number, and a parsed integer forwards', () => {
+    const { container, onChange } = harness(singleFieldVariant(field('integer')), 'not-a-number');
+    const input = container.querySelector('input[type="number"]') as HTMLInputElement;
+    // typeof value !== 'number' → the false arm renders ''.
+    expect(input.value).toBe('');
+    fireEvent.change(input, { target: { value: '7' } });
+    expect(onChange).toHaveBeenLastCalledWith({ X: 7 });
+  });
+
+  it('decimal — empty input when value is not a number, and a parsed float forwards', () => {
+    const { container, onChange } = harness(singleFieldVariant(field('decimal')), null);
+    const input = container.querySelector('input[type="number"]') as HTMLInputElement;
+    expect(input.value).toBe('');
+    fireEvent.change(input, { target: { value: '2.5' } });
+    expect(onChange).toHaveBeenLastCalledWith({ X: 2.5 });
+  });
+
+  it('boolean — unchecked when value is anything other than the literal true', () => {
+    const { container } = harness(singleFieldVariant(field('boolean')), 'true');
+    // value === true is the only truthy gate; the string 'true' must NOT check it.
+    expect((container.querySelector('input[type="checkbox"]') as HTMLInputElement).checked).toBe(
+      false
+    );
+  });
+
+  it.each([
+    { component: 'date', seed: '2026-01-01', next: '2026-04-30' },
+    { component: 'time', seed: '01:00', next: '12:30' },
+    { component: 'datetime', seed: '2026-01-01T01:00', next: '2026-04-30T12:30' },
+  ])(
+    '$component — empty value when not a string, and a non-empty change forwards the raw value',
+    ({ component, seed, next }) => {
+      // First render with a non-string value to exercise the `typeof === 'string'` false arm.
+      const empty = harness(singleFieldVariant(field(component)), 99);
+      expect((empty.container.querySelector('input') as HTMLInputElement).value).toBe('');
+      empty.unmount();
+
+      // Then a string-seeded field drives the non-empty `=== '' ? null : value` false arm.
+      const { container, onChange } = harness(singleFieldVariant(field(component)), seed);
+      const input = container.querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: next } });
+      expect(onChange).toHaveBeenLastCalledWith({ X: next });
+    }
+  );
+
+  it('select — renders option labelKey when present, else the stringified value', () => {
+    const variant = singleFieldVariant(
+      field('select', {
+        config: {
+          options: [
+            { value: 'A', labelKey: 'Label.A' },
+            { value: 2, labelKey: null },
+          ],
+        },
+      })
+    );
+    const { container } = harness(variant, null);
+    const labels = Array.from(container.querySelectorAll('option')).map((o) => o.textContent);
+    expect(labels).toContain('Label.A');
+    expect(labels).toContain('2');
+  });
+
+  it('select — boolean value coerced to its string form for the controlled <select>', () => {
+    const variant = singleFieldVariant(
+      field('select', { config: { options: [{ value: true, labelKey: null }] } })
+    );
+    const { container } = harness(variant, true);
+    expect((container.querySelector('select') as HTMLSelectElement).value).toBe('true');
+  });
+
+  it('select — misconfigured when config is non-null but options is not an array', () => {
+    const variant = singleFieldVariant(field('select', { config: { options: 'nope' } }));
+    const { container } = harness(variant, null);
+    expect(container.querySelector('[data-granit-select-misconfigured]')).not.toBeNull();
+  });
+
+  it('select — misconfigured when an option entry is not an object', () => {
+    const variant = singleFieldVariant(field('select', { config: { options: ['x', 'y'] } }));
+    const { container } = harness(variant, null);
+    expect(container.querySelector('[data-granit-select-misconfigured]')).not.toBeNull();
+  });
+
+  it('select — misconfigured when an option value is an unsupported type', () => {
+    const variant = singleFieldVariant(
+      field('select', { config: { options: [{ value: { nested: true }, labelKey: null }] } })
+    );
+    const { container } = harness(variant, null);
+    expect(container.querySelector('[data-granit-select-misconfigured]')).not.toBeNull();
+  });
+
+  it('select — tolerates a null option value (allowed) and a non-string labelKey (→ null)', () => {
+    const variant = singleFieldVariant(
+      field('select', { config: { options: [{ value: null, labelKey: 123 }] } })
+    );
+    const { container } = harness(variant, null);
+    // Not misconfigured: null value is permitted; the numeric labelKey is dropped so
+    // the option falls back to String(value) === 'null'.
+    expect(container.querySelector('[data-granit-select-misconfigured]')).toBeNull();
+    const labels = Array.from(container.querySelectorAll('option')).map((o) => o.textContent);
+    expect(labels).toContain('null');
+  });
+});

--- a/packages/@granit/react-entities/src/__tests__/use-entity-action-dispatcher-branches.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/use-entity-action-dispatcher-branches.test.tsx
@@ -1,0 +1,162 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntityActionModalContext } from '../actions/entity-action-overlay-context';
+import { useEntityActionDispatcher } from '../actions/use-entity-action-dispatcher';
+
+import type { EntityActionManifest } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// Branch-coverage backfill for useEntityActionDispatcher. The base suite drives
+// the host-context + warn paths and the happy ApiCall / Download / Navigate.
+// This file targets the remaining arms: the explicit handler overrides for
+// OpenDrawer / OpenModal, the no-op guards in the default ApiCall / Download /
+// Navigate handlers (missing urlTemplate / httpMethod), and the
+// Content-Disposition / filename-derivation branches of the default download.
+// ---------------------------------------------------------------------------
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers();
+  vi.restoreAllMocks();
+});
+afterAll(() => server.close());
+
+let originalLocation: Location;
+beforeEach(() => {
+  originalLocation = globalThis.location;
+});
+afterEach(() => {
+  Object.defineProperty(globalThis, 'location', { value: originalLocation, configurable: true });
+});
+
+function makeWrapper() {
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+  );
+  return { wrapper };
+}
+
+function makeAction(overrides: Partial<EntityActionManifest> = {}): EntityActionManifest {
+  return {
+    name: 'share',
+    kind: 'ApiCall',
+    displayKey: null,
+    icon: null,
+    order: 0,
+    urlTemplate: null,
+    httpMethod: null,
+    confirmationKey: null,
+    workflowTransitionName: null,
+    contributorAssemblyName: null,
+    ...overrides,
+  };
+}
+
+describe('useEntityActionDispatcher — handler overrides', () => {
+  it('OpenDrawer delegates to the openDrawer handler override when supplied', async () => {
+    const openDrawer = vi.fn();
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityActionDispatcher({ openDrawer }), { wrapper });
+    const action = makeAction({ kind: 'OpenDrawer' });
+    await result.current(action, 'abc', { id: 'abc' });
+    expect(openDrawer).toHaveBeenCalledOnce();
+    expect(openDrawer).toHaveBeenCalledWith(action, 'abc', { id: 'abc' }, expect.anything());
+  });
+
+  it('OpenModal prefers the openModal override even when a modal host is mounted', async () => {
+    const openModal = vi.fn();
+    const modalStub = { open: vi.fn(), close: vi.fn(), current: null };
+    const { wrapper: BaseWrapper } = makeWrapper();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <BaseWrapper>
+        <EntityActionModalContext.Provider value={modalStub}>
+          {children}
+        </EntityActionModalContext.Provider>
+      </BaseWrapper>
+    );
+    const { result } = renderHook(() => useEntityActionDispatcher({ openModal }), { wrapper });
+    await result.current(makeAction({ kind: 'OpenModal' }), 'abc', null);
+    expect(openModal).toHaveBeenCalledOnce();
+    expect(modalStub.open).not.toHaveBeenCalled();
+  });
+});
+
+describe('default handlers — no-op guards', () => {
+  it('ApiCall is a no-op when urlTemplate / httpMethod are missing', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityActionDispatcher(), { wrapper });
+    // No urlTemplate and no httpMethod → early return, no unhandled request (msw would 500).
+    await expect(
+      result.current(makeAction({ kind: 'ApiCall' }), 'abc', null)
+    ).resolves.toBeUndefined();
+  });
+
+  it('Download is a no-op when urlTemplate is missing', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityActionDispatcher(), { wrapper });
+    await expect(
+      result.current(makeAction({ kind: 'Download', urlTemplate: null }), null, null)
+    ).resolves.toBeUndefined();
+  });
+
+  it('Navigate is a no-op when urlTemplate is missing', async () => {
+    const hrefHolder = { href: 'about:blank' };
+    Object.defineProperty(globalThis, 'location', {
+      value: hrefHolder,
+      configurable: true,
+      writable: true,
+    });
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityActionDispatcher(), { wrapper });
+    await result.current(makeAction({ kind: 'Navigate', urlTemplate: null }), null, null);
+    expect(hrefHolder.href).toBe('about:blank');
+  });
+});
+
+describe('default download — filename derivation', () => {
+  function stubAnchor() {
+    const clickSpy = vi.fn();
+    const realCreate = globalThis.document.createElement.bind(globalThis.document);
+    vi.spyOn(globalThis.document, 'createElement').mockImplementation(((tagName: string) => {
+      const node = realCreate(tagName) as HTMLElement;
+      if (tagName === 'a') node.click = clickSpy;
+      return node;
+    }) as typeof globalThis.document.createElement);
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:fake');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+    return { clickSpy };
+  }
+
+  it('derives the filename from the URL last segment when no Content-Disposition header is present', async () => {
+    server.use(
+      // No Content-Disposition header at all → readFilename returns null → URL fallback.
+      http.get('http://localhost/api/exports/report.pdf', () => HttpResponse.text('pdf-bytes'))
+    );
+    const { clickSpy } = stubAnchor();
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityActionDispatcher(), { wrapper });
+    await result.current(
+      makeAction({ kind: 'Download', urlTemplate: '/api/exports/report.pdf?token=xyz' }),
+      null,
+      null
+    );
+    await waitFor(() => expect(clickSpy).toHaveBeenCalledOnce());
+  });
+
+  it('falls back to "download" when the URL has no usable last segment', async () => {
+    server.use(http.get('http://localhost/', () => HttpResponse.text('root-bytes')));
+    const { clickSpy } = stubAnchor();
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityActionDispatcher(), { wrapper });
+    await result.current(makeAction({ kind: 'Download', urlTemplate: '/' }), null, null);
+    await waitFor(() => expect(clickSpy).toHaveBeenCalledOnce());
+  });
+});

--- a/packages/@granit/react-ui-background-jobs/src/__tests__/background-job-columns.test.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/__tests__/background-job-columns.test.tsx
@@ -1,0 +1,196 @@
+import { toISODateString } from '@granit/types';
+import { screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createBackgroundJobColumns } from '../components/background-job-columns';
+
+import { renderBackgroundJobs } from './test-utils';
+
+import type { BackgroundJobStatus } from '@granit/background-jobs';
+import type { CellContext, ColumnDef } from '@tanstack/react-table';
+import type { ReactElement } from 'react';
+
+function makeJob(overrides: Partial<BackgroundJobStatus> = {}): BackgroundJobStatus {
+  return {
+    jobName: 'SampleJob',
+    cronExpression: '0 0 * * * ?',
+    isEnabled: true,
+    lastExecutedAt: toISODateString('2026-04-02T12:00:00Z'),
+    nextExecutionAt: toISODateString('2026-04-02T13:00:00Z'),
+    consecutiveFailures: 0,
+    deadLetterCount: 0,
+    lastError: null,
+    ...overrides,
+  };
+}
+
+const handlers = {
+  onPause: vi.fn(),
+  onResume: vi.fn(),
+  onTrigger: vi.fn(),
+};
+
+function buildColumns(isMutating = false): ColumnDef<BackgroundJobStatus, unknown>[] {
+  return createBackgroundJobColumns({
+    t: ((key: string, opts?: { count?: number }) =>
+      opts?.count === undefined ? key : `${key}#${opts.count}`) as never,
+    locale: 'en',
+    formatDateTime: () => 'FORMATTED_DATETIME',
+    formatTimeAgo: () => 'TIME_AGO',
+    ...handlers,
+    isMutating,
+  });
+}
+
+/** Renders a column's cell for a given job through the i18n/tooltip wrapper. */
+function renderCell(
+  columns: ColumnDef<BackgroundJobStatus, unknown>[],
+  columnId: string,
+  job: BackgroundJobStatus
+) {
+  const column = columns.find((c) => c.id === columnId);
+  if (!column?.cell || typeof column.cell !== 'function') {
+    throw new Error(`Column ${columnId} has no cell renderer`);
+  }
+  const ctx = { row: { original: job } } as unknown as CellContext<BackgroundJobStatus, unknown>;
+  const node = column.cell(ctx) as ReactElement | null;
+  return renderBackgroundJobs(<>{node}</>);
+}
+
+describe('createBackgroundJobColumns', () => {
+  it('produces a column per visible field plus an actions column', () => {
+    const ids = buildColumns()
+      .map((c) => c.id)
+      .filter(Boolean);
+    expect(ids).toEqual([
+      'jobName',
+      'cronExpression',
+      'isEnabled',
+      'lastExecutedAt',
+      'nextExecutionAt',
+      'consecutiveFailures',
+      'actions',
+    ]);
+  });
+
+  it('renders the job name cell', () => {
+    renderCell(buildColumns(), 'jobName', makeJob({ jobName: 'Indexer' }));
+    expect(screen.getByText('Indexer')).toBeInTheDocument();
+  });
+
+  it('renders a humanised cron cell', () => {
+    const { container } = renderCell(buildColumns(), 'cronExpression', makeJob());
+    expect(container.textContent).not.toBe('');
+  });
+
+  it('status cell: Active when enabled and healthy', () => {
+    renderCell(buildColumns(), 'isEnabled', makeJob({ isEnabled: true, consecutiveFailures: 0 }));
+    expect(screen.getByText('BackgroundJobs.Status.Active')).toBeInTheDocument();
+  });
+
+  it('status cell: Failing when enabled with failures', () => {
+    renderCell(buildColumns(), 'isEnabled', makeJob({ isEnabled: true, consecutiveFailures: 2 }));
+    expect(screen.getByText('BackgroundJobs.Status.Failing')).toBeInTheDocument();
+  });
+
+  it('status cell: Paused when disabled', () => {
+    renderCell(buildColumns(), 'isEnabled', makeJob({ isEnabled: false }));
+    expect(screen.getByText('BackgroundJobs.Status.Paused')).toBeInTheDocument();
+  });
+
+  it('last-execution cell: formatted value when present', () => {
+    renderCell(buildColumns(), 'lastExecutedAt', makeJob());
+    expect(screen.getByText('TIME_AGO')).toBeInTheDocument();
+  });
+
+  it('last-execution cell: Never when null', () => {
+    renderCell(buildColumns(), 'lastExecutedAt', makeJob({ lastExecutedAt: null }));
+    expect(screen.getByText('BackgroundJobs.Never')).toBeInTheDocument();
+  });
+
+  it('next-execution cell: formatted value when present', () => {
+    renderCell(buildColumns(), 'nextExecutionAt', makeJob());
+    expect(screen.getByText('FORMATTED_DATETIME')).toBeInTheDocument();
+  });
+
+  it('next-execution cell: NotScheduled when null', () => {
+    renderCell(buildColumns(), 'nextExecutionAt', makeJob({ nextExecutionAt: null }));
+    expect(screen.getByText('BackgroundJobs.NotScheduled')).toBeInTheDocument();
+  });
+
+  it('failures cell: null when no failures and no dead letters', () => {
+    const columns = buildColumns();
+    const column = columns.find((c) => c.id === 'consecutiveFailures');
+    const ctx = {
+      row: { original: makeJob({ consecutiveFailures: 0, deadLetterCount: 0 }) },
+    } as unknown as CellContext<BackgroundJobStatus, unknown>;
+    if (!column?.cell || typeof column.cell !== 'function') throw new Error('no cell');
+    expect(column.cell(ctx)).toBeNull();
+  });
+
+  it('failures cell: shows the failure count with lastError tooltip content', () => {
+    renderCell(
+      buildColumns(),
+      'consecutiveFailures',
+      makeJob({ consecutiveFailures: 5, lastError: 'boom' })
+    );
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('failures cell: falls back to the Failing label when lastError is null', async () => {
+    const { user } = renderCell(
+      buildColumns(),
+      'consecutiveFailures',
+      makeJob({ consecutiveFailures: 1, lastError: null })
+    );
+    await user.hover(screen.getByText('1'));
+    expect(await screen.findAllByText('BackgroundJobs.Status.Failing')).not.toHaveLength(0);
+  });
+
+  it('failures cell: shows the dead-letter line', () => {
+    renderCell(
+      buildColumns(),
+      'consecutiveFailures',
+      makeJob({ consecutiveFailures: 0, deadLetterCount: 4 })
+    );
+    expect(screen.getByText('BackgroundJobs.DeadLetters#4')).toBeInTheDocument();
+  });
+
+  it('actions cell: pause/trigger for an enabled job', async () => {
+    const columns = buildColumns();
+    const { user } = renderCell(columns, 'actions', makeJob({ isEnabled: true }));
+    await user.click(screen.getByRole('button', { name: /Actions for/ }));
+    await user.click(await screen.findByText('BackgroundJobs.Actions.Pause'));
+    expect(handlers.onPause).toHaveBeenCalled();
+  });
+
+  it('actions cell: triggers an enabled job from the menu', async () => {
+    handlers.onTrigger.mockClear();
+    const columns = buildColumns();
+    const { user } = renderCell(columns, 'actions', makeJob({ isEnabled: true }));
+    await user.click(screen.getByRole('button', { name: /Actions for/ }));
+    await user.click(await screen.findByText('BackgroundJobs.Actions.Trigger'));
+    expect(handlers.onTrigger).toHaveBeenCalled();
+  });
+
+  it('actions cell: resume for a disabled job, trigger disabled', async () => {
+    handlers.onResume.mockClear();
+    const columns = buildColumns();
+    const { user } = renderCell(columns, 'actions', makeJob({ isEnabled: false }));
+    await user.click(screen.getByRole('button', { name: /Actions for/ }));
+    const resume = await screen.findByText('BackgroundJobs.Actions.Resume');
+    await user.click(resume);
+    expect(handlers.onResume).toHaveBeenCalled();
+  });
+
+  it('actions cell: disables items while mutating', async () => {
+    const columns = buildColumns(true);
+    const { user } = renderCell(columns, 'actions', makeJob({ isEnabled: true }));
+    await user.click(screen.getByRole('button', { name: /Actions for/ }));
+    const menu = await screen.findByRole('menu');
+    const items = within(menu).getAllByRole('menuitem');
+    for (const item of items) {
+      expect(item).toHaveAttribute('aria-disabled', 'true');
+    }
+  });
+});

--- a/packages/@granit/react-ui-background-jobs/src/__tests__/cronstrue-locale.test.ts
+++ b/packages/@granit/react-ui-background-jobs/src/__tests__/cronstrue-locale.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCronstrueLocale, loadCronstrueLocale } from '../cronstrue-locale';
+
+// Mirror of LOCALE_MAP in cronstrue-locale.ts. Driving loadCronstrueLocale over
+// every entry exercises each `case` arm of the dynamic-import switch (branch
+// coverage), and getCronstrueLocale assertions pin the exact mapping behaviour.
+const LOCALE_MAP: Record<string, string> = {
+  af: 'af',
+  ar: 'ar',
+  be: 'be',
+  bg: 'bg',
+  ca: 'ca',
+  cs: 'cs',
+  da: 'da',
+  de: 'de',
+  en: 'en',
+  'en-GB': 'en',
+  es: 'es',
+  'es-MX': 'es',
+  fa: 'fa',
+  fi: 'fi',
+  fr: 'fr',
+  'fr-CA': 'fr',
+  he: 'he',
+  hr: 'hr',
+  hu: 'hu',
+  id: 'id',
+  it: 'it',
+  ja: 'ja',
+  ko: 'ko',
+  my: 'my',
+  nb: 'nb',
+  nl: 'nl',
+  pl: 'pl',
+  pt: 'pt_PT',
+  'pt-BR': 'pt_BR',
+  ro: 'ro',
+  ru: 'ru',
+  sk: 'sk',
+  sl: 'sl',
+  sr: 'sr',
+  sv: 'sv',
+  sw: 'sw',
+  th: 'th',
+  tr: 'tr',
+  uk: 'uk',
+  vi: 'vi',
+  zh: 'zh_CN',
+  'zh-TW': 'zh_TW',
+};
+
+describe('getCronstrueLocale', () => {
+  it('returns the dedicated locale for exact-key hits', () => {
+    expect(getCronstrueLocale('pt')).toBe('pt_PT');
+    expect(getCronstrueLocale('zh')).toBe('zh_CN');
+    expect(getCronstrueLocale('de')).toBe('de');
+  });
+
+  it('maps regional variants with their own map entry', () => {
+    expect(getCronstrueLocale('en-GB')).toBe('en');
+    expect(getCronstrueLocale('es-MX')).toBe('es');
+    expect(getCronstrueLocale('fr-CA')).toBe('fr');
+    expect(getCronstrueLocale('pt-BR')).toBe('pt_BR');
+    expect(getCronstrueLocale('zh-TW')).toBe('zh_TW');
+  });
+
+  it('falls back to the base language when the full tag is absent', () => {
+    expect(getCronstrueLocale('de-DE')).toBe('de');
+    expect(getCronstrueLocale('it-IT')).toBe('it');
+    expect(getCronstrueLocale('ja-JP')).toBe('ja');
+  });
+
+  it('falls back to en for unknown languages and tags', () => {
+    expect(getCronstrueLocale('hi')).toBe('en');
+    expect(getCronstrueLocale('xx-YY')).toBe('en');
+    expect(getCronstrueLocale('zz')).toBe('en');
+  });
+
+  it('returns en for an empty string', () => {
+    expect(getCronstrueLocale('')).toBe('en');
+  });
+});
+
+describe('loadCronstrueLocale', () => {
+  it('loads every mapped locale without throwing (covers each switch case)', async () => {
+    for (const tag of Object.keys(LOCALE_MAP)) {
+      await expect(loadCronstrueLocale(tag)).resolves.toBeUndefined();
+    }
+  });
+
+  it('no-ops on the second call for an already-loaded locale', async () => {
+    // 'de' was loaded in the previous test; calling again hits the
+    // `loaded.has(locale)` early-return branch.
+    await expect(loadCronstrueLocale('de')).resolves.toBeUndefined();
+    await expect(loadCronstrueLocale('de-DE')).resolves.toBeUndefined();
+  });
+
+  it('falls back to en (already loaded) for an unmapped locale', async () => {
+    await expect(loadCronstrueLocale('hi')).resolves.toBeUndefined();
+    await expect(loadCronstrueLocale('xx-YY')).resolves.toBeUndefined();
+  });
+});

--- a/packages/@granit/react-ui-background-jobs/src/__tests__/job-actions.test.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/__tests__/job-actions.test.tsx
@@ -1,0 +1,90 @@
+import { toISODateString } from '@granit/types';
+import { within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { JobActions } from '../components/job-actions';
+
+import { renderBackgroundJobs } from './test-utils';
+
+import type { BackgroundJobStatus } from '@granit/background-jobs';
+
+const pauseMutate = vi.fn();
+const resumeMutate = vi.fn();
+const triggerMutate = vi.fn();
+const pending = { pause: false, resume: false, trigger: false };
+
+vi.mock('@granit/react-background-jobs', () => ({
+  usePauseJob: () => ({ mutate: pauseMutate, isPending: pending.pause }),
+  useResumeJob: () => ({ mutate: resumeMutate, isPending: pending.resume }),
+  useTriggerJob: () => ({ mutate: triggerMutate, isPending: pending.trigger }),
+}));
+
+function makeJob(overrides: Partial<BackgroundJobStatus> = {}): BackgroundJobStatus {
+  return {
+    jobName: 'SampleJob',
+    cronExpression: '0 0 * * * ?',
+    isEnabled: true,
+    lastExecutedAt: toISODateString('2026-04-02T12:00:00Z'),
+    nextExecutionAt: toISODateString('2026-04-02T13:00:00Z'),
+    consecutiveFailures: 0,
+    deadLetterCount: 0,
+    lastError: null,
+    ...overrides,
+  };
+}
+
+describe('JobActions', () => {
+  beforeEach(() => {
+    pauseMutate.mockClear();
+    resumeMutate.mockClear();
+    triggerMutate.mockClear();
+    pending.pause = false;
+    pending.resume = false;
+    pending.trigger = false;
+  });
+
+  it('shows the pause control for an enabled job and pauses on click', async () => {
+    const { user } = renderBackgroundJobs(<JobActions job={makeJob({ isEnabled: true })} />);
+    const container = document.querySelector('[data-slot="job-actions"]') as HTMLElement;
+    const buttons = within(container).getAllByRole('button');
+    // First button is pause (enabled), second is trigger.
+    await user.click(buttons[0]);
+    expect(pauseMutate).toHaveBeenCalledWith('SampleJob');
+    expect(resumeMutate).not.toHaveBeenCalled();
+  });
+
+  it('shows the resume control for a disabled job and resumes on click', async () => {
+    const { user } = renderBackgroundJobs(<JobActions job={makeJob({ isEnabled: false })} />);
+    const container = document.querySelector('[data-slot="job-actions"]') as HTMLElement;
+    const buttons = within(container).getAllByRole('button');
+    await user.click(buttons[0]);
+    expect(resumeMutate).toHaveBeenCalledWith('SampleJob');
+    expect(pauseMutate).not.toHaveBeenCalled();
+  });
+
+  it('triggers the job when the trigger button is clicked', async () => {
+    const { user } = renderBackgroundJobs(<JobActions job={makeJob({ isEnabled: true })} />);
+    const container = document.querySelector('[data-slot="job-actions"]') as HTMLElement;
+    const buttons = within(container).getAllByRole('button');
+    await user.click(buttons[1]);
+    expect(triggerMutate).toHaveBeenCalledWith('SampleJob');
+  });
+
+  it('disables the trigger button for a disabled job', () => {
+    renderBackgroundJobs(<JobActions job={makeJob({ isEnabled: false })} />);
+    const container = document.querySelector('[data-slot="job-actions"]') as HTMLElement;
+    const buttons = within(container).getAllByRole('button');
+    // Second button is the trigger; disabled because the job is not enabled.
+    expect(buttons[1]).toBeDisabled();
+  });
+
+  it('disables all controls while a mutation is pending', () => {
+    pending.pause = true;
+    renderBackgroundJobs(<JobActions job={makeJob({ isEnabled: true })} />);
+    const container = document.querySelector('[data-slot="job-actions"]') as HTMLElement;
+    const buttons = within(container).getAllByRole('button');
+    for (const button of buttons) {
+      expect(button).toBeDisabled();
+    }
+  });
+});

--- a/packages/@granit/react-ui-background-jobs/src/__tests__/job-card.test.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/__tests__/job-card.test.tsx
@@ -1,0 +1,77 @@
+import { toISODateString } from '@granit/types';
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { JobCard } from '../components/job-card';
+
+import { renderBackgroundJobs } from './test-utils';
+
+import type { BackgroundJobStatus } from '@granit/background-jobs';
+
+// JobCard renders JobActions, which consumes the @granit/react-background-jobs
+// mutation hooks. Stub them so the card mounts without a real data layer.
+vi.mock('@granit/react-background-jobs', () => ({
+  usePauseJob: () => ({ mutate: vi.fn(), isPending: false }),
+  useResumeJob: () => ({ mutate: vi.fn(), isPending: false }),
+  useTriggerJob: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+function makeJob(overrides: Partial<BackgroundJobStatus> = {}): BackgroundJobStatus {
+  return {
+    jobName: 'NotificationDigestJob',
+    cronExpression: '0 */5 * * * ?',
+    isEnabled: true,
+    lastExecutedAt: toISODateString('2026-04-02T12:00:00Z'),
+    nextExecutionAt: toISODateString('2026-04-02T12:05:00Z'),
+    consecutiveFailures: 0,
+    deadLetterCount: 0,
+    lastError: null,
+    ...overrides,
+  };
+}
+
+describe('JobCard', () => {
+  it('renders the job name and a humanised cron expression', () => {
+    renderBackgroundJobs(<JobCard job={makeJob()} />);
+    expect(screen.getByText('NotificationDigestJob')).toBeInTheDocument();
+    expect(document.querySelector('[data-slot="job-card"]')).toBeInTheDocument();
+  });
+
+  it('shows "Never" / "Not scheduled" when timestamps are null', () => {
+    renderBackgroundJobs(
+      <JobCard job={makeJob({ lastExecutedAt: null, nextExecutionAt: null })} />
+    );
+    expect(screen.getByText('Never')).toBeInTheDocument();
+    expect(screen.getByText('Not scheduled')).toBeInTheDocument();
+  });
+
+  it('renders the failure panel with the last error when failing', () => {
+    renderBackgroundJobs(
+      <JobCard job={makeJob({ consecutiveFailures: 2, lastError: 'Connection refused' })} />
+    );
+    expect(screen.getByText('2 consecutive failures')).toBeInTheDocument();
+    expect(screen.getByText('Connection refused')).toBeInTheDocument();
+  });
+
+  it('renders the failure panel without an error line when lastError is null', () => {
+    renderBackgroundJobs(<JobCard job={makeJob({ consecutiveFailures: 1, lastError: null })} />);
+    expect(screen.getByText('1 consecutive failure')).toBeInTheDocument();
+  });
+
+  it('renders the dead-letter panel when dead letters exist', () => {
+    renderBackgroundJobs(<JobCard job={makeJob({ deadLetterCount: 3 })} />);
+    expect(screen.getByText('3 dead-letter messages')).toBeInTheDocument();
+  });
+
+  it('applies the dimmed style for a disabled job', () => {
+    renderBackgroundJobs(<JobCard job={makeJob({ isEnabled: false })} />);
+    const card = document.querySelector('[data-slot="job-card"]') as HTMLElement;
+    expect(card.className).toContain('opacity-70');
+  });
+
+  it('applies the destructive border for a failing job', () => {
+    renderBackgroundJobs(<JobCard job={makeJob({ consecutiveFailures: 4 })} />);
+    const card = document.querySelector('[data-slot="job-card"]') as HTMLElement;
+    expect(card.className).toContain('border-destructive/50');
+  });
+});

--- a/packages/@granit/react-ui-background-jobs/src/__tests__/job-status-badge.test.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/__tests__/job-status-badge.test.tsx
@@ -1,0 +1,52 @@
+import { toISODateString } from '@granit/types';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { JobStatusBadge } from '../components/job-status-badge';
+
+import { renderBackgroundJobs } from './test-utils';
+
+import type { BackgroundJobStatus } from '@granit/background-jobs';
+
+function makeJob(overrides: Partial<BackgroundJobStatus> = {}): BackgroundJobStatus {
+  return {
+    jobName: 'SampleJob',
+    cronExpression: '0 0 * * * ?',
+    isEnabled: true,
+    lastExecutedAt: toISODateString('2026-04-02T12:00:00Z'),
+    nextExecutionAt: toISODateString('2026-04-02T13:00:00Z'),
+    consecutiveFailures: 0,
+    deadLetterCount: 0,
+    lastError: null,
+    ...overrides,
+  };
+}
+
+describe('JobStatusBadge', () => {
+  it('renders the Paused badge when the job is disabled', () => {
+    renderBackgroundJobs(<JobStatusBadge job={makeJob({ isEnabled: false })} />);
+    expect(screen.getByText('Paused')).toBeInTheDocument();
+  });
+
+  it('renders the Failing badge when enabled with consecutive failures', () => {
+    renderBackgroundJobs(
+      <JobStatusBadge job={makeJob({ isEnabled: true, consecutiveFailures: 3 })} />
+    );
+    expect(screen.getByText('Failing')).toBeInTheDocument();
+  });
+
+  it('renders the Active badge when enabled and healthy', () => {
+    renderBackgroundJobs(
+      <JobStatusBadge job={makeJob({ isEnabled: true, consecutiveFailures: 0 })} />
+    );
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  it('prioritises Paused over Failing when disabled and failing', () => {
+    renderBackgroundJobs(
+      <JobStatusBadge job={makeJob({ isEnabled: false, consecutiveFailures: 5 })} />
+    );
+    expect(screen.getByText('Paused')).toBeInTheDocument();
+    expect(screen.queryByText('Failing')).not.toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/app-right-sidebar.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/app-right-sidebar.test.tsx
@@ -1,0 +1,44 @@
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderShell } from './test-utils';
+
+let state: { open: boolean; sheetOpen: boolean };
+const setSheetOpen = vi.fn();
+
+vi.mock('../right-sidebar-context', () => ({
+  useRightSidebar: () => ({ ...state, setSheetOpen }),
+}));
+
+const { AppRightSidebar } = await import('../app-right-sidebar');
+
+beforeEach(() => {
+  setSheetOpen.mockClear();
+  state = { open: false, sheetOpen: false };
+});
+
+describe('AppRightSidebar', () => {
+  it('renders the inline aside collapsed when closed', () => {
+    state = { open: false, sheetOpen: false };
+    renderShell(<AppRightSidebar />);
+    const aside = document.querySelector('[data-slot="app-right-sidebar"]');
+    expect(aside).toHaveAttribute('data-state', 'collapsed');
+    expect(aside).toHaveClass('w-0');
+  });
+
+  it('renders the inline aside expanded when open', () => {
+    state = { open: true, sheetOpen: false };
+    renderShell(<AppRightSidebar />);
+    const aside = document.querySelector('[data-slot="app-right-sidebar"]');
+    expect(aside).toHaveAttribute('data-state', 'expanded');
+    expect(aside).toHaveClass('w-(--sidebar-width)');
+  });
+
+  it('shows the mobile Sheet content with its title when the sheet is open', () => {
+    state = { open: false, sheetOpen: true };
+    renderShell(<AppRightSidebar />);
+    expect(screen.getByText('Right sidebar')).toBeInTheDocument();
+    // Placeholder body is rendered both inline and in the sheet.
+    expect(screen.getAllByText(/Placeholder content/).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/app-shell.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/app-shell.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ReactElement } from 'react';
+
+// AppShell reads `globalThis.matchMedia` in an effect; the shared jsdom setup
+// only installs it on `window`. Provide a minimal listener-capable stub.
+if (typeof globalThis.matchMedia !== 'function') {
+  globalThis.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof globalThis.matchMedia;
+}
+
+// Stub the composed children — each is covered by its own test. This keeps the
+// AppShell test focused on its layout + the sidebar-collapse state logic.
+vi.mock('../app-sidebar', () => ({
+  AppSidebar: ({ userMenu }: { userMenu?: React.ReactNode }) => (
+    <div data-slot="stub-sidebar">{userMenu}</div>
+  ),
+}));
+vi.mock('../app-right-sidebar', () => ({
+  AppRightSidebar: () => <div data-slot="stub-right" />,
+}));
+vi.mock('../header', () => ({
+  Header: ({ actions }: { actions?: React.ReactNode }) => (
+    <div data-slot="stub-header">{actions}</div>
+  ),
+}));
+
+const { AppShell } = await import('../app-shell');
+
+function renderAt(ui: ReactElement, route: string) {
+  return render(<MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>);
+}
+
+describe('AppShell', () => {
+  it('renders the children inside the layout content slot', () => {
+    renderAt(
+      <AppShell>
+        <p>page-body</p>
+      </AppShell>,
+      '/users'
+    );
+    expect(screen.getByText('page-body')).toBeInTheDocument();
+    expect(document.querySelector('[data-slot="layout-content"]')).not.toBeNull();
+    expect(document.querySelector('[data-slot="layout-main"]')).not.toBeNull();
+  });
+
+  it('forwards the user menu and header actions to the chrome slots', () => {
+    renderAt(
+      <AppShell userMenu={<span>menu-slot</span>} headerActions={<span>action-slot</span>}>
+        <p>body</p>
+      </AppShell>,
+      '/users'
+    );
+    expect(screen.getByText('menu-slot')).toBeInTheDocument();
+    expect(screen.getByText('action-slot')).toBeInTheDocument();
+  });
+
+  it('mounts the stubbed sidebar/header/right rail', () => {
+    renderAt(
+      <AppShell>
+        <p>body</p>
+      </AppShell>,
+      '/'
+    );
+    expect(document.querySelector('[data-slot="stub-sidebar"]')).not.toBeNull();
+    expect(document.querySelector('[data-slot="stub-header"]')).not.toBeNull();
+    expect(document.querySelector('[data-slot="stub-right"]')).not.toBeNull();
+  });
+
+  it('accepts a custom collapsedPaths set without crashing on a non-collapsed route', () => {
+    renderAt(
+      <AppShell collapsedPaths={['/launcher']}>
+        <p>body</p>
+      </AppShell>,
+      '/dashboard'
+    );
+    expect(screen.getByText('body')).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/app-sidebar.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/app-sidebar.test.tsx
@@ -1,0 +1,159 @@
+import { screen } from '@testing-library/react';
+import { Folder } from 'lucide-react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeItem, makeT, makeTree, makeWorkspace, renderShell } from './test-utils';
+
+import type { ShellNavGroup, ShellNavItem } from '../shell-chrome-context';
+import type { WorkspaceTreeResponse } from '@granit/workspaces';
+
+vi.mock('@granit/react-localization', () => ({ useTranslation: () => ({ t: makeT() }) }));
+
+// Stub the two heavy child trees; they have their own dedicated tests.
+vi.mock('../workspace-content-nav', () => ({
+  WorkspaceContentNav: () => <div data-slot="workspace-content-nav" />,
+}));
+vi.mock('../workspace-switcher-menu', () => ({
+  WorkspaceSwitcherMenu: () => <div data-slot="workspace-switcher" />,
+}));
+
+let granted: Set<string>;
+vi.mock('@granit/react-authorization', () => ({
+  usePermissions: () => ({ hasPermission: (p: string) => granted.has(p) }),
+}));
+
+let tree: WorkspaceTreeResponse | undefined;
+let activeWorkspaceName: string | null = null;
+vi.mock('@granit/react-workspaces', () => ({
+  useWorkspaces: () => ({ data: tree }),
+}));
+vi.mock('../use-active-workspace', () => ({
+  useActiveWorkspace: () => ({ activeWorkspaceName, setActiveWorkspace: vi.fn() }),
+}));
+
+let chrome: {
+  appKind: 'host' | 'tenant';
+  navModel: { mainNavigation: ShellNavItem[]; navGroups: ShellNavGroup[] };
+  appVersion?: string;
+};
+vi.mock('../shell-chrome-context', () => ({
+  useShellChrome: () => chrome,
+}));
+
+const { AppSidebar } = await import('../app-sidebar');
+
+const leaf = (over: Partial<ShellNavItem> = {}): ShellNavItem => ({
+  titleKey: 'Nav.Item',
+  href: '/users',
+  icon: Folder,
+  ...over,
+});
+
+beforeEach(() => {
+  granted = new Set();
+  tree = undefined;
+  activeWorkspaceName = null;
+  chrome = {
+    appKind: 'tenant',
+    navModel: { mainNavigation: [], navGroups: [] },
+  };
+});
+
+describe('AppSidebar', () => {
+  it('renders the static admin-console nav when no workspace nav is active', () => {
+    chrome.navModel.mainNavigation = [leaf({ titleKey: 'Users', href: '/users' })];
+    renderShell(<AppSidebar />, { route: '/' });
+    expect(screen.getByText('Admin Console')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Users' })).toHaveAttribute('href', '/users');
+    expect(screen.queryByTestId('workspace-content-nav')).not.toBeInTheDocument();
+  });
+
+  it('marks a static nav item active when the route matches', () => {
+    chrome.navModel.mainNavigation = [leaf({ titleKey: 'Users', href: '/users' })];
+    renderShell(<AppSidebar />, { route: '/users/42' });
+    expect(screen.getByRole('link', { name: 'Users' })).toHaveAttribute('data-active', 'true');
+  });
+
+  it('renders a collapsible parent with children and marks the active child', () => {
+    chrome.navModel.mainNavigation = [
+      leaf({
+        titleKey: 'Settings',
+        href: '/settings',
+        children: [
+          { titleKey: 'General', href: '/settings/general' },
+          { titleKey: 'Security', href: '/settings/security' },
+        ],
+      }),
+    ];
+    renderShell(<AppSidebar />, { route: '/settings/security' });
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Security' })).toHaveAttribute('data-active', 'true');
+    expect(screen.getByRole('link', { name: 'General' })).not.toHaveAttribute(
+      'data-active',
+      'true'
+    );
+  });
+
+  it('filters main nav items by permission', () => {
+    chrome.navModel.mainNavigation = [
+      leaf({ titleKey: 'Open', href: '/open' }),
+      leaf({ titleKey: 'Locked', href: '/locked', permission: 'admin' }),
+    ];
+    renderShell(<AppSidebar />, { route: '/' });
+    expect(screen.getByText('Open')).toBeInTheDocument();
+    expect(screen.queryByText('Locked')).not.toBeInTheDocument();
+  });
+
+  it('renders a nav group only when it has visible items', () => {
+    chrome.navModel.navGroups = [
+      { labelKey: 'Group.Visible', items: [leaf({ titleKey: 'Vis', href: '/vis' })] },
+      {
+        labelKey: 'Group.Hidden',
+        items: [leaf({ titleKey: 'Hid', href: '/hid', permission: 'x' })],
+      },
+    ];
+    renderShell(<AppSidebar />, { route: '/' });
+    expect(screen.getByText('Group.Visible')).toBeInTheDocument();
+    expect(screen.queryByText('Group.Hidden')).not.toBeInTheDocument();
+  });
+
+  it('renders the app version footer when provided', () => {
+    chrome.appVersion = '1.2.3';
+    renderShell(<AppSidebar />, { route: '/' });
+    expect(screen.getByText('v1.2.3')).toBeInTheDocument();
+  });
+
+  it('renders the app-supplied user menu slot', () => {
+    renderShell(<AppSidebar userMenu={<div>UserMenuSlot</div>} />, { route: '/' });
+    expect(screen.getByText('UserMenuSlot')).toBeInTheDocument();
+  });
+
+  it('uses workspace-driven nav when the active workspace has items', () => {
+    activeWorkspaceName = 'crm';
+    tree = makeTree([
+      makeWorkspace({
+        name: 'crm',
+        sections: [
+          {
+            key: 's',
+            displayKey: null,
+            order: 0,
+            collapsedByDefault: false,
+            items: [makeItem({ kind: 'Entity', entityName: 'Party' })],
+          },
+        ],
+      }),
+    ]);
+    renderShell(<AppSidebar />, { route: '/w/crm' });
+    expect(document.querySelector('[data-slot="workspace-content-nav"]')).not.toBeNull();
+    expect(screen.queryByText('Admin Console')).not.toBeInTheDocument();
+  });
+
+  it('falls back to static nav when the active workspace has no items', () => {
+    activeWorkspaceName = 'crm';
+    tree = makeTree([makeWorkspace({ name: 'crm', sections: [] })]);
+    chrome.navModel.mainNavigation = [leaf({ titleKey: 'Users', href: '/users' })];
+    renderShell(<AppSidebar />, { route: '/w/crm' });
+    expect(screen.getByText('Admin Console')).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/command-palette.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/command-palette.test.tsx
@@ -1,0 +1,220 @@
+import { act, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OPEN_COMMAND_PALETTE_EVENT } from '../command-palette-events';
+
+import {
+  emptyFeatureRoutes,
+  makeItem,
+  makeT,
+  makeTree,
+  makeWorkspace,
+  renderShell,
+} from './test-utils';
+
+import type { WorkspaceTreeResponse } from '@granit/workspaces';
+import type * as ReactRouter from 'react-router-dom';
+
+vi.mock('@granit/react-localization', () => ({ useTranslation: () => ({ t: makeT() }) }));
+
+vi.mock('./workspace-icon', () => ({
+  WorkspaceIcon: ({ name }: { name: string | null }) => <span data-slot="icon">{name ?? ''}</span>,
+}));
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactRouter>();
+  return { ...actual, useNavigate: () => navigate };
+});
+
+let tree: WorkspaceTreeResponse | undefined;
+const setActiveWorkspace = vi.fn();
+
+vi.mock('@granit/react-workspaces', () => ({
+  useWorkspaces: () => ({ data: tree }),
+  useFeatureRouteTable: () => emptyFeatureRoutes,
+}));
+
+vi.mock('../use-active-workspace', () => ({
+  useActiveWorkspace: () => ({ activeWorkspaceName: null, setActiveWorkspace }),
+}));
+
+const { CommandPalette } = await import('../command-palette');
+
+function openViaEvent() {
+  act(() => {
+    globalThis.dispatchEvent(new CustomEvent(OPEN_COMMAND_PALETTE_EVENT));
+  });
+}
+
+beforeEach(() => {
+  navigate.mockClear();
+  setActiveWorkspace.mockClear();
+  tree = undefined;
+});
+
+describe('CommandPalette', () => {
+  it('renders nothing visible until opened', () => {
+    tree = makeTree([makeWorkspace({ name: 'crm', displayKey: 'Crm:Customers' })]);
+    renderShell(<CommandPalette />);
+    expect(screen.queryByPlaceholderText('Type a command or search…')).not.toBeInTheDocument();
+  });
+
+  it('opens on the custom event and lists workspaces and items', async () => {
+    tree = makeTree([
+      makeWorkspace({
+        name: 'crm',
+        displayKey: 'Crm:Customers',
+        sections: [
+          {
+            key: 's',
+            displayKey: null,
+            order: 0,
+            collapsedByDefault: false,
+            items: [makeItem({ kind: 'Entity', entityName: 'Party', displayKey: 'Crm:Party' })],
+          },
+        ],
+      }),
+    ]);
+    renderShell(<CommandPalette />);
+    openViaEvent();
+    expect(await screen.findByPlaceholderText('Type a command or search…')).toBeInTheDocument();
+    expect(screen.getByText('Workspaces')).toBeInTheDocument();
+    expect(screen.getByText('Items')).toBeInTheDocument();
+    // "Customers" appears as the workspace entry and as each item's parent label.
+    expect(screen.getAllByText('Customers').length).toBeGreaterThan(0);
+    expect(screen.getByText('Party')).toBeInTheDocument();
+  });
+
+  it('hides the workspace group when only shell workspaces exist but still lists their items', async () => {
+    tree = makeTree([
+      makeWorkspace({
+        name: 'identity',
+        isShell: true,
+        displayKey: 'Id:Identity',
+        sections: [
+          {
+            key: 's',
+            displayKey: null,
+            order: 0,
+            collapsedByDefault: false,
+            items: [makeItem({ kind: 'Entity', entityName: 'User', displayKey: 'Id:User' })],
+          },
+        ],
+      }),
+    ]);
+    renderShell(<CommandPalette />);
+    openViaEvent();
+    await screen.findByPlaceholderText('Type a command or search…');
+    // No switchable (non-shell) workspaces -> the Workspaces group is omitted.
+    expect(screen.queryByText('Workspaces')).not.toBeInTheDocument();
+    // But the shell's items are still flattened into the Items group.
+    expect(screen.getByText('Items')).toBeInTheDocument();
+    expect(screen.getByText('User')).toBeInTheDocument();
+  });
+
+  it('renders the empty list when no workspaces are loaded', async () => {
+    tree = makeTree([]);
+    renderShell(<CommandPalette />);
+    openViaEvent();
+    await screen.findByPlaceholderText('Type a command or search…');
+    expect(screen.queryByText('Workspaces')).not.toBeInTheDocument();
+    expect(screen.queryByText('Items')).not.toBeInTheDocument();
+  });
+
+  it('navigates and sets the active workspace when a workspace entry is selected', async () => {
+    tree = makeTree([makeWorkspace({ name: 'crm', displayKey: 'Crm:Customers' })]);
+    const { user } = renderShell(<CommandPalette />);
+    openViaEvent();
+    await screen.findByPlaceholderText('Type a command or search…');
+    await user.click(screen.getByText('Customers'));
+    expect(setActiveWorkspace).toHaveBeenCalledWith('crm');
+    expect(navigate).toHaveBeenCalledWith('/w/crm');
+  });
+
+  it('navigates to an item href and sets its parent workspace active', async () => {
+    tree = makeTree([
+      makeWorkspace({
+        name: 'crm',
+        displayKey: 'Crm:Customers',
+        sections: [
+          {
+            key: 's',
+            displayKey: null,
+            order: 0,
+            collapsedByDefault: false,
+            items: [makeItem({ kind: 'Entity', entityName: 'Party', displayKey: 'Crm:Party' })],
+          },
+        ],
+      }),
+    ]);
+    const { user } = renderShell(<CommandPalette />);
+    openViaEvent();
+    await screen.findByPlaceholderText('Type a command or search…');
+    await user.click(screen.getByText('Party'));
+    expect(setActiveWorkspace).toHaveBeenCalledWith('crm');
+    expect(navigate).toHaveBeenCalledWith('/w/crm/Party');
+  });
+
+  it('opens external links in a new tab instead of navigating', async () => {
+    const openSpy = vi.spyOn(globalThis, 'open').mockImplementation(() => null);
+    tree = makeTree([
+      makeWorkspace({
+        name: 'crm',
+        displayKey: 'Crm:Customers',
+        sections: [
+          {
+            key: 's',
+            displayKey: null,
+            order: 0,
+            collapsedByDefault: false,
+            items: [
+              makeItem({ kind: 'Link', linkUrl: 'https://example.com', displayKey: 'Crm:Docs' }),
+            ],
+          },
+        ],
+      }),
+    ]);
+    const { user } = renderShell(<CommandPalette />);
+    openViaEvent();
+    await screen.findByPlaceholderText('Type a command or search…');
+    await user.click(screen.getByText('Docs'));
+    expect(openSpy).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer');
+    expect(navigate).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+
+  it('does not navigate when a disabled item (no href) is selected', async () => {
+    tree = makeTree([
+      makeWorkspace({
+        name: 'crm',
+        displayKey: 'Crm:Customers',
+        sections: [
+          {
+            key: 's',
+            displayKey: null,
+            order: 0,
+            collapsedByDefault: false,
+            // Entity with no entityName -> resolveItemHref returns null -> disabled.
+            items: [makeItem({ kind: 'Entity', entityName: null, displayKey: 'Crm:Empty' })],
+          },
+        ],
+      }),
+    ]);
+    const { user } = renderShell(<CommandPalette />);
+    openViaEvent();
+    await screen.findByPlaceholderText('Type a command or search…');
+    await user.click(screen.getByText('Empty'));
+    expect(navigate).not.toHaveBeenCalled();
+    expect(setActiveWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('toggles open via the Ctrl+K shortcut', async () => {
+    tree = makeTree([makeWorkspace({ name: 'crm', displayKey: 'Crm:Customers' })]);
+    renderShell(<CommandPalette />);
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true }));
+    });
+    expect(await screen.findByPlaceholderText('Type a command or search…')).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/header.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/header.test.tsx
@@ -1,0 +1,93 @@
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeT, renderShell } from './test-utils';
+
+vi.mock('@granit/react-localization', () => ({ useTranslation: () => ({ t: makeT() }) }));
+
+// useRightSidebar is consumed via the package's own context; stub it so we can
+// drive both the open and closed branches without a real provider.
+const toggle = vi.fn();
+let sidebarOpen = false;
+vi.mock('../right-sidebar-context', () => ({
+  useRightSidebar: () => ({ open: sidebarOpen, toggle }),
+}));
+
+const dispatchSpy = vi.fn();
+vi.mock('../command-palette-events', () => ({
+  openCommandPalette: () => dispatchSpy(),
+}));
+
+// Imported after the mocks are registered.
+const { Header } = await import('../header');
+
+beforeEach(() => {
+  toggle.mockClear();
+  dispatchSpy.mockClear();
+  sidebarOpen = false;
+});
+
+describe('Header', () => {
+  it('renders the command-palette trigger and sidebar trigger', () => {
+    renderShell(<Header />, { route: '/' });
+    expect(screen.getByRole('button', { name: 'Open command palette' })).toBeInTheDocument();
+    expect(screen.getByText('Type a command or search…')).toBeInTheDocument();
+  });
+
+  it('renders no breadcrumb on the root route (no segments)', () => {
+    renderShell(<Header routeLabels={{ users: 'Navigation.Users' }} />, { route: '/' });
+    expect(screen.queryByText('Navigation.Users')).not.toBeInTheDocument();
+  });
+
+  it('renders a single breadcrumb page when only the root segment matches a label', () => {
+    renderShell(<Header routeLabels={{ users: 'Navigation.Users' }} />, { route: '/users' });
+    expect(screen.getByText('Navigation.Users')).toBeInTheDocument();
+  });
+
+  it('renders root link + detail page for a two-segment route', () => {
+    renderShell(<Header routeLabels={{ users: 'Navigation.Users' }} />, { route: '/users/42' });
+    const link = screen.getByRole('link', { name: 'Navigation.Users' });
+    expect(link).toHaveAttribute('href', '/users');
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('labels a "new" detail segment with the New label instead of the raw value', () => {
+    renderShell(<Header routeLabels={{ users: 'Navigation.Users' }} />, { route: '/users/new' });
+    expect(screen.getByText('New')).toBeInTheDocument();
+    expect(screen.queryByText('new')).not.toBeInTheDocument();
+  });
+
+  it('omits the breadcrumb entirely when the root segment is unmapped', () => {
+    renderShell(<Header routeLabels={{}} />, { route: '/unknown/1' });
+    expect(screen.queryByText('unknown')).not.toBeInTheDocument();
+  });
+
+  it('renders app-supplied actions', () => {
+    renderShell(<Header actions={<button type="button">Bell</button>} />, { route: '/' });
+    expect(screen.getByRole('button', { name: 'Bell' })).toBeInTheDocument();
+  });
+
+  it('shows the "open" right-panel icon and toggles on click when closed', async () => {
+    sidebarOpen = false;
+    const { user } = renderShell(<Header />, { route: '/' });
+    const toggleButton = screen.getByRole('button', { name: 'Toggle right panel' });
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+    await user.click(toggleButton);
+    expect(toggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('reflects the expanded state when the right panel is open', () => {
+    sidebarOpen = true;
+    renderShell(<Header />, { route: '/' });
+    expect(screen.getByRole('button', { name: 'Toggle right panel' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+  });
+
+  it('opens the command palette when the trigger is clicked', async () => {
+    const { user } = renderShell(<Header />, { route: '/' });
+    await user.click(screen.getByRole('button', { name: 'Open command palette' }));
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/host-home-page.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/host-home-page.test.tsx
@@ -1,0 +1,84 @@
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeT, makeTree, makeWorkspace, renderShell } from './test-utils';
+
+import type { WorkspaceTreeResponse } from '@granit/workspaces';
+import type * as ReactRouter from 'react-router-dom';
+
+vi.mock('@granit/react-localization', () => ({ useTranslation: () => ({ t: makeT() }) }));
+
+vi.mock('./workspace-icon', () => ({
+  WorkspaceIcon: ({ name }: { name: string | null }) => <span data-slot="icon">{name ?? ''}</span>,
+}));
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactRouter>();
+  return { ...actual, useNavigate: () => navigate };
+});
+
+let tree: WorkspaceTreeResponse | undefined;
+let isLoading = false;
+const setActiveWorkspace = vi.fn();
+
+vi.mock('@granit/react-workspaces', () => ({
+  useWorkspaces: () => ({ data: tree, isLoading }),
+}));
+
+vi.mock('../use-active-workspace', () => ({
+  useActiveWorkspace: () => ({ activeWorkspaceName: null, setActiveWorkspace }),
+}));
+
+const { HostHomePage } = await import('../host-home-page');
+
+beforeEach(() => {
+  navigate.mockClear();
+  setActiveWorkspace.mockClear();
+  tree = undefined;
+  isLoading = false;
+});
+
+describe('HostHomePage', () => {
+  it('renders the title and subtitle', () => {
+    tree = makeTree([]);
+    renderShell(<HostHomePage />);
+    expect(screen.getByRole('heading', { name: 'Granit Showcase' })).toBeInTheDocument();
+    expect(screen.getByText('Choose a workspace to get started.')).toBeInTheDocument();
+  });
+
+  it('renders skeleton tiles while loading', () => {
+    isLoading = true;
+    renderShell(<HostHomePage />);
+    expect(document.querySelector('[data-slot="host-home-grid"]')).toBeNull();
+    expect(screen.queryByText('No workspaces are registered for the current user.')).toBeNull();
+  });
+
+  it('renders the empty state when no non-shell workspaces exist', () => {
+    tree = makeTree([makeWorkspace({ name: 'identity', isShell: true })]);
+    renderShell(<HostHomePage />);
+    expect(
+      screen.getByText('No workspaces are registered for the current user.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders a tile per launcher workspace, filtering out shells', () => {
+    tree = makeTree([
+      makeWorkspace({ name: 'crm', displayKey: 'Crm:Customers' }),
+      makeWorkspace({ name: 'identity', isShell: true, displayKey: 'Id:Identity' }),
+    ]);
+    renderShell(<HostHomePage />);
+    const tiles = document.querySelectorAll('[data-slot="host-home-tile"]');
+    expect(tiles).toHaveLength(1);
+    expect(screen.getByText('Customers')).toBeInTheDocument();
+    expect(screen.queryByText('Identity')).not.toBeInTheDocument();
+  });
+
+  it('selects the workspace and navigates when a tile is clicked', async () => {
+    tree = makeTree([makeWorkspace({ name: 'crm', displayKey: 'Crm:Customers' })]);
+    const { user } = renderShell(<HostHomePage />);
+    await user.click(screen.getByText('Customers'));
+    expect(setActiveWorkspace).toHaveBeenCalledWith('crm');
+    expect(navigate).toHaveBeenCalledWith('/w/crm');
+  });
+});

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/nav-user-presence-menu.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/nav-user-presence-menu.test.tsx
@@ -1,0 +1,83 @@
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@granit/react-ui';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeT } from './test-utils';
+
+import type { ReactElement } from 'react';
+
+vi.mock('@granit/react-localization', () => ({ useTranslation: () => ({ t: makeT() }) }));
+
+vi.mock('@granit/react-presence', () => ({
+  PresenceDot: ({ status }: { status: string }) => <span data-slot="dot">{status}</span>,
+  useMyPresence: () => ({ data: presenceData }),
+  useSetMyPresence: () => ({ mutate: setMutate }),
+  useClearMyPresenceOverride: () => ({ mutate: clearMutate }),
+}));
+
+const setMutate = vi.fn();
+const clearMutate = vi.fn();
+let presenceData: { effectiveStatus: string; manualOverride: string | null } | undefined;
+
+const { NavUserPresenceMenu } = await import('../nav-user-presence-menu');
+
+function renderOpen(ui: ReactElement) {
+  return {
+    ...render(
+      <DropdownMenu defaultOpen>
+        <DropdownMenuTrigger>menu</DropdownMenuTrigger>
+        <DropdownMenuContent>{ui}</DropdownMenuContent>
+      </DropdownMenu>
+    ),
+    user: userEvent.setup(),
+  };
+}
+
+beforeEach(() => {
+  setMutate.mockClear();
+  clearMutate.mockClear();
+  presenceData = undefined;
+});
+
+describe('NavUserPresenceMenu', () => {
+  it('renders the trigger with the effective status label (defaults to Offline)', () => {
+    presenceData = undefined;
+    renderOpen(<NavUserPresenceMenu />);
+    // triggerLabel = t('Status.Offline') -> last-segment fallback "Offline".
+    expect(screen.getByText('Status.Offline')).toBeInTheDocument();
+  });
+
+  it('reflects an Online effective status on the trigger', () => {
+    presenceData = { effectiveStatus: 'Online', manualOverride: null };
+    renderOpen(<NavUserPresenceMenu />);
+    expect(screen.getByText('Status.Online')).toBeInTheDocument();
+  });
+
+  it('opens the status submenu rendering every manual status option', async () => {
+    presenceData = { effectiveStatus: 'Online', manualOverride: null };
+    const { user } = renderOpen(<NavUserPresenceMenu />);
+    await user.click(screen.getByText('Status.Online'));
+    // Each STATUS_OPTIONS entry is rendered (covers the option map +
+    // manualToEffective for Available/Busy/DoNotDisturb/AppearOffline).
+    expect(await screen.findByText('Manual.Available')).toBeInTheDocument();
+    expect(screen.getByText('Manual.Busy')).toBeInTheDocument();
+    expect(screen.getByText('Manual.DoNotDisturb')).toBeInTheDocument();
+    // AppearOffline shows as "Offline" (Status.Offline key, last segment).
+    expect(screen.getByText('Status.Offline')).toBeInTheDocument();
+    // No active override -> none of the options is flagged active.
+    expect(document.querySelector('[role="menuitem"][data-active="true"]')).toBeNull();
+  });
+
+  it('flags the active override and enables the Until/Clear actions when an override exists', async () => {
+    presenceData = { effectiveStatus: 'Busy', manualOverride: 'Busy' };
+    const { user } = renderOpen(<NavUserPresenceMenu />);
+    await user.click(screen.getAllByText('Status.Busy')[0]);
+    // The matching option carries data-active (hasOverride branch).
+    expect(await screen.findByText('Picker.Clear')).toBeInTheDocument();
+    expect(document.querySelector('[role="menuitem"][data-active="true"]')).not.toBeNull();
+    // The "Until" duration sub-trigger is enabled (not aria-disabled).
+    const until = screen.getByText('Picker.Until').closest('[role="menuitem"]');
+    expect(until).not.toHaveAttribute('aria-disabled', 'true');
+  });
+});

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/right-sidebar-context.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/right-sidebar-context.test.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { RightSidebarProvider, useRightSidebar } from '../right-sidebar-context';
+
+import type { ReactNode } from 'react';
+
+const STORAGE_KEY = 'granit:right-sidebar-open';
+
+function wrapper({ children }: { readonly children: ReactNode }) {
+  return <RightSidebarProvider>{children}</RightSidebarProvider>;
+}
+
+const originalMatchMedia = globalThis.matchMedia;
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  globalThis.matchMedia = originalMatchMedia;
+});
+
+describe('useRightSidebar', () => {
+  it('throws when used outside the provider', () => {
+    expect(() => renderHook(() => useRightSidebar())).toThrow(/RightSidebarProvider/);
+  });
+
+  it('defaults to closed when nothing is persisted', () => {
+    const { result } = renderHook(() => useRightSidebar(), { wrapper });
+    expect(result.current.open).toBe(false);
+  });
+
+  it('hydrates the open state from localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    const { result } = renderHook(() => useRightSidebar(), { wrapper });
+    expect(result.current.open).toBe(true);
+  });
+
+  it('setOpen persists the new value', () => {
+    const { result } = renderHook(() => useRightSidebar(), { wrapper });
+    act(() => result.current.setOpen(true));
+    expect(result.current.open).toBe(true);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+  });
+
+  it('toggle flips the inline state on desktop', () => {
+    globalThis.matchMedia = (() => ({ matches: true })) as unknown as typeof globalThis.matchMedia;
+    const { result } = renderHook(() => useRightSidebar(), { wrapper });
+    act(() => result.current.toggle());
+    expect(result.current.open).toBe(true);
+    act(() => result.current.toggle());
+    expect(result.current.open).toBe(false);
+  });
+
+  it('toggle opens the mobile sheet instead of the inline panel on small screens', () => {
+    globalThis.matchMedia = (() => ({ matches: false })) as unknown as typeof globalThis.matchMedia;
+    const { result } = renderHook(() => useRightSidebar(), { wrapper });
+    act(() => result.current.toggle());
+    expect(result.current.sheetOpen).toBe(true);
+    expect(result.current.open).toBe(false);
+  });
+
+  it('setSheetOpen updates the mobile sheet state', () => {
+    const { result } = renderHook(() => useRightSidebar(), { wrapper });
+    act(() => result.current.setSheetOpen(true));
+    expect(result.current.sheetOpen).toBe(true);
+  });
+});

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/shell-chrome-context.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/shell-chrome-context.test.tsx
@@ -1,0 +1,41 @@
+import { render, renderHook, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  ShellChromeProvider,
+  useShellChrome,
+  type ShellChromeValue,
+} from '../shell-chrome-context';
+
+import type { ReactNode } from 'react';
+
+const value: ShellChromeValue = {
+  appKind: 'host',
+  navModel: { mainNavigation: [], navGroups: [] },
+  appVersion: '9.9.9',
+};
+
+describe('ShellChromeProvider / useShellChrome', () => {
+  it('provides the chrome value to consumers', () => {
+    const { result } = renderHook(() => useShellChrome(), {
+      wrapper: ({ children }: { readonly children: ReactNode }) => (
+        <ShellChromeProvider value={value}>{children}</ShellChromeProvider>
+      ),
+    });
+    expect(result.current.appKind).toBe('host');
+    expect(result.current.appVersion).toBe('9.9.9');
+  });
+
+  it('renders children inside the provider', () => {
+    render(
+      <ShellChromeProvider value={value}>
+        <span>chrome-child</span>
+      </ShellChromeProvider>
+    );
+    expect(screen.getByText('chrome-child')).toBeInTheDocument();
+  });
+
+  it('throws when used outside the provider', () => {
+    expect(() => renderHook(() => useShellChrome())).toThrow(/ShellChromeProvider/);
+  });
+});

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/test-utils.tsx
@@ -1,0 +1,101 @@
+import { SidebarProvider, TooltipProvider } from '@granit/react-ui';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import type {
+  FeatureRouteTable,
+  WorkspaceItemResponse,
+  WorkspaceResponse,
+  WorkspaceTreeResponse,
+} from '@granit/workspaces';
+import type { ReactElement, ReactNode } from 'react';
+
+// The shared jsdom setup installs `matchMedia` on `window` but `react-ui`'s
+// `useIsMobile` reads `globalThis.matchMedia`. Alias it so SidebarProvider's
+// mobile check resolves in tests.
+if (typeof globalThis.matchMedia !== 'function') {
+  globalThis.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof globalThis.matchMedia;
+}
+
+// ---------------------------------------------------------------------------
+// i18n stub
+// ---------------------------------------------------------------------------
+// The shell-admin package ships no locale bundle; every component calls
+// `t(key, fallback)` with an inline English fallback. Tests mock the
+// localization hook (`vi.mock('@granit/react-localization', …)`) so `t`
+// returns the provided fallback (or the key when none is given) — this yields
+// the same visible strings the app renders, without booting i18next.
+export function makeT() {
+  return (key: string, fallback?: string) => fallback ?? key;
+}
+
+// ---------------------------------------------------------------------------
+// Render helper — wraps in MemoryRouter (components read useLocation /
+// useNavigate), SidebarProvider (sidebar primitives require it) and
+// TooltipProvider (SidebarMenuButton tooltips). `route` seeds the initial
+// location so active/inactive nav branches can be exercised.
+// ---------------------------------------------------------------------------
+export function renderShell(ui: ReactElement, options: { readonly route?: string } = {}) {
+  const { route = '/' } = options;
+  return {
+    ...render(ui, {
+      wrapper: ({ children }: { readonly children: ReactNode }) => (
+        <MemoryRouter initialEntries={[route]}>
+          <TooltipProvider>
+            <SidebarProvider>{children}</SidebarProvider>
+          </TooltipProvider>
+        </MemoryRouter>
+      ),
+    }),
+    user: userEvent.setup(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Workspace fixture builders
+// ---------------------------------------------------------------------------
+export function makeItem(overrides: Partial<WorkspaceItemResponse> = {}): WorkspaceItemResponse {
+  return {
+    kind: 'Entity',
+    order: 0,
+    displayKey: null,
+    icon: null,
+    entityName: null,
+    entityViewName: null,
+    entityPresetOverlay: null,
+    dashboardName: null,
+    linkUrl: null,
+    subWorkspaceName: null,
+    featureName: null,
+    routeName: null,
+    ...overrides,
+  };
+}
+
+export function makeWorkspace(overrides: Partial<WorkspaceResponse> = {}): WorkspaceResponse {
+  return {
+    name: 'crm',
+    displayKey: null,
+    icon: null,
+    order: 0,
+    isShell: false,
+    sections: [],
+    ...overrides,
+  };
+}
+
+export function makeTree(workspaces: readonly WorkspaceResponse[]): WorkspaceTreeResponse {
+  return { schemaVersion: 1, workspaces };
+}
+
+export const emptyFeatureRoutes: FeatureRouteTable = {};

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/workspace-content-nav.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/workspace-content-nav.test.tsx
@@ -1,0 +1,226 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  emptyFeatureRoutes,
+  makeItem,
+  makeT,
+  makeTree,
+  makeWorkspace,
+  renderShell,
+} from './test-utils';
+
+import type { WorkspaceTreeResponse } from '@granit/workspaces';
+
+vi.mock('@granit/react-localization', () => ({ useTranslation: () => ({ t: makeT() }) }));
+
+vi.mock('./workspace-icon', () => ({
+  WorkspaceIcon: ({ name }: { name: string | null }) => <span data-slot="icon">{name ?? ''}</span>,
+}));
+
+let tree: WorkspaceTreeResponse | undefined;
+let activeWorkspaceName: string | null = 'crm';
+
+vi.mock('@granit/react-workspaces', () => ({
+  useWorkspaces: () => ({ data: tree }),
+  useFeatureRouteTable: () => emptyFeatureRoutes,
+}));
+
+vi.mock('../use-active-workspace', () => ({
+  useActiveWorkspace: () => ({ activeWorkspaceName, setActiveWorkspace: vi.fn() }),
+}));
+
+const { WorkspaceContentNav } = await import('../workspace-content-nav');
+
+function setState(next: { tree?: WorkspaceTreeResponse; active?: string | null }) {
+  tree = next.tree;
+  activeWorkspaceName = next.active ?? null;
+}
+
+describe('WorkspaceContentNav', () => {
+  it('returns null when no workspace data is loaded', () => {
+    setState({ tree: undefined, active: 'crm' });
+    const { container } = renderShell(<WorkspaceContentNav />);
+    expect(container.querySelector('[data-slot="workspace-content-section"]')).toBeNull();
+  });
+
+  it('returns null when there is no active workspace', () => {
+    setState({ tree: makeTree([makeWorkspace()]), active: null });
+    const { container } = renderShell(<WorkspaceContentNav />);
+    expect(container.querySelector('[data-slot="workspace-content-section"]')).toBeNull();
+  });
+
+  it('returns null when the active workspace is not in the tree', () => {
+    setState({ tree: makeTree([makeWorkspace({ name: 'other' })]), active: 'crm' });
+    const { container } = renderShell(<WorkspaceContentNav />);
+    expect(container.querySelector('[data-slot="workspace-content-section"]')).toBeNull();
+  });
+
+  it('returns null when the active workspace has no sections with items', () => {
+    setState({
+      tree: makeTree([makeWorkspace({ name: 'crm', sections: [] })]),
+      active: 'crm',
+    });
+    const { container } = renderShell(<WorkspaceContentNav />);
+    expect(container.querySelector('[data-slot="workspace-content-section"]')).toBeNull();
+  });
+
+  it('renders a section label from displayKey and a default label otherwise', () => {
+    setState({
+      tree: makeTree([
+        makeWorkspace({
+          name: 'crm',
+          sections: [
+            {
+              key: 'people',
+              displayKey: 'Crm:People',
+              order: 0,
+              collapsedByDefault: false,
+              items: [makeItem({ kind: 'Entity', entityName: 'Party', displayKey: 'Crm:Party' })],
+            },
+            {
+              key: 'misc',
+              displayKey: null,
+              order: 1,
+              collapsedByDefault: false,
+              items: [makeItem({ kind: 'Entity', entityName: 'Note', displayKey: null })],
+            },
+          ],
+        }),
+      ]),
+      active: 'crm',
+    });
+    renderShell(<WorkspaceContentNav />, { route: '/' });
+    // displayKey present -> last segment fallback "People"
+    expect(screen.getByText('People')).toBeInTheDocument();
+    // no displayKey -> default "Items" label
+    expect(screen.getByText('Items')).toBeInTheDocument();
+  });
+
+  it('renders an active leaf item as a link when the route matches its href', () => {
+    setState({
+      tree: makeTree([
+        makeWorkspace({
+          name: 'crm',
+          sections: [
+            {
+              key: 's',
+              displayKey: null,
+              order: 0,
+              collapsedByDefault: false,
+              items: [makeItem({ kind: 'Entity', entityName: 'Party', displayKey: 'Crm:Party' })],
+            },
+          ],
+        }),
+      ]),
+      active: 'crm',
+    });
+    renderShell(<WorkspaceContentNav />, { route: '/w/crm/Party' });
+    const link = screen.getByRole('link', { name: 'Party' });
+    expect(link).toHaveAttribute('href', '/w/crm/Party');
+    expect(link).toHaveAttribute('data-active', 'true');
+  });
+
+  it('renders a disabled leaf item (no href) without a link', () => {
+    setState({
+      tree: makeTree([
+        makeWorkspace({
+          name: 'crm',
+          sections: [
+            {
+              key: 's',
+              displayKey: null,
+              order: 0,
+              collapsedByDefault: false,
+              // Entity with no entityName -> resolveItemHref returns null.
+              items: [makeItem({ kind: 'Entity', entityName: null, displayKey: 'Crm:Empty' })],
+            },
+          ],
+        }),
+      ]),
+      active: 'crm',
+    });
+    renderShell(<WorkspaceContentNav />, { route: '/' });
+    expect(screen.getByText('Empty')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Empty' })).not.toBeInTheDocument();
+  });
+
+  it('renders a SubWorkspace as a collapsible group with its children', () => {
+    setState({
+      tree: makeTree([
+        makeWorkspace({
+          name: 'framework',
+          sections: [
+            {
+              key: 'shells',
+              displayKey: null,
+              order: 0,
+              collapsedByDefault: false,
+              items: [
+                makeItem({
+                  kind: 'SubWorkspace',
+                  subWorkspaceName: 'identity',
+                  displayKey: 'Fw:Identity',
+                }),
+              ],
+            },
+          ],
+        }),
+        makeWorkspace({
+          name: 'identity',
+          isShell: true,
+          sections: [
+            {
+              key: 'idsec',
+              displayKey: null,
+              order: 0,
+              collapsedByDefault: false,
+              items: [
+                makeItem({ kind: 'Entity', entityName: 'User', displayKey: 'Id:User' }),
+                makeItem({ kind: 'Entity', entityName: null, displayKey: 'Id:Disabled' }),
+              ],
+            },
+          ],
+        }),
+      ]),
+      active: 'framework',
+    });
+    renderShell(<WorkspaceContentNav />, { route: '/w/identity/User' });
+    // Parent group trigger label.
+    expect(screen.getByText('Identity')).toBeInTheDocument();
+    // Active child renders as a link; disabled child as plain text.
+    const childLink = screen.getByRole('link', { name: 'User' });
+    expect(childLink).toHaveAttribute('href', '/w/identity/User');
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+  });
+
+  it('falls back to a leaf item when the SubWorkspace target is missing', () => {
+    setState({
+      tree: makeTree([
+        makeWorkspace({
+          name: 'framework',
+          sections: [
+            {
+              key: 'shells',
+              displayKey: null,
+              order: 0,
+              collapsedByDefault: false,
+              items: [
+                makeItem({
+                  kind: 'SubWorkspace',
+                  subWorkspaceName: 'ghost',
+                  displayKey: 'Fw:Ghost',
+                }),
+              ],
+            },
+          ],
+        }),
+      ]),
+      active: 'framework',
+    });
+    renderShell(<WorkspaceContentNav />, { route: '/' });
+    // SubWorkspace href resolves to /w/ghost even without a matching workspace node.
+    const link = screen.getByRole('link', { name: 'Ghost' });
+    expect(link).toHaveAttribute('href', '/w/ghost');
+  });
+});

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/workspace-icon.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/workspace-icon.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// Replace lucide's DynamicIcon: throw for a sentinel "bad" name (to exercise
+// the error boundary), otherwise render a marker element.
+vi.mock('lucide-react/dynamic', () => ({
+  DynamicIcon: ({ name, className }: { name: string; className?: string }) => {
+    if (name === 'bad') throw new Error('Name not found');
+    return <span data-slot="dynamic-icon" data-name={name} className={className} />;
+  },
+}));
+
+vi.mock('lucide-react', () => ({
+  Square: ({ className }: { className?: string }) => (
+    <span data-slot="square-fallback" className={className} />
+  ),
+}));
+
+const { WorkspaceIcon } = await import('../workspace-icon');
+
+describe('WorkspaceIcon', () => {
+  it('renders the Square fallback when name is null', () => {
+    render(<WorkspaceIcon name={null} />);
+    expect(document.querySelector('[data-slot="square-fallback"]')).not.toBeNull();
+    expect(document.querySelector('[data-slot="dynamic-icon"]')).toBeNull();
+  });
+
+  it('renders the dynamic icon for a valid name and forwards the className', () => {
+    render(<WorkspaceIcon name="users" className="size-4" />);
+    const icon = document.querySelector('[data-slot="dynamic-icon"]');
+    expect(icon).not.toBeNull();
+    expect(icon).toHaveAttribute('data-name', 'users');
+    expect(icon).toHaveClass('size-4');
+  });
+
+  it('falls back to Square via the error boundary when the icon name is unknown', () => {
+    // Silence the expected React error-boundary console output.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<WorkspaceIcon name="bad" />);
+    expect(document.querySelector('[data-slot="square-fallback"]')).not.toBeNull();
+    spy.mockRestore();
+  });
+});

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/workspace-switcher-menu.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/workspace-switcher-menu.test.tsx
@@ -1,0 +1,105 @@
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeT, makeTree, makeWorkspace, renderShell } from './test-utils';
+
+import type { WorkspaceTreeResponse } from '@granit/workspaces';
+import type * as ReactRouter from 'react-router-dom';
+
+vi.mock('@granit/react-localization', () => ({ useTranslation: () => ({ t: makeT() }) }));
+
+vi.mock('./workspace-icon', () => ({
+  WorkspaceIcon: ({ name }: { name: string | null }) => <span data-slot="icon">{name ?? ''}</span>,
+}));
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactRouter>();
+  return { ...actual, useNavigate: () => navigate };
+});
+
+let tree: WorkspaceTreeResponse | undefined;
+let isLoading = false;
+let activeWorkspaceName: string | null = null;
+const setActiveWorkspace = vi.fn();
+
+vi.mock('@granit/react-workspaces', () => ({
+  useWorkspaces: () => ({ data: tree, isLoading }),
+}));
+
+vi.mock('../use-active-workspace', () => ({
+  useActiveWorkspace: () => ({ activeWorkspaceName, setActiveWorkspace }),
+}));
+
+const { WorkspaceSwitcherMenu } = await import('../workspace-switcher-menu');
+
+beforeEach(() => {
+  navigate.mockClear();
+  setActiveWorkspace.mockClear();
+  tree = undefined;
+  isLoading = false;
+  activeWorkspaceName = null;
+});
+
+describe('WorkspaceSwitcherMenu', () => {
+  it('shows the no-active-workspace title/subtitle when none is selected', () => {
+    tree = makeTree([makeWorkspace({ name: 'crm', displayKey: 'Crm:Name' })]);
+    renderShell(<WorkspaceSwitcherMenu />);
+    expect(screen.getByText('Common.AppName')).toBeInTheDocument();
+    expect(screen.getByText('No workspace selected')).toBeInTheDocument();
+  });
+
+  it('shows the active workspace label and app subtitle when one is selected', () => {
+    tree = makeTree([makeWorkspace({ name: 'crm', displayKey: 'Crm:Name' })]);
+    activeWorkspaceName = 'crm';
+    renderShell(<WorkspaceSwitcherMenu />, { route: '/w/crm' });
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Granit Showcase')).toBeInTheDocument();
+  });
+
+  it('shows the loading state inside the menu while workspaces load', async () => {
+    isLoading = true;
+    const { user } = renderShell(<WorkspaceSwitcherMenu />);
+    await user.click(screen.getByRole('button'));
+    expect(await screen.findByText('Loading…')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when no switchable workspaces remain', async () => {
+    // Only a shell workspace -> filtered out of the switchable list.
+    tree = makeTree([makeWorkspace({ name: 'identity', isShell: true })]);
+    const { user } = renderShell(<WorkspaceSwitcherMenu />);
+    await user.click(screen.getByRole('button'));
+    expect(await screen.findByText('No workspaces available')).toBeInTheDocument();
+  });
+
+  it('lists switchable workspaces, marks the active one, and navigates on click', async () => {
+    tree = makeTree([
+      makeWorkspace({ name: 'crm', displayKey: 'Crm:Customers' }),
+      makeWorkspace({ name: 'sales', displayKey: 'Sales:Pipeline' }),
+      makeWorkspace({ name: 'identity', isShell: true }),
+    ]);
+    activeWorkspaceName = 'crm';
+    const { user } = renderShell(<WorkspaceSwitcherMenu />, { route: '/w/crm' });
+    await user.click(screen.getByRole('button'));
+
+    const salesItem = await screen.findByRole('menuitem', { name: 'Pipeline' });
+    expect(salesItem).toBeInTheDocument();
+    // Active workspace is flagged.
+    expect(screen.getByRole('menuitem', { name: 'Customers' })).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+
+    await user.click(salesItem);
+    expect(setActiveWorkspace).toHaveBeenCalledWith('sales');
+    expect(navigate).toHaveBeenCalledWith('/w/sales');
+  });
+
+  it('navigates home from the Home menu entry', async () => {
+    tree = makeTree([makeWorkspace({ name: 'crm', displayKey: 'Crm:Name' })]);
+    const { user } = renderShell(<WorkspaceSwitcherMenu />);
+    await user.click(screen.getByRole('button'));
+    await user.click(await screen.findByRole('menuitem', { name: 'Home' }));
+    expect(navigate).toHaveBeenCalledWith('/');
+  });
+});


### PR DESCRIPTION
## Why

CI was failing the global coverage gate:

> ERROR: Coverage for branches (77.68%) does not meet global threshold (80%)

## What

Adds **co-located unit tests only — no source changes** — across the most under-covered packages, raising branch coverage above the 80% threshold.

| Metric | Before | After | Threshold |
|--------|--------|-------|-----------|
| **Branches** | 77.69% | **82.18%** | 80% ✅ |
| Statements | 86.23% | 89.26% | 80% ✅ |
| Functions | 85.16% | 87.30% | 80% ✅ |
| Lines | 87.75% | 90.46% | 80% ✅ |

### Coverage added by package

- **`@granit/react-ui-background-jobs`** (28 → 109 branches): exhaustive `cronstrue-locale` import switch + `job-card` / `job-actions` / `job-status-badge` / `background-job-columns` component tests.
- **`@granit/contract-tests` + `@granit/arch-tests-kit`** (+83): edge/error paths for `conformance.ts`, `endpoints.ts` and the architecture scanners (pure logic).
- **`@granit/react-ui-shell-admin`** (43 → 188 branches): the admin shell had no tests — added coverage for nav, command palette, sidebar, header, workspace switcher, presence menu, etc.
- **`@granit/react-entities`** (575 → 667 branches): field-components, entity list, gallery and the action dispatcher.

Remaining uncovered branches are unreachable defensive guards (`??` fallbacks, states forbidden by the functions' own invariants), noted inline.

## Verification

- `pnpm test:coverage` — **8433 tests pass**, all four thresholds met.
- `pnpm lint` (`--max-warnings 0`) clean · `pnpm tsc` clean · Prettier clean.
