### PR TITLE
fix(quality): resolve SonarQube issues across react-ui packages

### DIFF
--- a/packages/@granit/arch-tests-kit/src/scanners/deps.ts
+++ b/packages/@granit/arch-tests-kit/src/scanners/deps.ts
@@ -20,7 +20,7 @@ export interface UndeclaredDepsOptions extends ScanContext {
   ignore?: ReadonlyArray<string>;
 }
 
-type DepSection = Record<string, string> | undefined;
+type DepSection = Record<string, string>;
 interface PkgJson {
   name?: string;
   dependencies?: DepSection;

--- a/packages/@granit/arch-tests-kit/src/scanners/react.ts
+++ b/packages/@granit/arch-tests-kit/src/scanners/react.ts
@@ -9,7 +9,7 @@ import type { AllowlistedScanContext, Violation } from '../types';
 const CLIENT_API_RE = // NOSONAR S5852: bounded developer source files only — no user input
   /\buse(?:State|Effect|LayoutEffect|InsertionEffect|Reducer|Ref|Context|Memo|Callback|Id|SyncExternalStore|Transition|DeferredValue|ImperativeHandle)\s*\(|\bcreateContext\s*\(/;
 
-const USE_CLIENT_RE = /^\s*['"]use client['"]\s*;?\s*$/;
+const USE_CLIENT_RE = /^\s*['"]use client['"]\s*(?:;\s*)?$/;
 
 /** True when `'use client'` appears as one of the file's first statements. */
 function hasUseClientDirective(src: string): boolean {

--- a/packages/@granit/arch-tests-kit/src/scanners/uniformity.ts
+++ b/packages/@granit/arch-tests-kit/src/scanners/uniformity.ts
@@ -6,7 +6,7 @@ import { rel } from '../fs';
 import type { AllowlistedScanContext, ScanContext, Violation } from '../types';
 
 // NOSONAR: these regexes run only on bounded developer source files — no user input, no ReDoS risk
-const H1_RE = /^#\s+(.*\S)\s*$/m;
+const H1_RE = /^#\s+(\S.*)$/m;
 
 /**
  * Every module ships a `README.md` introducing it. The H1 (first `#` heading,
@@ -56,12 +56,13 @@ export function scanReadmePresence(opts: ReadmePresenceOptions): Violation[] {
       continue;
     }
     const expected = heading(m.name);
-    if (match[1] !== expected) {
+    const h1 = (match[1] ?? '').trimEnd();
+    if (h1 !== expected) {
       out.push({
         rule: 'readme-h1',
         module: m.name,
         file: relPath,
-        message: `README.md H1 is "${match[1]}", expected "${expected}"`,
+        message: `README.md H1 is "${h1}", expected "${expected}"`,
       });
     }
   }

--- a/packages/@granit/react-activities/src/components/activities-side-panel.tsx
+++ b/packages/@granit/react-activities/src/components/activities-side-panel.tsx
@@ -14,7 +14,7 @@ export interface ActivitiesSidePanelProps {
    * Action callbacks. When `undefined`, the matching button is not rendered
    * — apps use this to gate by permission.
    */
-  readonly onSelect?: ActivityListProps['onSelect'];
+  readonly onSelect?: NonNullable<ActivityListProps['onSelect']>;
   readonly onComplete?: (activity: ActivityResponse) => void;
   readonly onCancel?: (activity: ActivityResponse) => void;
   readonly onReassign?: (activity: ActivityResponse) => void;

--- a/packages/@granit/react-activities/src/contributions/entity-side-panel.tsx
+++ b/packages/@granit/react-activities/src/contributions/entity-side-panel.tsx
@@ -9,13 +9,13 @@ export interface ActivitiesSidePanelContributionOptions {
    * action wiring must come from this opt-in factory rather than per-render
    * props. Omit a callback to hide the matching button (permission gating).
    */
-  readonly onSelect?: Parameters<typeof ActivitiesSidePanel>[0]['onSelect'];
-  readonly onComplete?: Parameters<typeof ActivitiesSidePanel>[0]['onComplete'];
-  readonly onCancel?: Parameters<typeof ActivitiesSidePanel>[0]['onCancel'];
-  readonly onReassign?: Parameters<typeof ActivitiesSidePanel>[0]['onReassign'];
-  readonly onReschedule?: Parameters<typeof ActivitiesSidePanel>[0]['onReschedule'];
-  readonly onCreate?: Parameters<typeof ActivitiesSidePanel>[0]['onCreate'];
-  readonly actionLabels?: Parameters<typeof ActivitiesSidePanel>[0]['actionLabels'];
+  readonly onSelect?: NonNullable<Parameters<typeof ActivitiesSidePanel>[0]['onSelect']>;
+  readonly onComplete?: NonNullable<Parameters<typeof ActivitiesSidePanel>[0]['onComplete']>;
+  readonly onCancel?: NonNullable<Parameters<typeof ActivitiesSidePanel>[0]['onCancel']>;
+  readonly onReassign?: NonNullable<Parameters<typeof ActivitiesSidePanel>[0]['onReassign']>;
+  readonly onReschedule?: NonNullable<Parameters<typeof ActivitiesSidePanel>[0]['onReschedule']>;
+  readonly onCreate?: NonNullable<Parameters<typeof ActivitiesSidePanel>[0]['onCreate']>;
+  readonly actionLabels?: NonNullable<Parameters<typeof ActivitiesSidePanel>[0]['actionLabels']>;
   readonly pageSize?: number;
   readonly className?: string;
 }

--- a/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
@@ -81,6 +81,96 @@ export interface ChatComposerProps {
   readonly className?: string;
 }
 
+interface ComposerSuggestionPickerProps {
+  readonly show: boolean;
+  readonly trigger: ActiveTrigger | null;
+  readonly pickerLabels: ChatTranslations['Pickers'];
+  readonly promptMatches: readonly PromptOption[];
+  readonly mentionResults: readonly MentionOption[];
+  readonly mentionLoading: boolean;
+  readonly activeIndex: number;
+  readonly listboxId: string;
+  readonly getOptionId: (index: number) => string;
+  readonly onHover: (index: number) => void;
+  readonly onSelectPrompt: (option: PromptOption) => void;
+  readonly onSelectMention: (option: MentionOption) => void;
+  readonly onMouseDown: (event: MouseEvent) => void;
+}
+
+/** The `/` prompt / `@` mention popup that floats above the editor. */
+function ComposerSuggestionPicker({
+  show,
+  trigger,
+  pickerLabels,
+  promptMatches,
+  mentionResults,
+  mentionLoading,
+  activeIndex,
+  listboxId,
+  getOptionId,
+  onHover,
+  onSelectPrompt,
+  onSelectMention,
+  onMouseDown,
+}: ComposerSuggestionPickerProps) {
+  if (!show) return null;
+  return (
+    // The wrapper only swallows the picker's mousedown so the editor keeps its
+    // selection through the click; it's presentational, not a control.
+    <div
+      role="presentation"
+      /* NOSONAR: presentational wrapper, intentionally not a semantic element */ onMouseDown={
+        onMouseDown
+      }
+    >
+      {trigger?.kind === '/' ? (
+        <ComposerSuggestions<PromptOption>
+          title={pickerLabels.Prompts}
+          items={promptMatches}
+          activeIndex={activeIndex}
+          loadingLabel={pickerLabels.Loading}
+          emptyLabel={pickerLabels.NoResults}
+          listboxId={listboxId}
+          getOptionId={getOptionId}
+          getKey={(item) => item.id}
+          onHover={onHover}
+          onSelect={onSelectPrompt}
+          renderItem={(item) => (
+            <div className="flex flex-col">
+              <span className="font-medium">{item.name}</span>
+              {item.shortDescription ? (
+                <span className="text-muted-foreground text-xs">{item.shortDescription}</span>
+              ) : null}
+            </div>
+          )}
+        />
+      ) : (
+        <ComposerSuggestions<MentionOption>
+          title={pickerLabels.Mentions}
+          items={mentionResults}
+          activeIndex={activeIndex}
+          loading={mentionLoading}
+          loadingLabel={pickerLabels.Loading}
+          emptyLabel={pickerLabels.NoResults}
+          listboxId={listboxId}
+          getOptionId={getOptionId}
+          getKey={(item) => `${item.type}:${item.id}`}
+          onHover={onHover}
+          onSelect={onSelectMention}
+          renderItem={(item) => (
+            <div className="flex flex-col">
+              <span className="font-medium">{item.label}</span>
+              {item.description ? (
+                <span className="text-muted-foreground text-xs">{item.description}</span>
+              ) : null}
+            </div>
+          )}
+        />
+      )}
+    </div>
+  );
+}
+
 /**
  * The streaming chat composer: a `contenteditable` rich input where `/` prompts
  * and `@` mentions resolve to inline chips in the text flow, plus attachment
@@ -322,7 +412,7 @@ export function ChatComposer({
 
   // Rich options win; otherwise derive plain options from the workspace names.
   const resolvedWorkspaceOptions = useMemo<readonly WorkspaceOption[]>(() => {
-    if (workspaceOptions && workspaceOptions.length > 0) return workspaceOptions;
+    if (workspaceOptions?.length) return workspaceOptions;
     return (workspaces ?? []).map((ws) => ({ value: ws }));
   }, [workspaceOptions, workspaces]);
 
@@ -486,56 +576,21 @@ export function ChatComposer({
           'focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px]'
         )}
       >
-        {showSuggestions ? (
-          // The wrapper only swallows the picker's mousedown so the editor keeps
-          // its selection through the click; it's presentational, not a control.
-          <div role="presentation" onMouseDown={onSuggestionMouseDown}>
-            {trigger?.kind === '/' ? (
-              <ComposerSuggestions<PromptOption>
-                title={pickerLabels.Prompts}
-                items={promptMatches}
-                activeIndex={activeIndex}
-                loadingLabel={pickerLabels.Loading}
-                emptyLabel={pickerLabels.NoResults}
-                listboxId={listboxId}
-                getOptionId={getOptionId}
-                getKey={(item) => item.id}
-                onHover={setActiveIndex}
-                onSelect={selectPrompt}
-                renderItem={(item) => (
-                  <div className="flex flex-col">
-                    <span className="font-medium">{item.name}</span>
-                    {item.shortDescription ? (
-                      <span className="text-muted-foreground text-xs">{item.shortDescription}</span>
-                    ) : null}
-                  </div>
-                )}
-              />
-            ) : (
-              <ComposerSuggestions<MentionOption>
-                title={pickerLabels.Mentions}
-                items={mentionResults}
-                activeIndex={activeIndex}
-                loading={mentionLoading}
-                loadingLabel={pickerLabels.Loading}
-                emptyLabel={pickerLabels.NoResults}
-                listboxId={listboxId}
-                getOptionId={getOptionId}
-                getKey={(item) => `${item.type}:${item.id}`}
-                onHover={setActiveIndex}
-                onSelect={selectMention}
-                renderItem={(item) => (
-                  <div className="flex flex-col">
-                    <span className="font-medium">{item.label}</span>
-                    {item.description ? (
-                      <span className="text-muted-foreground text-xs">{item.description}</span>
-                    ) : null}
-                  </div>
-                )}
-              />
-            )}
-          </div>
-        ) : null}
+        <ComposerSuggestionPicker
+          show={showSuggestions}
+          trigger={trigger}
+          pickerLabels={pickerLabels}
+          promptMatches={promptMatches}
+          mentionResults={mentionResults}
+          mentionLoading={mentionLoading}
+          activeIndex={activeIndex}
+          listboxId={listboxId}
+          getOptionId={getOptionId}
+          onHover={setActiveIndex}
+          onSelectPrompt={selectPrompt}
+          onSelectMention={selectMention}
+          onMouseDown={onSuggestionMouseDown}
+        />
 
         <div className="relative">
           {isEmpty ? (
@@ -556,7 +611,7 @@ export function ChatComposer({
             // `/` `@` pickers expose the popup listbox. `combobox` (unlike
             // `textbox`) supports aria-expanded/-controls/-activedescendant; the
             // explicit tabIndex keeps it focusable when contentEditable is off.
-            role="combobox"
+            role="combobox" /* NOSONAR: editable contenteditable combobox — no native form element fits */
             tabIndex={disabled ? -1 : 0}
             aria-label={labels.Placeholder}
             aria-autocomplete="list"

--- a/packages/@granit/react-ai-chat/src/components/conversation-thread.tsx
+++ b/packages/@granit/react-ai-chat/src/components/conversation-thread.tsx
@@ -81,7 +81,7 @@ export interface ConversationThreadProps {
   readonly labels?: ChatTranslations['Thread'];
   readonly toolLabels?: ChatTranslations['Tools'];
   /** Localized error copy; defaults to the bundled English strings. */
-  readonly errorLabels?: ChatTranslations['Errors'];
+  readonly errorLabels?: NonNullable<ChatTranslations['Errors']>;
   readonly metricsLabels?: ChatTranslations['Metrics'];
   readonly className?: string;
 }

--- a/packages/@granit/react-ai-chat/src/components/workspace-selector.tsx
+++ b/packages/@granit/react-ai-chat/src/components/workspace-selector.tsx
@@ -182,7 +182,8 @@ export function WorkspaceSelector({
     lastGroup = option.group;
     const isActive = index === activeIndex;
     return (
-      <li key={option.value} role="presentation">
+      // ARIA listbox pattern — a presentational <li> wraps the role="option" row.
+      <li key={option.value} role="presentation" /* NOSONAR */>
         {heading ? (
           <p
             data-slot="workspace-group"
@@ -193,7 +194,7 @@ export function WorkspaceSelector({
         ) : null}
         <div
           id={getOptionId(index)}
-          role="option"
+          role="option" /* NOSONAR: custom listbox option — no native <option> equivalent for this rich row */
           // Arrow-key navigation is handled at the popover level (it owns the
           // active highlight), so each option is only programmatically focusable
           // (-1) — never in the tab order.
@@ -275,7 +276,7 @@ export function WorkspaceSelector({
           ) : (
             <ul
               ref={listboxRef}
-              role="listbox"
+              role="listbox" /* NOSONAR: custom popover listbox — a native <select> cannot render grouped, icon-rich options */
               id={listboxId}
               aria-label={label}
               // Focusable so arrow-key nav works when no search field is shown;

--- a/packages/@granit/react-documents/src/hooks/use-document-bookmarks.ts
+++ b/packages/@granit/react-documents/src/hooks/use-document-bookmarks.ts
@@ -108,8 +108,8 @@ export function useDocumentBookmarks(
 
   const toggleFavorite = useCallback((entry: Omit<DocumentBookmark, 'recordedAt'>) => {
     setFavorites((prev) => {
-      const existing = prev.find((f) => f.id === entry.id);
-      if (existing) return prev.filter((f) => f.id !== entry.id);
+      const exists = prev.some((f) => f.id === entry.id);
+      if (exists) return prev.filter((f) => f.id !== entry.id);
       const bookmark: DocumentBookmark = { ...entry, recordedAt: Date.now() };
       return [bookmark, ...prev];
     });

--- a/packages/@granit/react-taxonomy/src/components/tag-autocomplete.tsx
+++ b/packages/@granit/react-taxonomy/src/components/tag-autocomplete.tsx
@@ -89,8 +89,8 @@ export function TagAutocomplete({
   }, [tagsQuery.data, value]);
 
   const trimmed = query.trim();
-  const exactMatch = candidates.find((tag) => tag.name.toLowerCase() === trimmed.toLowerCase());
-  const showCreate = allowInlineCreate && canManage && trimmed.length > 0 && !exactMatch;
+  const hasExactMatch = candidates.some((tag) => tag.name.toLowerCase() === trimmed.toLowerCase());
+  const showCreate = allowInlineCreate && canManage && trimmed.length > 0 && !hasExactMatch;
 
   function handleKeyDown(event: KeyboardEvent<HTMLInputElement>): void {
     if (event.key === 'ArrowDown') {

--- a/packages/@granit/react-ui-background-jobs/src/cronstrue-locale.ts
+++ b/packages/@granit/react-ui-background-jobs/src/cronstrue-locale.ts
@@ -51,6 +51,53 @@ const LOCALE_MAP: Record<string, string> = {
 
 const loaded = new Set<string>();
 
+/**
+ * Explicit static `import()` specifiers per cronstrue locale, so Vite resolves
+ * the bare package paths at build time — a templated `import()` of a
+ * node_modules path would not be statically analyzable.
+ */
+const LOCALE_LOADERS: Record<string, () => Promise<unknown>> = {
+  af: () => import('cronstrue/locales/af'),
+  ar: () => import('cronstrue/locales/ar'),
+  be: () => import('cronstrue/locales/be'),
+  bg: () => import('cronstrue/locales/bg'),
+  ca: () => import('cronstrue/locales/ca'),
+  cs: () => import('cronstrue/locales/cs'),
+  da: () => import('cronstrue/locales/da'),
+  de: () => import('cronstrue/locales/de'),
+  en: () => import('cronstrue/locales/en'),
+  es: () => import('cronstrue/locales/es'),
+  fa: () => import('cronstrue/locales/fa'),
+  fi: () => import('cronstrue/locales/fi'),
+  fr: () => import('cronstrue/locales/fr'),
+  he: () => import('cronstrue/locales/he'),
+  hr: () => import('cronstrue/locales/hr'),
+  hu: () => import('cronstrue/locales/hu'),
+  id: () => import('cronstrue/locales/id'),
+  it: () => import('cronstrue/locales/it'),
+  ja: () => import('cronstrue/locales/ja'),
+  ko: () => import('cronstrue/locales/ko'),
+  my: () => import('cronstrue/locales/my'),
+  nb: () => import('cronstrue/locales/nb'),
+  nl: () => import('cronstrue/locales/nl'),
+  pl: () => import('cronstrue/locales/pl'),
+  pt_PT: () => import('cronstrue/locales/pt_PT'),
+  pt_BR: () => import('cronstrue/locales/pt_BR'),
+  ro: () => import('cronstrue/locales/ro'),
+  ru: () => import('cronstrue/locales/ru'),
+  sk: () => import('cronstrue/locales/sk'),
+  sl: () => import('cronstrue/locales/sl'),
+  sr: () => import('cronstrue/locales/sr'),
+  sv: () => import('cronstrue/locales/sv'),
+  sw: () => import('cronstrue/locales/sw'),
+  th: () => import('cronstrue/locales/th'),
+  tr: () => import('cronstrue/locales/tr'),
+  uk: () => import('cronstrue/locales/uk'),
+  vi: () => import('cronstrue/locales/vi'),
+  zh_CN: () => import('cronstrue/locales/zh_CN'),
+  zh_TW: () => import('cronstrue/locales/zh_TW'),
+};
+
 /** Returns the cronstrue locale name for a given BCP 47 language tag. */
 export function getCronstrueLocale(language: string): string {
   const base = language.split('-')[0] ?? language;
@@ -62,124 +109,5 @@ export async function loadCronstrueLocale(language: string): Promise<void> {
   const locale = getCronstrueLocale(language);
   if (loaded.has(locale)) return;
   loaded.add(locale);
-  // Explicit static imports so Vite can resolve bare specifiers at build time.
-  switch (locale) {
-    case 'af':
-      await import('cronstrue/locales/af');
-      break;
-    case 'ar':
-      await import('cronstrue/locales/ar');
-      break;
-    case 'be':
-      await import('cronstrue/locales/be');
-      break;
-    case 'bg':
-      await import('cronstrue/locales/bg');
-      break;
-    case 'ca':
-      await import('cronstrue/locales/ca');
-      break;
-    case 'cs':
-      await import('cronstrue/locales/cs');
-      break;
-    case 'da':
-      await import('cronstrue/locales/da');
-      break;
-    case 'de':
-      await import('cronstrue/locales/de');
-      break;
-    case 'en':
-      await import('cronstrue/locales/en');
-      break;
-    case 'es':
-      await import('cronstrue/locales/es');
-      break;
-    case 'fa':
-      await import('cronstrue/locales/fa');
-      break;
-    case 'fi':
-      await import('cronstrue/locales/fi');
-      break;
-    case 'fr':
-      await import('cronstrue/locales/fr');
-      break;
-    case 'he':
-      await import('cronstrue/locales/he');
-      break;
-    case 'hr':
-      await import('cronstrue/locales/hr');
-      break;
-    case 'hu':
-      await import('cronstrue/locales/hu');
-      break;
-    case 'id':
-      await import('cronstrue/locales/id');
-      break;
-    case 'it':
-      await import('cronstrue/locales/it');
-      break;
-    case 'ja':
-      await import('cronstrue/locales/ja');
-      break;
-    case 'ko':
-      await import('cronstrue/locales/ko');
-      break;
-    case 'my':
-      await import('cronstrue/locales/my');
-      break;
-    case 'nb':
-      await import('cronstrue/locales/nb');
-      break;
-    case 'nl':
-      await import('cronstrue/locales/nl');
-      break;
-    case 'pl':
-      await import('cronstrue/locales/pl');
-      break;
-    case 'pt_PT':
-      await import('cronstrue/locales/pt_PT');
-      break;
-    case 'pt_BR':
-      await import('cronstrue/locales/pt_BR');
-      break;
-    case 'ro':
-      await import('cronstrue/locales/ro');
-      break;
-    case 'ru':
-      await import('cronstrue/locales/ru');
-      break;
-    case 'sk':
-      await import('cronstrue/locales/sk');
-      break;
-    case 'sl':
-      await import('cronstrue/locales/sl');
-      break;
-    case 'sr':
-      await import('cronstrue/locales/sr');
-      break;
-    case 'sv':
-      await import('cronstrue/locales/sv');
-      break;
-    case 'sw':
-      await import('cronstrue/locales/sw');
-      break;
-    case 'th':
-      await import('cronstrue/locales/th');
-      break;
-    case 'tr':
-      await import('cronstrue/locales/tr');
-      break;
-    case 'uk':
-      await import('cronstrue/locales/uk');
-      break;
-    case 'vi':
-      await import('cronstrue/locales/vi');
-      break;
-    case 'zh_CN':
-      await import('cronstrue/locales/zh_CN');
-      break;
-    case 'zh_TW':
-      await import('cronstrue/locales/zh_TW');
-      break;
-  }
+  await LOCALE_LOADERS[locale]?.();
 }

--- a/packages/@granit/react-ui-hostnames/src/components/hostname-add-dialog.tsx
+++ b/packages/@granit/react-ui-hostnames/src/components/hostname-add-dialog.tsx
@@ -73,7 +73,12 @@ export function AddHostnameDialog({
     options: { fields: Record<string, { name: string }> }
   ) => {
     const result = await baseResolver(values, context, options);
-    if (!result.errors.host && values.host && !FQDN_RE.test(String(values.host))) {
+    if (
+      !result.errors.host &&
+      typeof values.host === 'string' &&
+      values.host &&
+      !FQDN_RE.test(values.host)
+    ) {
       result.errors.host = { type: 'fqdn', message: t('Hostnames.AddDialog.InvalidHost') };
     }
     return result;

--- a/packages/@granit/react-ui-hostnames/src/components/hostname-status-badge.stories.tsx
+++ b/packages/@granit/react-ui-hostnames/src/components/hostname-status-badge.stories.tsx
@@ -27,7 +27,7 @@ type Story = StoryObj<typeof meta>;
 export const Pending: Story = { args: { status: HostnameStatus.Pending } };
 export const Verifying: Story = { args: { status: HostnameStatus.Verifying } };
 export const Active: Story = { args: { status: HostnameStatus.Active } };
-export const Error: Story = { args: { status: HostnameStatus.Error } };
+export const ErrorState: Story = { name: 'Error', args: { status: HostnameStatus.Error } };
 
 export const All: Story = {
   render: () => (

--- a/packages/@granit/react-ui-shell-admin/src/use-active-workspace.ts
+++ b/packages/@granit/react-ui-shell-admin/src/use-active-workspace.ts
@@ -18,10 +18,10 @@ function writeStored(value: string | null): void {
   try {
     if (value) globalThis.localStorage?.setItem(STORAGE_KEY, value);
     else globalThis.localStorage?.removeItem(STORAGE_KEY);
-  } catch (caught) {
+  } catch (error_) {
     // localStorage can throw in private mode / SSR. Persistence is best-effort:
     // keep the reason instead of swallowing it silently.
-    error = caught;
+    error = error_;
   }
   // Notify listeners regardless so in-memory state stays in sync even when
   // persistence failed; surface the error on the event for diagnostics.

--- a/packages/@granit/react-ui/src/breadcrumb.tsx
+++ b/packages/@granit/react-ui/src/breadcrumb.tsx
@@ -52,8 +52,6 @@ function BreadcrumbPage({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
       data-slot="breadcrumb-page"
-      role="link"
-      aria-disabled="true"
       aria-current="page"
       className={cn('font-normal text-foreground', className)}
       {...props}
@@ -65,7 +63,6 @@ function BreadcrumbSeparator({ children, className, ...props }: React.ComponentP
   return (
     <li
       data-slot="breadcrumb-separator"
-      role="presentation"
       aria-hidden="true"
       className={cn('[&>svg]:size-3.5', className)}
       {...props}
@@ -79,7 +76,6 @@ function BreadcrumbEllipsis({ className, ...props }: React.ComponentProps<'span'
   return (
     <span
       data-slot="breadcrumb-ellipsis"
-      role="presentation"
       aria-hidden="true"
       className={cn('flex size-9 items-center justify-center', className)}
       {...props}

--- a/packages/@granit/react-ui/src/sidebar.tsx
+++ b/packages/@granit/react-ui/src/sidebar.tsx
@@ -90,8 +90,8 @@ function SidebarProvider({
       }
     };
 
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    globalThis.addEventListener('keydown', handleKeyDown);
+    return () => globalThis.removeEventListener('keydown', handleKeyDown);
   }, [toggleSidebar]);
 
   // We add a state so that we can do data-state="expanded" or "collapsed".
@@ -575,10 +575,14 @@ function SidebarMenuSkeleton({
 }: React.ComponentProps<'div'> & {
   showIcon?: boolean;
 }) {
-  // Random width between 50 to 90% (shadcn skeleton: intentional random width).
+  // Width between 50 and 90%, derived deterministically from the stable React id
+  // so the skeleton keeps shadcn's varied look without a pseudo-random generator.
+  const id = React.useId();
   const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
+    let hash = 0;
+    for (const ch of id) hash = (hash * 31 + ch.charCodeAt(0)) >>> 0;
+    return `${50 + (hash % 41)}%`;
+  }, [id]);
 
   return (
     <div

--- a/packages/@granit/timeline/src/utils/reaction-utils.ts
+++ b/packages/@granit/timeline/src/utils/reaction-utils.ts
@@ -21,7 +21,7 @@ const EMOJI_SEQUENCE = new RegExp(
   '^' +
     '(?:' +
     // Keycap
-    String.raw`[0-9#*]️?⃣` +
+    '[0-9#*]️?⃣' +
     '|' +
     // Regional Indicator pair (flag)
     String.raw`\p{Regional_Indicator}\p{Regional_Indicator}` +

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,8 @@ sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.exclusions=\
   **/*.test.ts,\
   **/*.test.tsx,\
-  **/*.d.ts
+  **/*.d.ts,\
+  **/src/constraints.ts
 
 # Test file inclusions — analyzed as test code (suppresses production-code rules:
 # security hotspots, duplication, credential detection, etc.)


### PR DESCRIPTION
## Summary

Resolves the open SonarQube findings flagged on the batch-1 packages — code smells, one security hotspot, and a set of false-positive accessibility findings on custom ARIA widgets.

## Changes

**Bug / hotspot**
- `react-ui/sidebar`: replaced `Math.random()` skeleton width (security hotspot) with a deterministic `useId`-derived value; `window` → `globalThis`.
- `react-ui-hostnames/hostname-status-badge.stories`: renamed the `Error` export to `ErrorState` (kept the displayed name via `name: 'Error'`).

**Reliability / performance**
- `arch-tests-kit`: removed super-linear backtracking from the `use client` and README-H1 regexes; dropped redundant `| undefined` on `DepSection`.
- `react-ui-background-jobs/cronstrue-locale`: replaced the 39-case `switch` with a static loader map (literal `import()` specifiers preserved for Vite).

**Maintainability**
- `.find()` → `.some()` (`react-documents`, `react-taxonomy`).
- Redundant `?` + `undefined` → `NonNullable<…>` (`react-activities`, `react-ai-chat`).
- `String.raw` fixes (`timeline`); `String()` object-stringification guard (`react-ui-hostnames`); catch-param naming (`react-ui-shell-admin`); optional chaining (`react-ai-chat`).
- `react-ai-chat/chat-composer`: extracted `ComposerSuggestionPicker` to cut cognitive complexity.

**Accessibility (intentional ARIA)**
- `react-ui/breadcrumb`: dropped the incorrect `role="link"` and redundant `role="presentation"` (kept `aria-current` / `aria-hidden`).
- Suppressed `combobox`/`listbox`/`option`/`presentation` findings on custom widgets (no native HTML equivalent) with inline `NOSONAR` justifications.

**Config**
- Excluded generated `**/src/constraints.ts` from Sonar analysis (both constraints files are codegen output; the `String.raw` smells were on `JSON.stringify`'d patterns).

## Verification
- `pnpm tsc` ✅
- `pnpm lint` (`--max-warnings 0`) ✅
- `pnpm test` for changed packages: 973 tests passing ✅