### PR TITLE
docs(skill/audit): add test-mock reuse + 3-tier layer separation checks

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -25,6 +25,11 @@ audit without the checklist — it contains the full verification matrix.
    `create*` / `update*` / `delete*` for writes
 6. Business/domain HTTP goes through `@granit/api-client` (Axios); native
    `fetch` is allowed only in BFF / telemetry / SSE infra layers (see CLAUDE.md)
+7. Three-layer separation, one-way deps: core `@granit/{module}` (types + api,
+   NO React) ← headless `@granit/react-{module}` (hooks/providers/testing) ←
+   UI `@granit/react-ui-{module}` (components, NO data access / NO api-client)
+8. Tests reuse shared `@granit/react-{module}/testing` fixtures — no duplicated
+   inline DTO data; every module with endpoints ships `/testing` mocks
 
 ---
 
@@ -46,6 +51,8 @@ audit without the checklist — it contains the full verification matrix.
 | `--scope api`     | Only check API functions and serialization       |
 | `--scope hooks`   | Only check React hooks patterns                  |
 | `--scope deps`    | Only check dependencies and peer deps            |
+| `--scope tests`   | Only check test data/mocks reuse + coverage      |
+| `--scope layers`  | Only check 3-tier layer separation               |
 | `--scope all`     | Full audit (default)                             |
 | `--base <branch>` | Base branch for `pr` mode (default: `develop`)   |
 
@@ -73,6 +80,8 @@ FLAGS
                       api     API functions and serialization
                       hooks   React hooks patterns
                       deps    Dependencies and peer deps
+                      tests   Test data/mocks reuse + coverage (no duplication)
+                      layers  3-tier layer separation (core/headless/react-ui)
                       all     Everything (default)
   --base <branch>   Base branch for pr mode (default: develop)
 
@@ -84,6 +93,8 @@ EXAMPLES
   /audit pr --fix               Check and fix before PR
   /audit all --scope types      Only check type conformity across all packages
   /audit notifications --scope api   Only check API coverage for notifications
+  /audit all --scope tests      Check mocks exist + no duplicated test data
+  /audit invoicing --scope layers    Check core/headless/react-ui separation
 
 SEVERITY LEVELS
   BREAKING        Type mismatch causing runtime errors — must fix
@@ -106,7 +117,10 @@ If a specific package was given, resolve it:
 - `query-engine` → `packages/@granit/query-engine` + `packages/@granit/react-query-engine`
 - `notifications` → `packages/@granit/notifications` + `packages/@granit/react-notifications`
   - transport packages (`notifications-signalr`, `notifications-sse`, etc.)
-- Any name → `packages/@granit/{name}` + `packages/@granit/react-{name}` if it exists
+- Any name → resolve the **whole layer trio** when present:
+  `packages/@granit/{name}` (core) + `packages/@granit/react-{name}` (headless) +
+  `packages/@granit/react-ui-{name}` (UI). Audit them together so layer-separation
+  (checklist 7) and fixture-reuse (checklist 5e) can be checked across the trio.
 
 If `all`, list all packages under `packages/@granit/` and process each.
 
@@ -119,6 +133,14 @@ For each target package, collect:
 1. **Frontend types**: read `src/types/` and `src/index.ts` (public API surface)
 2. **Frontend API functions**: read `src/api/` files
 3. **Frontend hooks**: read `src/hooks/` files (for `react-*` packages)
+3b. **Layer surface** (checklist 7): note which of the trio exist
+    (`@granit/{name}` / `react-{name}` / `react-ui-{name}`) and read each one's
+    `package.json` deps + top-level `src/` dirs to verify the one-way dependency
+    direction and that the UI layer holds no `api/`, data hooks, or api-client dep
+3c. **Test data & mocks** (checklist 5e): read `src/testing/` (does the headless
+    package ship `data.ts` + `handlers.ts` + barrel?) and check `vitest.config.ts`
+    for the `<pkg>/testing` alias; scan `src/__tests__/` for inline DTO literals
+    that duplicate an existing fixture
 4. **Backend contract** (multi-step discovery):
 
    a. **Module mapping**: resolve the .NET module name from the package name
@@ -186,7 +208,9 @@ For each target package, collect:
 Apply every category from [checklist.md](checklist.md) against the gathered context.
 Work through the checklist **in order** — type conformity first, then API (including
 HTTP-client conformity and endpoint drift), hooks, dependencies, cross-cutting
-concerns, and finally module decomposition (backend bounded-context alignment).
+concerns (including test data & mocks reuse, checklist 5e), module decomposition
+(backend bounded-context alignment), and finally the 3-tier layer separation
+(checklist 7 — core / headless / react-ui).
 
 For each finding, classify it:
 
@@ -338,6 +362,37 @@ When auditing all packages, perform these additional checks:
 8. **HTTP client + CSP conformity**: no domain `fetch()` outside the allowed
    infra layers (checklist 2d); every package writing to a DOM script sink
    exposes a `<pkg>/csp` subpath — run `pnpm check:csp` to confirm
+9. **Mocks coverage (checklist 5e)**: every domain `react-{module}` with HTTP
+   endpoints ships a `src/testing/` fixtures barrel with a registered
+   `<pkg>/testing` vitest alias. Enumerate the gaps:
+
+   ```bash
+   # modules with a /testing barrel
+   for f in packages/@granit/react-*/src/testing/index.ts; do echo "${f%/src/testing/index.ts}"; done | sed 's|packages/@granit/||'
+   # /testing aliases registered in vitest.config.ts
+   grep -oE "@granit/react-[a-z-]+/testing" vitest.config.ts | sort -u
+   ```
+
+   Flag a `react-{module}` (API-backed) with no `/testing` as GAP, and any
+   `/testing` barrel without a matching alias as BREAKING.
+10. **No duplicated test data (checklist 5e)**: across `react-*` and `react-ui-*`
+    tests, flag inline domain-DTO literals / `makeX()` factories that duplicate an
+    existing shared fixture (`mock*` / `sample*`) instead of importing it from
+    `@granit/react-{module}/testing`.
+11. **Layer separation (checklist 7)**: for every domain that has a
+    `react-ui-{module}`, verify the trio (core / headless / react-ui) and the
+    one-way dependency direction. Quick scans:
+
+    ```bash
+    # react-ui packages that wrongly carry a runtime/peer api-client or Axios dep
+    for p in packages/@granit/react-ui-*/package.json; do
+      grep -q '"@granit/api-client"' <(sed -n '/peerDependencies/,/}/p' "$p") && echo "PEER api-client: $p"
+    done
+    # react-ui packages with a forbidden api/ or HTTP hooks dir
+    ls -d packages/@granit/react-ui-*/src/api 2>/dev/null
+    # core packages that import React (back-edge)
+    grep -rlE "from 'react'|from \"react\"" packages/@granit/*/src 2>/dev/null | grep -vE "/react-|/react-ui-" | head
+    ```
 
 ---
 
@@ -442,12 +497,42 @@ git diff origin/develop...HEAD -- "packages/@granit/{pkg}/src/" | grep -nE "^\+.
 - Verify no forbidden structure mix (checklist 5a); if the package writes to a
   DOM script sink, confirm it exposes `<pkg>/csp` (run `pnpm check:csp`)
 
-#### Test coverage
+#### Test coverage & mocks (checklist 5b, 5e)
 
 For any new `src/api/*.ts` or `src/hooks/*.ts` file:
 
 - Verify a corresponding test file exists
 - If no test: flag as **GAP** with `Action: add test for {function}`
+
+For any new/changed test file in the diff:
+
+- **Reuse fixtures**: flag inline domain-DTO literals (`const x: {Name}Response =
+  {…}`) or `makeX()` factories that duplicate a fixture already exported by
+  `@granit/react-{module}/testing` — **INCONSISTENCY**, `Fix: import the fixture`
+- **New module ships mocks**: if the branch adds a `react-{module}` with HTTP
+  endpoints, verify it also adds `src/testing/` (fixtures + MSW barrel) and the
+  `<pkg>/testing` alias in `vitest.config.ts` (ordered before the base alias) —
+  missing fixtures = GAP, missing/mis-ordered alias = BREAKING
+- **Coverage ≥ 80%** on the changed package (all four metrics)
+
+#### Layer separation (checklist 7)
+
+For any new or changed `react-ui-{module}` package in the diff:
+
+```bash
+git diff origin/develop...HEAD -- "packages/@granit/react-ui-{pkg}/package.json"
+ls -d packages/@granit/react-ui-{pkg}/src/api packages/@granit/react-ui-{pkg}/src/hooks 2>/dev/null
+git diff origin/develop...HEAD -- "packages/@granit/react-ui-{pkg}/src/" | grep -nE "^\+.*(@granit/api-client|axios|\bfetch\()"
+```
+
+- **No data access in the UI layer**: flag `@granit/api-client` / Axios in
+  `peerDependencies`, an `src/api/` dir, an HTTP-performing `src/hooks/`, or a
+  domain `fetch(` as **BREAKING** — data must flow through `@granit/react-{module}`
+  hooks (checklist 7c)
+- **Headless counterpart exists**: a new `react-ui-{module}` without a
+  `@granit/react-{module}` peer dep (logic inlined) is an **INCONSISTENCY**
+- **No back-edges**: a core `@granit/{module}` importing React, or a
+  `react-{module}` importing a `react-ui-*`, is **BREAKING** (checklist 7d)
 
 ### PR Step 3 — Verification gate
 

--- a/.claude/skills/audit/checklist.md
+++ b/.claude/skills/audit/checklist.md
@@ -227,7 +227,41 @@ Then check each entry against the frontend `src/api/` functions:
 - [ ] **Mock client**: tests use `createMockClient()` from `@granit/testing`
 - [ ] **Response shape**: mock responses in tests match `PagedResult<T>` or
       the actual backend response shape (not outdated `PaginatedResponse`)
-- [ ] **Coverage >= 80%**: on all source files
+- [ ] **Coverage >= 80%**: on all source files (all four metrics — lines,
+      statements, functions, branches — the global Vitest threshold)
+
+### 5e. Test data & mocks (no duplication)
+
+The headless `@granit/react-{module}` package owns the **shared test fixtures**
+for its domain. Tests in that package AND in its `@granit/react-ui-{module}`
+consumer (and any other consumer) must reuse them — never re-create the same
+domain DTO inline.
+
+- [ ] **Shared mocks exist (every module)**: the headless `@granit/react-{module}`
+      ships `src/testing/` with `data.ts` (typed `mock*` / `sample*` fixtures) and,
+      where the module has HTTP endpoints, `handlers.ts` (MSW), re-exported via a
+      `src/testing/index.ts` barrel and the `<pkg>/testing` subpath. A module with
+      API endpoints but no `/testing` fixtures is a GAP
+      (`Action: add @granit/react-{module}/testing fixtures + MSW handlers`)
+- [ ] **Vitest alias registered**: every `/testing` barrel has a matching alias in
+      `vitest.config.ts` (`'@granit/react-{module}/testing'` →
+      `.../src/testing/index.ts`), declared **before** the broader base alias
+      `'@granit/react-{module}'` so the subpath is not shadowed by prefix match.
+      A missing or mis-ordered alias is BREAKING (tests can't resolve the import)
+- [ ] **No duplicated test data**: tests import the shared fixtures from
+      `@granit/react-{module}/testing` instead of hand-rolling the same domain DTO
+      inline. Flag a `const x: {Name}Response = {…}` literal — or a `makeX()`
+      factory rebuilding a DTO — where a matching fixture already exists as
+      INCONSISTENCY (`Fix: import {fixture} from '@granit/react-{module}/testing'`;
+      rebase `makeX()` on the fixture keeping spread-override). Same-package tests
+      may import their own fixtures via relative `../testing/data`
+- [ ] **Single source of truth**: a DTO shape change should require editing only
+      `testing/data.ts`, not N test files. Legitimately inline: UI-specific props,
+      form-input payloads, and edge values with no matching fixture
+- [ ] **tsc after fixture refactors**: Vitest type-strips, so it will NOT catch
+      `T | undefined` from fixture index access under `noUncheckedIndexedAccess`
+      (`mock[0]` needs `mock[0]!`). Always run `tsc --noEmit` per touched package —
+      the pre-commit `tsc -r` will otherwise block the commit
 
 ### 5c. Consumer compatibility
 
@@ -304,6 +338,77 @@ Granit.{Parent}.{Child}             → sub-module (e.g. Authentication.ApiKeys)
       across layers (framework vs business vs endpoints), the frontend split
       follows the same seam (generic mechanism in `@granit/{module}`, domain
       wiring in a glue package or the consuming app)
+
+---
+
+## 7. Layer Separation — 3-tier architecture (--scope layers)
+
+Every domain now spans **three layers** with a strict one-way dependency
+direction. The admin UI ships as dedicated `react-ui-*` packages on top of the
+headless `react-*` packages on top of the framework-agnostic core:
+
+```text
+@granit/{module}           API layer (core)    types/ + api/ (Axios) + permissions.ts — framework-agnostic, NO React
+        ▲
+@granit/react-{module}     React headless      hooks/ + providers/ + testing/ — logic & data access, NO admin pages
+        ▲
+@granit/react-ui-{module}  React UI            components/ (pages, dialogs, columns, forms) on @granit/react-ui — NO data access
+```
+
+Dependency direction is **react-ui → react → core**, never reversed.
+Prefer extending `@granit/arch-tests` over ad-hoc checks where a rule is
+expressible as an import-boundary test.
+
+### 7a. API layer — core `@granit/{module}`
+
+- [ ] **No React**: no `react` / `react-dom` import, no JSX, no hooks. Only
+      `types/`, `api/` (Axios functions), `permissions.ts` (if backend perms),
+      `index.ts`
+- [ ] **No react-layer dirs**: no `hooks/`, `components/`, `providers/`, or
+      `testing/` MSW (checklist 5a forbidden mixes)
+- [ ] **Owns the HTTP contract**: `api/` functions go through `@granit/api-client`
+      (checklist 2d); this is the ONLY layer that performs domain HTTP
+
+### 7b. React headless — `@granit/react-{module}`
+
+- [ ] **Logic, not chrome**: `hooks/` (React Query + query-key factories),
+      `providers/`, `testing/`. May ship low-level/primitive components, but NOT
+      the admin pages/tables/dialogs/forms — those belong in `react-ui`
+- [ ] **Depends on core only**: peerDeps include `@granit/{module}` (its core);
+      NEVER depends on or imports a `react-ui-*` package
+- [ ] **Ships the mocks**: provides `src/testing/` fixtures (+ MSW) per 5e
+- [ ] **No `api/` dir**: HTTP lives in core; hooks call the core API functions
+      (checklist 5a)
+
+### 7c. React UI — `@granit/react-ui-{module}`
+
+- [ ] **Presentational + composition**: `components/` (pages, dialogs, columns,
+      forms), `locales/`, optional `lib/`. Built on `@granit/react-ui` (the
+      shadcn/ui foundation)
+- [ ] **No data access**: NO `api/` dir, NO `src/hooks/` performing HTTP, NO
+      direct `@granit/api-client` / Axios / domain `fetch`. All data flows through
+      the headless hooks (`@granit/react-{module}`). `@granit/api-client` may
+      appear ONLY in `devDependencies` (test wiring), never `peerDependencies`.
+      A runtime api-client/Axios dependency, a domain `fetch`, or a re-implemented
+      fetching hook is BREAKING
+- [ ] **Depends on the headless layer**: peerDeps include `@granit/react-{module}`
+      and `@granit/react-ui` (+ core `@granit/{module}` for types). Does not depend
+      on another domain's `react-ui-*` except via documented composition
+- [ ] **No headless-logic duplication**: query keys, providers, and fetching hooks
+      are imported from `@granit/react-{module}`, not redefined
+- [ ] **i18n placement**: user-facing locale bundles live in this layer (or the
+      headless layer if it surfaces strings), never in core
+
+### 7d. Direction & boundaries (arch-test territory)
+
+- [ ] **One-way deps only**: core imports nothing React; `react-{module}` imports
+      core (not `react-ui-*`); `react-ui-{module}` imports `react-{module}` + core
+      + `@granit/react-ui`. Flag any back-edge (core → react, react → react-ui) as
+      BREAKING
+- [ ] **Trio completeness**: a domain with a `react-ui-{module}` should have the
+      full trio — core `@granit/{module}` + headless `@granit/react-{module}` +
+      UI `@granit/react-ui-{module}`. A `react-ui-*` with no headless counterpart
+      (data access inlined) is an INCONSISTENCY
 
 ---
 


### PR DESCRIPTION
## Summary

Extends the `/audit` skill with two new verification areas, prompted by the recurring test-data duplication found during the batch-6/7 coverage work and the introduction of the `react-ui-*` layer.

## New checks

**Test data & mocks — checklist 5e** (`--scope tests`)
- Every domain `react-{module}` with endpoints must ship `src/testing/` fixtures (+ MSW) via the `<pkg>/testing` barrel, with a vitest alias declared **before** the base alias (shadowing = unresolved import).
- Tests must reuse the shared `mock*`/`sample*` fixtures — flag inline DTO literals / `makeX()` factories that duplicate an existing fixture.
- Single source of truth; run `tsc` after fixture refactors (vitest type-strips `T | undefined`).

**Layer separation — checklist 7** (`--scope layers`)
- Formalizes the 3-tier architecture now that `react-ui-*` packages exist:
  - **API layer** — core `@granit/{module}`: types + api (Axios) + permissions, **no React**.
  - **React headless** — `@granit/react-{module}`: hooks / providers / testing, **no admin pages**.
  - **React UI** — `@granit/react-ui-{module}`: components on `@granit/react-ui`, **no data access** (no `api/`, no api-client peer dep, no domain fetch).
- One-way dependency direction (react-ui → react → core); back-edges are BREAKING.

## Also updated
- `--scope tests|layers` flags + help card + examples
- Step 1 resolves the whole **trio** (core / headless / react-ui) together
- Step 2 gathers `src/testing/` + layer/dep surface
- Step 5 cross-package scans (mocks coverage, duplicated test data, layer back-edges)
- PR-mode checks for new test files, new mocks, and new `react-ui-*` packages

Docs-only (skill files). markdownlint clean.