### PR TITLE
test(react): reuse shared /testing fixtures instead of inline DTOs

### DIFF
--- a/packages/@granit/react-account/src/__tests__/use-account-settings.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-account-settings.test.tsx
@@ -5,6 +5,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockAccountSettings } from '@granit/react-account/testing';
+
 import { useAccountSettings } from '../hooks/use-account-settings';
 import { AccountProvider } from '../providers/account-provider';
 
@@ -42,11 +44,7 @@ afterEach(() => {
 describe('useAccountSettings', () => {
   it('should fetch account settings with default basePath', async () => {
     const client = createMockClient();
-    const response: AccountSettingsResponse = {
-      allowSelfRegistration: true,
-      externalProviders: [],
-    };
-    vi.mocked(getAccountSettings).mockResolvedValue(response);
+    vi.mocked(getAccountSettings).mockResolvedValue(mockAccountSettings);
 
     const { result } = renderHook(() => useAccountSettings(), {
       wrapper: createWrapper(client),
@@ -55,14 +53,14 @@ describe('useAccountSettings', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(getAccountSettings).toHaveBeenCalledWith(client, '/api/v1/account');
-    expect(result.current.data).toEqual({ allowSelfRegistration: true, externalProviders: [] });
+    expect(result.current.data).toEqual(mockAccountSettings);
   });
 
   it('should return allowSelfRegistration false when endpoint returns false', async () => {
     const client = createMockClient();
     const response: AccountSettingsResponse = {
+      ...mockAccountSettings,
       allowSelfRegistration: false,
-      externalProviders: [],
     };
     vi.mocked(getAccountSettings).mockResolvedValue(response);
 

--- a/packages/@granit/react-account/src/__tests__/use-available-external-providers.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-available-external-providers.test.tsx
@@ -5,6 +5,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockAccountSettings } from '@granit/react-account/testing';
+
 import { useAvailableExternalProviders } from '../hooks/use-available-external-providers';
 import { AccountProvider } from '../providers/account-provider';
 
@@ -42,14 +44,7 @@ afterEach(() => {
 describe('useAvailableExternalProviders', () => {
   it('derives the providers list from the account config', async () => {
     const client = createMockClient();
-    const response: AccountSettingsResponse = {
-      allowSelfRegistration: true,
-      externalProviders: [
-        { name: 'Google', type: 'Google', displayName: 'Google' },
-        { name: 'corp-sso', type: 'Oidc', displayName: 'Corporate SSO' },
-      ],
-    };
-    vi.mocked(getAccountSettings).mockResolvedValue(response);
+    vi.mocked(getAccountSettings).mockResolvedValue(mockAccountSettings);
 
     const { result } = renderHook(() => useAvailableExternalProviders(), {
       wrapper: createWrapper(client),
@@ -57,7 +52,7 @@ describe('useAvailableExternalProviders', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(result.current.providers).toEqual(response.externalProviders);
+    expect(result.current.providers).toEqual(mockAccountSettings.externalProviders);
   });
 
   it('returns an empty list while loading', () => {

--- a/packages/@granit/react-account/src/__tests__/use-profile.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-profile.test.tsx
@@ -1,10 +1,11 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toEntityId } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { mockProfile } from '@granit/react-account/testing';
 
 import { useProfile, useUpdateProfile } from '../hooks/use-profile';
 import { AccountProvider } from '../providers/account-provider';
@@ -50,17 +51,6 @@ function createWrapperWithQueryClient(client: AxiosInstance) {
     queryClient,
   };
 }
-
-const mockProfile: AccountProfileResponse = {
-  userId: toEntityId<'User'>('user-1'),
-  email: 'user@example.com',
-  emailConfirmed: true,
-  firstName: 'John',
-  lastName: 'Doe',
-  twoFactorEnabled: false,
-  hasPassword: true,
-  externalLogins: [],
-};
 
 afterEach(() => {
   vi.clearAllMocks();

--- a/packages/@granit/react-account/src/__tests__/use-two-factor.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-two-factor.test.tsx
@@ -5,6 +5,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockTwoFactorStatus } from '@granit/react-account/testing';
+
 import {
   useAuthenticatorKey,
   useDisableTwoFactor,
@@ -22,7 +24,6 @@ import type {
   AccountAuthenticatorKeyResponse,
   AccountRecoveryCodesResponse,
   AccountTwoFactorEnableResponse,
-  AccountTwoFactorStatusResponse,
 } from '@granit/account';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -79,13 +80,6 @@ function createWrapperWithQueryClient(client: AxiosInstance) {
   };
 }
 
-const mockStatus: AccountTwoFactorStatusResponse = {
-  isEnabled: false,
-  hasAuthenticatorApp: false,
-  hasEmailOtp: false,
-  recoveryCodesLeft: 0,
-};
-
 afterEach(() => {
   vi.clearAllMocks();
 });
@@ -93,7 +87,7 @@ afterEach(() => {
 describe('useTwoFactorStatus', () => {
   it('should fetch two-factor status', async () => {
     const client = createMockClient();
-    vi.mocked(getTwoFactorStatus).mockResolvedValue(mockStatus);
+    vi.mocked(getTwoFactorStatus).mockResolvedValue(mockTwoFactorStatus);
 
     const { result } = renderHook(() => useTwoFactorStatus(), {
       wrapper: createWrapper(client),
@@ -102,7 +96,7 @@ describe('useTwoFactorStatus', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(getTwoFactorStatus).toHaveBeenCalledWith(client, '/api/v1/account');
-    expect(result.current.data).toEqual(mockStatus);
+    expect(result.current.data).toEqual(mockTwoFactorStatus);
   });
 
   it('should handle fetch error', async () => {

--- a/packages/@granit/react-activities/src/__tests__/use-activities.test.tsx
+++ b/packages/@granit/react-activities/src/__tests__/use-activities.test.tsx
@@ -6,6 +6,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockActivities, mockActivityCalendarItems } from '@granit/react-activities/testing';
+
 import { useActivities, useActivitiesCalendar, useActivity } from '../hooks/use-activities';
 import { ActivitiesProvider } from '../providers/activities-provider';
 
@@ -17,20 +19,7 @@ import type {
 import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
-const sampleActivity: ActivityResponse = {
-  id: 'act-1',
-  entityType: 'Quote',
-  entityId: 'quote-1',
-  type: 'FollowUp',
-  assignedToUserId: 'user-1',
-  createdByUserId: 'user-2',
-  dueAt: toISODateString('2026-05-10T10:00:00Z'),
-  description: null,
-  status: 'Open',
-  completedAt: null,
-  completedByUserId: null,
-  createdAt: toISODateString('2026-05-01T08:00:00Z'),
-};
+const sampleActivity: ActivityResponse = mockActivities[0]!;
 
 const sampleListResponse: ActivityListResponse = {
   items: [sampleActivity],
@@ -39,18 +28,7 @@ const sampleListResponse: ActivityListResponse = {
   pageSize: 20,
 };
 
-const sampleCalendarItem: ActivityCalendarItemResponse = {
-  id: 'act-1',
-  start: toISODateString('2026-05-10T10:00:00Z'),
-  end: null,
-  title: 'Quote · FollowUp',
-  color: 'open',
-  type: 'FollowUp',
-  status: 'Open',
-  entityType: 'Quote',
-  entityId: 'quote-1',
-  assignedToUserId: 'user-1',
-};
+const sampleCalendarItem: ActivityCalendarItemResponse = mockActivityCalendarItems[0]!;
 
 function createWrapper(client: AxiosInstance, basePath?: string) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -129,12 +107,12 @@ describe('useActivity', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: sampleActivity });
 
-    const { result } = renderHook(() => useActivity('act-1'), {
+    const { result } = renderHook(() => useActivity(sampleActivity.id), {
       wrapper: createWrapper(client),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/api/v1/activities/act-1');
+    expect(client.get).toHaveBeenCalledWith(`/api/v1/activities/${sampleActivity.id}`);
     expect(result.current.data).toEqual(sampleActivity);
   });
 

--- a/packages/@granit/react-ai-chat/src/__tests__/components.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/components.test.tsx
@@ -11,6 +11,7 @@ import { MessageMetrics } from '../components/message-metrics';
 import { SuggestedActions } from '../components/suggested-actions';
 import { ToolActivity } from '../components/tool-activity';
 import { AIChatProvider } from '../providers/ai-chat-provider';
+import { mockConversationMessages } from '../testing/data';
 
 import type { ComposerAttachment } from '../components/attachment-chips';
 import type { ChatTurnMetrics, ToolCallActivity } from '../hooks/use-chat-stream';
@@ -34,26 +35,14 @@ function renderWithMetricsFlag(ui: ReactNode, showMessageMetrics: boolean) {
   return render(<AIChatProvider config={{ client, showMessageMetrics }}>{ui}</AIChatProvider>);
 }
 
-const messages: MessageResponse[] = [
-  {
-    id: 'm1' as MessageResponse['id'],
-    role: 'user',
-    content: 'Hello',
-    createdAt: '2026-06-15T09:00:00Z' as MessageResponse['createdAt'],
-  },
-  {
-    id: 'm2' as MessageResponse['id'],
-    role: 'assistant',
-    content: 'Hi there',
-    createdAt: '2026-06-15T09:00:02Z' as MessageResponse['createdAt'],
-  },
-];
+const messages: readonly MessageResponse[] = mockConversationMessages;
+const [userMessage, assistantMessage] = messages;
 
 describe('ConversationThread', () => {
   it('renders messages inside an ARIA live log region', () => {
     const { container } = render(<ConversationThread messages={messages} />);
-    expect(screen.getByText('Hello')).toBeInTheDocument();
-    expect(screen.getByText('Hi there')).toBeInTheDocument();
+    expect(screen.getByText(userMessage!.content)).toBeInTheDocument();
+    expect(screen.getByText(assistantMessage!.content)).toBeInTheDocument();
     const log = container.querySelector('[data-slot="conversation-thread"]');
     expect(log).toHaveAttribute('role', 'log');
     expect(log).toHaveAttribute('aria-live', 'polite');
@@ -90,8 +79,8 @@ describe('ConversationThread', () => {
     expect(renderMessageActions).toHaveBeenCalledTimes(messages.length);
     expect(renderMessageActions).toHaveBeenNthCalledWith(1, messages[0], 0);
     expect(renderMessageActions).toHaveBeenNthCalledWith(2, messages[1], 1);
-    expect(screen.getByRole('button', { name: 'act m1' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'act m2' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: `act ${userMessage!.id}` })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: `act ${assistantMessage!.id}` })).toBeInTheDocument();
   });
 
   it('does not invoke renderMessageActions for the streaming bubble', () => {

--- a/packages/@granit/react-ai-chat/src/__tests__/use-chat-stream-append.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/use-chat-stream-append.test.tsx
@@ -8,6 +8,7 @@ import { DEFAULT_QUERY_KEY_PREFIX } from '../constants';
 import { conversationKeys } from '../hooks/query-keys';
 import { useChatStream } from '../hooks/use-chat-stream';
 import { AIChatProvider } from '../providers/ai-chat-provider';
+import { mockConversationMessages } from '../testing/data';
 
 import { createSSEStream, TEST_BASE_PATH } from './test-utils';
 
@@ -19,12 +20,8 @@ import type { ReactNode } from 'react';
 
 const CONV_ID = '11111111-1111-1111-1111-111111111111' as ConversationId;
 
-const seed: MessageResponse = {
-  id: 'c0000000-0000-0000-0000-000000000000' as MessageResponse['id'],
-  role: 'assistant',
-  content: 'earlier reply',
-  createdAt: '2026-06-15T08:59:00.000Z' as MessageResponse['createdAt'],
-};
+// Reuse the shared assistant turn as the already-loaded "earlier" message.
+const seed: MessageResponse = mockConversationMessages[1]!;
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -74,7 +71,7 @@ describe('useChatStream — optimistic message append', () => {
     const items = data?.pages[0]?.items ?? [];
     // Newest page is stored newest-first: the new turn (assistant, then user) is
     // prepended ahead of the seed. The display hook reverses this to oldest-first.
-    expect(items.map((m) => m.content)).toEqual(['Hi there', 'Hello', 'earlier reply']);
+    expect(items.map((m) => m.content)).toEqual(['Hi there', 'Hello', seed.content]);
     expect(items.map((m) => m.role)).toEqual(['assistant', 'user', 'assistant']);
   });
 

--- a/packages/@granit/react-analytics/src/__tests__/kpi-tile-view.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/kpi-tile-view.test.tsx
@@ -1,17 +1,17 @@
-import { toISODateString } from '@granit/types';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+
+import { buildMockMetric } from '@granit/react-analytics/testing';
 
 import { KpiTileView } from '../components/kpi-tile-view';
 
 import type { MetricResponse } from '@granit/analytics';
 
 function makeResponse(overrides: Partial<MetricResponse['snapshot']> = {}): MetricResponse {
+  // Reuse the shared envelope (name/sequence/emittedAt/refreshHint) and supply a
+  // concrete-value snapshot the KPI tile can format.
   return {
-    name: 'Test.Metric',
-    sequence: 1,
-    emittedAt: toISODateString('2026-04-28T12:00:00Z'),
-    refreshHint: 'Dynamic',
+    ...buildMockMetric('Test.Metric'),
     snapshot: {
       value: 12,
       valueKind: 'Count',

--- a/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-keys.test.tsx
+++ b/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-keys.test.tsx
@@ -1,20 +1,17 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockApiKeys } from '@granit/react-authentication-api-keys/testing';
+
 import { buildApiKeyQueryKey } from '../hooks/query-keys';
 import { useApiKey } from '../hooks/use-api-key';
 import { useApiKeys, useApiKeysQueryMeta } from '../hooks/use-api-keys';
 
-import type {
-  ApiKeyListItemResponse,
-  ApiKeyListPage,
-  ApiKeyResponse,
-} from '@granit/authentication-api-keys';
+import type { ApiKeyListItemResponse, ApiKeyListPage } from '@granit/authentication-api-keys';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -30,34 +27,20 @@ function createWrapper() {
   };
 }
 
-const mockApiKey: ApiKeyResponse = {
-  id: 'key-1',
-  name: 'Test Key',
-  type: 'Secret',
-  environment: 'production',
-  prefix: 'test',
-  lastFourChars: 'xYzW',
-  permissions: ['Invoices.Read'],
-  allowedCidrs: ['10.0.0.0/8'],
-  expiresAt: null,
-  lastUsedAt: null,
-  revokedAt: null,
-  cacheBehavior: 'Normal',
-  createdAt: toISODateString('2026-01-01T00:00:00Z'),
-};
+const mockApiKey = mockApiKeys[0]!;
 
 const mockListItem: ApiKeyListItemResponse = {
-  id: 'key-1',
-  name: 'Test Key',
-  type: 'Secret',
-  environment: 'production',
-  prefix: 'test',
-  lastFourChars: 'xYzW',
-  expiresAt: null,
-  lastUsedAt: null,
-  revokedAt: null,
-  cacheBehavior: 'Normal',
-  createdAt: toISODateString('2026-01-01T00:00:00Z'),
+  id: mockApiKey.id,
+  name: mockApiKey.name,
+  type: mockApiKey.type,
+  environment: mockApiKey.environment,
+  prefix: mockApiKey.prefix,
+  lastFourChars: mockApiKey.lastFourChars,
+  expiresAt: mockApiKey.expiresAt,
+  lastUsedAt: mockApiKey.lastUsedAt,
+  revokedAt: mockApiKey.revokedAt,
+  cacheBehavior: mockApiKey.cacheBehavior,
+  createdAt: mockApiKey.createdAt,
 };
 
 const emptyPage: ApiKeyListPage = {
@@ -118,7 +101,7 @@ describe('useApiKeys', () => {
 
     expect(calledUrl(client)).toBe('/api/v1/authentication/api-keys');
     expect(result.current.data?.items).toHaveLength(1);
-    expect(result.current.data?.items[0].id).toBe('key-1');
+    expect(result.current.data?.items[0].id).toBe('ak-1');
     expect(result.current.data?.totalCount).toBe(1);
   });
 
@@ -309,8 +292,8 @@ describe('useApiKey', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(client.get).toHaveBeenCalledWith('/api/v1/authentication/api-keys/key-1');
-    expect(result.current.data?.id).toBe('key-1');
-    expect(result.current.data?.name).toBe('Test Key');
+    expect(result.current.data?.id).toBe('ak-1');
+    expect(result.current.data?.name).toBe('Patient Sync Service');
   });
 
   it('should use custom basePath when provided', async () => {

--- a/packages/@granit/react-authentication-local/src/__tests__/use-complete-passkey-assertion.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-complete-passkey-assertion.test.tsx
@@ -5,11 +5,12 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockLoginSuccess } from '@granit/react-authentication-local/testing';
+
 import { useCompletePasskeyAssertion } from '../hooks/use-complete-passkey-assertion';
 import { LocalAuthProvider } from '../providers/local-auth-provider';
 
 import type { LocalAuthConfig } from '../providers/local-auth-provider';
-import type { AccountLoginResponse } from '@granit/authentication-local';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -42,13 +43,7 @@ afterEach(() => {
 describe('useCompletePasskeyAssertion', () => {
   it('should call completePasskeyAssertion with credential JSON', async () => {
     const client = createMockClient();
-    const response: AccountLoginResponse = {
-      succeeded: true,
-      requiresTwoFactor: false,
-      isLockedOut: false,
-      isNotAllowed: false,
-    };
-    vi.mocked(completePasskeyAssertion).mockResolvedValue(response);
+    vi.mocked(completePasskeyAssertion).mockResolvedValue(mockLoginSuccess);
 
     const { result } = renderHook(() => useCompletePasskeyAssertion(), {
       wrapper: createWrapper(client),
@@ -63,7 +58,7 @@ describe('useCompletePasskeyAssertion', () => {
     expect(completePasskeyAssertion).toHaveBeenCalledWith(client, '/api/v1/account', {
       credentialJson: '{"id":"cred-1","response":{"authenticatorData":"..."}}',
     });
-    expect(result.current.data).toEqual(response);
+    expect(result.current.data).toEqual(mockLoginSuccess);
   });
 
   it('should handle assertion failure', async () => {

--- a/packages/@granit/react-authentication-local/src/__tests__/use-login-with-redirect.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-login-with-redirect.test.tsx
@@ -5,11 +5,15 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  mockLoginRequiresTwoFactor,
+  mockLoginSuccess,
+} from '@granit/react-authentication-local/testing';
+
 import { useLoginWithRedirect } from '../hooks/use-login-with-redirect';
 import { LocalAuthProvider } from '../providers/local-auth-provider';
 
 import type { LocalAuthConfig } from '../providers/local-auth-provider';
-import type { AccountLoginResponse } from '@granit/authentication-local';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -35,20 +39,6 @@ function createWrapper(client: AxiosInstance) {
   };
 }
 
-const succeededResponse: AccountLoginResponse = {
-  succeeded: true,
-  requiresTwoFactor: false,
-  isLockedOut: false,
-  isNotAllowed: false,
-};
-
-const twoFactorResponse: AccountLoginResponse = {
-  succeeded: false,
-  requiresTwoFactor: true,
-  isLockedOut: false,
-  isNotAllowed: false,
-};
-
 let locationMock: { href: string; search: string };
 
 afterEach(() => {
@@ -65,7 +55,7 @@ describe('useLoginWithRedirect', () => {
   it('redirects to returnUrl on success', async () => {
     stubLocation();
     const client = createMockClient();
-    vi.mocked(loginAccount).mockResolvedValue(succeededResponse);
+    vi.mocked(loginAccount).mockResolvedValue(mockLoginSuccess);
 
     const { result } = renderHook(
       () =>
@@ -88,7 +78,7 @@ describe('useLoginWithRedirect', () => {
   it('redirects to fallbackUrl when returnUrl is absent', async () => {
     stubLocation();
     const client = createMockClient();
-    vi.mocked(loginAccount).mockResolvedValue(succeededResponse);
+    vi.mocked(loginAccount).mockResolvedValue(mockLoginSuccess);
 
     const { result } = renderHook(
       () => useLoginWithRedirect({ search: '', fallbackUrl: '/dashboard' }),
@@ -108,7 +98,7 @@ describe('useLoginWithRedirect', () => {
   it('redirects to "/" when no returnUrl and no fallbackUrl', async () => {
     stubLocation();
     const client = createMockClient();
-    vi.mocked(loginAccount).mockResolvedValue(succeededResponse);
+    vi.mocked(loginAccount).mockResolvedValue(mockLoginSuccess);
 
     const { result } = renderHook(() => useLoginWithRedirect({ search: '' }), {
       wrapper: createWrapper(client),
@@ -126,7 +116,7 @@ describe('useLoginWithRedirect', () => {
 
   it('calls onTwoFactorRequired when 2FA is needed', async () => {
     const client = createMockClient();
-    vi.mocked(loginAccount).mockResolvedValue(twoFactorResponse);
+    vi.mocked(loginAccount).mockResolvedValue(mockLoginRequiresTwoFactor);
     const onTwoFactorRequired = vi.fn();
 
     const { result } = renderHook(() => useLoginWithRedirect({ search: '', onTwoFactorRequired }), {

--- a/packages/@granit/react-authentication-local/src/__tests__/use-login.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-login.test.tsx
@@ -5,11 +5,12 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockLoginSuccess } from '@granit/react-authentication-local/testing';
+
 import { useLogin } from '../hooks/use-login';
 import { LocalAuthProvider } from '../providers/local-auth-provider';
 
 import type { LocalAuthConfig } from '../providers/local-auth-provider';
-import type { AccountLoginResponse } from '@granit/authentication-local';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -42,13 +43,7 @@ afterEach(() => {
 describe('useLogin', () => {
   it('should call loginAccount with correct arguments', async () => {
     const client = createMockClient();
-    const response: AccountLoginResponse = {
-      succeeded: true,
-      requiresTwoFactor: false,
-      isLockedOut: false,
-      isNotAllowed: false,
-    };
-    vi.mocked(loginAccount).mockResolvedValue(response);
+    vi.mocked(loginAccount).mockResolvedValue(mockLoginSuccess);
 
     const { result } = renderHook(() => useLogin(), {
       wrapper: createWrapper(client),
@@ -65,7 +60,7 @@ describe('useLogin', () => {
       login: 'user@example.com',
       password: 'P@ssw0rd!',
     });
-    expect(result.current.data).toEqual(response);
+    expect(result.current.data).toEqual(mockLoginSuccess);
   });
 
   it('should handle login error', async () => {

--- a/packages/@granit/react-authentication-local/src/__tests__/use-verify-two-factor-login.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-verify-two-factor-login.test.tsx
@@ -5,11 +5,12 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockLoginSuccess } from '@granit/react-authentication-local/testing';
+
 import { useVerifyTwoFactorLogin } from '../hooks/use-verify-two-factor-login';
 import { LocalAuthProvider } from '../providers/local-auth-provider';
 
 import type { LocalAuthConfig } from '../providers/local-auth-provider';
-import type { AccountLoginResponse } from '@granit/authentication-local';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -42,13 +43,7 @@ afterEach(() => {
 describe('useVerifyTwoFactorLogin', () => {
   it('should call verifyTwoFactorLogin with TOTP code', async () => {
     const client = createMockClient();
-    const response: AccountLoginResponse = {
-      succeeded: true,
-      requiresTwoFactor: false,
-      isLockedOut: false,
-      isNotAllowed: false,
-    };
-    vi.mocked(verifyTwoFactorLogin).mockResolvedValue(response);
+    vi.mocked(verifyTwoFactorLogin).mockResolvedValue(mockLoginSuccess);
 
     const { result } = renderHook(() => useVerifyTwoFactorLogin(), {
       wrapper: createWrapper(client),
@@ -61,18 +56,12 @@ describe('useVerifyTwoFactorLogin', () => {
     expect(verifyTwoFactorLogin).toHaveBeenCalledWith(client, '/api/v1/account', {
       code: '123456',
     });
-    expect(result.current.data).toEqual(response);
+    expect(result.current.data).toEqual(mockLoginSuccess);
   });
 
   it('should call verifyTwoFactorLogin with recovery code', async () => {
     const client = createMockClient();
-    const response: AccountLoginResponse = {
-      succeeded: true,
-      requiresTwoFactor: false,
-      isLockedOut: false,
-      isNotAllowed: false,
-    };
-    vi.mocked(verifyTwoFactorLogin).mockResolvedValue(response);
+    vi.mocked(verifyTwoFactorLogin).mockResolvedValue(mockLoginSuccess);
 
     const { result } = renderHook(() => useVerifyTwoFactorLogin(), {
       wrapper: createWrapper(client),
@@ -90,13 +79,7 @@ describe('useVerifyTwoFactorLogin', () => {
 
   it('should call verifyTwoFactorLogin with an emailed code', async () => {
     const client = createMockClient();
-    const response: AccountLoginResponse = {
-      succeeded: true,
-      requiresTwoFactor: false,
-      isLockedOut: false,
-      isNotAllowed: false,
-    };
-    vi.mocked(verifyTwoFactorLogin).mockResolvedValue(response);
+    vi.mocked(verifyTwoFactorLogin).mockResolvedValue(mockLoginSuccess);
 
     const { result } = renderHook(() => useVerifyTwoFactorLogin(), {
       wrapper: createWrapper(client),

--- a/packages/@granit/react-authorization/src/__tests__/use-permission-definitions.test.tsx
+++ b/packages/@granit/react-authorization/src/__tests__/use-permission-definitions.test.tsx
@@ -3,32 +3,14 @@ import { createMockClient } from '@granit/testing';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { mockPermissionGroups } from '@granit/react-authorization/testing';
+
 import { usePermissionDefinitions } from '../hooks/use-permission-definitions';
-
-import type { PermissionGroupResponse } from '@granit/authorization';
-
-const MOCK_GROUPS: PermissionGroupResponse[] = [
-  {
-    name: 'Invoices',
-    displayName: 'Facturation',
-    permissions: [
-      { name: 'Invoices.Create', displayName: 'Créer une facture', multiTenancySides: 'Tenant' },
-      { name: 'Invoices.Delete', displayName: null, multiTenancySides: 'Tenant' },
-    ],
-  },
-  {
-    name: 'Users',
-    displayName: null,
-    permissions: [
-      { name: 'Users.View', displayName: 'Voir les utilisateurs', multiTenancySides: 'Both' },
-    ],
-  },
-];
 
 describe('usePermissionDefinitions', () => {
   it('should fetch and return permission groups', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValueOnce({ data: MOCK_GROUPS });
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockPermissionGroups });
 
     const { result } = renderHook(() => usePermissionDefinitions({ client }), {
       wrapper: createQueryWrapper(),
@@ -36,7 +18,7 @@ describe('usePermissionDefinitions', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data).toEqual(MOCK_GROUPS);
+    expect(result.current.data).toEqual(mockPermissionGroups);
     expect(client.get).toHaveBeenCalledWith('/api/v1/authorization/permissions/definitions');
   });
 

--- a/packages/@granit/react-background-jobs/src/__tests__/use-background-job.test.tsx
+++ b/packages/@granit/react-background-jobs/src/__tests__/use-background-job.test.tsx
@@ -1,16 +1,16 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { mockBackgroundJobs } from '@granit/react-background-jobs/testing';
+
 import { useBackgroundJob } from '../hooks/use-background-jobs';
 import { BackgroundJobsProvider } from '../providers/background-jobs-provider';
 
 import type { BackgroundJobsConfig } from '../providers/background-jobs-provider';
-import type { BackgroundJobStatus } from '@granit/background-jobs';
 import type { AxiosInstance } from 'axios';
 
 function createWrapper(client: AxiosInstance, basePath?: string) {
@@ -26,16 +26,7 @@ function createWrapper(client: AxiosInstance, basePath?: string) {
   };
 }
 
-const mockJob: BackgroundJobStatus = {
-  jobName: 'InvoiceSync',
-  cronExpression: '0 */1 * * *',
-  isEnabled: true,
-  lastExecutedAt: toISODateString('2026-03-12T10:00:00Z'),
-  nextExecutionAt: toISODateString('2026-03-12T11:00:00Z'),
-  consecutiveFailures: 0,
-  deadLetterCount: 0,
-  lastError: null,
-};
+const mockJob = mockBackgroundJobs[0];
 
 describe('useBackgroundJob', () => {
   it('should fetch a single job by name with default basePath', async () => {

--- a/packages/@granit/react-background-jobs/src/__tests__/use-background-jobs.test.tsx
+++ b/packages/@granit/react-background-jobs/src/__tests__/use-background-jobs.test.tsx
@@ -1,10 +1,11 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
+
+import { mockBackgroundJobs } from '@granit/react-background-jobs/testing';
 
 import {
   backgroundJobKeys,
@@ -33,16 +34,7 @@ function createWrapper(client: AxiosInstance, basePath?: string) {
   };
 }
 
-const mockJob: BackgroundJobStatus = {
-  jobName: 'InvoiceSync',
-  cronExpression: '0 */1 * * *',
-  isEnabled: true,
-  lastExecutedAt: toISODateString('2026-03-12T10:00:00Z'),
-  nextExecutionAt: toISODateString('2026-03-12T11:00:00Z'),
-  consecutiveFailures: 0,
-  deadLetterCount: 0,
-  lastError: null,
-};
+const mockJob = mockBackgroundJobs[0];
 
 const mockPage: PagedResult<BackgroundJobStatus> = {
   items: [mockJob],

--- a/packages/@granit/react-bank-accounts/src/__tests__/use-bank-accounts.test.tsx
+++ b/packages/@granit/react-bank-accounts/src/__tests__/use-bank-accounts.test.tsx
@@ -5,6 +5,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { sampleBankAccounts } from '@granit/react-bank-accounts/testing';
+
 import {
   useArchiveBankAccount,
   useBankAccount,
@@ -15,7 +17,6 @@ import {
 import { BankAccountsProvider } from '../providers/bank-accounts-provider';
 
 import type { BankAccountsConfig } from '../providers/bank-accounts-provider';
-import type { BankAccountResponse } from '@granit/bank-accounts';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -31,24 +32,7 @@ function createWrapper(client: AxiosInstance, basePath?: string) {
   };
 }
 
-const sampleAccount: BankAccountResponse = {
-  id: 'acc-1',
-  partyId: 'party-1',
-  scheme: 'Iban',
-  accountType: 'Checking',
-  accountIdentifierMasked: '**** 7034',
-  routingCode: null,
-  bic: 'GEBABEBB',
-  holderName: 'Alice Doe',
-  countryCode: 'BE',
-  bankName: 'BNP Paribas Fortis',
-  bankAddress: null,
-  intermediaryBic: null,
-  status: 'Active',
-  verified: false,
-  trusted: false,
-  tenantId: null,
-};
+const sampleAccount = sampleBankAccounts[0]!;
 
 describe('use-bank-accounts', () => {
   afterEach(() => {

--- a/packages/@granit/react-bff/src/__tests__/use-bff-tenant.test.ts
+++ b/packages/@granit/react-bff/src/__tests__/use-bff-tenant.test.ts
@@ -1,37 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
+import { mockBffHostUser, mockBffTenantUser } from '@granit/react-bff/testing';
+
 import { resolveBffTenantId } from '../hooks/use-bff-tenant';
-
-import type { BffHostUser, BffTenantUser } from '@granit/bff';
-
-const tenantUser: BffTenantUser = {
-  authenticated: true,
-  isHost: false,
-  sub: 't',
-  name: 'T',
-  email: 't@x',
-  roles: [],
-  sessionExpiresAt: '2026-12-31T23:59:59Z',
-  tenantId: 'acme' as BffTenantUser['tenantId'],
-};
-
-const hostUser: BffHostUser = {
-  authenticated: true,
-  isHost: true,
-  sub: 'h',
-  name: 'H',
-  email: 'h@x',
-  roles: ['Host'],
-  sessionExpiresAt: '2026-12-31T23:59:59Z',
-};
 
 describe('resolveBffTenantId', () => {
   it('returns tenantId for a tenant user', () => {
-    expect(resolveBffTenantId(tenantUser)).toBe('acme');
+    expect(resolveBffTenantId(mockBffTenantUser)).toBe('acme');
   });
 
   it('returns undefined for a host user — never auto-inject X-Tenant-Id', () => {
-    expect(resolveBffTenantId(hostUser)).toBeUndefined();
+    expect(resolveBffTenantId(mockBffHostUser)).toBeUndefined();
   });
 
   it('returns undefined for an anonymous / bootstrap state', () => {

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob.test.tsx
@@ -1,17 +1,16 @@
-import { BlobStatus } from '@granit/blob-storage';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { mockBlobs } from '@granit/react-blob-storage/testing';
+
 import { useBlob } from '../hooks/use-blob';
 import { BlobStorageProvider } from '../providers/blob-storage-provider';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { BlobDescriptorResponse } from '@granit/blob-storage';
 
 function createWrapper(client: AxiosInstance, basePath?: string) {
   const queryClient = createTestQueryClient();
@@ -25,21 +24,7 @@ function createWrapper(client: AxiosInstance, basePath?: string) {
   };
 }
 
-const mockDescriptor: BlobDescriptorResponse = {
-  id: 'abc-123',
-  containerName: 'medical-images',
-  originalFileName: 'scan.png',
-  declaredContentType: 'image/png',
-  verifiedContentType: 'image/png',
-  declaredSizeBytes: 1024,
-  actualSizeBytes: 1020,
-  status: BlobStatus.Valid,
-  rejectionReason: null,
-  deletionReason: null,
-  createdAt: toISODateString('2026-03-20T10:00:00Z'),
-  validatedAt: toISODateString('2026-03-20T10:00:05Z'),
-  deletedAt: null,
-};
+const mockDescriptor = mockBlobs[0];
 
 describe('useBlob', () => {
   it('should fetch blob descriptor with default basePath', async () => {

--- a/packages/@granit/react-catalog/src/__tests__/use-products.test.tsx
+++ b/packages/@granit/react-catalog/src/__tests__/use-products.test.tsx
@@ -1,10 +1,11 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toEntityId } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { mockProducts } from '@granit/react-catalog/testing';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 import {
@@ -21,51 +22,17 @@ import {
 
 import type { CatalogConfig } from '../providers/catalog-provider';
 import type { AxiosInstance } from '@granit/api-client';
-import type {
-  ProductCreateRequest,
-  ProductExternalMappingId,
-  ProductExternalMappingResponse,
-  ProductId,
-  ProductResponse,
-} from '@granit/catalog';
+import type { ProductCreateRequest } from '@granit/catalog';
 import type { ReactNode } from 'react';
 
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
-const PRODUCT_ID = toEntityId<'Product'>('prod-001') as ProductId;
-const MAPPING_ID = toEntityId<'ProductExternalMapping'>('map-001') as ProductExternalMappingId;
+const sampleProduct = mockProducts[0]!;
+const PRODUCT_ID = sampleProduct.id;
 
-const sampleMapping: ProductExternalMappingResponse = {
-  id: MAPPING_ID,
-  providerName: 'Stripe',
-  externalId: 'price_abc123',
-};
-
-const sampleProduct: ProductResponse = {
-  id: PRODUCT_ID,
-  sku: 'SKU-001',
-  name: 'Widget Pro',
-  description: 'A professional widget',
-  type: 'Physical',
-  unit: 'each',
-  lifecycleStatus: 'Published',
-  metadata: { category: 'hardware' },
-  externalMappings: [sampleMapping],
-};
-
-const sampleDraftProduct: ProductResponse = {
-  id: toEntityId<'Product'>('prod-002') as ProductId,
-  sku: 'SKU-002',
-  name: 'Widget Lite',
-  description: null,
-  type: 'Physical',
-  unit: 'each',
-  lifecycleStatus: 'Draft',
-  metadata: {},
-  externalMappings: [],
-};
+const sampleDraftProduct = mockProducts[2]!;
 
 const createRequest: ProductCreateRequest = {
   sku: 'SKU-NEW',
@@ -276,13 +243,13 @@ describe('useProductBySku', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: sampleDraftProduct });
 
-    const { result } = renderHook(() => useProductBySku('SKU-002'), {
+    const { result } = renderHook(() => useProductBySku(sampleDraftProduct.sku), {
       wrapper: createWrapper(client),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(client.get).toHaveBeenCalledWith(
-      `${DEFAULT_BASE_PATH}/products/by-sku/${encodeURIComponent('SKU-002')}`
+      `${DEFAULT_BASE_PATH}/products/by-sku/${encodeURIComponent(sampleDraftProduct.sku)}`
     );
     expect(result.current.data).toEqual(sampleDraftProduct);
   });

--- a/packages/@granit/react-cms-hostnames/src/__tests__/use-site-hostname-mutations.test.ts
+++ b/packages/@granit/react-cms-hostnames/src/__tests__/use-site-hostname-mutations.test.ts
@@ -6,6 +6,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockHostnames } from '@granit/react-cms-hostnames/testing';
+
 import {
   useAddSiteHostname,
   useRemoveSiteHostname,
@@ -13,7 +15,6 @@ import {
 } from '../hooks/use-site-hostname-mutations';
 import { CmsHostnamesProvider } from '../providers/cms-hostnames-provider';
 
-import type { SiteHostnameResponse } from '@granit/cms-hostnames';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -23,15 +24,7 @@ vi.mock('@granit/cms-hostnames', () => ({
   verifySiteHostname: vi.fn(),
 }));
 
-const hostname: SiteHostnameResponse = {
-  id: 'h-1',
-  host: 'example.com',
-  status: 'Active',
-  isPrimary: true,
-  expectedDnsRecords: [],
-  lastCheckedAt: null,
-  certificateStatus: 'Unprovisioned',
-};
+const hostname = mockHostnames[0]!;
 
 function createWrapper(client: AxiosInstance) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -78,10 +71,10 @@ describe('useRemoveSiteHostname', () => {
     const { result } = renderHook(() => useRemoveSiteHostname('site-1'), {
       wrapper: createWrapper(client),
     });
-    result.current.mutate('h-1');
+    result.current.mutate(hostname.id);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(removeSiteHostname).toHaveBeenCalledWith(client, '', 'site-1', 'h-1');
+    expect(removeSiteHostname).toHaveBeenCalledWith(client, '', 'site-1', hostname.id);
   });
 });
 
@@ -97,10 +90,10 @@ describe('useVerifySiteHostname', () => {
     const { result } = renderHook(() => useVerifySiteHostname('site-1'), {
       wrapper: createWrapper(client),
     });
-    result.current.mutate('h-1');
+    result.current.mutate(hostname.id);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(verifySiteHostname).toHaveBeenCalledWith(client, '', 'site-1', 'h-1');
+    expect(verifySiteHostname).toHaveBeenCalledWith(client, '', 'site-1', hostname.id);
     expect(result.current.data).toEqual(hostname);
   });
 });

--- a/packages/@granit/react-cms-hostnames/src/__tests__/use-site-hostnames.test.ts
+++ b/packages/@granit/react-cms-hostnames/src/__tests__/use-site-hostnames.test.ts
@@ -6,10 +6,12 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockHostnames } from '@granit/react-cms-hostnames/testing';
+
 import { useSiteHostnameAvailability, useSiteHostnames } from '../hooks/use-site-hostnames';
 import { CmsHostnamesProvider } from '../providers/cms-hostnames-provider';
 
-import type { SiteHostnameAvailabilityResponse, SiteHostnameResponse } from '@granit/cms-hostnames';
+import type { SiteHostnameAvailabilityResponse } from '@granit/cms-hostnames';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -18,15 +20,7 @@ vi.mock('@granit/cms-hostnames', () => ({
   checkSiteHostnameAvailability: vi.fn(),
 }));
 
-const hostname: SiteHostnameResponse = {
-  id: 'h-1',
-  host: 'example.com',
-  status: 'Active',
-  isPrimary: true,
-  expectedDnsRecords: [],
-  lastCheckedAt: null,
-  certificateStatus: 'Unprovisioned',
-};
+const hostname = mockHostnames[0]!;
 
 function createWrapper(client: AxiosInstance) {
   return function Wrapper({ children }: { children: ReactNode }) {

--- a/packages/@granit/react-cms-redirects/src/__tests__/use-redirect-mutations.test.ts
+++ b/packages/@granit/react-cms-redirects/src/__tests__/use-redirect-mutations.test.ts
@@ -11,6 +11,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockRedirects } from '@granit/react-cms-redirects/testing';
+
 import {
   useCreateRedirect,
   useDeleteRedirect,
@@ -19,11 +21,7 @@ import {
 } from '../hooks/use-redirect-mutations';
 import { CmsRedirectsProvider } from '../providers/cms-redirects-provider';
 
-import type {
-  RedirectMutationResult,
-  RedirectResponse,
-  SiteRedirectSettingsResponse,
-} from '@granit/cms-redirects';
+import type { RedirectMutationResult, SiteRedirectSettingsResponse } from '@granit/cms-redirects';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -34,20 +32,7 @@ vi.mock('@granit/cms-redirects', () => ({
   updateRedirectSettings: vi.fn(),
 }));
 
-const redirect: RedirectResponse = {
-  id: 'r-1',
-  siteId: 'site-1',
-  source: '/old',
-  matchType: 'Exact',
-  target: '/new',
-  type: 'MovedPermanently',
-  statusCode: 301,
-  isActive: true,
-  culture: null,
-  origin: 'Manual',
-  hitCount: 0,
-  lastHitAt: null,
-};
+const redirect = mockRedirects[0]!;
 
 const mutationResult: RedirectMutationResult = { redirect, conflictWarning: null };
 
@@ -102,10 +87,10 @@ describe('useUpdateRedirect', () => {
 
     const request = { target: '/new-v2' };
     const { result } = renderHook(() => useUpdateRedirect(), { wrapper: createWrapper(client) });
-    result.current.mutate({ id: 'r-1', request });
+    result.current.mutate({ id: redirect.id, request });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(updateRedirect).toHaveBeenCalledWith(client, '', 'r-1', request);
+    expect(updateRedirect).toHaveBeenCalledWith(client, '', redirect.id, request);
   });
 });
 
@@ -117,10 +102,10 @@ describe('useDeleteRedirect', () => {
     vi.mocked(deleteRedirect).mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useDeleteRedirect(), { wrapper: createWrapper(client) });
-    result.current.mutate({ id: 'r-1', siteId: 'site-1' });
+    result.current.mutate({ id: redirect.id, siteId: redirect.siteId });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(deleteRedirect).toHaveBeenCalledWith(client, '', 'r-1');
+    expect(deleteRedirect).toHaveBeenCalledWith(client, '', redirect.id);
   });
 });
 

--- a/packages/@granit/react-cms-redirects/src/__tests__/use-redirects.test.ts
+++ b/packages/@granit/react-cms-redirects/src/__tests__/use-redirects.test.ts
@@ -12,6 +12,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockRedirects } from '@granit/react-cms-redirects/testing';
+
 import {
   useRedirect,
   useRedirectPreview,
@@ -38,20 +40,7 @@ vi.mock('@granit/cms-redirects', () => ({
   previewRedirect: vi.fn(),
 }));
 
-const redirect: RedirectResponse = {
-  id: 'r-1',
-  siteId: 'site-1',
-  source: '/old',
-  matchType: 'Exact',
-  target: '/new',
-  type: 'MovedPermanently',
-  statusCode: 301,
-  isActive: true,
-  culture: null,
-  origin: 'Manual',
-  hitCount: 0,
-  lastHitAt: null,
-};
+const redirect = mockRedirects[0]!;
 
 function createWrapper(client: AxiosInstance) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -99,10 +88,12 @@ describe('useRedirect', () => {
     const client = createMockClient();
     vi.mocked(getRedirect).mockResolvedValue(redirect);
 
-    const { result } = renderHook(() => useRedirect('r-1'), { wrapper: createWrapper(client) });
+    const { result } = renderHook(() => useRedirect(redirect.id), {
+      wrapper: createWrapper(client),
+    });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getRedirect).toHaveBeenCalledWith(client, '', 'r-1');
+    expect(getRedirect).toHaveBeenCalledWith(client, '', redirect.id);
   });
 });
 

--- a/packages/@granit/react-cms-seo/src/__tests__/use-seo-ai.test.ts
+++ b/packages/@granit/react-cms-seo/src/__tests__/use-seo-ai.test.ts
@@ -8,11 +8,12 @@ import {
 } from '@granit/cms-seo';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { mockSeoSuggestions } from '@granit/react-cms-seo/testing';
 
 import {
   useApplySeoSuggestion,
@@ -27,7 +28,6 @@ import { CmsSeoProvider } from '../providers/cms-seo-provider';
 import type {
   SeoSuggestRequest,
   SeoSuggestResponse,
-  SeoSuggestionResponse,
   SeoSuggestionDiff,
   SeoSuggestionListResponse,
 } from '@granit/cms-seo';
@@ -43,28 +43,7 @@ vi.mock('@granit/cms-seo', () => ({
   triggerBulkSeoAudit: vi.fn(),
 }));
 
-const suggestion: SeoSuggestionResponse = {
-  id: 'sug-1',
-  siteId: 'site-1',
-  contentType: 'page',
-  contentId: 'page-1',
-  culture: 'fr',
-  status: 'Pending',
-  scope: 'Title, Description',
-  appliedFields: 'None',
-  title: 'A title',
-  description: 'A description',
-  keywords: [],
-  ogImageAltText: null,
-  structuredDataJson: null,
-  modelId: 'gpt-4o-mini',
-  promptTemplateVersion: 'v1',
-  createdAt: toISODateString('2026-06-01T10:00:00.000Z'),
-  reviewedBy: null,
-  reviewedAt: null,
-  failureReason: null,
-  rejectionReason: null,
-};
+const suggestion = mockSeoSuggestions[0]!;
 
 function createWrapper(client: AxiosInstance) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -104,18 +83,18 @@ describe('useSeoSuggestionDiff', () => {
   it('fetches diff for a suggestion', async () => {
     const client = createMockClient();
     const diff: SeoSuggestionDiff = {
-      suggestionId: 'sug-1',
+      suggestionId: suggestion.id,
       scope: 'Title, Description',
       fields: [{ field: 'Title', inScope: true, current: null, proposed: 'New' }],
     };
     vi.mocked(getSeoSuggestionDiff).mockResolvedValue(diff);
 
-    const { result } = renderHook(() => useSeoSuggestionDiff('sug-1'), {
+    const { result } = renderHook(() => useSeoSuggestionDiff(suggestion.id), {
       wrapper: createWrapper(client),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getSeoSuggestionDiff).toHaveBeenCalledWith(client, '', 'sug-1');
+    expect(getSeoSuggestionDiff).toHaveBeenCalledWith(client, '', suggestion.id);
   });
 
   it('is disabled when id is empty', () => {
@@ -167,10 +146,10 @@ describe('useApplySeoSuggestion', () => {
     const { result } = renderHook(() => useApplySeoSuggestion(), {
       wrapper: createWrapper(client),
     });
-    result.current.mutate({ id: 'sug-1', request: { fields: 'Title' } });
+    result.current.mutate({ id: suggestion.id, request: { fields: 'Title' } });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(applySeoSuggestion).toHaveBeenCalledWith(client, '', 'sug-1', { fields: 'Title' });
+    expect(applySeoSuggestion).toHaveBeenCalledWith(client, '', suggestion.id, { fields: 'Title' });
   });
 });
 
@@ -186,10 +165,10 @@ describe('useRejectSeoSuggestion', () => {
     const { result } = renderHook(() => useRejectSeoSuggestion(), {
       wrapper: createWrapper(client),
     });
-    result.current.mutate({ id: 'sug-1', request: { reason: 'Not relevant' } });
+    result.current.mutate({ id: suggestion.id, request: { reason: 'Not relevant' } });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(rejectSeoSuggestion).toHaveBeenCalledWith(client, '', 'sug-1', {
+    expect(rejectSeoSuggestion).toHaveBeenCalledWith(client, '', suggestion.id, {
       reason: 'Not relevant',
     });
   });

--- a/packages/@granit/react-cms-seo/src/__tests__/use-seo-metadata.test.ts
+++ b/packages/@granit/react-cms-seo/src/__tests__/use-seo-metadata.test.ts
@@ -14,6 +14,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockSeoDefaults, mockSeoMetadataAudit } from '@granit/react-cms-seo/testing';
+
 import {
   useEffectiveSeo,
   useJsonLdPreview,
@@ -33,7 +35,6 @@ import type {
   SeoMetadataListItem,
   SeoMetadataResponse,
   SerpPreviewResponse,
-  SiteSeoDefaultsResponse,
 } from '@granit/cms-seo';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -82,25 +83,8 @@ const metadata: SeoMetadataResponse = {
   concurrencyStamp: 'stamp-1',
 };
 
-const defaults: SiteSeoDefaultsResponse = {
-  id: 'd-1',
-  siteId: 'site-1',
-  titleTemplate: null,
-  siteName: 'ACME',
-  defaultDescription: null,
-  defaultRobots: robots,
-  canonicalHost: null,
-  sitemapMaxUrlsPerFile: 45000,
-  inheritFromParentPage: false,
-  defaultOpenGraph: null,
-  defaultTwitterCard: null,
-  defaultOgImage: null,
-  robotsTxtRules: [],
-  robotsTxtExtra: null,
-  manifest: null,
-  enableAutomaticSeoGeneration: false,
-  concurrencyStamp: 'stamp-1',
-};
+const CORPORATE_SITE_ID = 'b1f0c3a4-1d2e-4f5a-8b6c-1a2b3c4d5e6f';
+const defaults = mockSeoDefaults[CORPORATE_SITE_ID]!;
 
 function createWrapper(client: AxiosInstance) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -217,16 +201,7 @@ describe('useSeoMetadataAudit', () => {
 
   it('fetches the audit grid page', async () => {
     const client = createMockClient();
-    const item: SeoMetadataListItem = {
-      id: 'm-1',
-      siteId: 'site-1',
-      contentType: 'page',
-      contentId: 'p-1',
-      culture: 'fr',
-      title: null,
-      description: null,
-      canonicalUrl: null,
-    };
+    const item = mockSeoMetadataAudit[0]!;
     const paged: PagedResult<SeoMetadataListItem> = {
       items: [item],
       totalCount: 1,

--- a/packages/@granit/react-cms-seo/src/__tests__/use-seo-mutations.test.ts
+++ b/packages/@granit/react-cms-seo/src/__tests__/use-seo-mutations.test.ts
@@ -11,6 +11,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockSeoDefaults } from '@granit/react-cms-seo/testing';
+
 import {
   useDeleteSeoMetadata,
   useInvalidateSitemap,
@@ -19,13 +21,11 @@ import {
 } from '../hooks/use-seo-mutations';
 import { CmsSeoProvider } from '../providers/cms-seo-provider';
 
-import type {
-  RobotsDirective,
-  SeoMetadataResponse,
-  SiteSeoDefaultsResponse,
-} from '@granit/cms-seo';
+import type { RobotsDirective, SeoMetadataResponse } from '@granit/cms-seo';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
+
+const CORPORATE_SITE_ID = 'b1f0c3a4-1d2e-4f5a-8b6c-1a2b3c4d5e6f';
 
 vi.mock('@granit/cms-seo', () => ({
   upsertSeoMetadata: vi.fn(),
@@ -120,25 +120,7 @@ describe('useUpdateSeoDefaults', () => {
 
   it('calls updateSeoDefaults', async () => {
     const client = createMockClient();
-    const updated: SiteSeoDefaultsResponse = {
-      id: 'd-1',
-      siteId: 'site-1',
-      titleTemplate: null,
-      siteName: 'ACME',
-      defaultDescription: null,
-      defaultRobots: robots,
-      canonicalHost: null,
-      sitemapMaxUrlsPerFile: 45000,
-      inheritFromParentPage: false,
-      defaultOpenGraph: null,
-      defaultTwitterCard: null,
-      defaultOgImage: null,
-      robotsTxtRules: [],
-      robotsTxtExtra: null,
-      manifest: null,
-      enableAutomaticSeoGeneration: false,
-      concurrencyStamp: 'stamp-1',
-    };
+    const updated = mockSeoDefaults[CORPORATE_SITE_ID]!;
     vi.mocked(updateSeoDefaults).mockResolvedValue(updated);
 
     const { result } = renderHook(() => useUpdateSeoDefaults(), { wrapper: createWrapper(client) });

--- a/packages/@granit/react-cms/src/__tests__/use-menu-mutations.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-menu-mutations.test.ts
@@ -1,16 +1,16 @@
 import { createMenu, deleteMenu, updateMenu } from '@granit/cms';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockMenus } from '@granit/react-cms/testing';
+
 import { useCreateMenu, useDeleteMenu, useUpdateMenu } from '../hooks/use-menu-mutations';
 import { CmsProvider } from '../providers/cms-provider';
 
-import type { MenuResponse } from '@granit/cms';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -20,15 +20,7 @@ vi.mock('@granit/cms', () => ({
   deleteMenu: vi.fn(),
 }));
 
-const menu: MenuResponse = {
-  id: 'menu-1',
-  siteId: 'site-1',
-  key: 'main',
-  title: 'Main navigation',
-  items: [],
-  createdAt: toISODateString('2026-01-01T00:00:00Z'),
-  modifiedAt: null,
-};
+const menu = mockMenus[0]!;
 
 function createWrapper(client: AxiosInstance) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -72,10 +64,10 @@ describe('useUpdateMenu', () => {
     vi.mocked(updateMenu).mockResolvedValue(menu);
 
     const { result } = renderHook(() => useUpdateMenu(), { wrapper: createWrapper(client) });
-    result.current.mutate({ id: 'menu-1', request: { title: 'Primary nav', items: [] } });
+    result.current.mutate({ id: menu.id, request: { title: 'Primary nav', items: [] } });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(updateMenu).toHaveBeenCalledWith(client, '', 'menu-1', {
+    expect(updateMenu).toHaveBeenCalledWith(client, '', menu.id, {
       title: 'Primary nav',
       items: [],
     });
@@ -92,9 +84,9 @@ describe('useDeleteMenu', () => {
     vi.mocked(deleteMenu).mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useDeleteMenu(), { wrapper: createWrapper(client) });
-    result.current.mutate({ id: 'menu-1', siteId: 'site-1' });
+    result.current.mutate({ id: menu.id, siteId: menu.siteId });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(deleteMenu).toHaveBeenCalledWith(client, '', 'menu-1');
+    expect(deleteMenu).toHaveBeenCalledWith(client, '', menu.id);
   });
 });

--- a/packages/@granit/react-cms/src/__tests__/use-menus-admin.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-menus-admin.test.ts
@@ -1,11 +1,12 @@
 import { getMenu, listMenus } from '@granit/cms';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { mockMenus } from '@granit/react-cms/testing';
 
 import { useMenu, useMenus } from '../hooks/use-menus-admin';
 import { CmsProvider } from '../providers/cms-provider';
@@ -20,15 +21,7 @@ vi.mock('@granit/cms', () => ({
   getMenu: vi.fn(),
 }));
 
-const menu: MenuResponse = {
-  id: 'menu-1',
-  siteId: 'site-1',
-  key: 'main',
-  title: 'Main navigation',
-  items: [],
-  createdAt: toISODateString('2026-01-01T00:00:00Z'),
-  modifiedAt: null,
-};
+const menu = mockMenus[0]!;
 
 function createWrapper(client: AxiosInstance) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -79,10 +72,10 @@ describe('useMenu', () => {
     const client = createMockClient();
     vi.mocked(getMenu).mockResolvedValue(menu);
 
-    const { result } = renderHook(() => useMenu('menu-1'), { wrapper: createWrapper(client) });
+    const { result } = renderHook(() => useMenu(menu.id), { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getMenu).toHaveBeenCalledWith(client, '', 'menu-1');
+    expect(getMenu).toHaveBeenCalledWith(client, '', menu.id);
   });
 
   it('is disabled when id is empty', () => {

--- a/packages/@granit/react-cms/src/__tests__/use-pages.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-pages.test.ts
@@ -7,10 +7,12 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockPageTree } from '@granit/react-cms/testing';
+
 import { usePage, usePageTree, usePageVersions, usePages } from '../hooks/use-pages';
 import { CmsProvider } from '../providers/cms-provider';
 
-import type { PageResponse, PageTreeNodeResponse, PageVersionSummaryResponse } from '@granit/cms';
+import type { PageResponse, PageVersionSummaryResponse } from '@granit/cms';
 import type { PagedResult } from '@granit/query-engine';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -22,14 +24,7 @@ vi.mock('@granit/cms', () => ({
   listPageVersions: vi.fn(),
 }));
 
-const treeNode: PageTreeNodeResponse = {
-  id: 'page-1',
-  parentId: null,
-  slugSegment: 'home',
-  structurePath: '/home',
-  depth: 0,
-  isSiteRoot: true,
-};
+const treeNode = mockPageTree[0]!;
 const page: PageResponse = {
   id: 'page-1',
   siteId: 'site-1',

--- a/packages/@granit/react-cms/src/__tests__/use-release-mutations.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-release-mutations.test.ts
@@ -9,11 +9,12 @@ import {
 } from '@granit/cms';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { mockReleases } from '@granit/react-cms/testing';
 
 import {
   useAddReleaseAction,
@@ -26,7 +27,6 @@ import {
 } from '../hooks/use-release-mutations';
 import { CmsProvider } from '../providers/cms-provider';
 
-import type { ReleaseResponse } from '@granit/cms';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -40,18 +40,8 @@ vi.mock('@granit/cms', () => ({
   publishRelease: vi.fn(),
 }));
 
-const release: ReleaseResponse = {
-  id: 'rel-1',
-  siteId: 'site-1',
-  name: 'Sprint 1',
-  status: 'Draft',
-  schedule: null,
-  tenantId: null,
-  actions: [],
-  createdAt: toISODateString('2026-01-01T00:00:00Z'),
-  modifiedAt: null,
-  concurrencyStamp: 'stamp-1',
-};
+const release = mockReleases[0]!;
+const stamp = release.concurrencyStamp;
 
 function createWrapper(client: AxiosInstance) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -92,14 +82,14 @@ describe('useUpdateRelease', () => {
 
     const { result } = renderHook(() => useUpdateRelease(), { wrapper: createWrapper(client) });
     result.current.mutate({
-      id: 'rel-1',
-      request: { name: 'Sprint 1 v2', concurrencyStamp: 'stamp-1' },
+      id: release.id,
+      request: { name: 'Sprint 1 v2', concurrencyStamp: stamp },
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(updateRelease).toHaveBeenCalledWith(client, '', 'rel-1', {
+    expect(updateRelease).toHaveBeenCalledWith(client, '', release.id, {
       name: 'Sprint 1 v2',
-      concurrencyStamp: 'stamp-1',
+      concurrencyStamp: stamp,
     });
   });
 });
@@ -118,13 +108,13 @@ describe('useAddReleaseAction', () => {
       contentId: 'page-1',
       culture: 'fr',
       type: 'Publish' as const,
-      concurrencyStamp: 'stamp-1',
+      concurrencyStamp: stamp,
     };
     const { result } = renderHook(() => useAddReleaseAction(), { wrapper: createWrapper(client) });
-    result.current.mutate({ id: 'rel-1', request: req });
+    result.current.mutate({ id: release.id, request: req });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(addReleaseAction).toHaveBeenCalledWith(client, '', 'rel-1', req);
+    expect(addReleaseAction).toHaveBeenCalledWith(client, '', release.id, req);
   });
 });
 
@@ -140,10 +130,10 @@ describe('useRemoveReleaseAction', () => {
     const { result } = renderHook(() => useRemoveReleaseAction(), {
       wrapper: createWrapper(client),
     });
-    result.current.mutate({ id: 'rel-1', actionId: 'action-1' });
+    result.current.mutate({ id: release.id, actionId: 'action-1' });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(removeReleaseAction).toHaveBeenCalledWith(client, '', 'rel-1', 'action-1');
+    expect(removeReleaseAction).toHaveBeenCalledWith(client, '', release.id, 'action-1');
   });
 });
 
@@ -159,13 +149,13 @@ describe('useScheduleRelease', () => {
     const req = {
       localDateTime: '2026-07-01T09:00:00',
       timeZoneId: 'Europe/Brussels',
-      concurrencyStamp: 'stamp-1',
+      concurrencyStamp: stamp,
     };
     const { result } = renderHook(() => useScheduleRelease(), { wrapper: createWrapper(client) });
-    result.current.mutate({ id: 'rel-1', request: req });
+    result.current.mutate({ id: release.id, request: req });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(scheduleRelease).toHaveBeenCalledWith(client, '', 'rel-1', req);
+    expect(scheduleRelease).toHaveBeenCalledWith(client, '', release.id, req);
   });
 });
 
@@ -179,10 +169,10 @@ describe('useCancelRelease', () => {
     vi.mocked(cancelRelease).mockResolvedValue({ ...release, status: 'Draft' });
 
     const { result } = renderHook(() => useCancelRelease(), { wrapper: createWrapper(client) });
-    result.current.mutate('rel-1');
+    result.current.mutate(release.id);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(cancelRelease).toHaveBeenCalledWith(client, '', 'rel-1');
+    expect(cancelRelease).toHaveBeenCalledWith(client, '', release.id);
   });
 });
 
@@ -196,9 +186,9 @@ describe('usePublishRelease', () => {
     vi.mocked(publishRelease).mockResolvedValue({ ...release, status: 'Done' });
 
     const { result } = renderHook(() => usePublishRelease(), { wrapper: createWrapper(client) });
-    result.current.mutate('rel-1');
+    result.current.mutate(release.id);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(publishRelease).toHaveBeenCalledWith(client, '', 'rel-1');
+    expect(publishRelease).toHaveBeenCalledWith(client, '', release.id);
   });
 });

--- a/packages/@granit/react-cms/src/__tests__/use-releases.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-releases.test.ts
@@ -1,11 +1,12 @@
 import { getRelease, listReleases } from '@granit/cms';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { mockReleases } from '@granit/react-cms/testing';
 
 import { useRelease, useReleases } from '../hooks/use-releases';
 import { CmsProvider } from '../providers/cms-provider';
@@ -20,18 +21,7 @@ vi.mock('@granit/cms', () => ({
   getRelease: vi.fn(),
 }));
 
-const release: ReleaseResponse = {
-  id: 'rel-1',
-  siteId: 'site-1',
-  name: 'Sprint 1',
-  status: 'Draft',
-  schedule: null,
-  tenantId: null,
-  actions: [],
-  createdAt: toISODateString('2026-01-01T00:00:00Z'),
-  modifiedAt: null,
-  concurrencyStamp: 'stamp-1',
-};
+const release = mockReleases[0]!;
 
 function createWrapper(client: AxiosInstance) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -82,10 +72,10 @@ describe('useRelease', () => {
     const client = createMockClient();
     vi.mocked(getRelease).mockResolvedValue(release);
 
-    const { result } = renderHook(() => useRelease('rel-1'), { wrapper: createWrapper(client) });
+    const { result } = renderHook(() => useRelease(release.id), { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getRelease).toHaveBeenCalledWith(client, '', 'rel-1');
+    expect(getRelease).toHaveBeenCalledWith(client, '', release.id);
   });
 
   it('is disabled when id is empty', () => {

--- a/packages/@granit/react-cms/src/__tests__/use-site-mutations.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-site-mutations.test.ts
@@ -1,16 +1,16 @@
 import { createSite, deleteSite, updateSite } from '@granit/cms';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockSites } from '@granit/react-cms/testing';
+
 import { useCreateSite, useDeleteSite, useUpdateSite } from '../hooks/use-site-mutations';
 import { CmsProvider } from '../providers/cms-provider';
 
-import type { SiteResponse } from '@granit/cms';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -20,20 +20,7 @@ vi.mock('@granit/cms', () => ({
   deleteSite: vi.fn(),
 }));
 
-const site: SiteResponse = {
-  id: 'site-1',
-  slug: 'acme',
-  defaultCulture: 'fr',
-  allowedCultures: ['fr'],
-  domains: [],
-  defaultTheme: 'default',
-  activated: true,
-  tenantId: null,
-  displayNames: {},
-  homePageId: null,
-  createdAt: toISODateString('2026-01-01T00:00:00Z'),
-  modifiedAt: null,
-};
+const site = mockSites[0]!;
 
 function createWrapper(client: AxiosInstance) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -84,10 +71,10 @@ describe('useUpdateSite', () => {
       activated: true,
     };
     const { result } = renderHook(() => useUpdateSite(), { wrapper: createWrapper(client) });
-    result.current.mutate({ id: 'site-1', request });
+    result.current.mutate({ id: site.id, request });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(updateSite).toHaveBeenCalledWith(client, '', 'site-1', request);
+    expect(updateSite).toHaveBeenCalledWith(client, '', site.id, request);
   });
 });
 
@@ -101,9 +88,9 @@ describe('useDeleteSite', () => {
     vi.mocked(deleteSite).mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useDeleteSite(), { wrapper: createWrapper(client) });
-    result.current.mutate('site-1');
+    result.current.mutate(site.id);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(deleteSite).toHaveBeenCalledWith(client, '', 'site-1');
+    expect(deleteSite).toHaveBeenCalledWith(client, '', site.id);
   });
 });

--- a/packages/@granit/react-cms/src/__tests__/use-sites.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-sites.test.ts
@@ -1,11 +1,12 @@
 import { getSite, listSites } from '@granit/cms';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { mockSites } from '@granit/react-cms/testing';
 
 import { useSite, useSites } from '../hooks/use-sites';
 import { CmsProvider } from '../providers/cms-provider';
@@ -20,20 +21,7 @@ vi.mock('@granit/cms', () => ({
   getSite: vi.fn(),
 }));
 
-const site: SiteResponse = {
-  id: 'site-1',
-  slug: 'acme',
-  defaultCulture: 'fr',
-  allowedCultures: ['fr'],
-  domains: [],
-  defaultTheme: 'default',
-  activated: true,
-  tenantId: null,
-  displayNames: {},
-  homePageId: null,
-  createdAt: toISODateString('2026-01-01T00:00:00Z'),
-  modifiedAt: null,
-};
+const site = mockSites[0]!;
 
 function createWrapper(client: AxiosInstance) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -105,10 +93,10 @@ describe('useSite', () => {
     const client = createMockClient();
     vi.mocked(getSite).mockResolvedValue(site);
 
-    const { result } = renderHook(() => useSite('site-1'), { wrapper: createWrapper(client) });
+    const { result } = renderHook(() => useSite(site.id), { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getSite).toHaveBeenCalledWith(client, '', 'site-1');
+    expect(getSite).toHaveBeenCalledWith(client, '', site.id);
     expect(result.current.data).toEqual(site);
   });
 

--- a/packages/@granit/react-customer-balance/src/__tests__/use-customer-balance.test.tsx
+++ b/packages/@granit/react-customer-balance/src/__tests__/use-customer-balance.test.tsx
@@ -6,6 +6,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { sampleBalance, sampleTransactions } from '@granit/react-customer-balance/testing';
+
 import {
   useAddAdminCredit,
   useApplyAdminDebit,
@@ -15,34 +17,11 @@ import {
 import { CustomerBalanceProvider } from '../providers/customer-balance-provider';
 
 import type { CustomerBalanceConfig } from '../providers/customer-balance-provider';
-import type {
-  AdminCreditRequest,
-  AdminDebitRequest,
-  BalanceTransactionResponse,
-  CustomerBalanceResponse,
-} from '@granit/customer-balance';
+import type { AdminCreditRequest, AdminDebitRequest } from '@granit/customer-balance';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
-const sampleBalance: CustomerBalanceResponse = {
-  balanceAccountId: 'ba-001',
-  currency: 'EUR',
-  balance: 150.0,
-  concurrencyStamp: 'stamp-1',
-  updatedAt: toISODateString('2026-04-01T10:00:00Z'),
-};
-
-const sampleTransaction: BalanceTransactionResponse = {
-  id: 'tx-001',
-  type: 'Credit',
-  amount: 50.0,
-  source: 'Promotional',
-  reason: 'Welcome bonus',
-  referenceId: null,
-  referenceType: null,
-  expiresAt: toISODateString('2026-12-31T23:59:59Z'),
-  createdAt: toISODateString('2026-04-01T10:00:00Z'),
-};
+const sampleTransaction = sampleTransactions[0]!;
 
 function createWrapper(client: AxiosInstance, basePath?: string) {
   return function Wrapper({ children }: { children: ReactNode }) {

--- a/packages/@granit/react-dashboards/src/__tests__/use-dashboard-crud.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-dashboard-crud.test.tsx
@@ -6,6 +6,8 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
+import { CATALOG, SAMPLE_FINANCE_DASHBOARD_ID } from '@granit/react-dashboards/testing';
+
 import { dashboardCatalogQueryKey, useDashboardCatalog } from '../hooks/use-dashboard-catalog';
 import { dashboardDetailQueryKey, useDashboardDetail } from '../hooks/use-dashboard-detail';
 import { useDashboardList } from '../hooks/use-dashboard-list';
@@ -21,7 +23,6 @@ import { useAddWidget, useRemoveWidget, useUpdateWidget } from '../hooks/use-wid
 import { DashboardsProvider } from '../providers/dashboards-provider';
 
 import type {
-  DashboardCatalogEntryResponse,
   DashboardDetailResponse,
   DashboardImportResponse,
   DashboardSummaryResponse,
@@ -30,20 +31,10 @@ import type {
 } from '@granit/dashboards';
 import type { ReactNode } from 'react';
 
-const ID = '8c6b1e10-0000-4000-8000-000000000001';
+const ID = SAMPLE_FINANCE_DASHBOARD_ID;
 const WIDGET_ID = '8c6b1e10-0000-0000-0000-000000000010';
-const DEFINITION_NAME = 'Granit.Showcase.InvoicingOverview';
-
-const CATALOG_ENTRY: DashboardCatalogEntryResponse = {
-  name: DEFINITION_NAME,
-  category: 'Finance',
-  isSystem: false,
-  version: '1.0.0',
-  widgetCount: 4,
-  hasViews: false,
-  hasAliases: false,
-  hasFilters: false,
-};
+const CATALOG_ENTRY = CATALOG[0];
+const DEFINITION_NAME = CATALOG_ENTRY.name;
 
 const SUMMARY: DashboardSummaryResponse = {
   id: ID,

--- a/packages/@granit/react-dashboards/src/__tests__/use-dashboard-render.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-dashboard-render.test.tsx
@@ -11,6 +11,11 @@ import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import {
+  SAMPLE_FINANCE_BUNDLE,
+  SAMPLE_FINANCE_DASHBOARD_ID,
+} from '@granit/react-dashboards/testing';
+
+import {
   dashboardRenderQueryKey,
   dashboardWidgetQueryKey,
   normalizeDashboardRenderRequest,
@@ -20,52 +25,16 @@ import {
 import { useDashboardWidget } from '../hooks/use-dashboard-widget';
 import { DashboardsProvider } from '../providers/dashboards-provider';
 
-import type {
-  DashboardRenderedWidget,
-  DashboardRenderRequest,
-  DashboardRenderResponse,
-} from '@granit/dashboards';
+import type { DashboardRenderedWidget, DashboardRenderRequest } from '@granit/dashboards';
 import type { ReactNode } from 'react';
 
-const DASHBOARD_ID = '8c6b1e10-0000-4000-8000-000000000000';
-const KPI_ID = '8c6b1e10-0000-0000-0000-000000000001';
-const MARKDOWN_ID = '8c6b1e10-0000-0000-0000-000000000002';
+const DASHBOARD_ID = SAMPLE_FINANCE_DASHBOARD_ID;
+const BUNDLE = SAMPLE_FINANCE_BUNDLE;
 
-const KPI_WIDGET: DashboardRenderedWidget = {
-  id: KPI_ID,
-  widgetType: 'Kpi',
-  status: 'Snapshot',
-  sequence: 1,
-  emittedAt: '2026-04-29T12:34:56.789Z',
-  refreshHint: 'Dynamic',
-  snapshot: {
-    value: 12,
-    valueKind: 'Count',
-    currency: null,
-    isHigherBetter: false,
-    noData: false,
-    previous: null,
-  },
-  reasonLocalizationKey: null,
-};
-
-const MARKDOWN_WIDGET: DashboardRenderedWidget = {
-  id: MARKDOWN_ID,
-  widgetType: 'Markdown',
-  status: 'Snapshot',
-  sequence: 1,
-  emittedAt: '2026-04-29T12:34:56.789Z',
-  refreshHint: 'Static',
-  snapshot: { contentLocalizationKey: 'Widget:Test.Banner' },
-  reasonLocalizationKey: null,
-};
-
-const BUNDLE: DashboardRenderResponse = {
-  dashboardId: DASHBOARD_ID,
-  renderedAt: '2026-04-29T12:34:56.789Z',
-  period: null,
-  widgets: [MARKDOWN_WIDGET, KPI_WIDGET],
-};
+const KPI_WIDGET = BUNDLE.widgets.find((w) => w.widgetType === 'Kpi')!;
+const MARKDOWN_WIDGET = BUNDLE.widgets.find((w) => w.widgetType === 'Markdown')!;
+const KPI_ID = KPI_WIDGET.id;
+const MARKDOWN_ID = MARKDOWN_WIDGET.id;
 
 const server = setupServer(
   http.post(`http://localhost/api/v1/dashboards/${DASHBOARD_ID}/render`, async () =>
@@ -159,7 +128,7 @@ describe('useDashboardRender — bundle fetch + per-widget cache split (ADR-039 
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useDashboardRender(DASHBOARD_ID), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data?.widgets).toHaveLength(2);
+    expect(result.current.data?.widgets).toHaveLength(BUNDLE.widgets.length);
   });
 
   it('populates one TanStack entry per widget', async () => {

--- a/packages/@granit/react-dashboards/src/__tests__/use-pushed-dashboard.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-pushed-dashboard.test.tsx
@@ -6,6 +6,11 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  SAMPLE_FINANCE_BUNDLE,
+  SAMPLE_FINANCE_DASHBOARD_ID,
+} from '@granit/react-dashboards/testing';
+
 import { dashboardRenderQueryKey, dashboardWidgetQueryKey } from '../hooks/use-dashboard-render';
 import { applyStreamSnapshot, type DashboardStreamSnapshot } from '../hooks/use-dashboard-stream';
 import { usePushedDashboard } from '../hooks/use-pushed-dashboard';
@@ -14,62 +19,20 @@ import { DashboardsProvider } from '../providers/dashboards-provider';
 import type { DashboardRenderedWidget, DashboardRenderResponse } from '@granit/dashboards';
 import type { ReactNode } from 'react';
 
-const DASHBOARD_ID = '8c6b1e10-0000-4000-8000-000000000000';
-const KPI_ID = '8c6b1e10-0000-0000-0000-000000000001';
-const BANNER_ID = '8c6b1e10-0000-0000-0000-000000000002';
+const DASHBOARD_ID = SAMPLE_FINANCE_DASHBOARD_ID;
 
-const KPI_WIDGET: DashboardRenderedWidget = {
-  id: KPI_ID,
-  widgetType: 'Kpi',
-  slug: 'UnpaidCount',
-  position: 0,
-  width: 3,
-  height: 2,
-  titleLocalizationKey: 'Widget:Test.UnpaidCount',
-  actions: null,
-  requiredPermission: null,
-  status: 'Snapshot',
-  sequence: 1,
-  emittedAt: '2026-04-29T12:34:56.789Z',
-  refreshHint: 'Realtime',
-  snapshot: { value: 12, valueKind: 'Count' },
-  reasonLocalizationKey: null,
-  transport: 'Push',
-};
+const KPI_WIDGET = SAMPLE_FINANCE_BUNDLE.widgets.find(
+  (w) => w.widgetType === 'Kpi' && w.transport === 'Push'
+)!;
+const KPI_ID = KPI_WIDGET.id;
 
-const BANNER_WIDGET: DashboardRenderedWidget = {
-  id: BANNER_ID,
-  widgetType: 'Markdown',
-  slug: 'Banner',
-  position: 1,
-  width: 12,
-  height: 1,
-  titleLocalizationKey: 'Widget:Test.Banner',
-  actions: null,
-  requiredPermission: null,
-  status: 'Snapshot',
-  sequence: 1,
-  emittedAt: '2026-04-29T12:34:56.789Z',
-  refreshHint: 'Static',
-  snapshot: { contentLocalizationKey: 'Widget:Test.Banner.Content' },
-  reasonLocalizationKey: null,
-  transport: 'Pull',
-};
-
-const PUSH_BUNDLE: DashboardRenderResponse = {
-  dashboardId: DASHBOARD_ID,
-  renderedAt: '2026-04-29T12:34:56.789Z',
-  period: null,
-  activeViewName: null,
-  driftStatus: 'Aligned',
-  sourceDefinitionVersion: '1.0.0',
-  registeredVersion: '1.0.0',
-  widgets: [KPI_WIDGET, BANNER_WIDGET],
-};
+const PUSH_BUNDLE = SAMPLE_FINANCE_BUNDLE;
 
 const PULL_ONLY_BUNDLE: DashboardRenderResponse = {
   ...PUSH_BUNDLE,
-  widgets: [BANNER_WIDGET, { ...KPI_WIDGET, transport: 'Pull' }],
+  widgets: PUSH_BUNDLE.widgets.map((w) =>
+    w.transport === 'Push' ? { ...w, transport: 'Pull' as const } : w
+  ),
 };
 
 // ---------------------------------------------------------------------------
@@ -179,11 +142,11 @@ describe('applyStreamSnapshot', () => {
   it('merges dynamic fields and preserves structural fields', () => {
     const merged = applyStreamSnapshot(KPI_WIDGET, event);
     expect(merged).toMatchObject({
-      slug: 'UnpaidCount',
-      position: 0,
-      width: 3,
-      height: 2,
-      titleLocalizationKey: 'Widget:Test.UnpaidCount',
+      slug: KPI_WIDGET.slug,
+      position: KPI_WIDGET.position,
+      width: KPI_WIDGET.width,
+      height: KPI_WIDGET.height,
+      titleLocalizationKey: KPI_WIDGET.titleLocalizationKey,
       transport: 'Push',
       sequence: 5,
       snapshot: { value: 99, valueKind: 'Count' },

--- a/packages/@granit/react-data-lookup/src/__tests__/data-lookup-provider.test.tsx
+++ b/packages/@granit/react-data-lookup/src/__tests__/data-lookup-provider.test.tsx
@@ -3,12 +3,14 @@ import { axiosResponse, createMockClient } from '@granit/testing';
 import { render, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { mockCountries } from '@granit/react-data-lookup/testing';
+
 import { LookupBadge } from '../components/lookup-badge';
 import { useLookup } from '../hooks/use-lookup';
 import { DataLookupProvider, useDataLookupConfig } from '../providers/data-lookup-provider';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { LookupItemResponse, LookupResultResponse } from '@granit/data-lookup';
+import type { LookupResultResponse } from '@granit/data-lookup';
 import type { ReactNode } from 'react';
 
 /** Wraps children in a QueryClient + DataLookupProvider with the given client. */
@@ -74,15 +76,18 @@ describe('DataLookupProvider', () => {
 
   it('lets a component resolve the client from the provider (no client prop)', async () => {
     const client = createMockClient();
-    const item: LookupItemResponse = { value: 'BE', label: 'Belgique', extra: null };
+    const item = mockCountries[0]!;
     vi.mocked(client.get).mockResolvedValue(axiosResponse(item));
 
-    const { container } = render(<LookupBadge descriptor={{ name: 'ref-country' }} value="BE" />, {
-      wrapper: createLookupWrapper(client),
-    });
+    const { container } = render(
+      <LookupBadge descriptor={{ name: 'ref-country' }} value={item.value} />,
+      {
+        wrapper: createLookupWrapper(client),
+      }
+    );
 
     await waitFor(() =>
-      expect(container.querySelector('[data-lookup-badge]')?.textContent).toBe('Belgique')
+      expect(container.querySelector('[data-lookup-badge]')?.textContent).toBe('Belgium')
     );
   });
 });

--- a/packages/@granit/react-data-lookup/src/__tests__/lookup-badge.test.tsx
+++ b/packages/@granit/react-data-lookup/src/__tests__/lookup-badge.test.tsx
@@ -3,21 +3,24 @@ import { axiosResponse, createMockClient } from '@granit/testing';
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { LookupBadge } from '../components/lookup-badge';
+import { mockCountries } from '@granit/react-data-lookup/testing';
 
-import type { LookupItemResponse } from '@granit/data-lookup';
+import { LookupBadge } from '../components/lookup-badge';
 
 describe('<LookupBadge>', () => {
   it('renders resolved label in a default span', async () => {
     const client = createMockClient();
-    const item: LookupItemResponse = { value: 'BE', label: 'Belgique', extra: null };
+    const item = mockCountries[0]!;
     vi.mocked(client.get).mockResolvedValue(axiosResponse(item));
 
-    render(<LookupBadge descriptor={{ name: 'ref-country' }} value="BE" client={client} />, {
-      wrapper: createQueryWrapper(),
-    });
+    render(
+      <LookupBadge descriptor={{ name: 'ref-country' }} value={item.value} client={client} />,
+      {
+        wrapper: createQueryWrapper(),
+      }
+    );
 
-    await waitFor(() => expect(screen.queryByText('Belgique')).not.toBeNull());
+    await waitFor(() => expect(screen.queryByText('Belgium')).not.toBeNull());
   });
 
   it('falls back to fallback prop while loading / on miss', () => {
@@ -60,13 +63,13 @@ describe('<LookupBadge>', () => {
 
   it('uses custom render prop when provided', async () => {
     const client = createMockClient();
-    const item: LookupItemResponse = { value: 'BE', label: 'Belgique', extra: null };
+    const item = mockCountries[0]!;
     vi.mocked(client.get).mockResolvedValue(axiosResponse(item));
 
     render(
       <LookupBadge
         descriptor={{ name: 'ref-country' }}
-        value="BE"
+        value={item.value}
         client={client}
         render={({ label, isLoading }) => (
           <span data-testid="custom">{isLoading ? 'loading' : label.toUpperCase()}</span>
@@ -75,7 +78,7 @@ describe('<LookupBadge>', () => {
       { wrapper: createQueryWrapper() }
     );
 
-    await waitFor(() => expect(screen.getByTestId('custom').textContent).toBe('BELGIQUE'));
+    await waitFor(() => expect(screen.getByTestId('custom').textContent).toBe('BELGIUM'));
   });
 
   it('renders empty string when value is null without fallback', () => {

--- a/packages/@granit/react-data-lookup/src/__tests__/use-lookup-resolve.test.tsx
+++ b/packages/@granit/react-data-lookup/src/__tests__/use-lookup-resolve.test.tsx
@@ -3,18 +3,18 @@ import { axiosResponse, createMockClient } from '@granit/testing';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { useLookupResolve } from '../hooks/use-lookup-resolve';
+import { mockCountries } from '@granit/react-data-lookup/testing';
 
-import type { LookupItemResponse } from '@granit/data-lookup';
+import { useLookupResolve } from '../hooks/use-lookup-resolve';
 
 describe('useLookupResolve', () => {
   it('fetches the item when value is defined', async () => {
     const client = createMockClient();
-    const item: LookupItemResponse = { value: 'BE', label: 'Belgium', extra: null };
+    const item = mockCountries[0]!;
     vi.mocked(client.get).mockResolvedValue(axiosResponse(item));
 
     const { result } = renderHook(
-      () => useLookupResolve({ name: 'ref-country' }, 'BE', { client }),
+      () => useLookupResolve({ name: 'ref-country' }, item.value, { client }),
       { wrapper: createQueryWrapper() }
     );
 

--- a/packages/@granit/react-diagnostics/src/__tests__/use-monitoring-health.test.tsx
+++ b/packages/@granit/react-diagnostics/src/__tests__/use-monitoring-health.test.tsx
@@ -1,15 +1,14 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { mockDiagnosticsHealth } from '@granit/react-diagnostics/testing';
+
 import { buildDiagnosticsQueryKey } from '../hooks/query-keys';
 import { useMonitoringHealth } from '../hooks/use-monitoring-health';
-
-import type { MonitoringHealthResponse } from '@granit/diagnostics';
 
 function createWrapper() {
   const queryClient = createTestQueryClient();
@@ -21,19 +20,7 @@ function createWrapper() {
   };
 }
 
-const mockResponse: MonitoringHealthResponse = {
-  services: [
-    {
-      id: 'postgresql',
-      name: 'Postgresql',
-      status: 'healthy',
-      responseTimeMs: 5.2,
-      description: 'Primary database cluster',
-      tags: ['readiness', 'startup'],
-    },
-  ],
-  checkedAt: toISODateString('2026-03-20T12:00:00+00:00'),
-};
+const mockResponse = mockDiagnosticsHealth;
 
 describe('buildDiagnosticsQueryKey', () => {
   it('should use default prefix when no queryKeyPrefix is provided', () => {
@@ -88,9 +75,9 @@ describe('useMonitoringHealth', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data?.services).toHaveLength(1);
-    expect(result.current.data?.services[0].id).toBe('postgresql');
-    expect(result.current.data?.checkedAt).toBe('2026-03-20T12:00:00+00:00');
+    expect(result.current.data?.services).toHaveLength(mockDiagnosticsHealth.services.length);
+    expect(result.current.data?.services[0].id).toBe('api-gateway');
+    expect(result.current.data?.checkedAt).toBe('2026-03-12T10:00:00Z');
   });
 
   it('should handle fetch error', async () => {

--- a/packages/@granit/react-documents/src/__tests__/use-document-mutations.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-document-mutations.test.tsx
@@ -5,6 +5,8 @@ import { renderHook } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockDocumentsData, mockVersionsData } from '@granit/react-documents/testing';
+
 import {
   useAppendDocumentVersion,
   useFinalizeUpload,
@@ -19,44 +21,14 @@ import {
 import { DocumentsProvider } from '../providers/documents-provider';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type {
-  DocumentResponse,
-  DocumentVersionResponse,
-  UploadTicketResponse,
-} from '@granit/documents';
+import type { UploadTicketResponse } from '@granit/documents';
 import type { QueryClient } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 
-const sampleDoc: DocumentResponse = {
-  id: 'doc-1',
-  folderId: 'fld-1',
-  name: 'contract.pdf',
-  description: null,
-  ownerId: 'user-1',
-  currentVersionId: 'ver-1',
-  concurrencyStamp: 'stamp-1',
-  sizeBytes: 1024,
-  contentType: 'application/pdf',
-  status: 'Active',
-  createdAt: toISODateString('2026-05-01T00:00:00Z'),
-  modifiedAt: null,
-  trashedAt: null,
-  permission: null,
-};
+const sampleDoc = mockDocumentsData[0]!;
+const docId = sampleDoc.id;
 
-const sampleVersion: DocumentVersionResponse = {
-  id: 'ver-1',
-  documentId: 'doc-1',
-  versionNumber: 1,
-  blobDescriptorId: 'blob-1',
-  sizeBytes: 1024,
-  contentType: 'application/pdf',
-  contentHash: null,
-  uploadedByUserId: 'user-1',
-  uploadedAt: toISODateString('2026-05-01T00:00:00Z'),
-  commitMessage: null,
-  isCurrent: true,
-};
+const sampleVersion = mockVersionsData[0]!;
 
 const sampleTicket: UploadTicketResponse = {
   blobId: 'blob-1',
@@ -145,11 +117,11 @@ describe('useRenameDocument', () => {
 
     const { result } = renderHook(() => useRenameDocument(), { wrapper });
     await result.current.mutateAsync({
-      id: 'doc-1',
+      id: docId,
       request: { name: 'renamed.pdf', description: null },
     });
 
-    expect(client.patch).toHaveBeenCalledWith('/api/v1/documents/documents/doc-1', {
+    expect(client.patch).toHaveBeenCalledWith(`/api/v1/documents/documents/${docId}`, {
       name: 'renamed.pdf',
       description: null,
     });
@@ -167,9 +139,9 @@ describe('useMoveDocument', () => {
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
 
     const { result } = renderHook(() => useMoveDocument(), { wrapper });
-    await result.current.mutateAsync({ id: 'doc-1', request: { newFolderId: 'fld-9' } });
+    await result.current.mutateAsync({ id: docId, request: { newFolderId: 'fld-9' } });
 
-    expect(client.post).toHaveBeenCalledWith('/api/v1/documents/documents/doc-1/move', {
+    expect(client.post).toHaveBeenCalledWith(`/api/v1/documents/documents/${docId}/move`, {
       newFolderId: 'fld-9',
     });
     const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
@@ -187,9 +159,9 @@ describe('useTransferDocumentOwner', () => {
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
 
     const { result } = renderHook(() => useTransferDocumentOwner(), { wrapper });
-    await result.current.mutateAsync({ id: 'doc-1', request: { newOwnerId: newOwner } });
+    await result.current.mutateAsync({ id: docId, request: { newOwnerId: newOwner } });
 
-    expect(client.put).toHaveBeenCalledWith('/api/v1/documents/documents/doc-1/owner', {
+    expect(client.put).toHaveBeenCalledWith(`/api/v1/documents/documents/${docId}/owner`, {
       newOwnerId: newOwner,
     });
     const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
@@ -206,9 +178,9 @@ describe('useTrashDocument', () => {
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
 
     const { result } = renderHook(() => useTrashDocument(), { wrapper });
-    await result.current.mutateAsync('doc-1');
+    await result.current.mutateAsync(docId);
 
-    expect(client.delete).toHaveBeenCalledWith('/api/v1/documents/documents/doc-1');
+    expect(client.delete).toHaveBeenCalledWith(`/api/v1/documents/documents/${docId}`);
     const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
     expect(keys).toEqual([
       ['documents', 'documents'],
@@ -227,9 +199,9 @@ describe('useRestoreDocument', () => {
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
 
     const { result } = renderHook(() => useRestoreDocument(), { wrapper });
-    await result.current.mutateAsync('doc-1');
+    await result.current.mutateAsync(docId);
 
-    expect(client.post).toHaveBeenCalledWith('/api/v1/documents/documents/doc-1/restore');
+    expect(client.post).toHaveBeenCalledWith(`/api/v1/documents/documents/${docId}/restore`);
     const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
     expect(keys).toEqual([
       ['documents', 'documents'],
@@ -248,9 +220,9 @@ describe('usePermanentlyDeleteDocument', () => {
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
 
     const { result } = renderHook(() => usePermanentlyDeleteDocument(), { wrapper });
-    await result.current.mutateAsync('doc-1');
+    await result.current.mutateAsync(docId);
 
-    expect(client.delete).toHaveBeenCalledWith('/api/v1/documents/documents/doc-1/permanent');
+    expect(client.delete).toHaveBeenCalledWith(`/api/v1/documents/documents/${docId}/permanent`);
     const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
     expect(keys).toEqual([
       ['documents', 'documents'],
@@ -270,18 +242,18 @@ describe('useAppendDocumentVersion', () => {
 
     const { result } = renderHook(() => useAppendDocumentVersion(), { wrapper });
     await result.current.mutateAsync({
-      id: 'doc-1',
+      id: docId,
       request: { blobId: 'blob-2', commitMessage: null },
     });
 
-    expect(client.post).toHaveBeenCalledWith('/api/v1/documents/documents/doc-1/versions', {
+    expect(client.post).toHaveBeenCalledWith(`/api/v1/documents/documents/${docId}/versions`, {
       blobId: 'blob-2',
       commitMessage: null,
     });
     const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
     expect(keys).toEqual([
-      ['documents', 'documents', 'doc-1', 'versions'],
-      ['documents', 'documents', 'doc-1'],
+      ['documents', 'documents', docId, 'versions'],
+      ['documents', 'documents', docId],
       ['documents', 'quota'],
     ]);
   });

--- a/packages/@granit/react-documents/src/__tests__/use-folders.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-folders.test.tsx
@@ -1,33 +1,18 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { mockFoldersData } from '@granit/react-documents/testing';
 
 import { useFolder, useFolderBreadcrumb, useFolders } from '../hooks/use-folders';
 import { DocumentsProvider } from '../providers/documents-provider';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type {
-  FolderBreadcrumbResponse,
-  FolderResponse,
-  ListFoldersResponse,
-} from '@granit/documents';
+import type { FolderBreadcrumbResponse, ListFoldersResponse } from '@granit/documents';
 import type { ReactNode } from 'react';
 
-const sampleFolder: FolderResponse = {
-  id: 'fld-1',
-  parentFolderId: null,
-  name: 'Contracts',
-  path: '/Contracts',
-  depth: 1,
-  createdAt: toISODateString('2026-05-01T10:00:00Z'),
-  modifiedAt: null,
-  ownerId: 'user-1',
-  status: 'Active',
-  trashedAt: null,
-  permission: null,
-};
+const sampleFolder = mockFoldersData[0]!;
 
 const sampleList: ListFoldersResponse = { folders: [sampleFolder] };
 const sampleBreadcrumb: FolderBreadcrumbResponse = { folders: [sampleFolder] };
@@ -95,10 +80,12 @@ describe('useFolder', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: sampleFolder });
 
-    const { result } = renderHook(() => useFolder('fld-1'), { wrapper: createWrapper(client) });
+    const { result } = renderHook(() => useFolder(sampleFolder.id), {
+      wrapper: createWrapper(client),
+    });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/api/v1/documents/folders/fld-1');
+    expect(client.get).toHaveBeenCalledWith(`/api/v1/documents/folders/${sampleFolder.id}`);
   });
 
   it('does not fire when id is empty', () => {
@@ -118,12 +105,14 @@ describe('useFolderBreadcrumb', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: sampleBreadcrumb });
 
-    const { result } = renderHook(() => useFolderBreadcrumb('fld-1'), {
+    const { result } = renderHook(() => useFolderBreadcrumb(sampleFolder.id), {
       wrapper: createWrapper(client),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/api/v1/documents/folders/fld-1/breadcrumb');
+    expect(client.get).toHaveBeenCalledWith(
+      `/api/v1/documents/folders/${sampleFolder.id}/breadcrumb`
+    );
     expect(result.current.data).toEqual(sampleBreadcrumb);
   });
 

--- a/packages/@granit/react-features/src/__tests__/use-features.test.tsx
+++ b/packages/@granit/react-features/src/__tests__/use-features.test.tsx
@@ -6,6 +6,12 @@ import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  mockFeatureDefinitions,
+  mockFeatureGroups,
+  mockFeatureValues,
+} from '@granit/react-features/testing';
+
+import {
   useDeleteFeatureOverride,
   useFeatureDefinitions,
   useFeatureValue,
@@ -15,7 +21,7 @@ import {
 import { FeaturesProvider } from '../providers/features-provider';
 
 import type { FeaturesConfig } from '../providers/features-provider';
-import type { FeatureGroupResponse, FeatureValueResponse } from '@granit/features';
+import type { FeatureValueResponse } from '@granit/features';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -23,25 +29,14 @@ import type { ReactNode } from 'react';
 // Fixtures
 // ---------------------------------------------------------------------------
 
-const sampleGroup: FeatureGroupResponse = {
-  name: 'ui',
-  displayName: 'User Interface',
-  features: [
-    {
-      name: 'ui.dark-mode',
-      defaultValue: 'false',
-      valueType: 'Toggle',
-      numericConstraint: null,
-      selectionValues: null,
-      displayName: 'Dark Mode',
-      description: null,
-    },
-  ],
-};
+const sampleGroups = mockFeatureGroups;
+
+/** A single feature name resolved from the shared definitions fixture. */
+const sampleFeatureName = mockFeatureDefinitions[0]!.name;
 
 const sampleValue: FeatureValueResponse = {
-  name: 'ui.dark-mode',
-  value: 'true',
+  name: sampleFeatureName,
+  value: mockFeatureValues[sampleFeatureName]!,
 };
 
 // ---------------------------------------------------------------------------
@@ -72,7 +67,7 @@ describe('use-features', () => {
   describe('useFeatureDefinitions', () => {
     it('fetches definitions with default basePath', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue({ data: [sampleGroup] });
+      vi.mocked(client.get).mockResolvedValue({ data: sampleGroups });
 
       const { result } = renderHook(() => useFeatureDefinitions(), {
         wrapper: createWrapper(client),
@@ -80,12 +75,12 @@ describe('use-features', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(client.get).toHaveBeenCalledWith('/api/v1/features/definitions');
-      expect(result.current.data).toEqual([sampleGroup]);
+      expect(result.current.data).toEqual(sampleGroups);
     });
 
     it('fetches definitions with custom basePath', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue({ data: [sampleGroup] });
+      vi.mocked(client.get).mockResolvedValue({ data: sampleGroups });
 
       const { result } = renderHook(() => useFeatureDefinitions(), {
         wrapper: createWrapper(client, '/custom/features'),
@@ -99,7 +94,7 @@ describe('use-features', () => {
   describe('useFeatureValues', () => {
     it('fetches all feature values as a dictionary', async () => {
       const client = createMockClient();
-      const values = { 'ui.dark-mode': 'true' };
+      const values = mockFeatureValues;
       vi.mocked(client.get).mockResolvedValue({ data: values });
 
       const { result } = renderHook(() => useFeatureValues(), {
@@ -117,12 +112,12 @@ describe('use-features', () => {
       const client = createMockClient();
       vi.mocked(client.get).mockResolvedValue({ data: sampleValue });
 
-      const { result } = renderHook(() => useFeatureValue('ui.dark-mode'), {
+      const { result } = renderHook(() => useFeatureValue(sampleFeatureName), {
         wrapper: createWrapper(client),
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/v1/features/values/ui.dark-mode');
+      expect(client.get).toHaveBeenCalledWith(`/api/v1/features/values/${sampleFeatureName}`);
       expect(result.current.data).toEqual(sampleValue);
     });
 

--- a/packages/@granit/react-hostnames/src/__tests__/use-hostnames.test.tsx
+++ b/packages/@granit/react-hostnames/src/__tests__/use-hostnames.test.tsx
@@ -1,10 +1,11 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
+
+import { mockHostnames } from '@granit/react-hostnames/testing';
 
 import { useHostnames } from '../hooks/use-hostnames';
 import { HostnamesProvider } from '../providers/hostnames-provider';
@@ -24,30 +25,7 @@ function createWrapper(client: AxiosInstance) {
   };
 }
 
-const mockList: readonly ManagedHostnameResponse[] = [
-  {
-    id: '11111111-0001-4000-a000-000000000001',
-    host: 'app.acme.com',
-    ownerType: 'cms.site',
-    ownerId: 'aaaaaaaa-0001-4000-a000-000000000001',
-    tenantId: 'tttttttt-0001-4000-a000-000000000001',
-    isPrimary: true,
-    status: 'Active',
-    verificationToken: null,
-    expectedDnsRecords: [],
-    lastCheckedAt: toISODateString('2026-06-01T08:00:00Z'),
-    conflicts: [],
-    failedCheckCount: 0,
-    nextCheckAt: toISODateString('2026-06-02T08:00:00Z'),
-    certificateStatus: 'Secured',
-    certExpiresAt: toISODateString('2027-06-01T08:00:00Z'),
-    createdAt: toISODateString('2026-01-01T00:00:00Z'),
-    createdBy: 'admin@acme.com',
-    modifiedAt: toISODateString('2026-06-01T08:00:00Z'),
-    modifiedBy: 'admin@acme.com',
-    concurrencyStamp: 'stamp-0001',
-  },
-];
+const mockList: readonly ManagedHostnameResponse[] = [mockHostnames[0]!];
 
 describe('useHostnames', () => {
   it('fetches the list with required owner params', async () => {

--- a/packages/@granit/react-identity/src/__tests__/use-identity-cache.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-cache.test.tsx
@@ -6,11 +6,13 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockUsers } from '@granit/react-identity/testing';
+
 import { useBatchResolveUsers, useIdentityCacheStats } from '../hooks/use-identity-cache';
 import { IdentityProvider } from '../providers/identity-provider';
 
 import type { IdentityProviderProps } from '../providers/identity-provider';
-import type { IdentityUser, IdentityUserCacheStats } from '@granit/identity';
+import type { IdentityUserCacheStats } from '@granit/identity';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -36,18 +38,6 @@ const mockStats: IdentityUserCacheStats = {
   oldestSyncAt: toISODateString('2026-01-01T00:00:00Z'),
   newestSyncAt: toISODateString('2026-03-17T00:00:00Z'),
 };
-
-const mockUsers: IdentityUser[] = [
-  {
-    userId: toEntityId<'User'>('user-1'),
-    username: 'jdoe',
-    email: 'jdoe@example.com',
-    firstName: 'John',
-    lastName: 'Doe',
-    enabled: true,
-    metadata: {},
-  },
-];
 
 // ---------------------------------------------------------------------------
 // Tests — useIdentityCacheStats

--- a/packages/@granit/react-identity/src/__tests__/use-identity-provider-users.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-provider-users.test.tsx
@@ -6,6 +6,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockUsers } from '@granit/react-identity/testing';
+
 import {
   useCreateUser,
   useProviderUser,
@@ -16,19 +18,10 @@ import {
 import { IdentityProvider } from '../providers/identity-provider';
 
 import type { IdentityProviderProps } from '../providers/identity-provider';
-import type { IdentityUser } from '@granit/identity';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
-const sampleUser: IdentityUser = {
-  userId: toEntityId<'User'>('user-1'),
-  username: 'jdoe',
-  email: 'jdoe@example.com',
-  firstName: 'John',
-  lastName: 'Doe',
-  enabled: true,
-  metadata: {},
-};
+const sampleUser = mockUsers[0]!;
 
 function createWrapper(client: AxiosInstance, providerBasePath?: string) {
   return function Wrapper({ children }: { children: ReactNode }) {

--- a/packages/@granit/react-identity/src/__tests__/use-identity-users.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-users.test.tsx
@@ -6,11 +6,13 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockUsers } from '@granit/react-identity/testing';
+
 import { useIdentityUser, useIdentityUsers } from '../hooks/use-identity-users';
 import { IdentityProvider } from '../providers/identity-provider';
 
 import type { IdentityProviderProps } from '../providers/identity-provider';
-import type { IdentityUser, IdentityUserPage } from '@granit/identity';
+import type { IdentityUserPage } from '@granit/identity';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -30,15 +32,7 @@ function createWrapper(client: AxiosInstance, basePath?: string) {
   };
 }
 
-const mockUser: IdentityUser = {
-  userId: toEntityId<'User'>('user-1'),
-  username: 'jdoe',
-  email: 'jdoe@example.com',
-  firstName: 'John',
-  lastName: 'Doe',
-  enabled: true,
-  metadata: {},
-};
+const mockUser = mockUsers[0]!;
 
 const mockPage: IdentityUserPage = {
   items: [mockUser],

--- a/packages/@granit/react-metering/src/__tests__/use-metering.test.tsx
+++ b/packages/@granit/react-metering/src/__tests__/use-metering.test.tsx
@@ -6,6 +6,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { sampleMeters, sampleQuota, sampleUsage } from '@granit/react-metering/testing';
+
 import {
   useActiveMeters,
   useArchiveMeterDefinition,
@@ -20,11 +22,6 @@ import {
 import { MeteringProvider } from '../providers/metering-provider';
 
 import type { MeteringConfig } from '../providers/metering-provider';
-import type {
-  MeterDefinitionResponse,
-  MeteringQuotaStatusResponse,
-  UsageAggregateResponse,
-} from '@granit/metering';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -44,34 +41,7 @@ function createWrapper(client: AxiosInstance, basePath?: string) {
   };
 }
 
-const sampleMeter: MeterDefinitionResponse = {
-  id: 'meter-1',
-  name: 'API Calls',
-  unit: 'calls',
-  description: 'Number of API calls',
-  aggregationType: 'Sum',
-  productId: null,
-  lifecycleStatus: 'Published',
-  distinctProperty: null,
-};
-
-const sampleUsage: UsageAggregateResponse = {
-  id: 'agg-1',
-  meterDefinitionId: 'meter-1',
-  period: 'Daily',
-  periodStart: toISODateString('2026-04-01T00:00:00Z'),
-  periodEnd: toISODateString('2026-04-02T00:00:00Z'),
-  aggregatedValue: 150,
-  eventCount: 30,
-};
-
-const sampleQuota: MeteringQuotaStatusResponse = {
-  meterName: 'API Calls',
-  currentUsage: 150,
-  limit: 1000,
-  percentUsed: 15,
-  isExceeded: false,
-};
+const sampleMeter = sampleMeters[0]!;
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/packages/@granit/react-notifications/src/__tests__/use-notification-preferences.test.tsx
+++ b/packages/@granit/react-notifications/src/__tests__/use-notification-preferences.test.tsx
@@ -2,6 +2,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { mockNotificationPreferences } from '@granit/react-notifications/testing';
+
 import { useNotificationPreferences } from '../hooks/use-notification-preferences';
 import { NotificationProvider } from '../providers/notification-provider';
 
@@ -39,29 +41,10 @@ function createWrapperWithoutBasePath(client: AxiosInstance) {
   };
 }
 
-const MOCK_PREFS: NotificationPreferenceResponse[] = [
-  {
-    id: 'pref-1',
-    userId: 'u-1',
-    notificationTypeName: 'AppointmentReminder',
-    channelName: 'InApp',
-    isEnabled: true,
-  },
-  {
-    id: 'pref-2',
-    userId: 'u-1',
-    notificationTypeName: 'AppointmentReminder',
-    channelName: 'Email',
-    isEnabled: true,
-  },
-  {
-    id: 'pref-3',
-    userId: 'u-1',
-    notificationTypeName: 'SystemAlert',
-    channelName: 'InApp',
-    isEnabled: true,
-  },
-] as unknown as NotificationPreferenceResponse[];
+// First three shared preference rows: all three target the same type across
+// channels, with `togglePreference` exercised on the second (index 1).
+const MOCK_PREFS: NotificationPreferenceResponse[] = mockNotificationPreferences.slice(0, 3);
+const TOGGLE_ID = MOCK_PREFS[1]!.id;
 
 describe('useNotificationPreferences', () => {
   it('should fetch preferences on mount', async () => {
@@ -75,7 +58,9 @@ describe('useNotificationPreferences', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.preferences).toHaveLength(3);
-    expect(result.current.preferences[0]!.notificationTypeName).toBe('AppointmentReminder');
+    expect(result.current.preferences[0]!.notificationTypeName).toBe(
+      MOCK_PREFS[0]!.notificationTypeName
+    );
   });
 
   it('should update preference optimistically via togglePreference', async () => {
@@ -96,7 +81,7 @@ describe('useNotificationPreferences', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     act(() => {
-      result.current.togglePreference('pref-2', false);
+      result.current.togglePreference(TOGGLE_ID, false);
     });
 
     await waitFor(() => expect(result.current.preferences[1]!.isEnabled).toBe(false));
@@ -118,7 +103,7 @@ describe('useNotificationPreferences', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     act(() => {
-      result.current.togglePreference('pref-2', false);
+      result.current.togglePreference(TOGGLE_ID, false);
     });
 
     await waitFor(() => expect(result.current.preferences[1]!.isEnabled).toBe(true));
@@ -174,7 +159,7 @@ describe('useNotificationPreferences', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     act(() => {
-      result.current.togglePreference('pref-2', false);
+      result.current.togglePreference(TOGGLE_ID, false);
     });
 
     await waitFor(() => expect(result.current.saving).toBe(true));
@@ -197,7 +182,7 @@ describe('useNotificationPreferences', () => {
 
     const updatedPrefs: NotificationPreferenceResponse[] = [
       { ...MOCK_PREFS[0]!, isEnabled: false },
-    ] as unknown as NotificationPreferenceResponse[];
+    ];
     vi.mocked(client.get).mockResolvedValue(axiosResponse(updatedPrefs));
 
     act(() => {

--- a/packages/@granit/react-notifications/src/__tests__/use-notifications.test.ts
+++ b/packages/@granit/react-notifications/src/__tests__/use-notifications.test.ts
@@ -1,6 +1,8 @@
-import { toEntityId, toISODateString } from '@granit/types';
+import { toEntityId } from '@granit/types';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+
+import { mockNotifications } from '@granit/react-notifications/testing';
 
 import { useNotifications } from '../hooks/use-notifications';
 
@@ -13,19 +15,7 @@ import {
 
 import type { UserNotification, UserNotificationPage } from '@granit/notifications';
 
-const MOCK_NOTIFICATION: UserNotification = {
-  id: toEntityId<'UserNotification'>('n-1'),
-  notificationId: toEntityId<'Notification'>('notif-1'),
-  notificationTypeName: 'NewMessage',
-  severity: 'Info',
-  data: { title: 'Nouveau message', body: 'Contenu du message' },
-  recipientUserId: toEntityId<'User'>('u-1'),
-  relatedEntityType: null,
-  relatedEntityId: null,
-  state: 'Unread',
-  createdAt: toISODateString('2026-01-15T10:00:00Z'),
-  readAt: null,
-};
+const MOCK_NOTIFICATION: UserNotification = mockNotifications[0]!;
 
 const MOCK_PAGE: UserNotificationPage = {
   items: [MOCK_NOTIFICATION],
@@ -45,7 +35,9 @@ describe('useNotifications', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.notifications).toHaveLength(1);
-    expect(result.current.notifications[0]!.notificationTypeName).toBe('NewMessage');
+    expect(result.current.notifications[0]!.notificationTypeName).toBe(
+      MOCK_NOTIFICATION.notificationTypeName
+    );
     expect(result.current.totalCount).toBe(1);
   });
 
@@ -61,7 +53,7 @@ describe('useNotifications', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     await act(async () => {
-      await result.current.markRead(toEntityId<'UserNotification'>('n-1'));
+      await result.current.markRead(MOCK_NOTIFICATION.id);
     });
 
     expect(result.current.notifications[0]!.state).toBe('Read');
@@ -211,12 +203,7 @@ describe('useNotifications', () => {
   });
 
   it('should not modify other notifications when marking one as read', async () => {
-    const n2: UserNotification = {
-      ...MOCK_NOTIFICATION,
-      id: toEntityId<'UserNotification'>('n-2'),
-      notificationId: toEntityId<'Notification'>('notif-2'),
-      data: { title: 'Autre notification' },
-    };
+    const n2: UserNotification = mockNotifications[1]!;
     const page: UserNotificationPage = {
       items: [MOCK_NOTIFICATION, n2],
       totalCount: 2,
@@ -233,12 +220,12 @@ describe('useNotifications', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     await act(async () => {
-      await result.current.markRead(toEntityId<'UserNotification'>('n-1'));
+      await result.current.markRead(MOCK_NOTIFICATION.id);
     });
 
     expect(result.current.notifications[0]!.state).toBe('Read');
     expect(result.current.notifications[1]!.state).toBe('Unread');
-    expect(result.current.notifications[1]!.id).toBe(toEntityId<'UserNotification'>('n-2'));
+    expect(result.current.notifications[1]!.id).toBe(n2.id);
   });
 
   it('should use default pageSize when no options are provided', async () => {

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-users.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-users.test.tsx
@@ -6,10 +6,12 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { mockAdminUsers } from '@granit/react-openiddict-admin/testing';
+
 import { useAdminUsers, useImpersonateUser } from '../hooks/use-admin-users';
 import { OpenIddictAdminProvider } from '../providers/openiddict-admin-provider';
 
-import type { AdminImpersonationResult, AdminUser, AdminUserPage } from '@granit/openiddict-admin';
+import type { AdminImpersonationResult, AdminUserPage } from '@granit/openiddict-admin';
 
 vi.mock('@granit/openiddict-admin', () => ({
   listUsers: vi.fn(),
@@ -34,19 +36,9 @@ function createWrapper() {
   };
 }
 
-const mockUser: AdminUser = {
-  userId: 'usr-001',
-  username: 'admin',
-  email: 'admin@example.com',
-  firstName: 'Admin',
-  lastName: 'User',
-  enabled: true,
-  metadata: {},
-};
-
 const mockPage: AdminUserPage = {
-  items: [mockUser],
-  totalCount: 1,
+  items: mockAdminUsers,
+  totalCount: mockAdminUsers.length,
 };
 
 describe('useAdminUsers', () => {
@@ -104,11 +96,15 @@ describe('useImpersonateUser', () => {
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useImpersonateUser(), { wrapper });
 
-    result.current.mutate('usr-001');
+    result.current.mutate(mockAdminUsers[0]!.userId);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(impersonateUser).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', 'usr-001');
+    expect(impersonateUser).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/v1/admin',
+      mockAdminUsers[0]!.userId
+    );
     expect(result.current.data).toEqual(mockImpersonation);
   });
 

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-applications.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-applications.test.tsx
@@ -12,6 +12,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { mockOidcApplications } from '@granit/react-openiddict-admin/testing';
+
 import {
   useCreateOidcApplication,
   useDeleteOidcApplication,
@@ -48,21 +50,11 @@ function createWrapper() {
   };
 }
 
-const mockApp: AdminOidcApplicationResponse = {
-  clientId: 'guava-front',
-  displayName: 'Guava Frontend',
-  type: 'confidential',
-  tenantId: null,
-  permissions: ['ept:token', 'gt:authorization_code'],
-  redirectUris: ['https://guava.local/callback'],
-  postLogoutRedirectUris: ['https://guava.local/signout-callback'],
-  consentType: 'implicit',
-  clientSide: 3,
-  deviceKind: null,
-  hasSigningKey: false,
-};
+const mockApp: AdminOidcApplicationResponse = mockOidcApplications[0]!;
+const clientId = mockApp.clientId!;
+const displayName = mockApp.displayName!;
 
-const mockApps: readonly AdminOidcApplicationResponse[] = [mockApp];
+const mockApps: readonly AdminOidcApplicationResponse[] = mockOidcApplications;
 
 describe('useOidcApplications', () => {
   it('should fetch all OIDC applications', async () => {
@@ -99,15 +91,15 @@ describe('useCreateOidcApplication', () => {
     const { result } = renderHook(() => useCreateOidcApplication(), { wrapper });
 
     result.current.mutate({
-      clientId: 'guava-front',
-      displayName: 'Guava Frontend',
+      clientId,
+      displayName,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(createApplication).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', {
-      clientId: 'guava-front',
-      displayName: 'Guava Frontend',
+      clientId,
+      displayName,
     });
     expect(result.current.data).toEqual(mockApp);
     expect(invalidateSpy).toHaveBeenCalledWith({
@@ -138,15 +130,11 @@ describe('useDeleteOidcApplication', () => {
 
     const { result } = renderHook(() => useDeleteOidcApplication(), { wrapper });
 
-    result.current.mutate('guava-front');
+    result.current.mutate(clientId);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(deleteApplication).toHaveBeenCalledWith(
-      expect.anything(),
-      '/api/v1/admin',
-      'guava-front'
-    );
+    expect(deleteApplication).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', clientId);
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'oidc', 'applications'],
     });
@@ -177,20 +165,15 @@ describe('useUpdateOidcApplication', () => {
     const { result } = renderHook(() => useUpdateOidcApplication(), { wrapper });
 
     result.current.mutate({
-      clientId: 'guava-front',
+      clientId,
       request: { displayName: 'Guava Frontend v2' },
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(updateApplication).toHaveBeenCalledWith(
-      expect.anything(),
-      '/api/v1/admin',
-      'guava-front',
-      {
-        displayName: 'Guava Frontend v2',
-      }
-    );
+    expect(updateApplication).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', clientId, {
+      displayName: 'Guava Frontend v2',
+    });
     expect(result.current.data).toEqual(updated);
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'oidc', 'applications'],
@@ -213,8 +196,8 @@ describe('useUpdateOidcApplication', () => {
 
 describe('useRotateApplicationSecret', () => {
   const mockSecretResponse: AdminOidcRotateSecretResponse = {
-    clientId: 'guava-front',
-    displayName: 'Guava Frontend',
+    clientId,
+    displayName,
     newClientSecret: 'generated-secret-value',
   };
 
@@ -224,14 +207,14 @@ describe('useRotateApplicationSecret', () => {
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useRotateApplicationSecret(), { wrapper });
 
-    result.current.mutate('guava-front');
+    result.current.mutate(clientId);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(rotateApplicationSecret).toHaveBeenCalledWith(
       expect.anything(),
       '/api/v1/admin',
-      'guava-front'
+      clientId
     );
     expect(result.current.data).toEqual(mockSecretResponse);
   });

--- a/packages/@granit/react-parties/src/__tests__/merge-wizard.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/merge-wizard.test.tsx
@@ -1,12 +1,14 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { axiosResponse, createMockClient } from '@granit/testing';
-import { toEntityId, toISODateString } from '@granit/types';
+import { toEntityId } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import i18next from 'i18next';
 import * as React from 'react';
 import { initReactI18next, I18nextProvider } from 'react-i18next';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { sampleParty } from '@granit/react-parties/testing';
 
 import { MergeWizard } from '../components/merge-wizard';
 import { partiesTranslationsEn } from '../locales/en';
@@ -348,21 +350,9 @@ function makeParty(
     : [];
 
   return {
+    ...sampleParty,
     id,
-    tenantId: null,
-    kind: 'Company',
     name: override.name,
-    defaultCurrency: 'EUR',
-    timezone: 'UTC',
-    language: null,
-    website: null,
-    taxId: null,
-    registrationNumber: null,
-    parentPartyId: null,
-    userId: null,
-    avatar: null,
-    roles: 'Customer',
-    status: 'Active',
     addresses: [],
     emails,
     phones: [],
@@ -375,7 +365,5 @@ function makeParty(
     },
     metadata: {},
     internalNotes: null,
-    createdAt: toISODateString('2026-01-01T00:00:00Z'),
-    modifiedAt: null,
   };
 }

--- a/packages/@granit/react-parties/src/__tests__/use-parties.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/use-parties.test.tsx
@@ -1,10 +1,12 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toEntityId, toISODateString } from '@granit/types';
+import { toEntityId } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { sampleParty, samplePartyId } from '@granit/react-parties/testing';
 
 import {
   useActivatePartyMutation,
@@ -43,14 +45,13 @@ import type {
   PartyMetadataRequest,
   PartyPhoneId,
   PartyPhoneRequest,
-  PartyResponse,
   PartyTaxStatusRequest,
   PartyUpdateRequest,
 } from '@granit/parties';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
-const partyId: PartyId = toEntityId<'Party'>('00000000-0000-0000-0000-000000000001');
+const partyId: PartyId = samplePartyId;
 
 const sampleListItem: PartyListItemResponse = {
   id: partyId,
@@ -62,33 +63,6 @@ const sampleListItem: PartyListItemResponse = {
   defaultCurrency: 'EUR',
   primaryEmail: 'billing@acme.example',
   primaryPhone: null,
-};
-
-const sampleParty: PartyResponse = {
-  id: partyId,
-  tenantId: null,
-  kind: 'Company',
-  name: 'Acme Corp',
-  defaultCurrency: 'EUR',
-  timezone: 'UTC',
-  language: null,
-  website: null,
-  taxId: null,
-  registrationNumber: null,
-  parentPartyId: null,
-  userId: null,
-  avatar: null,
-  roles: 'Customer',
-  status: 'Active',
-  addresses: [],
-  emails: [],
-  phones: [],
-  externalMappings: [],
-  taxStatus: { isExempt: false, reverseCharge: false, vatin: null, evidenceBlobId: null },
-  metadata: {},
-  internalNotes: null,
-  createdAt: toISODateString('2026-01-01T00:00:00Z'),
-  modifiedAt: null,
 };
 
 function createWrapper(client: AxiosInstance, basePath?: string) {

--- a/packages/@granit/react-payments-sepa-direct-debit/src/__tests__/use-sepa-direct-debit.test.tsx
+++ b/packages/@granit/react-payments-sepa-direct-debit/src/__tests__/use-sepa-direct-debit.test.tsx
@@ -7,6 +7,11 @@ import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  sampleConfiguration,
+  sampleMandates,
+} from '@granit/react-payments-sepa-direct-debit/testing';
+
+import {
   useCancelMandate,
   useConfirmMandate,
   useCreateMandate,
@@ -17,49 +22,17 @@ import {
 import { SepaDirectDebitProvider } from '../providers/sepa-direct-debit-provider';
 
 import type { SepaDirectDebitConfig } from '../providers/sepa-direct-debit-provider';
-import type {
-  MandateResponse,
-  MandateSetupResponse,
-  SepaConfigurationResponse,
-} from '@granit/payments-sepa-direct-debit';
+import type { MandateSetupResponse } from '@granit/payments-sepa-direct-debit';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
-const sampleMandate: MandateResponse = {
-  id: 'mdt-1',
-  mandateReference: 'RUM-0001',
-  status: 'Active',
-  scheme: 'Core',
-  debtorName: 'Alice Martin',
-  debtorIbanMasked: 'BE** **** **** 1234',
-  creditorId: 'BE68ZZZ0123456789',
-  providerName: 'GoCardless',
-  providerMandateId: 'MD0001',
-  signedAt: toISODateString('2026-05-01T10:00:00Z'),
-  activatedAt: toISODateString('2026-05-01T10:05:00Z'),
-  cancelledAt: null,
-  tenantId: null,
-  concurrencyStamp: 'stamp-1',
-};
+const sampleMandate = sampleMandates[0]!;
 
 const sampleSetup: MandateSetupResponse = {
   id: 'mdt-1',
   mandateReference: 'RUM-0001',
   status: 'Pending',
   redirectUrl: null,
-};
-
-const sampleConfiguration: SepaConfigurationResponse = {
-  creditorId: 'BE68ZZZ0123456789',
-  creditorName: 'Acme NV',
-  defaultScheme: 'Core',
-  defaultProviderName: 'GoCardless',
-  isActive: true,
-  companyPartyId: null,
-  creditorIbanMasked: 'BE** **** **** 9999',
-  creditorBic: 'GEBABEBB',
-  tenantId: null,
-  concurrencyStamp: 'stamp-cfg',
 };
 
 function createWrapper(client: AxiosInstance, basePath?: string) {

--- a/packages/@granit/react-payments-sepa-transfer/src/__tests__/use-sepa-transfer.test.tsx
+++ b/packages/@granit/react-payments-sepa-transfer/src/__tests__/use-sepa-transfer.test.tsx
@@ -5,6 +5,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { sampleConfiguration } from '@granit/react-payments-sepa-transfer/testing';
+
 import {
   useSepaTransferConfiguration,
   useUpsertSepaTransferConfiguration,
@@ -12,19 +14,8 @@ import {
 import { SepaTransferProvider } from '../providers/sepa-transfer-provider';
 
 import type { SepaTransferConfig } from '../providers/sepa-transfer-provider';
-import type { SepaTransferConfigurationResponse } from '@granit/payments-sepa-transfer';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
-
-const sampleConfiguration: SepaTransferConfigurationResponse = {
-  beneficiaryName: 'Acme NV',
-  isActive: true,
-  companyPartyId: 'party-1',
-  beneficiaryIbanMasked: 'BE** **** **** 9999',
-  beneficiaryBic: 'GEBABEBB',
-  tenantId: null,
-  concurrencyStamp: 'stamp-1',
-};
 
 function createWrapper(client: AxiosInstance, basePath?: string) {
   return function Wrapper({ children }: { children: ReactNode }) {

--- a/packages/@granit/react-payments/src/__tests__/use-payments.test.tsx
+++ b/packages/@granit/react-payments/src/__tests__/use-payments.test.tsx
@@ -7,6 +7,13 @@ import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  sampleAvailableMethods,
+  samplePaymentMethods,
+  sampleRefunds,
+  sampleTransactions,
+} from '@granit/react-payments/testing';
+
+import {
   useActivatePaymentMethod,
   useAttachPaymentMethod,
   useAvailablePaymentMethods,
@@ -26,15 +33,11 @@ import { PaymentsProvider } from '../providers/payments-provider';
 
 import type { PaymentsConfig } from '../providers/payments-provider';
 import type {
-  PaymentAvailableMethodResponse,
   PaymentCheckoutSessionResponse,
   PaymentMethodCapabilityResponse,
   PaymentMethodConfigurationItemResponse,
-  PaymentMethodResponse,
   PaymentProviderCatalogResponse,
   PaymentProviderConfigurationResponse,
-  PaymentRefundResponse,
-  PaymentTransactionResponse,
 } from '@granit/payments';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -43,35 +46,9 @@ import type { ReactNode } from 'react';
 // Fixtures
 // ---------------------------------------------------------------------------
 
-const sampleTransaction: PaymentTransactionResponse = {
-  id: 'txn-1',
-  invoiceId: 'inv-1',
-  amount: 5000,
-  currency: 'EUR',
-  status: 'Succeeded',
-  providerName: 'Stripe',
-  providerTransactionId: 'pi_abc123',
-  paymentMethodId: 'pm-1',
-  actionUrl: null,
-  idempotencyKey: 'key-1',
-  failureCode: null,
-  succeededAt: toISODateString('2026-04-01T10:00:00Z'),
-  canceledAt: null,
-  refunds: [],
-  disputes: [],
-  tenantId: null,
-};
+const sampleTransaction = sampleTransactions[0]!;
 
-const sampleRefund: PaymentRefundResponse = {
-  id: 'ref-1',
-  amount: 2000,
-  currency: 'EUR',
-  status: 'Succeeded',
-  providerRefundId: 're_abc123',
-  reason: 'Customer request',
-  createdAt: toISODateString('2026-04-02T10:00:00Z'),
-  completedAt: toISODateString('2026-04-02T10:05:00Z'),
-};
+const sampleRefund = sampleRefunds[0]!;
 
 const sampleCheckoutSession: PaymentCheckoutSessionResponse = {
   url: 'https://checkout.stripe.com/session/abc123',
@@ -79,16 +56,7 @@ const sampleCheckoutSession: PaymentCheckoutSessionResponse = {
   expiresAt: toISODateString('2026-04-01T11:00:00Z'),
 };
 
-const sampleMethod: PaymentMethodResponse = {
-  id: 'pm-1',
-  type: 'card',
-  providerName: 'Stripe',
-  providerMethodId: 'pm_abc123',
-  displayLabel: 'Visa •••• 4242',
-  isDefault: true,
-  expiresAt: toISODateString('2028-12-01T00:00:00Z'),
-  tenantId: null,
-};
+const sampleMethod = samplePaymentMethods[0]!;
 
 const sampleCapability: PaymentMethodCapabilityResponse = {
   supportedCountries: ['BE'],
@@ -97,13 +65,7 @@ const sampleCapability: PaymentMethodCapabilityResponse = {
   amountBounds: [{ currencyCode: 'EUR', minAmount: 1, maxAmount: 1000000 }],
 };
 
-const sampleAvailableMethod: PaymentAvailableMethodResponse = {
-  methodType: 'card',
-  category: 'Card',
-  providerName: 'Stripe',
-  displayLabel: 'Credit / Debit Card',
-  capability: sampleCapability,
-};
+const sampleAvailableMethod = sampleAvailableMethods[0]!;
 
 const sampleConfigurationItem: PaymentMethodConfigurationItemResponse = {
   methodType: 'bancontact',

--- a/packages/@granit/react-presence/src/__tests__/presence-picker.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/presence-picker.test.tsx
@@ -1,15 +1,16 @@
 import { createMockClient } from '@granit/react-testing';
-import { toEntityId, toISODateString } from '@granit/types';
+import { toISODateString } from '@granit/types';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mockMyPresence, mockOtherPresences, mockUsers } from '@granit/react-presence/testing';
 
 import { PresencePicker } from '../components/presence-picker';
 
 import { createPresenceTestHarness } from './test-utils';
 
-import type { PresenceResponse, SetPresenceRequest } from '@granit/presence';
-import type { UserId } from '@granit/types';
+import type { SetPresenceRequest } from '@granit/presence';
 
 vi.mock('@granit/presence', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
@@ -23,15 +24,7 @@ vi.mock('@granit/presence', async (importOriginal) => {
 
 const { getMyPresence, setMyPresence, clearMyPresenceOverride } = await import('@granit/presence');
 
-const userId = toEntityId<'User'>('user-1') as UserId;
-
-const baseSnapshot: PresenceResponse = {
-  userId,
-  effectiveStatus: 'Online',
-  manualOverride: null,
-  overrideUntilUtc: null,
-  lastSeenUtc: toISODateString('2026-05-22T10:00:00Z'),
-};
+const baseSnapshot = mockMyPresence;
 
 beforeEach(() => {
   vi.mocked(getMyPresence).mockResolvedValue(baseSnapshot);
@@ -44,12 +37,7 @@ afterEach(() => {
 describe('PresencePicker', () => {
   it('submits the selected status with the 1h preset by default', async () => {
     const client = createMockClient();
-    const dnd: PresenceResponse = {
-      ...baseSnapshot,
-      effectiveStatus: 'DoNotDisturb',
-      manualOverride: 'DoNotDisturb',
-      overrideUntilUtc: toISODateString('2026-05-22T11:00:00Z'),
-    };
+    const dnd = mockOtherPresences[mockUsers[3]!.id]!;
     vi.mocked(setMyPresence).mockResolvedValue(dnd);
     const { wrapper } = createPresenceTestHarness(client);
 

--- a/packages/@granit/react-presence/src/__tests__/use-batch-presence.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/use-batch-presence.test.tsx
@@ -1,7 +1,9 @@
 import { createMockClient } from '@granit/react-testing';
-import { toEntityId, toISODateString } from '@granit/types';
+import { toEntityId } from '@granit/types';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { mockOtherPresences, mockUsers } from '@granit/react-presence/testing';
 
 import { useBatchPresence } from '../hooks/use-batch-presence';
 
@@ -18,13 +20,7 @@ vi.mock('@granit/presence', async (importOriginal) => {
 const { getBatchPresence } = await import('@granit/presence');
 
 function makeSnapshot(id: string): PresenceResponse {
-  return {
-    userId: toEntityId<'User'>(id) as UserId,
-    effectiveStatus: 'Online',
-    manualOverride: null,
-    overrideUntilUtc: null,
-    lastSeenUtc: toISODateString('2026-05-22T10:00:00Z'),
-  };
+  return { ...mockOtherPresences[mockUsers[1]!.id]!, userId: toEntityId<'User'>(id) as UserId };
 }
 
 afterEach(() => {

--- a/packages/@granit/react-presence/src/__tests__/use-heartbeat.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/use-heartbeat.test.tsx
@@ -1,7 +1,8 @@
 import { createMockClient } from '@granit/react-testing';
-import { toEntityId, toISODateString } from '@granit/types';
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mockMyPresence, mockOtherPresences, mockUsers } from '@granit/react-presence/testing';
 
 import { presenceKeys } from '../hooks/query-keys';
 import { useHeartbeat } from '../hooks/use-heartbeat';
@@ -10,7 +11,6 @@ import { useMyPresence } from '../hooks/use-my-presence';
 import { createPresenceTestHarness } from './test-utils';
 
 import type { PresenceResponse } from '@granit/presence';
-import type { UserId } from '@granit/types';
 
 vi.mock('@granit/presence', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
@@ -19,13 +19,7 @@ vi.mock('@granit/presence', async (importOriginal) => {
 
 const { pollMyPresence, getMyPresence } = await import('@granit/presence');
 
-const snapshot: PresenceResponse = {
-  userId: toEntityId<'User'>('user-1') as UserId,
-  effectiveStatus: 'Online',
-  manualOverride: null,
-  overrideUntilUtc: null,
-  lastSeenUtc: toISODateString('2026-05-22T10:00:00Z'),
-};
+const snapshot = mockMyPresence;
 
 function setVisibility(state: DocumentVisibilityState) {
   Object.defineProperty(document, 'visibilityState', {
@@ -91,7 +85,7 @@ describe('useHeartbeat', () => {
     const client = createMockClient();
     const { wrapper, queryClient } = createPresenceTestHarness(client);
 
-    const offlineSnapshot: PresenceResponse = { ...snapshot, effectiveStatus: 'Offline' };
+    const offlineSnapshot = mockOtherPresences[mockUsers[4]!.id]!;
     let resolveGet: (value: PresenceResponse) => void = () => {};
     vi.mocked(getMyPresence).mockReturnValue(
       new Promise<PresenceResponse>((resolve) => {

--- a/packages/@granit/react-presence/src/__tests__/use-my-presence.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/use-my-presence.test.tsx
@@ -1,14 +1,12 @@
 import { createMockClient } from '@granit/react-testing';
-import { toEntityId, toISODateString } from '@granit/types';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { mockMyPresence } from '@granit/react-presence/testing';
 
 import { useMyPresence } from '../hooks/use-my-presence';
 
 import { createPresenceTestHarness } from './test-utils';
-
-import type { PresenceResponse } from '@granit/presence';
-import type { UserId } from '@granit/types';
 
 vi.mock('@granit/presence', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
@@ -17,13 +15,7 @@ vi.mock('@granit/presence', async (importOriginal) => {
 
 const { getMyPresence } = await import('@granit/presence');
 
-const snapshot: PresenceResponse = {
-  userId: toEntityId<'User'>('user-1') as UserId,
-  effectiveStatus: 'Online',
-  manualOverride: null,
-  overrideUntilUtc: null,
-  lastSeenUtc: toISODateString('2026-05-22T10:00:00Z'),
-};
+const snapshot = mockMyPresence;
 
 afterEach(() => {
   vi.clearAllMocks();

--- a/packages/@granit/react-presence/src/__tests__/use-set-my-presence.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/use-set-my-presence.test.tsx
@@ -1,15 +1,14 @@
 import { createMockClient } from '@granit/react-testing';
-import { toEntityId, toISODateString } from '@granit/types';
+import { toISODateString } from '@granit/types';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { mockMyPresence, mockOtherPresences, mockUsers } from '@granit/react-presence/testing';
 
 import { useMyPresence } from '../hooks/use-my-presence';
 import { useSetMyPresence } from '../hooks/use-set-my-presence';
 
 import { createPresenceTestHarness } from './test-utils';
-
-import type { PresenceResponse } from '@granit/presence';
-import type { UserId } from '@granit/types';
 
 vi.mock('@granit/presence', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
@@ -22,15 +21,7 @@ vi.mock('@granit/presence', async (importOriginal) => {
 
 const { getMyPresence, setMyPresence } = await import('@granit/presence');
 
-const userId = toEntityId<'User'>('user-1') as UserId;
-
-const baseSnapshot: PresenceResponse = {
-  userId,
-  effectiveStatus: 'Online',
-  manualOverride: null,
-  overrideUntilUtc: null,
-  lastSeenUtc: toISODateString('2026-05-22T10:00:00Z'),
-};
+const baseSnapshot = mockMyPresence;
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -40,12 +31,7 @@ describe('useSetMyPresence', () => {
   it('optimistically updates the cache and confirms on success', async () => {
     const client = createMockClient();
     vi.mocked(getMyPresence).mockResolvedValue(baseSnapshot);
-    const serverDnd: PresenceResponse = {
-      ...baseSnapshot,
-      effectiveStatus: 'DoNotDisturb',
-      manualOverride: 'DoNotDisturb',
-      overrideUntilUtc: toISODateString('2026-05-22T11:00:00Z'),
-    };
+    const serverDnd = mockOtherPresences[mockUsers[3]!.id]!;
     vi.mocked(setMyPresence).mockResolvedValue(serverDnd);
 
     const { wrapper } = createPresenceTestHarness(client);

--- a/packages/@granit/react-presence/src/__tests__/use-user-presence.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/use-user-presence.test.tsx
@@ -1,13 +1,13 @@
 import { createMockClient } from '@granit/react-testing';
-import { toEntityId, toISODateString } from '@granit/types';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { mockOtherPresences, mockUsers } from '@granit/react-presence/testing';
 
 import { useUserPresence } from '../hooks/use-user-presence';
 
 import { createPresenceTestHarness } from './test-utils';
 
-import type { PresenceResponse } from '@granit/presence';
 import type { UserId } from '@granit/types';
 
 vi.mock('@granit/presence', async (importOriginal) => {
@@ -17,15 +17,8 @@ vi.mock('@granit/presence', async (importOriginal) => {
 
 const { getUserPresence } = await import('@granit/presence');
 
-const USER_ID = toEntityId<'User'>('user-1') as UserId;
-
-const MOCK_PRESENCE: PresenceResponse = {
-  userId: USER_ID,
-  effectiveStatus: 'Online',
-  manualOverride: null,
-  overrideUntilUtc: null,
-  lastSeenUtc: toISODateString('2026-06-06T12:00:00Z'),
-};
+const USER_ID = mockUsers[1]!.id;
+const MOCK_PRESENCE = mockOtherPresences[USER_ID]!;
 
 afterEach(() => vi.clearAllMocks());
 

--- a/packages/@granit/react-scheduling/src/__tests__/use-scheduling.test.tsx
+++ b/packages/@granit/react-scheduling/src/__tests__/use-scheduling.test.tsx
@@ -5,6 +5,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockScheduledActions } from '@granit/react-scheduling/testing';
+
 import {
   buildSchedulingQueryKey,
   useCancelScheduledAction,
@@ -24,17 +26,7 @@ import type { ReactNode } from 'react';
 // Fixtures
 // ---------------------------------------------------------------------------
 
-const sampleAction: ScheduledActionResponse = {
-  id: 'action-1',
-  payloadType: 'SendEmail',
-  executeAt: '2026-04-05T09:00:00Z',
-  correlationId: null,
-  status: 'Pending',
-  executedAt: null,
-  cancelledBy: null,
-  failureReason: null,
-  createdAt: '2026-04-02T14:30:00Z',
-};
+const sampleAction: ScheduledActionResponse = mockScheduledActions[0]!;
 
 const samplePagedResult: PagedResult<ScheduledActionResponse> = {
   items: [sampleAction],

--- a/packages/@granit/react-settings/src/__tests__/admin-settings-hooks.test.tsx
+++ b/packages/@granit/react-settings/src/__tests__/admin-settings-hooks.test.tsx
@@ -4,10 +4,12 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { mockAppSettings } from '@granit/react-settings/testing';
+
 import { useAdminAppSettings, useBulkUpdateSettings } from '../hooks/use-admin-app-settings';
 import { SettingsProvider } from '../providers/settings-provider';
 
-import type { AdminAppSettingResponse, BulkUpdateSettingsResponse } from '@granit/settings';
+import type { BulkUpdateSettingsResponse } from '@granit/settings';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -38,23 +40,10 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-const mockSettings: AdminAppSettingResponse[] = [
-  {
-    key: 'ui.theme',
-    label: 'Theme',
-    description: 'Default theme',
-    defaultValue: 'system',
-    value: 'light',
-    valueKind: 'String',
-    allowedValues: ['light', 'dark', 'system'],
-    isEncrypted: false,
-  },
-];
-
 describe('useAdminAppSettings', () => {
   it('should fetch admin settings for the given scope', async () => {
     const client = createMockClient();
-    vi.mocked(getAdminAppSettings).mockResolvedValue(mockSettings);
+    vi.mocked(getAdminAppSettings).mockResolvedValue(mockAppSettings);
 
     const { wrapper } = createWrapper(client, '/api');
     const { result } = renderHook(() => useAdminAppSettings('global'), { wrapper });
@@ -62,7 +51,7 @@ describe('useAdminAppSettings', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(getAdminAppSettings).toHaveBeenCalledWith(client, '/api', 'global');
-    expect(result.current.data).toEqual(mockSettings);
+    expect(result.current.data).toEqual(mockAppSettings);
   });
 
   it('should respect enabled option', () => {

--- a/packages/@granit/react-subscriptions/src/__tests__/use-plans.test.tsx
+++ b/packages/@granit/react-subscriptions/src/__tests__/use-plans.test.tsx
@@ -1,10 +1,11 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { mockPlans } from '@granit/react-subscriptions/testing';
 
 import {
   useActivePlans,
@@ -19,33 +20,12 @@ import {
 import { SubscriptionsProvider } from '../providers/subscriptions-provider';
 
 import type { SubscriptionsConfig } from '../providers/subscriptions-provider';
-import type { PlanPriceResponse, PlanResponse } from '@granit/subscriptions';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
-const samplePlan: PlanResponse = {
-  id: 'plan-1',
-  name: 'Pro',
-  description: 'Professional plan',
-  pricingModel: 'PerSeat',
-  defaultInterval: 'Monthly',
-  trialDays: 14,
-  seatLimit: 50,
-  sortOrder: 1,
-  lifecycleStatus: 'Draft',
-  prices: [],
-};
+const samplePlan = mockPlans[0]!;
 
-const samplePrice: PlanPriceResponse = {
-  id: 'price-1',
-  amount: 29.99,
-  currency: 'EUR',
-  interval: 'Monthly',
-  effectiveFrom: toISODateString('2026-01-01T00:00:00Z'),
-  isCurrent: true,
-  replacedByPriceId: null,
-  replacedAt: null,
-};
+const samplePrice = mockPlans[1]!.prices[2]!;
 
 function createWrapper(client: AxiosInstance, basePath?: string) {
   return function Wrapper({ children }: { children: ReactNode }) {

--- a/packages/@granit/react-subscriptions/src/__tests__/use-subscriptions.test.tsx
+++ b/packages/@granit/react-subscriptions/src/__tests__/use-subscriptions.test.tsx
@@ -1,10 +1,11 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { mockSubscriptions } from '@granit/react-subscriptions/testing';
 
 import {
   useActiveSubscription,
@@ -24,23 +25,7 @@ import type { BulkMigratePriceResponse, SubscriptionResponse } from '@granit/sub
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
-const sampleSubscription: SubscriptionResponse = {
-  id: 'sub-1',
-  partyId: 'party-1',
-  planId: 'plan-1',
-  status: 'Active',
-  currency: 'EUR',
-  currentPeriodStart: toISODateString('2026-01-01T00:00:00Z'),
-  currentPeriodEnd: toISODateString('2026-02-01T00:00:00Z'),
-  trialEndsAt: null,
-  cancelAtPeriodEnd: false,
-  cancelledAt: null,
-  cancellationReason: null,
-  seatCount: 5,
-  createdAt: toISODateString('2026-03-01T00:00:00Z'),
-  modifiedAt: null,
-  planPriceId: 'price-1',
-};
+const sampleSubscription = mockSubscriptions[0]!;
 
 function createWrapper(client: AxiosInstance, basePath?: string) {
   return function Wrapper({ children }: { children: ReactNode }) {

--- a/packages/@granit/react-tax/src/__tests__/use-tax.test.tsx
+++ b/packages/@granit/react-tax/src/__tests__/use-tax.test.tsx
@@ -6,6 +6,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { sampleTaxRates, sampleValidation } from '@granit/react-tax/testing';
+
 import {
   useTaxRateByCountry,
   useTaxRates,
@@ -16,7 +18,7 @@ import { TaxProvider } from '../providers/tax-provider';
 
 import type { TaxConfig } from '../providers/tax-provider';
 import type { PagedResult, QueryMetadata } from '@granit/query-engine';
-import type { TaxRateEntry, TaxRateResponse, TaxValidateResponse } from '@granit/tax';
+import type { TaxRateEntry, TaxRateResponse } from '@granit/tax';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -36,24 +38,9 @@ function createWrapper(client: AxiosInstance, basePath?: string) {
   };
 }
 
-const mockValidateResponse: TaxValidateResponse = {
-  isValid: true,
-  companyName: 'Digital Dynamics SRL',
-  companyAddress: 'Rue de la Loi 1, 1000 Bruxelles',
-  requestIdentifier: 'req-abc-123',
-  validatedAt: toISODateString('2026-04-04T10:00:00Z'),
-  source: 'VIES',
-};
+const mockValidateResponse = sampleValidation;
 
-const mockBelgiumEntry: TaxRateEntry = {
-  countryCode: 'BE',
-  standardRate: 21,
-  reducedRate: 6,
-  superReducedRate: null,
-  parkingRate: 12,
-  effectiveFrom: toISODateString('2024-01-01'),
-  effectiveTo: null,
-};
+const mockBelgiumEntry = sampleTaxRates[0]!;
 
 const mockLuxembourgEntry: TaxRateEntry = {
   countryCode: 'LU',

--- a/packages/@granit/react-timeline/src/__tests__/use-timeline.test.ts
+++ b/packages/@granit/react-timeline/src/__tests__/use-timeline.test.ts
@@ -1,7 +1,8 @@
-import { TimelineEntryType } from '@granit/timeline';
-import { toEntityId, toISODateString } from '@granit/types';
+import { toEntityId } from '@granit/types';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+
+import { mockTimelineEntries } from '@granit/react-timeline/testing';
 
 import { useTimeline } from '../hooks/use-timeline';
 
@@ -13,14 +14,7 @@ function makeEntry(
   overrides: Partial<TimelineStreamEntryResponse> = {}
 ): TimelineStreamEntryResponse {
   return {
-    id: toEntityId<'TimelineStreamEntryResponse'>('e-1'),
-    entryType: TimelineEntryType.Comment,
-    body: 'Test comment',
-    authorId: toEntityId<'User'>('u-1'),
-    authorName: 'Dr. Martin',
-    parentEntryId: null,
-    occurredAt: toISODateString('2026-01-01T00:00:00Z'),
-    attachments: [],
+    ...mockTimelineEntries[0]!,
     ...overrides,
   };
 }
@@ -44,7 +38,7 @@ describe('useTimeline', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.entries).toHaveLength(1);
-    expect(result.current.entries[0]!.body).toBe('Test comment');
+    expect(result.current.entries[0]!.body).toBe(mockTimelineEntries[0]!.body);
     expect(result.current.totalCount).toBe(1);
     expect(result.current.hasMore).toBe(false);
   });

--- a/packages/@granit/react-ui-background-jobs/src/__tests__/background-job-columns.test.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/__tests__/background-job-columns.test.tsx
@@ -1,4 +1,4 @@
-import { toISODateString } from '@granit/types';
+import { mockBackgroundJobs } from '@granit/react-background-jobs/testing';
 import { screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -12,14 +12,7 @@ import type { ReactElement } from 'react';
 
 function makeJob(overrides: Partial<BackgroundJobStatus> = {}): BackgroundJobStatus {
   return {
-    jobName: 'SampleJob',
-    cronExpression: '0 0 * * * ?',
-    isEnabled: true,
-    lastExecutedAt: toISODateString('2026-04-02T12:00:00Z'),
-    nextExecutionAt: toISODateString('2026-04-02T13:00:00Z'),
-    consecutiveFailures: 0,
-    deadLetterCount: 0,
-    lastError: null,
+    ...mockBackgroundJobs[0],
     ...overrides,
   };
 }

--- a/packages/@granit/react-ui-background-jobs/src/__tests__/background-job-list-page.test.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/__tests__/background-job-list-page.test.tsx
@@ -1,4 +1,4 @@
-import { toISODateString } from '@granit/types';
+import { mockBackgroundJobs } from '@granit/react-background-jobs/testing';
 import { screen } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -7,24 +7,11 @@ import { BackgroundJobListPage } from '../background-job-list-page';
 
 import { renderBackgroundJobs } from './test-utils';
 
-import type { BackgroundJobStatus } from '@granit/background-jobs';
-
 // ---------------------------------------------------------------------------
 // Mock data
 // ---------------------------------------------------------------------------
 
-const mockJobs: BackgroundJobStatus[] = [
-  {
-    jobName: 'NotificationDigestJob',
-    cronExpression: '0 */5 * * * ?',
-    isEnabled: true,
-    lastExecutedAt: toISODateString('2026-04-02T12:00:00Z'),
-    nextExecutionAt: toISODateString('2026-04-02T12:05:00Z'),
-    consecutiveFailures: 0,
-    deadLetterCount: 0,
-    lastError: null,
-  },
-];
+const mockJobs = mockBackgroundJobs;
 
 // ---------------------------------------------------------------------------
 // Mocks — the page consumes the @granit/react-background-jobs hooks directly

--- a/packages/@granit/react-ui-background-jobs/src/__tests__/job-actions.test.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/__tests__/job-actions.test.tsx
@@ -1,4 +1,4 @@
-import { toISODateString } from '@granit/types';
+import { mockBackgroundJobs } from '@granit/react-background-jobs/testing';
 import { within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -21,14 +21,7 @@ vi.mock('@granit/react-background-jobs', () => ({
 
 function makeJob(overrides: Partial<BackgroundJobStatus> = {}): BackgroundJobStatus {
   return {
-    jobName: 'SampleJob',
-    cronExpression: '0 0 * * * ?',
-    isEnabled: true,
-    lastExecutedAt: toISODateString('2026-04-02T12:00:00Z'),
-    nextExecutionAt: toISODateString('2026-04-02T13:00:00Z'),
-    consecutiveFailures: 0,
-    deadLetterCount: 0,
-    lastError: null,
+    ...mockBackgroundJobs[0],
     ...overrides,
   };
 }
@@ -49,7 +42,7 @@ describe('JobActions', () => {
     const buttons = within(container).getAllByRole('button');
     // First button is pause (enabled), second is trigger.
     await user.click(buttons[0]);
-    expect(pauseMutate).toHaveBeenCalledWith('SampleJob');
+    expect(pauseMutate).toHaveBeenCalledWith('vault-credential-renewal');
     expect(resumeMutate).not.toHaveBeenCalled();
   });
 
@@ -58,7 +51,7 @@ describe('JobActions', () => {
     const container = document.querySelector('[data-slot="job-actions"]') as HTMLElement;
     const buttons = within(container).getAllByRole('button');
     await user.click(buttons[0]);
-    expect(resumeMutate).toHaveBeenCalledWith('SampleJob');
+    expect(resumeMutate).toHaveBeenCalledWith('vault-credential-renewal');
     expect(pauseMutate).not.toHaveBeenCalled();
   });
 
@@ -67,7 +60,7 @@ describe('JobActions', () => {
     const container = document.querySelector('[data-slot="job-actions"]') as HTMLElement;
     const buttons = within(container).getAllByRole('button');
     await user.click(buttons[1]);
-    expect(triggerMutate).toHaveBeenCalledWith('SampleJob');
+    expect(triggerMutate).toHaveBeenCalledWith('vault-credential-renewal');
   });
 
   it('disables the trigger button for a disabled job', () => {

--- a/packages/@granit/react-ui-background-jobs/src/__tests__/job-card.test.tsx
+++ b/packages/@granit/react-ui-background-jobs/src/__tests__/job-card.test.tsx
@@ -1,4 +1,4 @@
-import { toISODateString } from '@granit/types';
+import { mockBackgroundJobs } from '@granit/react-background-jobs/testing';
 import { screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -18,14 +18,7 @@ vi.mock('@granit/react-background-jobs', () => ({
 
 function makeJob(overrides: Partial<BackgroundJobStatus> = {}): BackgroundJobStatus {
   return {
-    jobName: 'NotificationDigestJob',
-    cronExpression: '0 */5 * * * ?',
-    isEnabled: true,
-    lastExecutedAt: toISODateString('2026-04-02T12:00:00Z'),
-    nextExecutionAt: toISODateString('2026-04-02T12:05:00Z'),
-    consecutiveFailures: 0,
-    deadLetterCount: 0,
-    lastError: null,
+    ...mockBackgroundJobs[0],
     ...overrides,
   };
 }
@@ -33,7 +26,7 @@ function makeJob(overrides: Partial<BackgroundJobStatus> = {}): BackgroundJobSta
 describe('JobCard', () => {
   it('renders the job name and a humanised cron expression', () => {
     renderBackgroundJobs(<JobCard job={makeJob()} />);
-    expect(screen.getByText('NotificationDigestJob')).toBeInTheDocument();
+    expect(screen.getByText('vault-credential-renewal')).toBeInTheDocument();
     expect(document.querySelector('[data-slot="job-card"]')).toBeInTheDocument();
   });
 

--- a/packages/@granit/react-ui-customer-balance/src/__tests__/customer-balance-page.test.tsx
+++ b/packages/@granit/react-ui-customer-balance/src/__tests__/customer-balance-page.test.tsx
@@ -1,11 +1,12 @@
-import { toISODateString } from '@granit/types';
+import {
+  sampleBalance as mockBalance,
+  sampleTransactions as mockTransactions,
+} from '@granit/react-customer-balance/testing';
 import { screen, waitFor } from '@testing-library/react';
 
 import { CustomerBalancePage } from '../customer-balance-page';
 
 import { renderCustomerBalance } from './test-utils';
-
-import type { BalanceTransactionResponse, CustomerBalanceResponse } from '@granit/customer-balance';
 
 const { mockUseCustomerBalance, mockUseBalanceTransactions } = vi.hoisted(() => ({
   mockUseCustomerBalance: vi.fn(),
@@ -19,43 +20,10 @@ vi.mock('@granit/react-customer-balance', () => ({
   useApplyAdminDebit: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
-const mockBalance: CustomerBalanceResponse = {
-  balanceAccountId: 'acct-1',
-  currency: 'EUR',
-  balance: 1250.5,
-  concurrencyStamp: 'stamp-1',
-  updatedAt: toISODateString('2026-06-01T10:00:00Z'),
-};
-
-const mockTransactions: BalanceTransactionResponse[] = [
-  {
-    id: 'txn-1',
-    type: 'Credit',
-    amount: 500,
-    source: 'Promotional',
-    reason: 'Welcome bonus',
-    referenceId: null,
-    referenceType: null,
-    expiresAt: null,
-    createdAt: toISODateString('2026-06-01T10:00:00Z'),
-  },
-  {
-    id: 'txn-2',
-    type: 'Debit',
-    amount: 100,
-    source: 'ManualAdjustment',
-    reason: 'Correction',
-    referenceId: 'ref-99',
-    referenceType: 'Order',
-    expiresAt: null,
-    createdAt: toISODateString('2026-06-02T10:00:00Z'),
-  },
-];
-
 function setData() {
   mockUseCustomerBalance.mockReturnValue({ data: mockBalance, isLoading: false });
   mockUseBalanceTransactions.mockReturnValue({
-    data: { items: mockTransactions, totalCount: 2, hasMore: false },
+    data: { items: mockTransactions, totalCount: mockTransactions.length, hasMore: false },
     isLoading: false,
   });
 }
@@ -109,9 +77,9 @@ describe('CustomerBalancePage', () => {
     setData();
     renderCustomerBalance(<CustomerBalancePage />);
     await waitFor(() => {
-      expect(screen.getByText('Welcome bonus')).toBeInTheDocument();
+      expect(screen.getByText('Admin credit - Welcome bonus')).toBeInTheDocument();
     });
-    expect(screen.getByText('Correction')).toBeInTheDocument();
+    expect(screen.getByText('Invoice INV-2026-001 payment')).toBeInTheDocument();
   });
 
   it('should render the empty state when there are no transactions', async () => {

--- a/packages/@granit/react-ui-data-exchange/src/__tests__/export-list-page.test.tsx
+++ b/packages/@granit/react-ui-data-exchange/src/__tests__/export-list-page.test.tsx
@@ -1,3 +1,4 @@
+import { mockExportHistory } from '@granit/react-data-exchange/testing';
 import { screen } from '@testing-library/react';
 import * as React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -42,15 +43,7 @@ vi.mock('@granit/data-exchange', async (importOriginal) => {
   };
 });
 
-const completedJob: ExportJobResponse = {
-  id: 'e1',
-  definitionName: 'Admin.UserExport',
-  status: 'Completed',
-  format: 'csv',
-  rowCount: 12,
-  createdAt: '2026-01-01T00:00:00Z',
-  fileName: 'export.csv',
-} as ExportJobResponse;
+const completedJob: ExportJobResponse = mockExportHistory[0];
 
 describe('ExportListPage', () => {
   beforeEach(() => {

--- a/packages/@granit/react-ui-data-exchange/src/__tests__/history-columns.test.tsx
+++ b/packages/@granit/react-ui-data-exchange/src/__tests__/history-columns.test.tsx
@@ -1,3 +1,4 @@
+import { mockExportHistory, mockImportHistory } from '@granit/react-data-exchange/testing';
 import { screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -26,35 +27,20 @@ function renderCell<TRow>(column: ColumnDef<TRow, unknown>, original: TRow): Rea
   return cell({ row: { original } } as never) as ReactNode;
 }
 
-const exportJob: ExportJobResponse = {
-  id: 'e1',
-  definitionName: 'Admin.UserExport',
-  status: 'Completed',
-  format: 'csv',
-  rowCount: 1234,
-  createdAt: '2026-01-01T00:00:00Z',
-  fileName: 'export.csv',
-} as ExportJobResponse;
-
-const importJob: ImportJobResponse = {
-  id: 'i1',
-  definitionName: 'Admin.UserImport',
-  status: 'Completed',
-  originalFileName: 'import.csv',
-  createdAt: '2026-01-01T00:00:00Z',
-} as ImportJobResponse;
+const exportJob: ExportJobResponse = mockExportHistory[0];
+const importJob: ImportJobResponse = mockImportHistory[0];
 
 describe('job-history-columns shared factories', () => {
   it('should render the date column cell using formatDateTime', () => {
     const column = createJobDateColumn<ExportJobResponse>(t, formatDateTime);
     renderDataExchange(<>{renderCell(column, exportJob)}</>);
-    expect(screen.getByText('formatted:2026-01-01T00:00:00Z')).toBeInTheDocument();
+    expect(screen.getByText('formatted:2026-03-07T10:00:00Z')).toBeInTheDocument();
   });
 
   it('should render the entity column cell', () => {
     const column = createJobEntityColumn<ExportJobResponse>(t);
     renderDataExchange(<>{renderCell(column, exportJob)}</>);
-    expect(screen.getByText('Admin.UserExport')).toBeInTheDocument();
+    expect(screen.getByText('countries')).toBeInTheDocument();
   });
 
   it('should render the status column cell as a badge', () => {
@@ -100,7 +86,7 @@ describe('createExportHistoryColumns', () => {
       </>
     );
     expect(screen.getByText('csv')).toBeInTheDocument();
-    expect(screen.getByText('1,234')).toBeInTheDocument();
+    expect(screen.getByText('195')).toBeInTheDocument();
   });
 
   it('should render an em-dash when rowCount is missing', () => {
@@ -151,7 +137,7 @@ describe('createImportHistoryColumns', () => {
     renderDataExchange(
       <>{renderCell(fileColumn as ColumnDef<ImportJobResponse, unknown>, importJob)}</>
     );
-    expect(screen.getByText('import.csv')).toBeInTheDocument();
+    expect(screen.getByText('countries-2026-03.csv')).toBeInTheDocument();
   });
 
   it('should render the view-report action and call onViewReport', async () => {

--- a/packages/@granit/react-ui-diagnostics/src/__tests__/diagnostic-list-page.test.tsx
+++ b/packages/@granit/react-ui-diagnostics/src/__tests__/diagnostic-list-page.test.tsx
@@ -1,10 +1,9 @@
+import { mockDiagnosticsHealth } from '@granit/react-diagnostics/testing';
 import { screen } from '@testing-library/react';
 
 import { DiagnosticListPage } from '../diagnostic-list-page';
 
 import { renderDiagnostics } from './test-utils';
-
-import type { ServiceHealthResponse } from '@granit/diagnostics';
 
 const { mockUseMonitoringHealth } = vi.hoisted(() => ({ mockUseMonitoringHealth: vi.fn() }));
 
@@ -12,36 +11,11 @@ vi.mock('@granit/react-diagnostics', () => ({
   useMonitoringHealth: () => mockUseMonitoringHealth(),
 }));
 
-const services: ServiceHealthResponse[] = [
-  {
-    id: 'api',
-    name: 'API Gateway',
-    description: null,
-    status: 'healthy',
-    responseTimeMs: 42,
-    tags: [],
-  },
-  {
-    id: 'iam',
-    name: 'Keycloak (IAM)',
-    description: null,
-    status: 'degraded',
-    responseTimeMs: 850,
-    tags: [],
-  },
-  {
-    id: 'fhir',
-    name: 'FHIR Server',
-    description: null,
-    status: 'down',
-    responseTimeMs: null,
-    tags: [],
-  },
-];
+const { services, checkedAt } = mockDiagnosticsHealth;
 
 beforeEach(() => {
   mockUseMonitoringHealth.mockReturnValue({
-    data: { services, checkedAt: '2026-06-01T10:00:00Z' },
+    data: { services, checkedAt },
     isLoading: false,
     isFetching: false,
     refetch: vi.fn(),

--- a/packages/@granit/react-ui-localization/src/__tests__/translation-delete-dialog.test.tsx
+++ b/packages/@granit/react-ui-localization/src/__tests__/translation-delete-dialog.test.tsx
@@ -1,22 +1,11 @@
+import { mockLocalizationOverrides } from '@granit/react-localization/testing';
 import { screen } from '@testing-library/react';
 
 import { TranslationDeleteDialog } from '../components/translation-delete-dialog';
 
 import { renderWithProviders } from './test-utils';
 
-import type { LocalizationOverride } from '@granit/localization';
-
-const mockOverride: LocalizationOverride = {
-  id: '1',
-  resourceName: 'Showcase',
-  cultureName: 'fr',
-  key: 'common.save',
-  value: 'Sauvegarder',
-  createdAt: '2026-01-01T00:00:00Z',
-  createdBy: 'admin@granit-showcase.dev',
-  modifiedAt: '2026-01-01T00:00:00Z',
-  modifiedBy: 'admin@granit-showcase.dev',
-};
+const mockOverride = mockLocalizationOverrides[0];
 
 describe('TranslationDeleteDialog', () => {
   it('should render the dialog when open', () => {

--- a/packages/@granit/react-ui-payments/src/__tests__/tenant-payment-methods-page.test.tsx
+++ b/packages/@granit/react-ui-payments/src/__tests__/tenant-payment-methods-page.test.tsx
@@ -1,11 +1,9 @@
-import { toISODateString } from '@granit/types';
+import { samplePaymentMethods } from '@granit/react-payments/testing';
 import { screen, waitFor } from '@testing-library/react';
 
 import { TenantPaymentMethodsPage } from '../tenant-payment-methods-page';
 
 import { renderWithProviders } from './test-utils';
-
-import type { PaymentMethodResponse } from '@granit/payments';
 
 // ---------------------------------------------------------------------------
 // Mocks — stub the saved-methods query hook so the page renders both the
@@ -27,28 +25,7 @@ vi.mock('@granit/react-payments', async (importOriginal) => {
   };
 });
 
-const sampleMethods: PaymentMethodResponse[] = [
-  {
-    id: 'pm_visa_4242',
-    type: 'Card',
-    providerName: 'Stripe',
-    providerMethodId: 'pm_stripe_visa_4242',
-    displayLabel: 'Visa ending in 4242',
-    isDefault: true,
-    expiresAt: toISODateString('2028-12-31T23:59:59Z'),
-    tenantId: 'tenant_01',
-  },
-  {
-    id: 'pm_sepa_6789',
-    type: 'BankTransfer',
-    providerName: 'Stripe',
-    providerMethodId: 'pm_stripe_sepa_6789',
-    displayLabel: 'SEPA ending in 6789',
-    isDefault: false,
-    expiresAt: null,
-    tenantId: 'tenant_01',
-  },
-];
+const sampleMethods = samplePaymentMethods;
 
 describe('TenantPaymentMethodsPage', () => {
   afterEach(() => vi.clearAllMocks());
@@ -71,8 +48,9 @@ describe('TenantPaymentMethodsPage', () => {
     mockUsePaymentMethods.mockReturnValue({ data: sampleMethods, isLoading: false });
     renderWithProviders(<TenantPaymentMethodsPage />);
     const cards = document.querySelectorAll('[data-slot="payment-method-card"]');
-    expect(cards).toHaveLength(2);
+    expect(cards).toHaveLength(3);
     expect(screen.getByText('Visa ending in 4242')).toBeInTheDocument();
+    expect(screen.getByText('Mastercard ending in 5555')).toBeInTheDocument();
     expect(screen.getByText('SEPA ending in 6789')).toBeInTheDocument();
   });
 

--- a/packages/@granit/react-ui-payments/src/__tests__/transaction-detail-page.test.tsx
+++ b/packages/@granit/react-ui-payments/src/__tests__/transaction-detail-page.test.tsx
@@ -1,11 +1,9 @@
-import { toISODateString } from '@granit/types';
+import { sampleTransactions } from '@granit/react-payments/testing';
 import { screen, waitFor } from '@testing-library/react';
 
 import { TransactionDetailPage } from '../transaction-detail-page';
 
 import { renderWithProviders } from './test-utils';
-
-import type { PaymentTransactionResponse } from '@granit/payments';
 
 // ---------------------------------------------------------------------------
 // Mocks — useParams (route id) + the single-transaction fetch hook.
@@ -36,24 +34,7 @@ vi.mock('@granit/react-payments', async (importOriginal) => {
   };
 });
 
-const mockTransaction: PaymentTransactionResponse = {
-  id: 'txn_4kLm8nPqRs',
-  invoiceId: 'inv_001',
-  amount: 24900,
-  currency: 'EUR',
-  status: 'Succeeded',
-  providerName: 'Stripe',
-  providerTransactionId: 'pi_stripe_001',
-  paymentMethodId: 'pm_visa_4242',
-  actionUrl: null,
-  idempotencyKey: 'idem_001',
-  failureCode: null,
-  succeededAt: toISODateString('2026-03-28T14:22:00Z'),
-  canceledAt: null,
-  refunds: [],
-  disputes: [],
-  tenantId: 'tenant_01',
-};
+const mockTransaction = sampleTransactions[0]!;
 
 describe('TransactionDetailPage', () => {
   beforeEach(() => {

--- a/packages/@granit/react-ui-payments/src/__tests__/transaction-list-page.test.tsx
+++ b/packages/@granit/react-ui-payments/src/__tests__/transaction-list-page.test.tsx
@@ -1,11 +1,9 @@
-import { toISODateString } from '@granit/types';
+import { sampleTransactions } from '@granit/react-payments/testing';
 import { screen, waitFor } from '@testing-library/react';
 
 import { TransactionListPage } from '../transaction-list-page';
 
 import { renderWithProviders } from './test-utils';
-
-import type { PaymentTransactionResponse } from '@granit/payments';
 
 // ---------------------------------------------------------------------------
 // Mocks — stub the paginated transactions query hook (usePaymentTransactions
@@ -24,45 +22,6 @@ vi.mock('@granit/react-payments', async (importOriginal) => {
     useInitiatePaymentCharge: () => ({ mutate: vi.fn(), isPending: false }),
   };
 });
-
-const sampleTransactions: PaymentTransactionResponse[] = [
-  {
-    id: 'txn_4kLm8nPqRs',
-    invoiceId: 'inv_001',
-    amount: 24900,
-    currency: 'EUR',
-    status: 'Succeeded',
-    providerName: 'Stripe',
-    providerTransactionId: 'pi_stripe_001',
-    paymentMethodId: 'pm_visa_4242',
-    actionUrl: null,
-    idempotencyKey: 'idem_001',
-    failureCode: null,
-    succeededAt: toISODateString('2026-03-28T14:22:00Z'),
-    canceledAt: null,
-    refunds: [],
-    disputes: [],
-    tenantId: 'tenant_01',
-  },
-  {
-    id: 'txn_2gHiJkLmNo',
-    invoiceId: 'inv_003',
-    amount: 12000,
-    currency: 'USD',
-    status: 'Failed',
-    providerName: 'Stripe',
-    providerTransactionId: 'pi_stripe_003',
-    paymentMethodId: 'pm_visa_1234',
-    actionUrl: null,
-    idempotencyKey: 'idem_003',
-    failureCode: 'card_declined',
-    succeededAt: null,
-    canceledAt: null,
-    refunds: [],
-    disputes: [],
-    tenantId: 'tenant_01',
-  },
-];
 
 const pagedResult = {
   items: sampleTransactions,

--- a/packages/@granit/react-ui-settings/src/__tests__/app-settings-panel.test.tsx
+++ b/packages/@granit/react-ui-settings/src/__tests__/app-settings-panel.test.tsx
@@ -1,3 +1,4 @@
+import { mockAppSettings } from '@granit/react-settings/testing';
 import { screen, waitFor } from '@testing-library/react';
 import { toast } from 'sonner';
 
@@ -5,11 +6,7 @@ import { AppSettingsPanel } from '../components/app-settings-panel';
 
 import { renderSettings } from './test-utils';
 
-import type {
-  AdminAppSettingResponse,
-  BulkSettingEntry,
-  BulkUpdateSettingsResponse,
-} from '@granit/settings';
+import type { BulkSettingEntry, BulkUpdateSettingsResponse } from '@granit/settings';
 
 let saveResponse: BulkUpdateSettingsResponse;
 const mockSave = vi.fn<
@@ -19,51 +16,8 @@ const mockSave = vi.fn<
   ) => void
 >((_entries, opts) => opts?.onSuccess?.(saveResponse));
 
-const mockSettings: AdminAppSettingResponse[] = [
-  {
-    key: 'audit.retention_days',
-    label: 'Audit Log Retention',
-    description: 'Days to retain audit logs',
-    defaultValue: '365',
-    value: '1095',
-    valueKind: 'Int',
-    allowedValues: null,
-    isEncrypted: false,
-  },
-  {
-    key: 'notifications.email_enabled',
-    label: 'Email Notifications',
-    description: null,
-    defaultValue: 'false',
-    value: 'true',
-    valueKind: 'Bool',
-    allowedValues: null,
-    isEncrypted: false,
-  },
-  {
-    key: 'ui.theme',
-    label: 'Theme',
-    description: null,
-    defaultValue: 'system',
-    value: 'light',
-    valueKind: 'String',
-    allowedValues: ['light', 'dark', 'system'],
-    isEncrypted: false,
-  },
-  {
-    key: 'integrations.stripe_secret_key',
-    label: 'Stripe Secret',
-    description: null,
-    defaultValue: null,
-    value: '***',
-    valueKind: 'String',
-    allowedValues: null,
-    isEncrypted: true,
-  },
-];
-
 vi.mock('@granit/react-settings', () => ({
-  useAdminAppSettings: () => ({ data: mockSettings, isLoading: false }),
+  useAdminAppSettings: () => ({ data: mockAppSettings, isLoading: false }),
   useBulkUpdateSettings: () => ({ mutate: mockSave, isPending: false }),
   useSettings: () => ({ data: {}, isLoading: false }),
   useUpdateSetting: () => ({
@@ -85,7 +39,7 @@ vi.mock('sonner', () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   saveResponse = {
-    results: mockSettings.map((s) => ({ key: s.key, outcome: 'Updated', errorCode: null })),
+    results: mockAppSettings.map((s) => ({ key: s.key, outcome: 'Updated', errorCode: null })),
   };
 });
 
@@ -103,7 +57,7 @@ describe('AppSettingsPanel', () => {
     });
     expect(screen.getByText('Email Notifications')).toBeInTheDocument();
     expect(screen.getByText('Theme')).toBeInTheDocument();
-    expect(screen.getByText('Stripe Secret')).toBeInTheDocument();
+    expect(screen.getByText('Stripe Secret Key')).toBeInTheDocument();
   });
 
   it('should render a number input for Int kind', async () => {
@@ -116,21 +70,24 @@ describe('AppSettingsPanel', () => {
     renderSettings(<AppSettingsPanel />);
     await waitFor(() => expect(screen.getByText('Email Notifications')).toBeInTheDocument());
     const switches = screen.getAllByRole('switch');
-    expect(switches).toHaveLength(1);
+    expect(switches).toHaveLength(2);
     expect(switches[0]).toHaveAttribute('data-state', 'checked');
+    expect(switches[1]).toHaveAttribute('data-state', 'unchecked');
   });
 
   it('should render a dropdown when allowedValues is present', async () => {
     renderSettings(<AppSettingsPanel />);
     await waitFor(() => expect(screen.getByText('Theme')).toBeInTheDocument());
-    const combobox = screen.getByRole('combobox');
-    expect(combobox).toBeInTheDocument();
-    expect(combobox).toHaveTextContent('light');
+    // Two rows expose allowedValues (ui.default_page_size, ui.theme), so both
+    // render as comboboxes. Target the Theme dropdown via its trigger id.
+    const themeCombobox = screen.getByRole('combobox', { name: 'Theme' });
+    expect(themeCombobox).toBeInTheDocument();
+    expect(themeCombobox).toHaveTextContent('light');
   });
 
   it('should mask encrypted fields until Change is clicked', async () => {
     const { user } = renderSettings(<AppSettingsPanel />);
-    await waitFor(() => expect(screen.getByText('Stripe Secret')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Stripe Secret Key')).toBeInTheDocument());
 
     const masked = screen.getByDisplayValue('••••••••');
     expect(masked).toBeDisabled();

--- a/packages/@granit/react-webhooks/src/__tests__/use-subscription.test.tsx
+++ b/packages/@granit/react-webhooks/src/__tests__/use-subscription.test.tsx
@@ -1,11 +1,11 @@
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toEntityId, toISODateString } from '@granit/types';
-import { WebhookSubscriptionStatus } from '@granit/webhooks';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
+
+import { mockWebhookSubscriptions } from '@granit/react-webhooks/testing';
 
 import { useSubscription } from '../hooks/use-subscription';
 import { WebhooksProvider } from '../providers/webhooks-provider';
@@ -25,17 +25,8 @@ function createWrapper(client: AxiosInstance, basePath?: string) {
   };
 }
 
-const mockSubscription: WebhookSubscriptionResponse = {
-  id: toEntityId<'WebhookSubscription'>('sub-001'),
-  targetUrl: 'https://example.com/webhook',
-  eventType: 'document.uploaded',
-  status: WebhookSubscriptionStatus.Active,
-  consecutiveFailureCount: 0,
-  lastSuccessAt: toISODateString('2026-03-20T10:00:00Z'),
-  createdAt: toISODateString('2026-03-01T08:00:00Z'),
-  modifiedAt: null,
-  signingSecretHint: 'whsec_b46a****************5182',
-};
+const mockSubscription: WebhookSubscriptionResponse = mockWebhookSubscriptions[0]!;
+const subscriptionId = mockSubscription.id;
 
 describe('useSubscription', () => {
   it('should fetch subscription with default basePath', async () => {
@@ -43,11 +34,11 @@ describe('useSubscription', () => {
     vi.mocked(client.get).mockResolvedValueOnce({ data: mockSubscription });
 
     const { wrapper } = createWrapper(client);
-    const { result } = renderHook(() => useSubscription('sub-001'), { wrapper });
+    const { result } = renderHook(() => useSubscription(subscriptionId), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/webhooks/subscriptions/sub-001');
+    expect(client.get).toHaveBeenCalledWith(`/api/v1/webhooks/subscriptions/${subscriptionId}`);
     expect(result.current.data).toEqual(mockSubscription);
   });
 
@@ -56,11 +47,11 @@ describe('useSubscription', () => {
     vi.mocked(client.get).mockResolvedValueOnce({ data: mockSubscription });
 
     const { wrapper } = createWrapper(client, '/api/v2/webhooks');
-    const { result } = renderHook(() => useSubscription('sub-001'), { wrapper });
+    const { result } = renderHook(() => useSubscription(subscriptionId), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v2/webhooks/subscriptions/sub-001');
+    expect(client.get).toHaveBeenCalledWith(`/api/v2/webhooks/subscriptions/${subscriptionId}`);
   });
 
   it('should be disabled when id is empty', () => {
@@ -78,7 +69,7 @@ describe('useSubscription', () => {
     vi.mocked(client.get).mockRejectedValueOnce(new Error('Not Found'));
 
     const { wrapper } = createWrapper(client);
-    const { result } = renderHook(() => useSubscription('sub-001'), { wrapper });
+    const { result } = renderHook(() => useSubscription(subscriptionId), { wrapper });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
 

--- a/packages/@granit/react-workflow/src/__tests__/use-transitions.test.ts
+++ b/packages/@granit/react-workflow/src/__tests__/use-transitions.test.ts
@@ -1,6 +1,8 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { mockWorkflowStatus } from '@granit/react-workflow/testing';
+
 import { useTransitions } from '../hooks/use-transitions';
 
 import { axiosResponse, createMockClient, createWrapper } from './test-utils.tsx';
@@ -10,16 +12,10 @@ import type { WorkflowStatus } from '@granit/workflow';
 describe('useTransitions', () => {
   it('should load transitions on mount', async () => {
     const client = createMockClient();
-    const status: WorkflowStatus = {
-      currentState: 'Draft',
-      availableTransitions: [
-        { targetState: 'Published', name: 'Publier', allowed: true, requiresApproval: false },
-        { targetState: 'Archived', name: 'Archiver', allowed: false, requiresApproval: true },
-      ],
-    };
+    const status: WorkflowStatus = mockWorkflowStatus;
     vi.mocked(client.get).mockResolvedValue(axiosResponse(status));
 
-    const { result } = renderHook(() => useTransitions({ currentState: 'Draft' }), {
+    const { result } = renderHook(() => useTransitions({ currentState: status.currentState }), {
       wrapper: createWrapper(client),
     });
 
@@ -28,7 +24,9 @@ describe('useTransitions', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.data?.availableTransitions).toHaveLength(2);
-    expect(result.current.data?.availableTransitions[0]!.name).toBe('Publier');
+    expect(result.current.data?.availableTransitions[0]!.name).toBe(
+      status.availableTransitions[0]!.name
+    );
     expect(result.current.data?.availableTransitions[1]!.requiresApproval).toBe(true);
   });
 
@@ -49,10 +47,9 @@ describe('useTransitions', () => {
   it('should not fetch when enabled is false', () => {
     const client = createMockClient();
 
-    const { result } = renderHook(
-      () => useTransitions({ currentState: 'Draft', enabled: false }),
-      { wrapper: createWrapper(client) }
-    );
+    const { result } = renderHook(() => useTransitions({ currentState: 'Draft', enabled: false }), {
+      wrapper: createWrapper(client),
+    });
 
     expect(client.get).not.toHaveBeenCalled();
     expect(result.current.isLoading).toBe(false);
@@ -61,19 +58,13 @@ describe('useTransitions', () => {
 
   it('should refetch on manual refetch call', async () => {
     const client = createMockClient();
+    // One transition first, then the full fixture (two) — exercises the refetch
+    // growing the available-transition list.
     const status1: WorkflowStatus = {
-      currentState: 'Draft',
-      availableTransitions: [
-        { targetState: 'Published', name: 'Publier', allowed: true, requiresApproval: false },
-      ],
+      ...mockWorkflowStatus,
+      availableTransitions: mockWorkflowStatus.availableTransitions.slice(0, 1),
     };
-    const status2: WorkflowStatus = {
-      currentState: 'Draft',
-      availableTransitions: [
-        { targetState: 'Published', name: 'Publier', allowed: true, requiresApproval: false },
-        { targetState: 'Archived', name: 'Archiver', allowed: true, requiresApproval: false },
-      ],
-    };
+    const status2: WorkflowStatus = mockWorkflowStatus;
     vi.mocked(client.get)
       .mockResolvedValueOnce(axiosResponse(status1))
       .mockResolvedValueOnce(axiosResponse(status2));
@@ -87,8 +78,6 @@ describe('useTransitions', () => {
 
     await result.current.refetch();
 
-    await waitFor(() =>
-      expect(result.current.data?.availableTransitions).toHaveLength(2)
-    );
+    await waitFor(() => expect(result.current.data?.availableTransitions).toHaveLength(2));
   });
 });

--- a/packages/@granit/react-workspaces/src/__tests__/use-workspaces.test.tsx
+++ b/packages/@granit/react-workspaces/src/__tests__/use-workspaces.test.tsx
@@ -6,47 +6,13 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
+import { mockWorkspaceTree } from '@granit/react-workspaces/testing';
+
 import { useWorkspaces, workspaceTreeQueryKey } from '../hooks/use-workspaces';
 
-import type { WorkspaceTreeResponse } from '@granit/workspaces';
 import type { ReactNode } from 'react';
 
-const TREE: WorkspaceTreeResponse = {
-  schemaVersion: 1,
-  workspaces: [
-    {
-      name: 'Granit.Showcase.CRM',
-      displayKey: 'Granit.Showcase.CRM.DisplayName',
-      icon: 'briefcase',
-      order: 100,
-      isShell: false,
-      sections: [
-        {
-          key: 'parties',
-          displayKey: 'Granit.Showcase.CRM.Parties',
-          order: 0,
-          collapsedByDefault: false,
-          items: [
-            {
-              kind: 'Entity',
-              order: 0,
-              displayKey: null,
-              icon: null,
-              entityName: 'Granit.Parties.Party',
-              entityViewName: null,
-              entityPresetOverlay: null,
-              dashboardName: null,
-              linkUrl: null,
-              subWorkspaceName: null,
-              featureName: null,
-              routeName: null,
-            },
-          ],
-        },
-      ],
-    },
-  ],
-};
+const TREE = mockWorkspaceTree;
 
 let getCalls = 0;
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -55,6 +55,10 @@ export default defineConfig({
         __dirname,
         'packages/@granit/react-data-exchange/src/testing/index.ts'
       ),
+      '@granit/react-data-lookup/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-data-lookup/src/testing/index.ts'
+      ),
       '@granit/react-diagnostics/testing': path.resolve(
         __dirname,
         'packages/@granit/react-diagnostics/src/testing/index.ts'


### PR DESCRIPTION
## Summary

Repo-wide test cleanup: refactor hook and UI test suites across ~45 `@granit/*` packages to import the canonical mock fixtures from each module's `@granit/react-<module>/testing` subpath instead of hand-rolling the same domain DTOs inline.

Motivation: spotted during PR #739 review — tests were re-creating data (e.g. `const baseInvoice: InvoiceResponse = {…}`) when a shared fixture (`sampleInvoices`, `mockTenants`, …) already existed. This establishes a **single source of truth** for test data, so DTO shape changes only need updating in one place.

## Changes
- ~85 test files across ~45 packages now import fixtures from `/testing` subpaths.
- Assertions updated to the fixtures' actual values; `makeX()` factories rebased on fixtures while keeping spread-override capability.
- Added the missing `@granit/react-data-lookup/testing` alias to `vitest.config.ts` (consistent with every other module's `/testing` barrel).
- Non-domain-DTO data (UI props, form payloads, edge-case values with no matching fixture) left inline by design.

## Verification
- **2289 tests pass** across all 47 touched packages.
- ESLint `--max-warnings 0`: clean.
- `tsc --noEmit`: clean across all 47 packages.

Scope is test-files-only (plus the one vitest alias). No runtime/source changes.