### PR TITLE
feat: extract auth pieces from the showcase app-shell (PermissionGuard, AccessDeniedPage, MockAuthProvider, KeycloakAuthProvider)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3866,6 +3866,23 @@
       ]
     },
     {
+      "name": "@granit/react-authentication-mock",
+      "description": "Mock auth provider for development and tests — satisfies the auth context with a configurable fake user and no real IdP (optionally wrapped in BffProvider so MSW-backed BFF endpoints still resolve).",
+      "exports": [
+        {
+          "name": "MockAuthProvider",
+          "kind": "function",
+          "signature": "function MockAuthProvider("
+        },
+        {
+          "name": "MockAuthProviderProps",
+          "kind": "interface",
+          "signature": "interface MockAuthProviderProps",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/react-authorization",
       "description": "React hooks for @granit/authorization — permission checking, definitions, role grants",
       "exports": [
@@ -8138,6 +8155,23 @@
       ]
     },
     {
+      "name": "@granit/react-ui-authentication-keycloak",
+      "description": "Keycloak auth provider for Granit apps — wires @granit/react-authentication-keycloak's useKeycloakInit into the app's auth context, with locale-aware login and an init loading state. The Keycloak parallel to @granit/react-ui-authentication-local (which carries OpenIddict login pages; Keycloak hosts its own login, so this ships only the provider).",
+      "exports": [
+        {
+          "name": "KeycloakAuthProvider",
+          "kind": "function",
+          "signature": "function KeycloakAuthProvider("
+        },
+        {
+          "name": "KeycloakAuthProviderProps",
+          "kind": "interface",
+          "signature": "interface KeycloakAuthProviderProps",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/react-ui-authentication-local",
       "description": "Granit end-user authentication UI for the local (OpenIddict) provider — login (credentials, passkey, two-factor), registration, forgot/reset password, email confirmation and change-email pages. Composes the headless @granit/react-authentication-local and @granit/react-account data layers with the foundation UI packages.",
       "exports": [
@@ -8268,6 +8302,22 @@
           "name": "PermissionSideBadge",
           "kind": "function",
           "signature": "function PermissionSideBadge("
+        },
+        {
+          "name": "PermissionGuard",
+          "kind": "function",
+          "signature": "function PermissionGuard("
+        },
+        {
+          "name": "AccessDeniedPage",
+          "kind": "function",
+          "signature": "function AccessDeniedPage("
+        },
+        {
+          "name": "AccessDeniedPageProps",
+          "kind": "interface",
+          "signature": "interface AccessDeniedPageProps",
+          "members": []
         }
       ]
     },

--- a/packages/@granit/react-authentication-mock/README.md
+++ b/packages/@granit/react-authentication-mock/README.md
@@ -1,0 +1,24 @@
+# @granit/react-authentication-mock
+
+Mock auth provider for **development and tests** — it satisfies the app's auth
+context with a configurable fake user and no real IdP, so `useAuth()` resolves
+without Keycloak/BFF wiring. Optionally wraps the tree in a `BffProvider` so
+`useBffConfig` consumers (session cards, etc.) keep working against MSW-backed
+BFF endpoints.
+
+## Usage
+
+```tsx
+import { MockAuthProvider } from '@granit/react-authentication-mock';
+
+import { AuthContext } from './auth-context'; // your createAuthContext() instance
+import { MOCK_USER } from './mock-user'; // your demo user (app-owned)
+
+<MockAuthProvider context={AuthContext} user={MOCK_USER} bffConfig={{ pathPrefix: '/bff' }}>
+  <App />
+</MockAuthProvider>;
+```
+
+The app keeps owning its context instance and demo user; this package owns the
+reusable mechanism. Pattern-agnostic — choosing mock vs bff vs keycloak stays a
+host concern.

--- a/packages/@granit/react-authentication-mock/package.json
+++ b/packages/@granit/react-authentication-mock/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@granit/react-authentication-mock",
+  "description": "Mock auth provider for development and tests — satisfies the auth context with a configurable fake user and no real IdP (optionally wrapped in BffProvider so MSW-backed BFF endpoints still resolve).",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/authentication": "workspace:*",
+    "@granit/authentication-keycloak": "workspace:*",
+    "@granit/bff": "workspace:*",
+    "@granit/react-bff": "workspace:*",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/authentication": "workspace:*",
+    "@granit/authentication-keycloak": "workspace:*",
+    "@granit/bff": "workspace:*",
+    "@granit/react-bff": "workspace:*"
+  }
+}

--- a/packages/@granit/react-authentication-mock/src/index.ts
+++ b/packages/@granit/react-authentication-mock/src/index.ts
@@ -1,0 +1,1 @@
+export { MockAuthProvider, type MockAuthProviderProps } from './mock-auth-provider';

--- a/packages/@granit/react-authentication-mock/src/mock-auth-provider.tsx
+++ b/packages/@granit/react-authentication-mock/src/mock-auth-provider.tsx
@@ -1,0 +1,61 @@
+import { BffProvider } from '@granit/react-bff';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { KeycloakAuthContextType, KeycloakUserInfo } from '@granit/authentication-keycloak';
+import type { BffConfig } from '@granit/bff';
+import type { Context, ReactNode } from 'react';
+
+const noop = () => {};
+
+export interface MockAuthProviderProps {
+  /**
+   * The app's auth context (from `createAuthContext`). The provider fills it with
+   * a fake authenticated value so `useAuth()` resolves without a real IdP.
+   */
+  readonly context: Context<KeycloakAuthContextType | undefined>;
+  /** The fake signed-in user. */
+  readonly user: KeycloakUserInfo;
+  /**
+   * When set, the tree is wrapped in a `BffProvider` so `useBffConfig` consumers
+   * (e.g. session cards) work against MSW-backed BFF endpoints in mock mode.
+   */
+  readonly bffConfig?: BffConfig;
+  /** Artificial init delay (ms) before children render. Default 0 (immediate). */
+  readonly loadingMs?: number;
+  /** Rendered while the artificial delay elapses. Default `null`. */
+  readonly loadingFallback?: ReactNode;
+  readonly children: ReactNode;
+}
+
+/**
+ * Development / test auth provider. Pattern-agnostic and IdP-free: it satisfies
+ * the app's auth context with a configurable fake user and no-op login/logout.
+ * The app keeps owning its context instance and demo user; this package owns the
+ * reusable mechanism.
+ */
+export function MockAuthProvider({
+  context: AuthContext,
+  user,
+  bffConfig,
+  loadingMs = 0,
+  loadingFallback = null,
+  children,
+}: MockAuthProviderProps) {
+  const [loading, setLoading] = useState(loadingMs > 0);
+
+  useEffect(() => {
+    if (loadingMs <= 0) return undefined;
+    const timer = setTimeout(() => setLoading(false), loadingMs);
+    return () => clearTimeout(timer);
+  }, [loadingMs]);
+
+  const value = useMemo<KeycloakAuthContextType>(
+    () => ({ keycloak: null, authenticated: true, loading, user, login: noop, logout: noop }),
+    [loading, user]
+  );
+
+  if (loading) return <>{loadingFallback}</>;
+
+  const tree = <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  return bffConfig ? <BffProvider config={bffConfig}>{tree}</BffProvider> : tree;
+}

--- a/packages/@granit/react-authentication-mock/tsconfig.json
+++ b/packages/@granit/react-authentication-mock/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/@granit/react-authentication-mock/tsup.config.ts
+++ b/packages/@granit/react-authentication-mock/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-ui-authentication-keycloak/README.md
+++ b/packages/@granit/react-ui-authentication-keycloak/README.md
@@ -1,0 +1,28 @@
+# @granit/react-ui-authentication-keycloak
+
+The **Keycloak auth provider** for Granit apps. Wires
+[`@granit/react-authentication-keycloak`](../react-authentication-keycloak)'s
+`useKeycloakInit` into the app's auth context, forwards the active UI locale to
+the IdP login, and shows an init spinner until the session resolves.
+
+The Keycloak parallel to [`@granit/react-ui-authentication-local`](../react-ui-authentication-local):
+the local package carries the OpenIddict **login pages**; Keycloak hosts its own
+login UI, so this package ships only the **provider**.
+
+## Usage
+
+```tsx
+import { KeycloakAuthProvider } from '@granit/react-ui-authentication-keycloak';
+
+import { AuthContext } from './auth-context'; // your createAuthContext() instance
+
+<KeycloakAuthProvider
+  context={AuthContext}
+  config={{ url: KEYCLOAK_URL, realm: KEYCLOAK_REALM, clientId: KEYCLOAK_CLIENT_ID }}
+>
+  <App />
+</KeycloakAuthProvider>;
+```
+
+The app owns its context instance and decides — via its auth-mode — whether to
+mount this provider; the package owns the reusable wiring.

--- a/packages/@granit/react-ui-authentication-keycloak/package.json
+++ b/packages/@granit/react-ui-authentication-keycloak/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@granit/react-ui-authentication-keycloak",
+  "description": "Keycloak auth provider for Granit apps — wires @granit/react-authentication-keycloak's useKeycloakInit into the app's auth context, with locale-aware login and an init loading state. The Keycloak parallel to @granit/react-ui-authentication-local (which carries OpenIddict login pages; Keycloak hosts its own login, so this ships only the provider).",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/authentication": "workspace:*",
+    "@granit/authentication-keycloak": "workspace:*",
+    "@granit/react-authentication-keycloak": "workspace:*",
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/authentication": "workspace:*",
+    "@granit/authentication-keycloak": "workspace:*",
+    "@granit/react-authentication-keycloak": "workspace:*",
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*"
+  }
+}

--- a/packages/@granit/react-ui-authentication-keycloak/src/index.ts
+++ b/packages/@granit/react-ui-authentication-keycloak/src/index.ts
@@ -1,0 +1,1 @@
+export { KeycloakAuthProvider, type KeycloakAuthProviderProps } from './keycloak-auth-provider';

--- a/packages/@granit/react-ui-authentication-keycloak/src/keycloak-auth-provider.tsx
+++ b/packages/@granit/react-ui-authentication-keycloak/src/keycloak-auth-provider.tsx
@@ -1,0 +1,66 @@
+import { useKeycloakInit } from '@granit/react-authentication-keycloak';
+import { useTranslation } from '@granit/react-localization';
+import { Spinner } from '@granit/react-ui';
+import { useCallback, useMemo } from 'react';
+
+import type { KeycloakAuthContextType, KeycloakCoreConfig } from '@granit/authentication-keycloak';
+import type { Context, ReactNode } from 'react';
+
+export interface KeycloakAuthProviderProps {
+  /**
+   * The app's auth context (from `createAuthContext`). The provider fills it with
+   * the live Keycloak session so `useAuth()` resolves.
+   */
+  readonly context: Context<KeycloakAuthContextType | undefined>;
+  /**
+   * Keycloak core config (`url` / `realm` / `clientId` + optional lifecycle
+   * callbacks). The host supplies these from its environment.
+   */
+  readonly config: KeycloakCoreConfig;
+  readonly children: ReactNode;
+}
+
+/**
+ * Keycloak auth provider. Wires `useKeycloakInit` into the app's auth context,
+ * forwards the active UI locale to the IdP login, and renders an init spinner
+ * until the session resolves. App-agnostic: the host owns its context instance
+ * and decides (via its auth-mode) whether to mount this provider.
+ */
+export function KeycloakAuthProvider({
+  context: AuthContext,
+  config,
+  children,
+}: KeycloakAuthProviderProps) {
+  const { t, i18n } = useTranslation();
+  const {
+    keycloak,
+    authenticated,
+    loading,
+    user,
+    login: hookLogin,
+    logout: hookLogout,
+  } = useKeycloakInit(config);
+
+  const login = useCallback(() => hookLogin({ locale: i18n.language }), [hookLogin, i18n.language]);
+  const logout = useCallback(() => hookLogout(), [hookLogout]);
+
+  const value = useMemo<KeycloakAuthContextType>(
+    () => ({ keycloak, authenticated, loading, user, login, logout }),
+    [keycloak, authenticated, loading, user, login, logout]
+  );
+
+  if (loading) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-background">
+        <div className="flex flex-col items-center">
+          <Spinner size="lg" className="mb-4" />
+          <p className="text-sm font-medium text-muted-foreground">
+            {t('Auth.Initializing', 'Initializing…')}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/packages/@granit/react-ui-authentication-keycloak/tsconfig.json
+++ b/packages/@granit/react-ui-authentication-keycloak/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/@granit/react-ui-authentication-keycloak/tsup.config.ts
+++ b/packages/@granit/react-ui-authentication-keycloak/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-ui-authorization/src/__tests__/access-denied-page.test.tsx
+++ b/packages/@granit/react-ui-authorization/src/__tests__/access-denied-page.test.tsx
@@ -1,0 +1,31 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { AccessDeniedPage } from '../components/access-denied-page';
+
+import { renderAuthorization } from './test-utils';
+
+describe('AccessDeniedPage', () => {
+  it('renders the title and the access-denied message', () => {
+    renderAuthorization(<AccessDeniedPage />);
+    expect(screen.getByText('Access Denied')).toBeInTheDocument();
+    expect(
+      screen.getByText('You do not have the required permissions to access this page.')
+    ).toBeInTheDocument();
+  });
+
+  it('shows the connected email when provided', () => {
+    renderAuthorization(<AccessDeniedPage userEmail="marie@granit.test" />);
+    expect(screen.getByText('marie@granit.test')).toBeInTheDocument();
+  });
+
+  it('renders the sign-out button only when onSignOut is given and calls it', async () => {
+    const onSignOut = vi.fn();
+    const { rerender } = renderAuthorization(<AccessDeniedPage />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+
+    rerender(<AccessDeniedPage onSignOut={onSignOut} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Switch account' }));
+    expect(onSignOut).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/@granit/react-ui-authorization/src/__tests__/permission-guard.test.tsx
+++ b/packages/@granit/react-ui-authorization/src/__tests__/permission-guard.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+
+import { PermissionGuard } from '../components/permission-guard';
+
+let perms = { hasPermission: (_p: string) => true, isLoading: false };
+vi.mock('@granit/react-authorization', () => ({
+  usePermissions: () => perms,
+}));
+
+describe('PermissionGuard', () => {
+  it('renders children when the permission is granted', () => {
+    perms = { hasPermission: () => true, isLoading: false };
+    render(
+      <PermissionGuard permission="X.Read">
+        <div>secret</div>
+      </PermissionGuard>
+    );
+    expect(screen.getByText('secret')).toBeInTheDocument();
+  });
+
+  it('renders the fallback when denied', () => {
+    perms = { hasPermission: () => false, isLoading: false };
+    render(
+      <PermissionGuard permission="X.Read" fallback={<div>denied</div>}>
+        <div>secret</div>
+      </PermissionGuard>
+    );
+    expect(screen.getByText('denied')).toBeInTheDocument();
+    expect(screen.queryByText('secret')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing while loading (deny-by-default)', () => {
+    perms = { hasPermission: () => true, isLoading: true };
+    const { container } = render(
+      <PermissionGuard permission="X.Read">
+        <div>secret</div>
+      </PermissionGuard>
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/@granit/react-ui-authorization/src/components/access-denied-page.tsx
+++ b/packages/@granit/react-ui-authorization/src/components/access-denied-page.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from '@granit/react-localization';
+import { Button } from '@granit/react-ui';
+import { ShieldX } from 'lucide-react';
+
+export interface AccessDeniedPageProps {
+  /** Email of the signed-in user, shown as "Connected as …" (optional). */
+  readonly userEmail?: string;
+  /** Sign-out / switch-account action; the button is hidden when absent. */
+  readonly onSignOut?: () => void;
+}
+
+/**
+ * Full-screen 403 page. App-agnostic: the host injects the current user's email
+ * and the sign-out action (the app owns its auth context), so this stays free of
+ * any `useAuth` dependency.
+ */
+export function AccessDeniedPage({ userEmail, onSignOut }: AccessDeniedPageProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      data-slot="access-denied-page"
+      className="flex min-h-screen items-center justify-center bg-background px-4"
+    >
+      <div className="w-full max-w-md text-center">
+        <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-alert-500/10">
+          <ShieldX className="h-10 w-10 text-alert-600" aria-hidden="true" />
+        </div>
+
+        <h1 className="mb-2 text-2xl font-semibold text-foreground">
+          {t('Auth.AccessDenied.Title')}
+        </h1>
+
+        {userEmail && (
+          <p className="mb-4 text-sm text-muted-foreground">
+            {t('Auth.AccessDenied.ConnectedAs', 'Connected as')}{' '}
+            <span className="font-medium">{userEmail}</span>
+          </p>
+        )}
+
+        <p className="mb-2 text-muted-foreground">{t('Auth.AccessDeniedMessage')}</p>
+        <p className="mb-8 text-sm text-muted-foreground">{t('Auth.AccessDeniedContact')}</p>
+
+        {onSignOut && (
+          <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+            <Button variant="outline" onClick={onSignOut}>
+              {t('Auth.SwitchAccount')}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-authorization/src/components/permission-guard.tsx
+++ b/packages/@granit/react-ui-authorization/src/components/permission-guard.tsx
@@ -1,0 +1,26 @@
+import { usePermissions } from '@granit/react-authorization';
+
+import type { ReactNode } from 'react';
+
+interface PermissionGuardProps {
+  readonly permission: string;
+  readonly children: ReactNode;
+  readonly fallback?: ReactNode;
+}
+
+/**
+ * Renders children only when the current user holds `permission`.
+ *
+ * Returns `null` while permissions are loading (deny-by-default). Renders the
+ * optional `fallback` when the permission is not granted. Reads the headless
+ * `usePermissions` from `@granit/react-authorization`, so it works in any app
+ * that mounts an authorization provider — no app coupling.
+ */
+export function PermissionGuard({ permission, children, fallback = null }: PermissionGuardProps) {
+  const { hasPermission, isLoading } = usePermissions();
+
+  if (isLoading) return null;
+  if (!hasPermission(permission)) return <>{fallback}</>;
+
+  return <>{children}</>;
+}

--- a/packages/@granit/react-ui-authorization/src/index.ts
+++ b/packages/@granit/react-ui-authorization/src/index.ts
@@ -10,6 +10,8 @@ export { RoleMetadataPage } from './role-metadata-page';
 export { RolePermissionsPanel } from './components/role-permissions-panel';
 export type { RolePermissionsPanelProps } from './components/role-permissions-panel';
 export { PermissionSideBadge } from './components/permission-side-badge';
+export { PermissionGuard } from './components/permission-guard';
+export { AccessDeniedPage, type AccessDeniedPageProps } from './components/access-denied-page';
 
 // i18next resource bundles (flat keys, "translation" ns)
 export { authorizationTranslationsEn, authorizationTranslationsFr } from './locales/index';

--- a/packages/@granit/react-ui-authorization/src/locales/en.ts
+++ b/packages/@granit/react-ui-authorization/src/locales/en.ts
@@ -4,6 +4,11 @@
 //   i18n.addResourceBundle("en", "translation", authorizationTranslationsEn, true, true);
 
 export const authorizationTranslationsEn = {
+  'Auth.AccessDenied.ConnectedAs': 'Connected as',
+  'Auth.AccessDenied.Title': 'Access Denied',
+  'Auth.AccessDeniedContact': 'Please contact your system administrator to request access.',
+  'Auth.AccessDeniedMessage': 'You do not have the required permissions to access this page.',
+  'Auth.SwitchAccount': 'Switch account',
   'PermissionGrants.Columns.Created': 'Created',
   'PermissionGrants.Columns.Permission': 'Permission',
   'PermissionGrants.Columns.Provider': 'Provider',

--- a/packages/@granit/react-ui-authorization/src/locales/fr.ts
+++ b/packages/@granit/react-ui-authorization/src/locales/fr.ts
@@ -1,6 +1,13 @@
 // @granit/react-ui-authorization — French resource bundle (flat keys, "translation" ns).
 
 export const authorizationTranslationsFr = {
+  'Auth.AccessDenied.ConnectedAs': 'Connecté en tant que',
+  'Auth.AccessDenied.Title': 'Accès refusé',
+  'Auth.AccessDeniedContact':
+    "Veuillez contacter votre administrateur système pour demander l'accès.",
+  'Auth.AccessDeniedMessage':
+    'Vous ne disposez pas des permissions requises pour accéder à cette page.',
+  'Auth.SwitchAccount': 'Changer de compte',
   'PermissionGrants.Columns.Created': 'Créé le',
   'PermissionGrants.Columns.Permission': 'Permission',
   'PermissionGrants.Columns.Provider': 'Fournisseur',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1583,6 +1583,25 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/react-authentication-mock:
+    dependencies:
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+    devDependencies:
+      '@granit/authentication':
+        specifier: workspace:*
+        version: link:../authentication
+      '@granit/authentication-keycloak':
+        specifier: workspace:*
+        version: link:../authentication-keycloak
+      '@granit/bff':
+        specifier: workspace:*
+        version: link:../bff
+      '@granit/react-bff':
+        specifier: workspace:*
+        version: link:../react-bff
+
   packages/@granit/react-authorization:
     dependencies:
       '@granit/authorization':
@@ -3913,6 +3932,28 @@ importers:
       storybook:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
+  packages/@granit/react-ui-authentication-keycloak:
+    dependencies:
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+    devDependencies:
+      '@granit/authentication':
+        specifier: workspace:*
+        version: link:../authentication
+      '@granit/authentication-keycloak':
+        specifier: workspace:*
+        version: link:../authentication-keycloak
+      '@granit/react-authentication-keycloak':
+        specifier: workspace:*
+        version: link:../react-authentication-keycloak
+      '@granit/react-localization':
+        specifier: workspace:*
+        version: link:../react-localization
+      '@granit/react-ui':
+        specifier: workspace:*
+        version: link:../react-ui
 
   packages/@granit/react-ui-authentication-local:
     dependencies:


### PR DESCRIPTION
## What

Follow-up to the domain-UI backfill: pull the genuinely-reusable pieces out of the showcase's
`authentication` app-shell, leaving only true app composition (auth-mode env, the real provider
selection, the per-app `createAuthContext` instance, demo user, branded login).

| Piece | New home | Injection |
|---|---|---|
| `PermissionGuard` | `@granit/react-ui-authorization` | none — gates on headless `usePermissions` |
| `AccessDeniedPage` | `@granit/react-ui-authorization` | `userEmail` + `onSignOut` props |
| `MockAuthProvider` | **`@granit/react-authentication-mock`** (new headless) | app passes `context` + `user` (+ optional `bffConfig`) |
| `KeycloakAuthProvider` | **`@granit/react-ui-authentication-keycloak`** (new) | app passes `context` + Keycloak `config` |

## Design

- The providers populate the app's `createAuthContext()` instance, so each takes that `context`
  as a prop — the app keeps choosing *which* provider to mount via its `auth-mode`. No package
  references BFF/mock/keycloak as a default; the pattern stays a host decision.
- `react-authentication-mock` is headless (no react-ui dep): renders an optional `loadingFallback`,
  no baked-in spinner. `react-ui-authentication-keycloak` is the Keycloak parallel to
  `react-ui-authentication-local` (local ships login *pages*; Keycloak hosts its own login UI, so
  this ships only the provider, with its init spinner).
- `AccessDeniedPage` ships its `Auth.AccessDenied.*` / `Auth.SwitchAccount` strings in the
  authorization bundle.

## Verification

- `tsc --noEmit` clean on all 3 packages.
- `eslint --max-warnings 0` clean.
- Arch-tests: **2840 passed**. New authz component tests: **+6**.

The showcase MR (re-points the guard/403, wraps the mock + keycloak providers, deletes the moved
code) stays in Draft until this merges.