### PR TITLE
fix(quality): resolve SonarQube issues across react-ui packages

### DIFF
--- a/packages/@granit/react-ui-admin-kit/src/layout/detail-aside-layout.tsx
+++ b/packages/@granit/react-ui-admin-kit/src/layout/detail-aside-layout.tsx
@@ -8,10 +8,7 @@ const DESKTOP_MEDIA_QUERY = '(min-width: 1024px)';
 const STORAGE_KEY_DEFAULT = 'granit:detail-aside-open';
 
 function getMatchMedia(): ((query: string) => MediaQueryList) | undefined {
-  if (
-    typeof globalThis.window === 'undefined' ||
-    typeof globalThis.window.matchMedia !== 'function'
-  )
+  if (globalThis.window === undefined || typeof globalThis.window.matchMedia !== 'function')
     return undefined;
   return globalThis.window.matchMedia.bind(globalThis.window);
 }

--- a/packages/@granit/react-ui-admin-kit/src/timezone-picker/timezone-picker.stories.tsx
+++ b/packages/@granit/react-ui-admin-kit/src/timezone-picker/timezone-picker.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from 'storybook/test';
 import { TimezonePicker } from './timezone-picker';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ComponentProps } from 'react';
 
 const meta: Meta<typeof TimezonePicker> = {
   title: 'Admin Kit/TimezonePicker',
@@ -20,59 +21,39 @@ const meta: Meta<typeof TimezonePicker> = {
 export default meta;
 type Story = StoryObj<typeof TimezonePicker>;
 
+type TimezonePickerArgs = ComponentProps<typeof TimezonePicker>;
+
+function ControlledTimezonePicker({
+  initialValue = null,
+  ...args
+}: TimezonePickerArgs & { initialValue?: string | null }) {
+  const [value, setValue] = useState<string | null>(initialValue);
+  return (
+    <div className="w-80">
+      <TimezonePicker
+        {...args}
+        value={value}
+        onChange={(v) => {
+          setValue(v);
+          args.onChange?.(v);
+        }}
+      />
+    </div>
+  );
+}
+
 export const Default: Story = {
-  render: (args) => {
-    const [value, setValue] = useState<string | null>(null);
-    return (
-      <div className="w-80">
-        <TimezonePicker
-          {...args}
-          value={value}
-          onChange={(v) => {
-            setValue(v);
-            args.onChange(v);
-          }}
-        />
-      </div>
-    );
-  },
+  render: (args) => <ControlledTimezonePicker {...args} />,
 };
 
 export const WithPreselectedValue: Story = {
-  render: (args) => {
-    const [value, setValue] = useState<string | null>('Europe/Brussels');
-    return (
-      <div className="w-80">
-        <TimezonePicker
-          {...args}
-          value={value}
-          onChange={(v) => {
-            setValue(v);
-            args.onChange(v);
-          }}
-        />
-      </div>
-    );
-  },
+  render: (args) => <ControlledTimezonePicker {...args} initialValue="Europe/Brussels" />,
 };
 
 export const NonClearable: Story = {
-  render: (args) => {
-    const [value, setValue] = useState<string | null>('America/New_York');
-    return (
-      <div className="w-80">
-        <TimezonePicker
-          {...args}
-          value={value}
-          clearable={false}
-          onChange={(v) => {
-            setValue(v);
-            args.onChange(v);
-          }}
-        />
-      </div>
-    );
-  },
+  render: (args) => (
+    <ControlledTimezonePicker {...args} initialValue="America/New_York" clearable={false} />
+  ),
 };
 
 export const Disabled: Story = {

--- a/packages/@granit/react-ui-authentication-api-keys/src/stories-i18n.ts
+++ b/packages/@granit/react-ui-authentication-api-keys/src/stories-i18n.ts
@@ -19,7 +19,7 @@ const Common = {
 } as const;
 
 export const storyI18n = i18next.createInstance();
-void storyI18n.use(initReactI18next).init({
+await storyI18n.use(initReactI18next).init({
   lng: 'en',
   fallbackLng: 'en',
   ns: ['translation'],

--- a/packages/@granit/react-ui-catalog/src/catalog-create-page.stories.tsx
+++ b/packages/@granit/react-ui-catalog/src/catalog-create-page.stories.tsx
@@ -12,7 +12,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 
 const storyI18n = i18next.createInstance();
-void storyI18n.use(initReactI18next).init({
+await storyI18n.use(initReactI18next).init({
   lng: 'en',
   fallbackLng: 'en',
   ns: ['translation'],

--- a/packages/@granit/react-ui-catalog/src/components/external-mappings-manager.stories.tsx
+++ b/packages/@granit/react-ui-catalog/src/components/external-mappings-manager.stories.tsx
@@ -13,7 +13,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 
 const storyI18n = i18next.createInstance();
-void storyI18n.use(initReactI18next).init({
+await storyI18n.use(initReactI18next).init({
   lng: 'en',
   fallbackLng: 'en',
   ns: ['translation'],

--- a/packages/@granit/react-ui-catalog/src/components/lifecycle-actions.stories.tsx
+++ b/packages/@granit/react-ui-catalog/src/components/lifecycle-actions.stories.tsx
@@ -14,7 +14,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 
 const storyI18n = i18next.createInstance();
-void storyI18n.use(initReactI18next).init({
+await storyI18n.use(initReactI18next).init({
   lng: 'en',
   fallbackLng: 'en',
   ns: ['translation', 'workflow'],

--- a/packages/@granit/react-ui-catalog/src/components/lifecycle-status-badge.stories.tsx
+++ b/packages/@granit/react-ui-catalog/src/components/lifecycle-status-badge.stories.tsx
@@ -9,7 +9,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 
 const storyI18n = i18next.createInstance();
-void storyI18n.use(initReactI18next).init({
+await storyI18n.use(initReactI18next).init({
   lng: 'en',
   fallbackLng: 'en',
   ns: ['translation'],

--- a/packages/@granit/react-ui-catalog/src/components/metadata-editor.stories.tsx
+++ b/packages/@granit/react-ui-catalog/src/components/metadata-editor.stories.tsx
@@ -13,7 +13,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 
 const storyI18n = i18next.createInstance();
-void storyI18n.use(initReactI18next).init({
+await storyI18n.use(initReactI18next).init({
   lng: 'en',
   fallbackLng: 'en',
   ns: ['translation'],

--- a/packages/@granit/react-ui-catalog/src/components/product-columns.stories.tsx
+++ b/packages/@granit/react-ui-catalog/src/components/product-columns.stories.tsx
@@ -13,7 +13,7 @@ import type { TFunction } from 'i18next';
 import type { ReactNode } from 'react';
 
 const storyI18n = i18next.createInstance();
-void storyI18n.use(initReactI18next).init({
+await storyI18n.use(initReactI18next).init({
   lng: 'en',
   fallbackLng: 'en',
   ns: ['translation'],

--- a/packages/@granit/react-ui-cms-hostnames/src/components/cms-hostname-status-badge.stories.tsx
+++ b/packages/@granit/react-ui-cms-hostnames/src/components/cms-hostname-status-badge.stories.tsx
@@ -15,5 +15,5 @@ type Story = StoryObj<typeof meta>;
 export const Active: Story = { args: { status: 'Active' } };
 export const Pending: Story = { args: { status: 'Pending' } };
 export const Verifying: Story = { args: { status: 'Verifying' } };
-export const Error: Story = { args: { status: 'Error' } };
+export const Errored: Story = { args: { status: 'Error' } };
 export const Unknown: Story = { args: { status: 'Suspended' } };

--- a/packages/@granit/react-ui-cms-pages/src/page-form-page.tsx
+++ b/packages/@granit/react-ui-cms-pages/src/page-form-page.tsx
@@ -32,6 +32,30 @@ function capitalize(value: string): string {
 }
 
 /**
+ * Spec-driven validation from the OpenAPI contract (CreatePageRequest constrains
+ * parentId / slugSegment / layoutKey). `layoutKey` is a required-key / nullable-value
+ * field — empty is a legitimate "no layout", so its `required` error is dropped here
+ * (mirrors the field augmentation in @granit/react-ui-hostnames' add dialog).
+ * `Validation:Builtin:*` messages are owned by the host's @granit/Validation bundle.
+ */
+function buildFormResolver(t: ReturnType<typeof useTranslation>['t']): Resolver<PageFormValues> {
+  const baseResolver = createConstraintsResolver(cmsConstraints.CreatePageRequest, t, {
+    labelResolver: (field) => t(`cms:Pages.Fields.${capitalize(field)}`, field),
+  });
+  return (async (
+    values: Record<string, unknown>,
+    context: unknown,
+    options: { fields: Record<string, { name: string }> }
+  ) => {
+    const result = await baseResolver(values, context, options);
+    if (result.errors.layoutKey && (values.layoutKey ?? '') === '') {
+      delete result.errors.layoutKey;
+    }
+    return result;
+  }) as unknown as Resolver<PageFormValues>;
+}
+
+/**
  * Create / rename a CMS page *structure* node (slug + parent + layout).
  *
  * Page *content* (blocks) is authored in the granit-cms-renderer Puck editor —
@@ -52,25 +76,7 @@ export function PageFormPage() {
   const createPage = useCreatePage();
   const updatePage = useUpdatePage();
 
-  // Spec-driven validation from the OpenAPI contract (CreatePageRequest constrains
-  // parentId / slugSegment / layoutKey). `layoutKey` is a required-key / nullable-value
-  // field — empty is a legitimate "no layout", so its `required` error is dropped here
-  // (mirrors the field augmentation in @granit/react-ui-hostnames' add dialog).
-  // `Validation:Builtin:*` messages are owned by the host's @granit/Validation bundle.
-  const baseResolver = createConstraintsResolver(cmsConstraints.CreatePageRequest, t, {
-    labelResolver: (field) => t(`cms:Pages.Fields.${capitalize(field)}`, field),
-  });
-  const formResolver = (async (
-    values: Record<string, unknown>,
-    context: unknown,
-    options: { fields: Record<string, { name: string }> }
-  ) => {
-    const result = await baseResolver(values, context, options);
-    if (result.errors.layoutKey && (values.layoutKey ?? '') === '') {
-      delete result.errors.layoutKey;
-    }
-    return result;
-  }) as unknown as Resolver<PageFormValues>;
+  const formResolver = buildFormResolver(t);
 
   const {
     register,

--- a/packages/@granit/react-ui-cms-sites/src/site-form-page.stories.tsx
+++ b/packages/@granit/react-ui-cms-sites/src/site-form-page.stories.tsx
@@ -12,7 +12,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 
 const storyI18n = i18next.createInstance();
-void storyI18n.use(initReactI18next).init({
+await storyI18n.use(initReactI18next).init({
   lng: 'en',
   fallbackLng: 'en',
   ns: ['translation'],

--- a/packages/@granit/react-ui-cms-sites/src/sites-list-page.stories.tsx
+++ b/packages/@granit/react-ui-cms-sites/src/sites-list-page.stories.tsx
@@ -1,6 +1,5 @@
 import { createApiClient } from '@granit/api-client';
-import { CmsProvider } from '@granit/react-cms';
-import { cmsKeys } from '@granit/react-cms';
+import { CmsProvider, cmsKeys } from '@granit/react-cms';
 import { mockSites } from '@granit/react-cms/testing';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import i18next from 'i18next';
@@ -14,7 +13,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 
 const storyI18n = i18next.createInstance();
-void storyI18n.use(initReactI18next).init({
+await storyI18n.use(initReactI18next).init({
   lng: 'en',
   fallbackLng: 'en',
   ns: ['translation'],

--- a/packages/@granit/react-ui-payments/src/payment-method-category.ts
+++ b/packages/@granit/react-ui-payments/src/payment-method-category.ts
@@ -18,8 +18,7 @@ const CATEGORY_ORDER: readonly PaymentMethodCategory[] = [
 
 /** Index of a `PaymentMethodCategory` for `PaymentMethodIcon` (falls back to Card). */
 export function categoryIndex(category: PaymentMethodCategory): number {
-  const index = CATEGORY_ORDER.indexOf(category);
-  return index >= 0 ? index : 0;
+  return Math.max(CATEGORY_ORDER.indexOf(category), 0);
 }
 
 /**

--- a/packages/@granit/react-ui/src/sidebar.tsx
+++ b/packages/@granit/react-ui/src/sidebar.tsx
@@ -580,7 +580,7 @@ function SidebarMenuSkeleton({
   const id = React.useId();
   const width = React.useMemo(() => {
     let hash = 0;
-    for (const ch of id) hash = (hash * 31 + ch.charCodeAt(0)) >>> 0;
+    for (const ch of id) hash = (hash * 31 + (ch.codePointAt(0) ?? 0)) >>> 0;
     return `${50 + (hash % 41)}%`;
   }, [id]);
 


### PR DESCRIPTION
## Summary

Resolves the open SonarQube issues across `react-ui` packages.

### Bugs (Major)
- **timezone-picker.stories.tsx** — `useState` was called inside `render()`. Extracted a `ControlledTimezonePicker` component (uppercase name → valid hook context), parameterized via `initialValue`.
- **cms-hostname-status-badge.stories.tsx** — renamed story export `Error` → `Errored` (no shadowing of the `Error` global).

### Code Smells
- **`void` operator (Critical, 9 files)** — replaced `void storyI18n…init({…})` with top-level `await`, matching the authentication-local stories pattern.
- **page-form-page.tsx** — extracted `buildFormResolver` to module scope, dropping cognitive complexity 16 → 15.
- **sidebar.tsx** — `charCodeAt` → `codePointAt`.
- **payment-method-category.ts** — ternary → `Math.max`.
- **detail-aside-layout.tsx** — `typeof … === 'undefined'` → compare with `undefined` directly.
- **sites-list-page.stories.tsx** — merged duplicate `@granit/react-cms` import.

### Left as-is
The `react-ai-chat` accessibility findings (`presentation`/`combobox`/`listbox`/`option` roles) were already addressed in #732 with justified `// NOSONAR` comments — the report shows stale pre-fix line numbers.

## Test plan
- `eslint --max-warnings 0` clean on all touched files
- `tsc --noEmit` passes for every affected package