### PR TITLE
test(react-ui): backfill coverage for batch-8 + batch-9 packages to ≥80%

### DIFF
--- a/packages/@granit/react-authentication-mock/src/__tests__/mock-auth-provider.test.tsx
+++ b/packages/@granit/react-authentication-mock/src/__tests__/mock-auth-provider.test.tsx
@@ -1,0 +1,189 @@
+import { createAuthContext } from '@granit/react-authentication';
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MockAuthProvider } from '../mock-auth-provider';
+
+import type { KeycloakAuthContextType, KeycloakUserInfo } from '@granit/authentication-keycloak';
+import type { BffConfig } from '@granit/bff';
+import type { ReactNode } from 'react';
+
+const { AuthContext, useAuth } = createAuthContext<KeycloakAuthContextType>();
+
+const demoUser: KeycloakUserInfo = {
+  sub: 'user-123',
+  name: 'Ada Lovelace',
+  preferred_username: 'ada',
+  email: 'ada@example.com',
+};
+
+function wrapperFor(props?: Partial<Omit<Parameters<typeof MockAuthProvider>[0], 'children'>>) {
+  return ({ children }: { children: ReactNode }) => (
+    <MockAuthProvider context={AuthContext} user={demoUser} {...props}>
+      {children}
+    </MockAuthProvider>
+  );
+}
+
+describe('MockAuthProvider', () => {
+  it('provides a fake authenticated context value immediately (no delay)', () => {
+    const { result } = renderHook(() => useAuth(), { wrapper: wrapperFor() });
+
+    expect(result.current.authenticated).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.keycloak).toBeNull();
+    expect(result.current.user).toEqual(demoUser);
+  });
+
+  it('exposes no-op login/logout callbacks that do not throw', () => {
+    const { result } = renderHook(() => useAuth(), { wrapper: wrapperFor() });
+
+    expect(typeof result.current.login).toBe('function');
+    expect(typeof result.current.logout).toBe('function');
+    expect(() => {
+      result.current.login();
+      result.current.logout();
+    }).not.toThrow();
+  });
+
+  it('renders children when not loading', () => {
+    render(
+      <MockAuthProvider context={AuthContext} user={demoUser}>
+        <span data-testid="child">visible</span>
+      </MockAuthProvider>
+    );
+
+    expect(screen.getByTestId('child')).toBeTruthy();
+  });
+
+  it('honours a custom user object', () => {
+    const customUser: KeycloakUserInfo = { sub: 'other-9', name: 'Grace Hopper' };
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: wrapperFor({ user: customUser }),
+    });
+
+    expect(result.current.user).toEqual(customUser);
+  });
+
+  describe('artificial loading delay', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    });
+
+    it('shows the loadingFallback while the delay elapses, then the children', () => {
+      render(
+        <MockAuthProvider
+          context={AuthContext}
+          user={demoUser}
+          loadingMs={500}
+          loadingFallback={<span data-testid="spinner">loading…</span>}
+        >
+          <span data-testid="child">ready</span>
+        </MockAuthProvider>
+      );
+
+      // Before the timer fires: fallback shown, children hidden.
+      expect(screen.getByTestId('spinner')).toBeTruthy();
+      expect(screen.queryByTestId('child')).toBeNull();
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      // After the delay: children rendered, fallback gone.
+      expect(screen.getByTestId('child')).toBeTruthy();
+      expect(screen.queryByTestId('spinner')).toBeNull();
+    });
+
+    it('renders null fallback by default while loading', () => {
+      const { container } = render(
+        <MockAuthProvider context={AuthContext} user={demoUser} loadingMs={200}>
+          <span data-testid="child">ready</span>
+        </MockAuthProvider>
+      );
+
+      expect(screen.queryByTestId('child')).toBeNull();
+      expect(container).toBeTruthy();
+
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(screen.getByTestId('child')).toBeTruthy();
+    });
+
+    it('clears the timer on unmount without firing', () => {
+      const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+      const { unmount } = render(
+        <MockAuthProvider context={AuthContext} user={demoUser} loadingMs={300}>
+          <span data-testid="child">ready</span>
+        </MockAuthProvider>
+      );
+
+      unmount();
+      expect(clearSpy).toHaveBeenCalled();
+      clearSpy.mockRestore();
+    });
+  });
+
+  describe('BFF wrapping', () => {
+    beforeEach(() => {
+      // BffProvider performs a `/bff/user` fetch on mount; stub it so the tree
+      // mounts cleanly without hitting the network.
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
+      );
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('does not wrap in BffProvider when bffConfig is absent', () => {
+      render(
+        <MockAuthProvider context={AuthContext} user={demoUser}>
+          <span data-testid="child">no-bff</span>
+        </MockAuthProvider>
+      );
+
+      expect(screen.getByTestId('child')).toBeTruthy();
+      // No BFF session fetch should have been triggered.
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('wraps the tree in BffProvider when bffConfig is provided', async () => {
+      const bffConfig: BffConfig = { pathPrefix: '/admin', sessionCheckInterval: 0 };
+
+      render(
+        <MockAuthProvider context={AuthContext} user={demoUser} bffConfig={bffConfig}>
+          <span data-testid="child">with-bff</span>
+        </MockAuthProvider>
+      );
+
+      expect(screen.getByTestId('child')).toBeTruthy();
+      await waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledWith(
+          '/admin/bff/user',
+          expect.objectContaining({ credentials: 'include' })
+        );
+      });
+    });
+
+    it('still provides the auth context value through the BffProvider wrapper', async () => {
+      const bffConfig: BffConfig = { pathPrefix: '', sessionCheckInterval: 0 };
+      const { result } = renderHook(() => useAuth(), {
+        wrapper: wrapperFor({ bffConfig }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.authenticated).toBe(true);
+      });
+      expect(result.current.user).toEqual(demoUser);
+    });
+  });
+});

--- a/packages/@granit/react-ui-account/src/__tests__/delete-account-error.test.tsx
+++ b/packages/@granit/react-ui-account/src/__tests__/delete-account-error.test.tsx
@@ -1,0 +1,59 @@
+import { screen, waitFor } from '@testing-library/react';
+
+import { DeleteAccountPage } from '../delete-account-page';
+
+import { renderWithProviders } from './test-utils';
+
+// ---------------------------------------------------------------------------
+// Delete-account error path: a failed deletion flags the password field as
+// invalid (the catch branch the happy-path test does not reach).
+// ---------------------------------------------------------------------------
+
+const { mockMutateAsync } = vi.hoisted(() => ({
+  mockMutateAsync: vi.fn(),
+}));
+
+vi.mock('@granit/react-account', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useDeleteAccount: () => ({ mutateAsync: mockMutateAsync, isPending: false }),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('DeleteAccountPage — error path', () => {
+  it('should flag the password field invalid when deletion fails', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('wrong password'));
+    const { user } = renderWithProviders(<DeleteAccountPage />);
+
+    await user.click(screen.getByRole('button', { name: /delete account/i }));
+    const password = await screen.findByLabelText('Current password');
+    await user.type(password, 'wrong');
+    await user.click(screen.getByRole('button', { name: 'Delete my account' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Incorrect password.')).toBeInTheDocument();
+    });
+    expect(password).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('should clear the error flag when the password is edited again', async () => {
+    mockMutateAsync.mockRejectedValue(new Error('wrong password'));
+    const { user } = renderWithProviders(<DeleteAccountPage />);
+
+    await user.click(screen.getByRole('button', { name: /delete account/i }));
+    const password = await screen.findByLabelText('Current password');
+    await user.type(password, 'wrong');
+    await user.click(screen.getByRole('button', { name: 'Delete my account' }));
+    await screen.findByText('Incorrect password.');
+
+    await user.type(password, 'x');
+    await waitFor(() => {
+      expect(screen.queryByText('Incorrect password.')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/@granit/react-ui-account/src/__tests__/passkeys-flows.test.tsx
+++ b/packages/@granit/react-ui-account/src/__tests__/passkeys-flows.test.tsx
@@ -1,0 +1,261 @@
+import { mockPasskeys } from '@granit/react-account/testing';
+import { screen, waitFor } from '@testing-library/react';
+
+import { PasskeysPage } from '../security/passkeys-page';
+
+import { renderWithProviders } from './test-utils';
+
+// ---------------------------------------------------------------------------
+// Interactive passkey flows: register (success / cancel / WebAuthn error),
+// rename and delete. The WebAuthn dance is stubbed via navigator.credentials
+// and a mocked fromBase64Url; mutations are vi.hoisted so payloads assert.
+// ---------------------------------------------------------------------------
+
+const {
+  mockUsePasskeys,
+  mockBeginRegistration,
+  mockCompleteRegistration,
+  mockDeletePasskey,
+  mockRenamePasskey,
+  mockIsAxiosError,
+} = vi.hoisted(() => ({
+  mockUsePasskeys: vi.fn(),
+  mockBeginRegistration: vi.fn(),
+  mockCompleteRegistration: vi.fn(),
+  mockDeletePasskey: vi.fn(),
+  mockRenamePasskey: vi.fn(),
+  mockIsAxiosError: vi.fn(() => false),
+}));
+
+vi.mock('@granit/react-account', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    usePasskeys: mockUsePasskeys,
+    useBeginPasskeyRegistration: () => ({ mutateAsync: mockBeginRegistration, isPending: false }),
+    useCompletePasskeyRegistration: () => ({
+      mutateAsync: mockCompleteRegistration,
+      isPending: false,
+    }),
+    useDeletePasskey: () => ({ mutateAsync: mockDeletePasskey, isPending: false }),
+    useRenamePasskey: () => ({ mutateAsync: mockRenamePasskey, isPending: false }),
+  };
+});
+
+vi.mock('@granit/api-client', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, isAxiosError: mockIsAxiosError };
+});
+
+vi.mock('@granit/react-ui-authentication-local', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, fromBase64Url: (s: string) => new TextEncoder().encode(s) };
+});
+
+const registrationOptionsJson = JSON.stringify({
+  challenge: 'Y2hhbGxlbmdl',
+  user: { id: 'dXNlcg', name: 'alice', displayName: 'Alice' },
+  rp: { id: 'example.com', name: 'Example' },
+  pubKeyCredParams: [],
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAxiosError.mockReturnValue(false);
+  vi.stubGlobal('PublicKeyCredential', function PublicKeyCredential() {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('PasskeysPage — registration', () => {
+  it('should run the full register flow and call complete with the credential', async () => {
+    mockUsePasskeys.mockReturnValue({ data: [], isLoading: false });
+    mockBeginRegistration.mockResolvedValue(registrationOptionsJson);
+    const create = vi.fn().mockResolvedValue({ id: 'cred-1', type: 'public-key' });
+    vi.stubGlobal('navigator', { credentials: { create } });
+    mockCompleteRegistration.mockResolvedValue(undefined);
+    const { user } = renderWithProviders(<PasskeysPage />);
+
+    await user.click(screen.getByRole('button', { name: /add passkey/i }));
+    const nameInput = screen.getByLabelText('Name (optional)');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'YubiKey');
+    await user.click(screen.getByRole('button', { name: 'Register passkey' }));
+
+    await waitFor(() => expect(mockBeginRegistration).toHaveBeenCalledTimes(1));
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(mockCompleteRegistration).toHaveBeenCalledWith({
+      credentialJson: JSON.stringify({ id: 'cred-1', type: 'public-key' }),
+      name: 'YubiKey',
+    });
+  });
+
+  it('should send an undefined name when the field is left blank', async () => {
+    mockUsePasskeys.mockReturnValue({ data: [], isLoading: false });
+    mockBeginRegistration.mockResolvedValue(registrationOptionsJson);
+    const create = vi.fn().mockResolvedValue({ id: 'cred-2', type: 'public-key' });
+    vi.stubGlobal('navigator', { credentials: { create } });
+    mockCompleteRegistration.mockResolvedValue(undefined);
+    const { user } = renderWithProviders(<PasskeysPage />);
+
+    await user.click(screen.getByRole('button', { name: /add passkey/i }));
+    await user.clear(screen.getByLabelText('Name (optional)'));
+    await user.click(screen.getByRole('button', { name: 'Register passkey' }));
+
+    await waitFor(() => expect(mockCompleteRegistration).toHaveBeenCalledTimes(1));
+    expect(mockCompleteRegistration).toHaveBeenCalledWith({
+      credentialJson: JSON.stringify({ id: 'cred-2', type: 'public-key' }),
+      name: undefined,
+    });
+  });
+
+  it('should not complete when the user cancels the WebAuthn prompt', async () => {
+    mockUsePasskeys.mockReturnValue({ data: [], isLoading: false });
+    mockBeginRegistration.mockResolvedValue(registrationOptionsJson);
+    const create = vi.fn().mockResolvedValue(null);
+    vi.stubGlobal('navigator', { credentials: { create } });
+    const { user } = renderWithProviders(<PasskeysPage />);
+
+    await user.click(screen.getByRole('button', { name: /add passkey/i }));
+    await user.click(screen.getByRole('button', { name: 'Register passkey' }));
+
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+    expect(mockCompleteRegistration).not.toHaveBeenCalled();
+  });
+
+  it('should surface a non-Axios WebAuthn failure', async () => {
+    mockUsePasskeys.mockReturnValue({ data: [], isLoading: false });
+    mockBeginRegistration.mockResolvedValue(registrationOptionsJson);
+    const create = vi.fn().mockRejectedValue(new Error('NotAllowedError'));
+    vi.stubGlobal('navigator', { credentials: { create } });
+    mockIsAxiosError.mockReturnValue(false);
+    const { user } = renderWithProviders(<PasskeysPage />);
+
+    await user.click(screen.getByRole('button', { name: /add passkey/i }));
+    await user.click(screen.getByRole('button', { name: 'Register passkey' }));
+
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+    expect(mockCompleteRegistration).not.toHaveBeenCalled();
+  });
+
+  it('should not surface its own toast for an Axios error', async () => {
+    mockUsePasskeys.mockReturnValue({ data: [], isLoading: false });
+    mockBeginRegistration.mockRejectedValue(new Error('500'));
+    mockIsAxiosError.mockReturnValue(true);
+    const { user } = renderWithProviders(<PasskeysPage />);
+
+    await user.click(screen.getByRole('button', { name: /add passkey/i }));
+    await user.click(screen.getByRole('button', { name: 'Register passkey' }));
+
+    await waitFor(() => expect(mockBeginRegistration).toHaveBeenCalledTimes(1));
+    expect(mockIsAxiosError).toHaveBeenCalled();
+  });
+
+  it('should close the register form when Cancel is clicked', async () => {
+    mockUsePasskeys.mockReturnValue({ data: [], isLoading: false });
+    const { user } = renderWithProviders(<PasskeysPage />);
+
+    await user.click(screen.getByRole('button', { name: /add passkey/i }));
+    expect(screen.getByText('Register a new passkey')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByText('Register a new passkey')).not.toBeInTheDocument();
+  });
+});
+
+describe('PasskeysPage — list, rename and delete', () => {
+  it('should show the loading spinner while passkeys load', () => {
+    mockUsePasskeys.mockReturnValue({ data: undefined, isLoading: true });
+    renderWithProviders(<PasskeysPage />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('should render fixture passkeys including a last-used timestamp', () => {
+    mockUsePasskeys.mockReturnValue({ data: mockPasskeys, isLoading: false });
+    renderWithProviders(<PasskeysPage />);
+
+    expect(screen.getByText(mockPasskeys[0]!.name!)).toBeInTheDocument();
+    expect(screen.getByText(mockPasskeys[1]!.name!)).toBeInTheDocument();
+  });
+
+  it('should rename a passkey via the dialog', async () => {
+    mockUsePasskeys.mockReturnValue({ data: mockPasskeys, isLoading: false });
+    mockRenamePasskey.mockResolvedValue(undefined);
+    const { user } = renderWithProviders(<PasskeysPage />);
+
+    await user.click(screen.getAllByRole('button', { name: 'Rename' })[0]!);
+    const dialogNameInput = await screen.findByLabelText('Name');
+    await user.clear(dialogNameInput);
+    await user.type(dialogNameInput, 'Renamed key');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(mockRenamePasskey).toHaveBeenCalledWith({
+      id: mockPasskeys[0]!.id,
+      request: { name: 'Renamed key' },
+    });
+  });
+
+  it('should swallow a rename error', async () => {
+    mockUsePasskeys.mockReturnValue({ data: mockPasskeys, isLoading: false });
+    mockRenamePasskey.mockRejectedValue(new Error('conflict'));
+    const { user } = renderWithProviders(<PasskeysPage />);
+
+    await user.click(screen.getAllByRole('button', { name: 'Rename' })[0]!);
+    await screen.findByLabelText('Name');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(mockRenamePasskey).toHaveBeenCalledTimes(1));
+  });
+
+  it('should close the rename dialog via Cancel', async () => {
+    mockUsePasskeys.mockReturnValue({ data: mockPasskeys, isLoading: false });
+    const { user } = renderWithProviders(<PasskeysPage />);
+
+    await user.click(screen.getAllByRole('button', { name: 'Rename' })[0]!);
+    await screen.findByText('Rename passkey');
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Rename passkey')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should delete a passkey via the confirm dialog', async () => {
+    mockUsePasskeys.mockReturnValue({ data: mockPasskeys, isLoading: false });
+    mockDeletePasskey.mockResolvedValue(undefined);
+    const { user } = renderWithProviders(<PasskeysPage />);
+
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+    await screen.findByText('Remove passkey');
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(mockDeletePasskey).toHaveBeenCalledWith(mockPasskeys[0]!.id);
+  });
+
+  it('should swallow a delete error', async () => {
+    mockUsePasskeys.mockReturnValue({ data: mockPasskeys, isLoading: false });
+    mockDeletePasskey.mockRejectedValue(new Error('boom'));
+    const { user } = renderWithProviders(<PasskeysPage />);
+
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+    await screen.findByText('Remove passkey');
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(mockDeletePasskey).toHaveBeenCalledTimes(1));
+  });
+
+  it('should close the delete dialog via Cancel', async () => {
+    mockUsePasskeys.mockReturnValue({ data: mockPasskeys, isLoading: false });
+    const { user } = renderWithProviders(<PasskeysPage />);
+
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+    await screen.findByText('Remove passkey');
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Remove passkey')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/@granit/react-ui-account/src/__tests__/profile-edit.test.tsx
+++ b/packages/@granit/react-ui-account/src/__tests__/profile-edit.test.tsx
@@ -1,0 +1,90 @@
+import { mockProfile } from '@granit/react-account/testing';
+import { screen, waitFor } from '@testing-library/react';
+
+import { ProfilePage } from '../profile-page';
+
+import { renderWithProviders } from './test-utils';
+
+// ---------------------------------------------------------------------------
+// Profile edit flow: field edits, cancel, and the save error path. Render-only
+// states are covered by the co-located ProfilePage test; this file drives the
+// editable form to exercise the onChange handlers and the catch branch.
+// ---------------------------------------------------------------------------
+
+const { mockUseProfile, mockUpdate } = vi.hoisted(() => ({
+  mockUseProfile: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock('@granit/react-account', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useProfile: mockUseProfile,
+    useUpdateProfile: () => ({ mutateAsync: mockUpdate, isPending: false }),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseProfile.mockReturnValue({ data: mockProfile, isLoading: false });
+});
+
+describe('ProfilePage — edit flow', () => {
+  it('should edit both names and save the new values', async () => {
+    mockUpdate.mockResolvedValue(undefined);
+    const { user } = renderWithProviders(<ProfilePage />);
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const firstName = await screen.findByLabelText('First name');
+    const lastName = screen.getByLabelText('Last name');
+    await user.clear(firstName);
+    await user.type(firstName, 'Grace');
+    await user.clear(lastName);
+    await user.type(lastName, 'Hopper');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(mockUpdate).toHaveBeenCalledWith({ firstName: 'Grace', lastName: 'Hopper' });
+  });
+
+  it('should leave edit mode and discard edits on cancel', async () => {
+    const { user } = renderWithProviders(<ProfilePage />);
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    const firstName = await screen.findByLabelText('First name');
+    await user.clear(firstName);
+    await user.type(firstName, 'Temporary');
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('First name')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText('Temporary')).not.toBeInTheDocument();
+    expect(screen.getByText(mockProfile.firstName!)).toBeInTheDocument();
+  });
+
+  it('should stay in edit mode when the save mutation fails', async () => {
+    mockUpdate.mockRejectedValue(new Error('server error'));
+    const { user } = renderWithProviders(<ProfilePage />);
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    await screen.findByLabelText('First name');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(screen.getByLabelText('First name')).toBeInTheDocument();
+  });
+
+  it('should render an em dash placeholder for empty name fields', () => {
+    mockUseProfile.mockReturnValue({
+      data: { ...mockProfile, firstName: '', lastName: '', emailConfirmed: false },
+      isLoading: false,
+    });
+    renderWithProviders(<ProfilePage />);
+
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+    // emailConfirmed: false → "No"
+    expect(screen.getByText('No')).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-account/src/__tests__/two-factor-flows.test.tsx
+++ b/packages/@granit/react-ui-account/src/__tests__/two-factor-flows.test.tsx
@@ -1,0 +1,293 @@
+import { screen, waitFor } from '@testing-library/react';
+
+import { TwoFactorPage } from '../security/two-factor-page';
+
+import { renderWithProviders } from './test-utils';
+
+import type { AccountTwoFactorStatusResponse } from '@granit/account';
+
+// ---------------------------------------------------------------------------
+// Interactive 2FA flows: enable / disable authenticator, regenerate recovery
+// codes, and the email-OTP send → confirm → disable enrollment. Each mutation
+// is a vi.hoisted mock so individual flows can resolve / reject and assert on
+// the call payload. Mirrors the co-located render-state test's mock shape.
+// ---------------------------------------------------------------------------
+
+const {
+  mockUseTwoFactorStatus,
+  mockUseAuthenticatorKey,
+  mockEnable,
+  mockDisable,
+  mockGenerateCodes,
+  mockEnableEmail,
+  mockDisableEmail,
+  mockSendEmailCode,
+} = vi.hoisted(() => ({
+  mockUseTwoFactorStatus: vi.fn(),
+  mockUseAuthenticatorKey: vi.fn(),
+  mockEnable: vi.fn(),
+  mockDisable: vi.fn(),
+  mockGenerateCodes: vi.fn(),
+  mockEnableEmail: vi.fn(),
+  mockDisableEmail: vi.fn(),
+  mockSendEmailCode: vi.fn(),
+}));
+
+vi.mock('@granit/react-account', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useTwoFactorStatus: mockUseTwoFactorStatus,
+    useAuthenticatorKey: mockUseAuthenticatorKey,
+    useEnableTwoFactor: () => ({ mutateAsync: mockEnable, isPending: false }),
+    useDisableTwoFactor: () => ({ mutateAsync: mockDisable, isPending: false }),
+    useGenerateRecoveryCodes: () => ({ mutateAsync: mockGenerateCodes, isPending: false }),
+    useEnableTwoFactorEmail: () => ({ mutateAsync: mockEnableEmail, isPending: false }),
+    useDisableTwoFactorEmail: () => ({ mutateAsync: mockDisableEmail, isPending: false }),
+    useSendTwoFactorEmailEnrollmentCode: () => ({
+      mutateAsync: mockSendEmailCode,
+      isPending: false,
+    }),
+  };
+});
+
+const disabledStatus: AccountTwoFactorStatusResponse = {
+  isEnabled: false,
+  hasAuthenticatorApp: false,
+  hasEmailOtp: false,
+  recoveryCodesLeft: 0,
+};
+
+const enabledStatus: AccountTwoFactorStatusResponse = {
+  isEnabled: true,
+  hasAuthenticatorApp: true,
+  hasEmailOtp: false,
+  recoveryCodesLeft: 5,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseAuthenticatorKey.mockReturnValue({
+    data: { sharedKey: 'ABCDEF123456', qrCodeUri: 'otpauth://totp/Demo' }, // gitleaks:allow (fake TOTP key)
+    isLoading: false,
+  });
+});
+
+describe('TwoFactorPage — enable authenticator', () => {
+  it('should call the enable mutation with the typed code and report recovery codes', async () => {
+    mockUseTwoFactorStatus.mockReturnValue({ data: disabledStatus, isLoading: false });
+    mockEnable.mockResolvedValue({ recoveryCodes: ['code-a', 'code-b'] });
+    const { user } = renderWithProviders(<TwoFactorPage />);
+
+    await user.type(screen.getByLabelText('Verification code'), '123 456');
+    await user.click(screen.getByRole('button', { name: 'Enable 2FA' }));
+
+    expect(mockEnable).toHaveBeenCalledWith({ code: '123456' });
+  });
+
+  it('should flag the code field invalid when enabling fails', async () => {
+    mockUseTwoFactorStatus.mockReturnValue({ data: disabledStatus, isLoading: false });
+    mockEnable.mockRejectedValue(new Error('bad code'));
+    const { user } = renderWithProviders(<TwoFactorPage />);
+
+    const input = screen.getByLabelText('Verification code');
+    await user.type(input, '000000');
+    await user.click(screen.getByRole('button', { name: 'Enable 2FA' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid verification code.')).toBeInTheDocument();
+    });
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('should copy the authenticator setup key to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(navigator.clipboard, 'writeText').mockImplementation(writeText);
+    mockUseTwoFactorStatus.mockReturnValue({ data: disabledStatus, isLoading: false });
+    const { user } = renderWithProviders(<TwoFactorPage />);
+
+    await user.click(screen.getByRole('button', { name: 'Copy' }));
+
+    expect(writeText).toHaveBeenCalledWith('ABCDEF123456');
+  });
+
+  it('should render the enable form spinner while the authenticator key loads', () => {
+    mockUseAuthenticatorKey.mockReturnValue({ data: undefined, isLoading: true });
+    mockUseTwoFactorStatus.mockReturnValue({ data: disabledStatus, isLoading: false });
+    renderWithProviders(<TwoFactorPage />);
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+});
+
+describe('TwoFactorPage — disable authenticator', () => {
+  it('should call the disable mutation with the current password', async () => {
+    mockUseTwoFactorStatus.mockReturnValue({ data: enabledStatus, isLoading: false });
+    mockDisable.mockResolvedValue(undefined);
+    const { user } = renderWithProviders(<TwoFactorPage />);
+
+    await user.type(
+      screen.getByLabelText('Current password', { selector: '#disablePassword' }),
+      'hunter2'
+    );
+    await user.click(screen.getByRole('button', { name: 'Disable 2FA' }));
+
+    expect(mockDisable).toHaveBeenCalledWith({ password: 'hunter2' });
+  });
+
+  it('should swallow a disable error without crashing', async () => {
+    mockUseTwoFactorStatus.mockReturnValue({ data: enabledStatus, isLoading: false });
+    mockDisable.mockRejectedValue(new Error('wrong password'));
+    const { user } = renderWithProviders(<TwoFactorPage />);
+
+    await user.type(
+      screen.getByLabelText('Current password', { selector: '#disablePassword' }),
+      'wrong'
+    );
+    await user.click(screen.getByRole('button', { name: 'Disable 2FA' }));
+
+    await waitFor(() => expect(mockDisable).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('button', { name: 'Disable 2FA' })).toBeInTheDocument();
+  });
+});
+
+describe('TwoFactorPage — recovery codes', () => {
+  it('should generate and display new recovery codes, then dismiss them', async () => {
+    mockUseTwoFactorStatus.mockReturnValue({ data: enabledStatus, isLoading: false });
+    mockGenerateCodes.mockResolvedValue({ recoveryCodes: ['rc-1', 'rc-2'] });
+    const { user } = renderWithProviders(<TwoFactorPage />);
+
+    await user.type(
+      screen.getByLabelText('Current password', { selector: '#regenPassword' }),
+      'hunter2'
+    );
+    await user.click(screen.getByRole('button', { name: 'Generate new codes' }));
+
+    expect(mockGenerateCodes).toHaveBeenCalledWith({ password: 'hunter2' });
+    await waitFor(() => {
+      expect(screen.getByText('rc-1')).toBeInTheDocument();
+    });
+    expect(screen.getByText('rc-2')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Done' }));
+    await waitFor(() => {
+      expect(screen.queryByText('rc-1')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should copy all generated codes to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(navigator.clipboard, 'writeText').mockImplementation(writeText);
+    mockUseTwoFactorStatus.mockReturnValue({ data: enabledStatus, isLoading: false });
+    mockGenerateCodes.mockResolvedValue({ recoveryCodes: ['rc-1', 'rc-2'] });
+    const { user } = renderWithProviders(<TwoFactorPage />);
+
+    await user.type(
+      screen.getByLabelText('Current password', { selector: '#regenPassword' }),
+      'hunter2'
+    );
+    await user.click(screen.getByRole('button', { name: 'Generate new codes' }));
+    await screen.findByText('rc-1');
+    await user.click(screen.getByRole('button', { name: 'Copy all' }));
+
+    expect(writeText).toHaveBeenCalledWith('rc-1\nrc-2');
+  });
+
+  it('should swallow a recovery-code generation error', async () => {
+    mockUseTwoFactorStatus.mockReturnValue({ data: enabledStatus, isLoading: false });
+    mockGenerateCodes.mockRejectedValue(new Error('boom'));
+    const { user } = renderWithProviders(<TwoFactorPage />);
+
+    await user.type(
+      screen.getByLabelText('Current password', { selector: '#regenPassword' }),
+      'hunter2'
+    );
+    await user.click(screen.getByRole('button', { name: 'Generate new codes' }));
+
+    await waitFor(() => expect(mockGenerateCodes).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText('Save your recovery codes')).not.toBeInTheDocument();
+  });
+});
+
+describe('TwoFactorPage — email one-time codes', () => {
+  it('should send an enrollment code then confirm it', async () => {
+    mockUseTwoFactorStatus.mockReturnValue({ data: disabledStatus, isLoading: false });
+    mockSendEmailCode.mockResolvedValue(undefined);
+    mockEnableEmail.mockResolvedValue(undefined);
+    const { user } = renderWithProviders(<TwoFactorPage />);
+
+    await user.click(screen.getByRole('button', { name: 'Send verification code' }));
+    expect(mockSendEmailCode).toHaveBeenCalledTimes(1);
+
+    const codeInput = await screen.findByLabelText('Verification code', {
+      selector: '#emailOtpCode',
+    });
+    await user.type(codeInput, '654321');
+    await user.click(screen.getByRole('button', { name: 'Enable email codes' }));
+
+    expect(mockEnableEmail).toHaveBeenCalledWith({ code: '654321' });
+  });
+
+  it('should flag the email code field invalid when confirmation fails', async () => {
+    mockUseTwoFactorStatus.mockReturnValue({ data: disabledStatus, isLoading: false });
+    mockSendEmailCode.mockResolvedValue(undefined);
+    mockEnableEmail.mockRejectedValue(new Error('bad'));
+    const { user } = renderWithProviders(<TwoFactorPage />);
+
+    await user.click(screen.getByRole('button', { name: 'Send verification code' }));
+    const codeInput = await screen.findByLabelText('Verification code', {
+      selector: '#emailOtpCode',
+    });
+    await user.type(codeInput, '111111');
+    await user.click(screen.getByRole('button', { name: 'Enable email codes' }));
+
+    await waitFor(() => {
+      expect(codeInput).toHaveAttribute('aria-invalid', 'true');
+    });
+  });
+
+  it('should swallow a send-code error and stay on the send step', async () => {
+    mockUseTwoFactorStatus.mockReturnValue({ data: disabledStatus, isLoading: false });
+    mockSendEmailCode.mockRejectedValue(new Error('mail down'));
+    const { user } = renderWithProviders(<TwoFactorPage />);
+
+    await user.click(screen.getByRole('button', { name: 'Send verification code' }));
+
+    await waitFor(() => expect(mockSendEmailCode).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('button', { name: 'Send verification code' })).toBeInTheDocument();
+  });
+
+  it('should disable the email factor with the current password when enrolled', async () => {
+    mockUseTwoFactorStatus.mockReturnValue({
+      data: { ...enabledStatus, hasEmailOtp: true },
+      isLoading: false,
+    });
+    mockDisableEmail.mockResolvedValue(undefined);
+    const { user } = renderWithProviders(<TwoFactorPage />);
+
+    await user.type(
+      screen.getByLabelText('Current password', { selector: '#emailOtpDisablePassword' }),
+      'hunter2'
+    );
+    await user.click(screen.getByRole('button', { name: 'Disable email codes' }));
+
+    expect(mockDisableEmail).toHaveBeenCalledWith({ password: 'hunter2' });
+  });
+
+  it('should swallow an email-disable error', async () => {
+    mockUseTwoFactorStatus.mockReturnValue({
+      data: { ...enabledStatus, hasEmailOtp: true },
+      isLoading: false,
+    });
+    mockDisableEmail.mockRejectedValue(new Error('nope'));
+    const { user } = renderWithProviders(<TwoFactorPage />);
+
+    await user.type(
+      screen.getByLabelText('Current password', { selector: '#emailOtpDisablePassword' }),
+      'bad'
+    );
+    await user.click(screen.getByRole('button', { name: 'Disable email codes' }));
+
+    await waitFor(() => expect(mockDisableEmail).toHaveBeenCalledTimes(1));
+  });
+});

--- a/packages/@granit/react-ui-admin-kit/src/__tests__/phone-input.test.tsx
+++ b/packages/@granit/react-ui-admin-kit/src/__tests__/phone-input.test.tsx
@@ -1,0 +1,212 @@
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type CountryCode } from 'libphonenumber-js/min';
+import { useState } from 'react';
+
+import { PhoneInput } from '../inputs/phone-input';
+
+import { renderWithI18n, setupI18n } from './test-utils';
+
+beforeAll(setupI18n);
+
+// A small, multi-continent country subset keeps the cmdk popover cheap to
+// render while still exercising the continental grouping path.
+const COUNTRIES: readonly CountryCode[] = ['BE', 'FR', 'US', 'JP', 'AU', 'ZA'];
+
+function getNational(): HTMLInputElement {
+  return document.querySelector('[data-slot="phone-input-national"]') as HTMLInputElement;
+}
+
+// Controlled wrapper: PhoneInput reconciles internal state against `value`, so
+// realistic typing/selection tests must feed onChange back into the prop.
+function ControlledPhone({
+  initial = null,
+  onChange,
+  defaultCountry,
+  countries = COUNTRIES,
+}: {
+  readonly initial?: string | null;
+  readonly onChange: (v: string | null) => void;
+  readonly defaultCountry?: CountryCode;
+  readonly countries?: readonly CountryCode[];
+}) {
+  const [value, setValue] = useState<string | null>(initial);
+  return (
+    <PhoneInput
+      value={value}
+      defaultCountry={defaultCountry}
+      countries={countries}
+      onChange={(v) => {
+        setValue(v);
+        onChange(v);
+      }}
+    />
+  );
+}
+
+describe('PhoneInput', () => {
+  it('renders the country trigger and the national input', () => {
+    renderWithI18n(<PhoneInput value={null} onChange={vi.fn()} countries={COUNTRIES} />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(getNational()).toBeInTheDocument();
+  });
+
+  it('shows the default country calling code when no value is set', () => {
+    renderWithI18n(
+      <PhoneInput value={null} onChange={vi.fn()} defaultCountry="FR" countries={COUNTRIES} />
+    );
+    expect(screen.getByRole('combobox')).toHaveTextContent('+33');
+    expect(getNational().value).toBe('');
+  });
+
+  it('parses an E.164 value into country and national parts', () => {
+    renderWithI18n(<PhoneInput value="+32479123456" onChange={vi.fn()} countries={COUNTRIES} />);
+    expect(screen.getByRole('combobox')).toHaveTextContent('+32');
+    expect(getNational().value.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to the default country for an unparseable value', () => {
+    renderWithI18n(
+      <PhoneInput value="garbage" onChange={vi.fn()} defaultCountry="US" countries={COUNTRIES} />
+    );
+    expect(screen.getByRole('combobox')).toHaveTextContent('+1');
+    expect(getNational().value).toBe('garbage');
+  });
+
+  it('emits an E.164 number as the user types a national number', async () => {
+    const onChange = vi.fn();
+    renderWithI18n(<ControlledPhone onChange={onChange} defaultCountry="BE" />);
+    await userEvent.type(getNational(), '479123456');
+    expect(onChange).toHaveBeenCalled();
+    const last = onChange.mock.calls.at(-1)?.[0] as string;
+    expect(last.startsWith('+32')).toBe(true);
+  });
+
+  it('emits null when the national input is cleared', async () => {
+    const onChange = vi.fn();
+    renderWithI18n(<ControlledPhone initial="+32479123456" onChange={onChange} />);
+    await userEvent.clear(getNational());
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('falls back to a digit-only E.164 when the number is not fully parseable', () => {
+    const onChange = vi.fn();
+    renderWithI18n(<ControlledPhone onChange={onChange} defaultCountry="BE" />);
+    fireEvent.change(getNational(), { target: { value: '12' } });
+    const last = onChange.mock.calls.at(-1)?.[0] as string;
+    expect(last.startsWith('+32')).toBe(true);
+    expect(last).toContain('12');
+  });
+
+  it('opens the country list and selects a country, re-emitting the value', async () => {
+    const onChange = vi.fn();
+    renderWithI18n(<ControlledPhone onChange={onChange} defaultCountry="BE" />);
+    // Type a national number first so the country switch re-emits.
+    await userEvent.type(getNational(), '612345678');
+    onChange.mockClear();
+
+    await userEvent.click(screen.getByRole('combobox'));
+    const list = await screen.findByRole('listbox');
+    const usOption = await within(list).findByText('United States');
+    await userEvent.click(usOption);
+
+    expect(screen.getByRole('combobox')).toHaveTextContent('+1');
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('selects a country without re-emitting when there is no national number', async () => {
+    const onChange = vi.fn();
+    renderWithI18n(<ControlledPhone onChange={onChange} defaultCountry="BE" />);
+    await userEvent.click(screen.getByRole('combobox'));
+    const list = await screen.findByRole('listbox');
+    await userEvent.click(await within(list).findByText('Japan'));
+    expect(screen.getByRole('combobox')).toHaveTextContent('+81');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('filters the country list on search', async () => {
+    renderWithI18n(
+      <PhoneInput
+        value={null}
+        onChange={vi.fn()}
+        countries={COUNTRIES}
+        searchPlaceholder="Search"
+      />
+    );
+    await userEvent.click(screen.getByRole('combobox'));
+    const search = await screen.findByPlaceholderText('Search');
+    fireEvent.change(search, { target: { value: 'japan' } });
+    const list = await screen.findByRole('listbox');
+    expect(await within(list).findByText('Japan')).toBeInTheDocument();
+    expect(within(list).queryByText('United States')).toBeNull();
+  });
+
+  it('shows the empty message when no country matches', async () => {
+    renderWithI18n(
+      <PhoneInput
+        value={null}
+        onChange={vi.fn()}
+        countries={COUNTRIES}
+        searchPlaceholder="Search"
+        emptyText="No country found"
+      />
+    );
+    await userEvent.click(screen.getByRole('combobox'));
+    const search = await screen.findByPlaceholderText('Search');
+    fireEvent.change(search, { target: { value: 'zzzznomatch' } });
+    expect(await screen.findByText('No country found')).toBeInTheDocument();
+  });
+
+  it('groups countries under an "Other" heading when the continent is unknown', async () => {
+    // AC (Ascension Island) is a valid libphonenumber territory with a calling
+    // code but is absent from COUNTRY_TO_CONTINENT, driving the "Other" bucket.
+    renderWithI18n(
+      <PhoneInput value={null} onChange={vi.fn()} countries={['BE', 'AC'] as CountryCode[]} />
+    );
+    await userEvent.click(screen.getByRole('combobox'));
+    expect(await screen.findByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('reconciles an external value change (form reset)', () => {
+    const { rerender } = renderWithI18n(
+      <PhoneInput value="+32479123456" onChange={vi.fn()} countries={COUNTRIES} />
+    );
+    expect(screen.getByRole('combobox')).toHaveTextContent('+32');
+    rerender(<PhoneInput value="+33612345678" onChange={vi.fn()} countries={COUNTRIES} />);
+    expect(screen.getByRole('combobox')).toHaveTextContent('+33');
+  });
+
+  it('renders disabled state and forwards id, name and aria-label', () => {
+    renderWithI18n(
+      <PhoneInput
+        value={null}
+        onChange={vi.fn()}
+        countries={COUNTRIES}
+        disabled
+        id="phone"
+        name="telephone"
+        ariaLabelCountry="Pick country"
+        placeholder="number"
+      />
+    );
+    const country = screen.getByRole('combobox', { name: 'Pick country' });
+    expect(country).toBeDisabled();
+    const national = getNational();
+    expect(national).toBeDisabled();
+    expect(national.id).toBe('phone');
+    expect(national.name).toBe('telephone');
+    expect(screen.getByPlaceholderText('number')).toBeInTheDocument();
+  });
+
+  it('builds the full country list when no countries filter is given', async () => {
+    // Exercises the getCountries() branch in buildCountryOptions.
+    renderWithI18n(<PhoneInput value={null} onChange={vi.fn()} searchPlaceholder="Search" />);
+    await userEvent.click(screen.getByRole('combobox'));
+    const search = await screen.findByPlaceholderText('Search');
+    fireEvent.change(search, { target: { value: 'belgium' } });
+    await waitFor(async () => {
+      const list = await screen.findByRole('listbox');
+      expect(within(list).getByText('Belgium')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/@granit/react-ui-admin-kit/src/__tests__/url-input.test.tsx
+++ b/packages/@granit/react-ui-admin-kit/src/__tests__/url-input.test.tsx
@@ -1,0 +1,159 @@
+import { fireEvent, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+
+import { UrlInput } from '../inputs/url-input';
+
+import { renderWithI18n, setupI18n } from './test-utils';
+
+beforeAll(setupI18n);
+
+function getRest(): HTMLInputElement {
+  return document.querySelector('[data-slot="url-input-rest"]') as HTMLInputElement;
+}
+
+// Controlled wrapper: the component reconciles internal state against the
+// `value` prop, so realistic interaction tests must feed onChange back in.
+function ControlledUrl({
+  initial = null,
+  onChange,
+  protocols,
+  defaultProtocol,
+}: {
+  readonly initial?: string | null;
+  readonly onChange: (v: string | null) => void;
+  readonly protocols?: readonly string[];
+  readonly defaultProtocol?: string;
+}) {
+  const [value, setValue] = useState<string | null>(initial);
+  return (
+    <UrlInput
+      value={value}
+      protocols={protocols}
+      defaultProtocol={defaultProtocol}
+      onChange={(v) => {
+        setValue(v);
+        onChange(v);
+      }}
+    />
+  );
+}
+
+describe('UrlInput', () => {
+  it('renders the protocol trigger and the rest input', () => {
+    renderWithI18n(<UrlInput value={null} onChange={vi.fn()} />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(getRest()).toBeInTheDocument();
+  });
+
+  it('splits an existing value into protocol and rest', () => {
+    renderWithI18n(<UrlInput value="https://example.com/path" onChange={vi.fn()} />);
+    expect(getRest().value).toBe('example.com/path');
+    expect(screen.getByRole('combobox')).toHaveTextContent('https');
+  });
+
+  it('falls back to the default protocol for an unknown scheme', () => {
+    renderWithI18n(<UrlInput value="ftp://files.example.com" onChange={vi.fn()} />);
+    // ftp is not in the default protocols list, so the recognised scheme is
+    // stripped and the fallback protocol (https) is selected.
+    expect(getRest().value).toBe('files.example.com');
+    expect(screen.getByRole('combobox')).toHaveTextContent('https');
+  });
+
+  it('keeps a recognised non-default protocol from the value', () => {
+    renderWithI18n(<UrlInput value="http://example.com" onChange={vi.fn()} />);
+    expect(screen.getByRole('combobox')).toHaveTextContent('http');
+    expect(getRest().value).toBe('example.com');
+  });
+
+  it('emits a joined URL when the rest changes', async () => {
+    const onChange = vi.fn();
+    renderWithI18n(<ControlledUrl onChange={onChange} />);
+    await userEvent.type(getRest(), 'example.org');
+    expect(onChange).toHaveBeenLastCalledWith('https://example.org');
+  });
+
+  it('emits null when the rest is cleared', async () => {
+    const onChange = vi.fn();
+    renderWithI18n(<ControlledUrl initial="https://example.com" onChange={onChange} />);
+    await userEvent.clear(getRest());
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('re-splits a pasted full URL and updates the protocol dropdown', () => {
+    const onChange = vi.fn();
+    renderWithI18n(<ControlledUrl onChange={onChange} />);
+    fireEvent.change(getRest(), { target: { value: 'http://pasted.example.com/x' } });
+    expect(onChange).toHaveBeenLastCalledWith('http://pasted.example.com/x');
+    expect(screen.getByRole('combobox')).toHaveTextContent('http');
+    expect(getRest().value).toBe('pasted.example.com/x');
+  });
+
+  it('keeps the current protocol when a pasted scheme is unknown', () => {
+    const onChange = vi.fn();
+    renderWithI18n(<ControlledUrl initial="http://start.example.com" onChange={onChange} />);
+    fireEvent.change(getRest(), { target: { value: 'ws://other.example.com' } });
+    // ws is not in the protocol list; rest keeps the raw value, protocol unchanged.
+    expect(screen.getByRole('combobox')).toHaveTextContent('http');
+  });
+
+  it('changes the protocol via the select and re-emits', async () => {
+    const onChange = vi.fn();
+    renderWithI18n(<ControlledUrl initial="https://example.com" onChange={onChange} />);
+    await userEvent.click(screen.getByRole('combobox'));
+    const listbox = await screen.findByRole('listbox');
+    await userEvent.click(within(listbox).getByText('http://'));
+    expect(onChange).toHaveBeenLastCalledWith('http://example.com');
+  });
+
+  it('supports a custom protocol list and default protocol', () => {
+    renderWithI18n(
+      <UrlInput
+        value={null}
+        onChange={vi.fn()}
+        protocols={['mailto', 'tel']}
+        defaultProtocol="tel"
+      />
+    );
+    expect(screen.getByRole('combobox')).toHaveTextContent('tel');
+  });
+
+  it('reconciles an external value change (form reset)', () => {
+    const { rerender } = renderWithI18n(<UrlInput value="https://a.example" onChange={vi.fn()} />);
+    expect(getRest().value).toBe('a.example');
+    rerender(<UrlInput value="http://b.example" onChange={vi.fn()} />);
+    expect(getRest().value).toBe('b.example');
+    expect(screen.getByRole('combobox')).toHaveTextContent('http');
+  });
+
+  it('treats an empty string value as null without resetting protocol choice', () => {
+    const { rerender } = renderWithI18n(<UrlInput value="http://x.example" onChange={vi.fn()} />);
+    expect(screen.getByRole('combobox')).toHaveTextContent('http');
+    rerender(<UrlInput value="" onChange={vi.fn()} />);
+    // empty string normalises to null; the synced value does not change so the
+    // protocol choice is preserved.
+    expect(screen.getByRole('combobox')).toHaveTextContent('http');
+  });
+
+  it('renders disabled state and a custom protocol aria-label and placeholder', () => {
+    renderWithI18n(
+      <UrlInput
+        value={null}
+        onChange={vi.fn()}
+        disabled
+        ariaLabelProtocol="Scheme"
+        placeholder="type here"
+      />
+    );
+    expect(screen.getByRole('combobox', { name: 'Scheme' })).toBeDisabled();
+    expect(getRest()).toBeDisabled();
+    expect(screen.getByPlaceholderText('type here')).toBeInTheDocument();
+  });
+
+  it('forwards id and name to the rest input', () => {
+    renderWithI18n(<UrlInput value={null} onChange={vi.fn()} id="site" name="website" />);
+    const rest = getRest();
+    expect(rest.id).toBe('site');
+    expect(rest.name).toBe('website');
+  });
+});

--- a/packages/@granit/react-ui-authentication-keycloak/src/__tests__/keycloak-auth-provider.test.tsx
+++ b/packages/@granit/react-ui-authentication-keycloak/src/__tests__/keycloak-auth-provider.test.tsx
@@ -1,0 +1,215 @@
+import { render, screen } from '@testing-library/react';
+import { useContext, createContext } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { KeycloakAuthProvider } from '../keycloak-auth-provider';
+
+import type { KeycloakAuthContextType, KeycloakCoreConfig } from '@granit/authentication-keycloak';
+import type { Context } from 'react';
+
+// ---------------------------------------------------------------------------
+// Hoisted mock references (declared before vi.mock hoisting)
+// ---------------------------------------------------------------------------
+const { mockUseKeycloakInit, mockHookLogin, mockHookLogout, mockUseTranslation } = vi.hoisted(
+  () => ({
+    mockUseKeycloakInit: vi.fn(),
+    mockHookLogin: vi.fn(),
+    mockHookLogout: vi.fn(),
+    mockUseTranslation: vi.fn(),
+  })
+);
+
+vi.mock('@granit/react-authentication-keycloak', () => ({
+  useKeycloakInit: mockUseKeycloakInit,
+}));
+
+vi.mock('@granit/react-localization', () => ({
+  useTranslation: mockUseTranslation,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const config: KeycloakCoreConfig = {
+  url: 'https://auth.example.com',
+  realm: 'test-realm',
+  clientId: 'test-client',
+};
+
+type HookResult = ReturnType<typeof mockUseKeycloakInit>;
+
+/**
+ * Build the object the mocked `useKeycloakInit` returns. The provider only
+ * reads `keycloak`, `authenticated`, `loading`, `user`, `login`, `logout`.
+ */
+function buildHookReturn(overrides: Partial<HookResult> = {}): HookResult {
+  return {
+    keycloak: null,
+    authenticated: false,
+    loading: false,
+    user: null,
+    login: mockHookLogin,
+    logout: mockHookLogout,
+    ...overrides,
+  };
+}
+
+// A probe component reads the provided auth context so tests can assert the
+// exact value the provider supplies (and that callbacks wire through).
+const AuthContext: Context<KeycloakAuthContextType | undefined> = createContext<
+  KeycloakAuthContextType | undefined
+>(undefined);
+
+function Probe() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    return <div data-testid="probe">no-context</div>;
+  }
+  return (
+    <div data-testid="probe">
+      <span data-testid="authenticated">{String(ctx.authenticated)}</span>
+      <span data-testid="loading">{String(ctx.loading)}</span>
+      <span data-testid="user">{ctx.user ? ctx.user.sub : 'null'}</span>
+      <span data-testid="keycloak">{ctx.keycloak ? 'instance' : 'null'}</span>
+      <button type="button" data-testid="login" onClick={() => ctx.login()}>
+        login
+      </button>
+      <button type="button" data-testid="logout" onClick={() => ctx.logout()}>
+        logout
+      </button>
+    </div>
+  );
+}
+
+function renderProvider() {
+  return render(
+    <KeycloakAuthProvider context={AuthContext} config={config}>
+      <Probe />
+    </KeycloakAuthProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('KeycloakAuthProvider', () => {
+  beforeEach(() => {
+    mockUseTranslation.mockReturnValue({
+      t: (_key: string, fallback?: string) => fallback ?? _key,
+      i18n: { language: 'en' },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the init spinner while loading and does not provide the context', () => {
+    mockUseKeycloakInit.mockReturnValue(buildHookReturn({ loading: true }));
+
+    renderProvider();
+
+    // The probe child is not rendered while loading.
+    expect(screen.queryByTestId('probe')).not.toBeInTheDocument();
+    expect(screen.getByText('Initializing…')).toBeInTheDocument();
+  });
+
+  it('uses the translated string for the initializing label when provided', () => {
+    mockUseTranslation.mockReturnValue({
+      t: (_key: string) => 'Chargement…',
+      i18n: { language: 'fr' },
+    });
+    mockUseKeycloakInit.mockReturnValue(buildHookReturn({ loading: true }));
+
+    renderProvider();
+
+    expect(screen.getByText('Chargement…')).toBeInTheDocument();
+  });
+
+  it('provides the auth context with the authenticated session once loading completes', () => {
+    const keycloak = { token: 'abc' } as unknown as KeycloakAuthContextType['keycloak'];
+    mockUseKeycloakInit.mockReturnValue(
+      buildHookReturn({
+        loading: false,
+        authenticated: true,
+        user: { sub: 'user-1', email: 'test@example.com' },
+        keycloak,
+      })
+    );
+
+    renderProvider();
+
+    expect(screen.getByTestId('authenticated').textContent).toBe('true');
+    expect(screen.getByTestId('loading').textContent).toBe('false');
+    expect(screen.getByTestId('user').textContent).toBe('user-1');
+    expect(screen.getByTestId('keycloak').textContent).toBe('instance');
+  });
+
+  it('provides an unauthenticated context (no user, null keycloak)', () => {
+    mockUseKeycloakInit.mockReturnValue(
+      buildHookReturn({ loading: false, authenticated: false, user: null, keycloak: null })
+    );
+
+    renderProvider();
+
+    expect(screen.getByTestId('authenticated').textContent).toBe('false');
+    expect(screen.getByTestId('user').textContent).toBe('null');
+    expect(screen.getByTestId('keycloak').textContent).toBe('null');
+  });
+
+  it('passes the hook config straight through to useKeycloakInit', () => {
+    mockUseKeycloakInit.mockReturnValue(buildHookReturn({ loading: false }));
+
+    renderProvider();
+
+    expect(mockUseKeycloakInit).toHaveBeenCalledWith(config);
+  });
+
+  it('forwards the active UI locale to the hook login on login()', async () => {
+    mockUseTranslation.mockReturnValue({
+      t: (_key: string, fallback?: string) => fallback ?? _key,
+      i18n: { language: 'fr' },
+    });
+    mockUseKeycloakInit.mockReturnValue(buildHookReturn({ loading: false, authenticated: true }));
+
+    const { default: userEventDefault } = await import('@testing-library/user-event');
+    const user = userEventDefault.setup();
+
+    renderProvider();
+
+    await user.click(screen.getByTestId('login'));
+
+    expect(mockHookLogin).toHaveBeenCalledWith({ locale: 'fr' });
+  });
+
+  it('delegates logout() to the hook logout', async () => {
+    mockUseKeycloakInit.mockReturnValue(buildHookReturn({ loading: false, authenticated: true }));
+
+    const { default: userEventDefault } = await import('@testing-library/user-event');
+    const user = userEventDefault.setup();
+
+    renderProvider();
+
+    await user.click(screen.getByTestId('logout'));
+
+    expect(mockHookLogout).toHaveBeenCalledOnce();
+    expect(mockHookLogout).toHaveBeenCalledWith();
+  });
+
+  it('reflects a locale change in the login callback', async () => {
+    mockUseKeycloakInit.mockReturnValue(buildHookReturn({ loading: false, authenticated: true }));
+    mockUseTranslation.mockReturnValue({
+      t: (_key: string, fallback?: string) => fallback ?? _key,
+      i18n: { language: 'de' },
+    });
+
+    const { default: userEventDefault } = await import('@testing-library/user-event');
+    const user = userEventDefault.setup();
+
+    renderProvider();
+
+    await user.click(screen.getByTestId('login'));
+
+    expect(mockHookLogin).toHaveBeenCalledWith({ locale: 'de' });
+  });
+});

--- a/packages/@granit/react-ui-authorization/src/__tests__/permission-grants-page.interactions.test.tsx
+++ b/packages/@granit/react-ui-authorization/src/__tests__/permission-grants-page.interactions.test.tsx
@@ -1,0 +1,72 @@
+import { mockPermissionGrants } from '@granit/react-authorization/testing';
+import { screen } from '@testing-library/react';
+
+import { PermissionGrantsPage } from '../permission-grants-page';
+
+import { renderAuthorization } from './test-utils';
+
+const mockUsePermissionGrants = vi.fn();
+const mockUsePermissionGrantMeta = vi.fn();
+
+vi.mock('@granit/react-authorization', () => ({
+  AuthorizationProvider: ({ children }: { children: unknown }) => <>{children}</>,
+  usePermissionGrants: (...args: unknown[]) => mockUsePermissionGrants(...args),
+  usePermissionGrantMeta: (...args: unknown[]) => mockUsePermissionGrantMeta(...args),
+}));
+
+beforeEach(() => {
+  mockUsePermissionGrantMeta.mockReturnValue({ data: undefined, isLoading: false });
+  mockUsePermissionGrants.mockReturnValue({
+    data: { items: mockPermissionGrants, totalCount: 80, hasMore: true, nextCursor: null },
+    isLoading: false,
+  });
+});
+
+describe('PermissionGrantsPage interactions', () => {
+  it('should show a spinner while metadata is loading', () => {
+    mockUsePermissionGrantMeta.mockReturnValue({ data: undefined, isLoading: true });
+    const { container } = renderAuthorization(<PermissionGrantsPage />);
+    expect(
+      container.querySelector('[data-slot="spinner"]') ?? container.querySelector('.animate-spin')
+    ).toBeTruthy();
+  });
+
+  it('should debounce the search input and reset the page', async () => {
+    const { user } = renderAuthorization(<PermissionGrantsPage />);
+    const input = screen.getByPlaceholderText('Search…');
+    await user.type(input, 'admin');
+    expect(input).toHaveValue('admin');
+  });
+
+  it('should toggle sort when the sortable header is clicked', async () => {
+    const { user } = renderAuthorization(<PermissionGrantsPage />);
+    const header = screen.getByRole('button', { name: /permission/i });
+    await user.click(header);
+    expect(header).toBeInTheDocument();
+    // Second click flips asc -> desc, exercising the alternate branch.
+    await user.click(header);
+    expect(header).toBeInTheDocument();
+  });
+
+  it('should call the pagination next-page callback', async () => {
+    const { user } = renderAuthorization(<PermissionGrantsPage />);
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.getByText(mockPermissionGrants[0]!.name)).toBeInTheDocument();
+  });
+
+  it('should change the page size via the rows-per-page selector', async () => {
+    const { user } = renderAuthorization(<PermissionGrantsPage />);
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('option', { name: '50' }));
+    expect(screen.getByText(mockPermissionGrants[0]!.name)).toBeInTheDocument();
+  });
+
+  it('should render an empty table when there are no items', () => {
+    mockUsePermissionGrants.mockReturnValue({
+      data: { items: [], totalCount: 0, hasMore: false, nextCursor: null },
+      isLoading: false,
+    });
+    renderAuthorization(<PermissionGrantsPage />);
+    expect(screen.getByText(/no permission grants/i)).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-authorization/src/__tests__/permission-side-badge.test.tsx
+++ b/packages/@granit/react-ui-authorization/src/__tests__/permission-side-badge.test.tsx
@@ -1,0 +1,18 @@
+import { screen } from '@testing-library/react';
+
+import { PermissionSideBadge } from '../components/permission-side-badge';
+
+import { renderAuthorization } from './test-utils';
+
+import type { PermissionMultiTenancySide } from '@granit/authorization';
+
+describe('PermissionSideBadge', () => {
+  it.each<[PermissionMultiTenancySide, string]>([
+    ['Host', 'Host'],
+    ['Tenant', 'Tenant'],
+    ['Both', 'Both'],
+  ])('should render the %s side label', (side, label) => {
+    renderAuthorization(<PermissionSideBadge side={side} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-authorization/src/__tests__/role-metadata-page.interactions.test.tsx
+++ b/packages/@granit/react-ui-authorization/src/__tests__/role-metadata-page.interactions.test.tsx
@@ -1,0 +1,86 @@
+import { mockRoleMetadata } from '@granit/react-authorization/testing';
+import { screen } from '@testing-library/react';
+
+import { RoleMetadataPage } from '../role-metadata-page';
+
+import { renderAuthorization } from './test-utils';
+
+const mockUseRoleMetadata = vi.fn();
+const mockUseRoleMetadataMeta = vi.fn();
+
+vi.mock('@granit/react-authorization', () => ({
+  AuthorizationProvider: ({ children }: { children: unknown }) => <>{children}</>,
+  useRoleMetadata: (...args: unknown[]) => mockUseRoleMetadata(...args),
+  useRoleMetadataMeta: (...args: unknown[]) => mockUseRoleMetadataMeta(...args),
+}));
+
+beforeEach(() => {
+  mockUseRoleMetadataMeta.mockReturnValue({ data: undefined, isLoading: false });
+  mockUseRoleMetadata.mockReturnValue({
+    data: { items: mockRoleMetadata, totalCount: 80, hasMore: true, nextCursor: null },
+    isLoading: false,
+  });
+});
+
+describe('RoleMetadataPage interactions', () => {
+  it('should show a spinner while metadata is loading', () => {
+    mockUseRoleMetadataMeta.mockReturnValue({ data: undefined, isLoading: true });
+    const { container } = renderAuthorization(<RoleMetadataPage />);
+    expect(
+      container.querySelector('[data-slot="spinner"]') ?? container.querySelector('.animate-spin')
+    ).toBeTruthy();
+  });
+
+  it('should update the search input value', async () => {
+    const { user } = renderAuthorization(<RoleMetadataPage />);
+    const input = screen.getByPlaceholderText('Search…');
+    await user.type(input, 'viewer');
+    expect(input).toHaveValue('viewer');
+  });
+
+  it('should toggle sort when the sortable header is clicked', async () => {
+    const { user } = renderAuthorization(<RoleMetadataPage />);
+    const header = screen.getByRole('button', { name: /^role$/i });
+    await user.click(header);
+    expect(header).toBeInTheDocument();
+    await user.click(header);
+    expect(header).toBeInTheDocument();
+  });
+
+  it('should call the pagination next-page callback', async () => {
+    const { user } = renderAuthorization(<RoleMetadataPage />);
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.getByText(mockRoleMetadata[0]!.name)).toBeInTheDocument();
+  });
+
+  it('should change the page size via the rows-per-page selector', async () => {
+    const { user } = renderAuthorization(<RoleMetadataPage />);
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByRole('option', { name: '50' }));
+    expect(screen.getByText(mockRoleMetadata[0]!.name)).toBeInTheDocument();
+  });
+
+  it('should render the system badge and the dash for a missing description', () => {
+    mockUseRoleMetadata.mockReturnValue({
+      data: {
+        items: [{ ...mockRoleMetadata[1]!, description: null }],
+        totalCount: 1,
+        hasMore: false,
+        nextCursor: null,
+      },
+      isLoading: false,
+    });
+    renderAuthorization(<RoleMetadataPage />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(screen.getByText('No')).toBeInTheDocument();
+  });
+
+  it('should render an empty table when there are no items', () => {
+    mockUseRoleMetadata.mockReturnValue({
+      data: { items: [], totalCount: 0, hasMore: false, nextCursor: null },
+      isLoading: false,
+    });
+    renderAuthorization(<RoleMetadataPage />);
+    expect(screen.getByText(/no roles found/i)).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-authorization/src/__tests__/role-permissions-panel.tenant.test.tsx
+++ b/packages/@granit/react-ui-authorization/src/__tests__/role-permissions-panel.tenant.test.tsx
@@ -1,0 +1,60 @@
+import { mockPermissionGroups } from '@granit/react-authorization/testing';
+import { screen } from '@testing-library/react';
+
+import { RolePermissionsPanel } from '../components/role-permissions-panel';
+
+import { renderAuthorization } from './test-utils';
+
+const mockUsePermissionDefinitions = vi.fn();
+const mockUseRolePermissions = vi.fn();
+const mockUsePermissionGrant = vi.fn();
+
+vi.mock('@granit/react-authorization', () => ({
+  AuthorizationProvider: ({ children }: { children: unknown }) => <>{children}</>,
+  usePermissionDefinitions: (...args: unknown[]) => mockUsePermissionDefinitions(...args),
+  useRolePermissions: (...args: unknown[]) => mockUseRolePermissions(...args),
+  usePermissionGrant: (...args: unknown[]) => mockUsePermissionGrant(...args),
+}));
+
+vi.mock('@granit/react-identity', () => ({
+  useRoles: () => ({ data: [{ id: '1', name: 'admin' }], isLoading: false }),
+}));
+
+beforeEach(() => {
+  mockUsePermissionDefinitions.mockReturnValue({ isLoading: false, data: mockPermissionGroups });
+  mockUseRolePermissions.mockReturnValue({
+    isLoading: false,
+    data: { roleName: 'admin', permissions: [] },
+  });
+  mockUsePermissionGrant.mockReturnValue({
+    grant: { mutate: vi.fn(), isPending: false },
+    revoke: { mutate: vi.fn(), isPending: false },
+  });
+});
+
+describe('RolePermissionsPanel tenant scoping', () => {
+  it('should hide Host-only permissions when isTenant is true', () => {
+    renderAuthorization(<RolePermissionsPanel isTenant />);
+    // Settings group has two Host-only perms — hidden — and two Tenant perms — kept.
+    expect(screen.queryByText('View global settings')).not.toBeInTheDocument();
+    expect(screen.queryByText('Modify global settings')).not.toBeInTheDocument();
+    expect(screen.getByText('View tenant settings')).toBeInTheDocument();
+    expect(screen.getByText('Modify tenant settings')).toBeInTheDocument();
+  });
+
+  it('should show Host-only permissions when isTenant is false (default)', () => {
+    renderAuthorization(<RolePermissionsPanel />);
+    expect(screen.getByText('View global settings')).toBeInTheDocument();
+    expect(screen.getByText('View tenant settings')).toBeInTheDocument();
+  });
+
+  it('should disable switches while a mutation is pending', () => {
+    mockUsePermissionGrant.mockReturnValue({
+      grant: { mutate: vi.fn(), isPending: true },
+      revoke: { mutate: vi.fn(), isPending: false },
+    });
+    renderAuthorization(<RolePermissionsPanel />);
+    const switches = screen.getAllByRole('switch');
+    expect(switches[0]).toBeDisabled();
+  });
+});

--- a/packages/@granit/react-ui-authorization/src/__tests__/use-debounce.test.tsx
+++ b/packages/@granit/react-ui-authorization/src/__tests__/use-debounce.test.tsx
@@ -1,0 +1,65 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useDebounce } from '../hooks/use-debounce';
+
+describe('useDebounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should return the initial value immediately', () => {
+    const { result } = renderHook(() => useDebounce('a', 300));
+    expect(result.current).toBe('a');
+  });
+
+  it('should not update before the delay elapses', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 300), {
+      initialProps: { value: 'a' },
+    });
+
+    rerender({ value: 'b' });
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+    expect(result.current).toBe('a');
+  });
+
+  it('should update to the debounced value after the delay', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 300), {
+      initialProps: { value: 'a' },
+    });
+
+    rerender({ value: 'b' });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current).toBe('b');
+  });
+
+  it('should reset the timer when the value changes again (cleanup branch)', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 300), {
+      initialProps: { value: 'a' },
+    });
+
+    rerender({ value: 'b' });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    // New change before the first timer fires — clears the pending timer.
+    rerender({ value: 'c' });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    // First timer was cancelled; only 200ms of the second has elapsed.
+    expect(result.current).toBe('a');
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(result.current).toBe('c');
+  });
+});

--- a/packages/@granit/react-ui-openiddict-admin/src/__tests__/oidc-applications-page.test.tsx
+++ b/packages/@granit/react-ui-openiddict-admin/src/__tests__/oidc-applications-page.test.tsx
@@ -1,43 +1,69 @@
-import { screen } from '@testing-library/react';
+import { mockOidcApplications } from '@granit/react-openiddict-admin/testing';
+import { screen, waitFor, within } from '@testing-library/react';
 
 import { OidcApplicationsPage } from '../applications/oidc-applications-page';
 
 import { renderWithProviders } from './test-utils';
 
-const sampleApp = {
-  id: 'app-1',
-  clientId: 'web-spa',
-  displayName: 'Web SPA',
-  type: 'web',
-  permissions: [],
-  redirectUris: ['https://app.example.com/callback'],
-  postLogoutRedirectUris: [],
-  consentType: 'explicit',
-  signingKeyJwk: null,
-  clientSide: 1,
+import type { AdminOidcApplicationResponse } from '@granit/openiddict-admin';
+
+// An application with all optional fields null/empty, to exercise the `?? '—'`
+// row fallbacks, the XCircle "no signing key" path is shared, and the
+// null-coalescing branches in openEdit.
+const nullApp: AdminOidcApplicationResponse = {
+  clientId: 'sparse-client',
+  displayName: null,
+  type: null,
+  tenantId: null,
+  permissions: null,
+  redirectUris: null,
+  postLogoutRedirectUris: null,
+  consentType: null,
+  clientSide: null,
+  deviceKind: null,
   hasSigningKey: true,
 };
 
-let appsQuery: { data: readonly (typeof sampleApp)[]; isLoading: boolean } = {
+let appsQuery: { data: readonly AdminOidcApplicationResponse[]; isLoading: boolean } = {
   data: [],
   isLoading: false,
 };
 let canManage = true;
 
+const createMutate = vi.fn();
+const updateMutate = vi.fn();
+const deleteMutate = vi.fn();
+let pending = false;
+
 vi.mock('@granit/react-openiddict-admin', () => ({
   useOidcApplications: () => appsQuery,
-  useCreateOidcApplication: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useUpdateOidcApplication: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useDeleteOidcApplication: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useCreateOidcApplication: () => ({ mutateAsync: createMutate, isPending: pending }),
+  useUpdateOidcApplication: () => ({ mutateAsync: updateMutate, isPending: pending }),
+  useDeleteOidcApplication: () => ({ mutateAsync: deleteMutate, isPending: pending }),
 }));
 
 vi.mock('@granit/react-authorization', () => ({
   usePermissions: () => ({ hasPermission: () => canManage, isLoading: false }),
 }));
 
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: (msg: string) => toastSuccess(msg),
+    error: (msg: string) => toastError(msg),
+  },
+}));
+
 beforeEach(() => {
   appsQuery = { data: [], isLoading: false };
   canManage = true;
+  pending = false;
+  createMutate.mockReset().mockResolvedValue(undefined);
+  updateMutate.mockReset().mockResolvedValue(undefined);
+  deleteMutate.mockReset().mockResolvedValue(undefined);
+  toastSuccess.mockReset();
+  toastError.mockReset();
 });
 
 describe('OidcApplicationsPage', () => {
@@ -58,12 +84,15 @@ describe('OidcApplicationsPage', () => {
     expect(screen.queryByText('No applications registered yet.')).not.toBeInTheDocument();
   });
 
-  it('renders a row per application with edit and delete actions', () => {
-    appsQuery = { data: [sampleApp], isLoading: false };
+  it('renders a row per application with permission/uri counts and signing-key icons', () => {
+    appsQuery = { data: mockOidcApplications, isLoading: false };
     renderWithProviders(<OidcApplicationsPage />);
-    expect(screen.getByText('web-spa')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    expect(screen.getByText('granit-showcase-admin')).toBeInTheDocument();
+    expect(screen.getByText('Granit Showcase Admin')).toBeInTheDocument();
+    // no signing key on both fixtures
+    expect(screen.getAllByLabelText('No signing key').length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: 'Edit' }).length).toBe(2);
+    expect(screen.getAllByRole('button', { name: 'Delete' }).length).toBe(2);
   });
 
   it('exposes the create action when the user can manage applications', () => {
@@ -71,9 +100,253 @@ describe('OidcApplicationsPage', () => {
     expect(screen.getByRole('button', { name: /create application/i })).toBeInTheDocument();
   });
 
-  it('hides the create action without the manage permission', () => {
+  it('hides the create action and row actions without the manage permission', () => {
     canManage = false;
+    appsQuery = { data: mockOidcApplications, isLoading: false };
     renderWithProviders(<OidcApplicationsPage />);
     expect(screen.queryByRole('button', { name: /create application/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+  });
+
+  it('creates an application from the dialog and shows a success toast', async () => {
+    const { user } = renderWithProviders(<OidcApplicationsPage />);
+    await user.click(screen.getByRole('button', { name: /create application/i }));
+
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.type(dialog.getByLabelText('Client ID'), 'new-client');
+    await user.type(dialog.getByLabelText('Display Name'), 'New Client');
+    await user.type(dialog.getByLabelText('Redirect URIs'), 'https://app.example.com/callback');
+
+    await user.click(dialog.getByRole('button', { name: 'Create Application' }));
+
+    await waitFor(() => expect(createMutate).toHaveBeenCalledTimes(1));
+    expect(createMutate.mock.calls[0]![0]).toMatchObject({
+      clientId: 'new-client',
+      displayName: 'New Client',
+      redirectUris: ['https://app.example.com/callback'],
+    });
+    expect(toastSuccess).toHaveBeenCalledWith('Application created successfully');
+  });
+
+  it('selects a type via the Type dropdown when creating', async () => {
+    const { user } = renderWithProviders(<OidcApplicationsPage />);
+    await user.click(screen.getByRole('button', { name: /create application/i }));
+
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.type(dialog.getByLabelText('Client ID'), 'typed-client');
+
+    // open the Type select (first combobox in the dialog) and pick "Web"
+    const comboboxes = dialog.getAllByRole('combobox');
+    await user.click(comboboxes[0]!);
+    await user.click(await screen.findByRole('option', { name: 'Web' }));
+
+    await user.click(dialog.getByRole('button', { name: 'Create Application' }));
+
+    await waitFor(() => expect(createMutate).toHaveBeenCalledTimes(1));
+    expect(createMutate.mock.calls[0]![0]).toMatchObject({ clientId: 'typed-client', type: 'web' });
+  });
+
+  it('shows an error toast when application creation fails', async () => {
+    createMutate.mockRejectedValue(new Error('boom'));
+    const { user } = renderWithProviders(<OidcApplicationsPage />);
+    await user.click(screen.getByRole('button', { name: /create application/i }));
+
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.type(dialog.getByLabelText('Client ID'), 'new-client');
+    await user.click(dialog.getByRole('button', { name: 'Create Application' }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Failed to create application'));
+  });
+
+  it('cancels the create dialog without calling the mutation', async () => {
+    const { user } = renderWithProviders(<OidcApplicationsPage />);
+    await user.click(screen.getByRole('button', { name: /create application/i }));
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.click(dialog.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(createMutate).not.toHaveBeenCalled();
+  });
+
+  it('edits an application and shows a success toast', async () => {
+    appsQuery = { data: mockOidcApplications, isLoading: false };
+    const { user } = renderWithProviders(<OidcApplicationsPage />);
+    await user.click(screen.getAllByRole('button', { name: 'Edit' })[0]!);
+
+    const dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByText('Edit Application')).toBeInTheDocument();
+    const displayName = dialog.getByLabelText('Display Name');
+    await user.clear(displayName);
+    await user.type(displayName, 'Renamed App');
+    await user.click(dialog.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    expect(updateMutate.mock.calls[0]![0]).toMatchObject({
+      clientId: 'granit-showcase-admin',
+      request: { displayName: 'Renamed App' },
+    });
+    expect(toastSuccess).toHaveBeenCalledWith('Application updated successfully');
+  });
+
+  it('renders fallback dashes and the has-signing-key icon for a sparse application', () => {
+    appsQuery = { data: [nullApp], isLoading: false };
+    renderWithProviders(<OidcApplicationsPage />);
+    expect(screen.getByText('sparse-client')).toBeInTheDocument();
+    expect(screen.getByLabelText('Has signing key')).toBeInTheDocument();
+    // displayName, type, permissions, redirect, tenant all fall back to dashes
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('opens the edit dialog for a sparse application using null fallbacks', async () => {
+    appsQuery = { data: [nullApp], isLoading: false };
+    const { user } = renderWithProviders(<OidcApplicationsPage />);
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByText('sparse-client')).toBeInTheDocument();
+    await user.click(dialog.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    expect(updateMutate.mock.calls[0]![0]).toMatchObject({
+      clientId: 'sparse-client',
+      request: { displayName: null, type: null },
+    });
+  });
+
+  it('shows spinners and disables actions on every dialog while pending', async () => {
+    pending = true;
+    appsQuery = { data: mockOidcApplications, isLoading: false };
+    const { user } = renderWithProviders(<OidcApplicationsPage />);
+
+    await user.click(screen.getByRole('button', { name: /create application/i }));
+    let dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(dialog.getByRole('button', { name: 'Create Application' })).toBeDisabled();
+    await user.keyboard('{Escape}');
+
+    await user.click(screen.getAllByRole('button', { name: 'Edit' })[0]!);
+    dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByRole('button', { name: 'Save' })).toBeDisabled();
+    await user.keyboard('{Escape}');
+
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+    dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByRole('button', { name: 'Delete' })).toBeDisabled();
+  });
+
+  it('edits every form control including the selects and uri/permission textareas', async () => {
+    appsQuery = { data: mockOidcApplications, isLoading: false };
+    const { user } = renderWithProviders(<OidcApplicationsPage />);
+    await user.click(screen.getAllByRole('button', { name: 'Edit' })[0]!);
+
+    const dialog = within(await screen.findByRole('dialog'));
+
+    // Type select
+    const comboboxes = dialog.getAllByRole('combobox');
+    await user.click(comboboxes[0]!);
+    await user.click(await screen.findByRole('option', { name: 'Native' }));
+    // Consent type select
+    await user.click(dialog.getAllByRole('combobox')[1]!);
+    await user.click(await screen.findByRole('option', { name: 'Explicit' }));
+    // Client side select
+    await user.click(dialog.getAllByRole('combobox')[2]!);
+    await user.click(await screen.findByRole('option', { name: 'Tenant' }));
+
+    const redirect = dialog.getByLabelText('Redirect URIs');
+    await user.clear(redirect);
+    await user.type(redirect, 'https://edited.example.com/cb');
+
+    const permissions = dialog.getByLabelText('Permissions');
+    await user.clear(permissions);
+    await user.type(permissions, 'ept:token');
+
+    await user.click(dialog.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    expect(updateMutate.mock.calls[0]![0]).toMatchObject({
+      clientId: 'granit-showcase-admin',
+      request: {
+        type: 'native',
+        consentType: 'explicit',
+        clientSide: 2,
+        redirectUris: ['https://edited.example.com/cb'],
+        permissions: ['ept:token'],
+      },
+    });
+  });
+
+  it('resets the Type select back to none when creating', async () => {
+    const { user } = renderWithProviders(<OidcApplicationsPage />);
+    await user.click(screen.getByRole('button', { name: /create application/i }));
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.type(dialog.getByLabelText('Client ID'), 'none-client');
+
+    const typeSelect = dialog.getAllByRole('combobox')[0]!;
+    await user.click(typeSelect);
+    await user.click(await screen.findByRole('option', { name: 'Web' }));
+    await user.click(typeSelect);
+    await user.click(await screen.findByRole('option', { name: '—' }));
+
+    // Client side select to a numeric value, then post-logout URIs
+    await user.click(dialog.getAllByRole('combobox')[2]!);
+    await user.click(await screen.findByRole('option', { name: 'Host' }));
+    await user.type(
+      dialog.getByLabelText('Post-Logout Redirect URIs'),
+      'https://app.example.com/logout'
+    );
+    await user.type(dialog.getByLabelText('Client Secret'), 's3cret');
+    await user.type(dialog.getByLabelText('Signing Key (JWK)'), '{{ "kty": "RSA" }');
+
+    await user.click(dialog.getByRole('button', { name: 'Create Application' }));
+    await waitFor(() => expect(createMutate).toHaveBeenCalledTimes(1));
+    expect(createMutate.mock.calls[0]![0]).toMatchObject({
+      clientId: 'none-client',
+      type: undefined,
+      clientSide: 1,
+      clientSecret: 's3cret',
+      postLogoutRedirectUris: ['https://app.example.com/logout'],
+    });
+  });
+
+  it('shows a not-found toast when editing returns 404', async () => {
+    updateMutate.mockRejectedValue({ response: { status: 404 } });
+    appsQuery = { data: mockOidcApplications, isLoading: false };
+    const { user } = renderWithProviders(<OidcApplicationsPage />);
+    await user.click(screen.getAllByRole('button', { name: 'Edit' })[0]!);
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.click(dialog.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Application not found'));
+  });
+
+  it('shows a generic error toast on a non-404 edit failure', async () => {
+    updateMutate.mockRejectedValue({ response: { status: 500 } });
+    appsQuery = { data: mockOidcApplications, isLoading: false };
+    const { user } = renderWithProviders(<OidcApplicationsPage />);
+    await user.click(screen.getAllByRole('button', { name: 'Edit' })[0]!);
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.click(dialog.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Failed to update application'));
+  });
+
+  it('deletes an application and shows a success toast', async () => {
+    appsQuery = { data: mockOidcApplications, isLoading: false };
+    const { user } = renderWithProviders(<OidcApplicationsPage />);
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+
+    const dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByText('Delete Application')).toBeInTheDocument();
+    await user.click(dialog.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(deleteMutate).toHaveBeenCalledWith('granit-showcase-admin'));
+    expect(toastSuccess).toHaveBeenCalledWith('Application deleted successfully');
+  });
+
+  it('shows an error toast when deletion fails', async () => {
+    deleteMutate.mockRejectedValue(new Error('boom'));
+    appsQuery = { data: mockOidcApplications, isLoading: false };
+    const { user } = renderWithProviders(<OidcApplicationsPage />);
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.click(dialog.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Failed to delete application'));
   });
 });

--- a/packages/@granit/react-ui-openiddict-admin/src/__tests__/oidc-authorizations-page.test.tsx
+++ b/packages/@granit/react-ui-openiddict-admin/src/__tests__/oidc-authorizations-page.test.tsx
@@ -1,20 +1,13 @@
-import { screen } from '@testing-library/react';
+import { mockOidcAuthorizations } from '@granit/react-openiddict-admin/testing';
+import { screen, waitFor, within } from '@testing-library/react';
 
 import { OidcAuthorizationsPage } from '../authorizations/oidc-authorizations-page';
 
 import { renderWithProviders } from './test-utils';
 
-const sampleAuthorization = {
-  id: 'auth-1',
-  subject: 'user-1',
-  clientId: 'web-spa',
-  status: 'valid',
-  type: 'permanent',
-  scopes: ['openid', 'profile'],
-  creationDate: '2026-01-01T00:00:00Z',
-};
+import type { AdminOidcAuthorizationResponse } from '@granit/openiddict-admin';
 
-let authQuery: { data: readonly (typeof sampleAuthorization)[]; isLoading: boolean } = {
+let authQuery: { data: readonly AdminOidcAuthorizationResponse[]; isLoading: boolean } = {
   data: [],
   isLoading: false,
 };
@@ -23,15 +16,29 @@ let granted = new Set<string>([
   'OpenIddict.Authorizations.Revoke',
 ]);
 
+const createMutate = vi.fn();
+const revokeMutate = vi.fn();
+const revokeUserMutate = vi.fn();
+let pending = false;
+
 vi.mock('@granit/react-openiddict-admin', () => ({
   useOidcAuthorizations: () => authQuery,
-  useCreateOidcAuthorization: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useRevokeAuthorization: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useRevokeUserAuthorizations: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useCreateOidcAuthorization: () => ({ mutateAsync: createMutate, isPending: pending }),
+  useRevokeAuthorization: () => ({ mutateAsync: revokeMutate, isPending: pending }),
+  useRevokeUserAuthorizations: () => ({ mutateAsync: revokeUserMutate, isPending: pending }),
 }));
 
 vi.mock('@granit/react-authorization', () => ({
   usePermissions: () => ({ hasPermission: (p: string) => granted.has(p), isLoading: false }),
+}));
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: (msg: string) => toastSuccess(msg),
+    error: (msg: string) => toastError(msg),
+  },
 }));
 
 beforeEach(() => {
@@ -40,6 +47,12 @@ beforeEach(() => {
     'OpenIddict.Authorizations.Create',
     'OpenIddict.Authorizations.Revoke',
   ]);
+  pending = false;
+  createMutate.mockReset().mockResolvedValue(undefined);
+  revokeMutate.mockReset().mockResolvedValue(undefined);
+  revokeUserMutate.mockReset().mockResolvedValue(undefined);
+  toastSuccess.mockReset();
+  toastError.mockReset();
 });
 
 describe('OidcAuthorizationsPage', () => {
@@ -60,11 +73,13 @@ describe('OidcAuthorizationsPage', () => {
     expect(screen.queryByText('No authorizations found.')).not.toBeInTheDocument();
   });
 
-  it('renders a row per authorization with subject and client', () => {
-    authQuery = { data: [sampleAuthorization], isLoading: false };
+  it('renders a row per authorization with subject, client and scope chips', () => {
+    authQuery = { data: mockOidcAuthorizations, isLoading: false };
     renderWithProviders(<OidcAuthorizationsPage />);
-    expect(screen.getByText('user-1')).toBeInTheDocument();
-    expect(screen.getByText('web-spa')).toBeInTheDocument();
+    expect(screen.getByText('usr_01HZ9KQX0000000000001')).toBeInTheDocument();
+    expect(screen.getAllByText('granit-showcase-admin').length).toBeGreaterThan(0);
+    // scope chips for the first row
+    expect(screen.getAllByText('openid').length).toBeGreaterThan(0);
   });
 
   it('exposes the grant action with the create permission', () => {
@@ -76,5 +91,188 @@ describe('OidcAuthorizationsPage', () => {
     granted = new Set<string>(['OpenIddict.Authorizations.Revoke']);
     renderWithProviders(<OidcAuthorizationsPage />);
     expect(screen.queryByRole('button', { name: /grant consent/i })).not.toBeInTheDocument();
+  });
+
+  it('hides revoke row actions without the revoke permission', () => {
+    granted = new Set<string>(['OpenIddict.Authorizations.Create']);
+    authQuery = { data: mockOidcAuthorizations, isLoading: false };
+    renderWithProviders(<OidcAuthorizationsPage />);
+    expect(screen.queryByRole('button', { name: /revoke all/i })).not.toBeInTheDocument();
+  });
+
+  it('renders fallbacks for an authorization with no client and no scopes', () => {
+    authQuery = {
+      data: [
+        {
+          id: 'auth-empty',
+          clientId: null,
+          subject: 'lonely-user',
+          status: 'valid',
+          type: 'permanent',
+          scopes: [],
+        },
+      ],
+      isLoading: false,
+    };
+    renderWithProviders(<OidcAuthorizationsPage />);
+    expect(screen.getByText('lonely-user')).toBeInTheDocument();
+    // clientId and scopes both render an em dash
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('ignores non-Enter keystrokes in the scope input', async () => {
+    const { user } = renderWithProviders(<OidcAuthorizationsPage />);
+    await user.click(screen.getByRole('button', { name: /grant consent/i }));
+    const dialog = within(await screen.findByRole('dialog'));
+    const scopeInput = dialog.getByPlaceholderText('e.g. openid');
+    await user.type(scopeInput, 'openid');
+    // a non-Enter key does not commit the scope chip
+    await user.keyboard('{Space}');
+    expect(dialog.queryByRole('button', { name: 'Remove openid' })).not.toBeInTheDocument();
+  });
+
+  it('disables dialog actions while a mutation is pending', async () => {
+    pending = true;
+    authQuery = { data: mockOidcAuthorizations, isLoading: false };
+    const { user } = renderWithProviders(<OidcAuthorizationsPage />);
+
+    await user.click(screen.getByRole('button', { name: /grant consent/i }));
+    let dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    await user.keyboard('{Escape}');
+
+    await user.click(screen.getAllByRole('button', { name: 'Revoke' })[0]!);
+    dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    await user.keyboard('{Escape}');
+
+    await user.click(screen.getAllByRole('button', { name: 'Revoke All' })[0]!);
+    dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+  });
+
+  it('grants an authorization, adding scopes via the Add button', async () => {
+    const { user } = renderWithProviders(<OidcAuthorizationsPage />);
+    await user.click(screen.getByRole('button', { name: /grant consent/i }));
+
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.type(dialog.getByLabelText('Subject (User ID)'), 'usr-42');
+    await user.type(dialog.getByLabelText('Client ID'), 'web-spa');
+
+    const scopeInput = dialog.getByPlaceholderText('e.g. openid');
+    await user.type(scopeInput, 'openid');
+    await user.click(dialog.getByRole('button', { name: 'Add' }));
+    // duplicate is ignored
+    await user.type(scopeInput, 'openid');
+    await user.click(dialog.getByRole('button', { name: 'Add' }));
+    // second scope via Enter key
+    await user.type(scopeInput, 'profile{Enter}');
+
+    await user.click(dialog.getByRole('button', { name: 'Grant Consent' }));
+
+    await waitFor(() => expect(createMutate).toHaveBeenCalledTimes(1));
+    expect(createMutate).toHaveBeenCalledWith({
+      subject: 'usr-42',
+      clientId: 'web-spa',
+      scopes: ['openid', 'profile'],
+    });
+    expect(toastSuccess).toHaveBeenCalledWith('Authorization granted successfully');
+  });
+
+  it('removes a scope chip before granting', async () => {
+    const { user } = renderWithProviders(<OidcAuthorizationsPage />);
+    await user.click(screen.getByRole('button', { name: /grant consent/i }));
+
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.type(dialog.getByLabelText('Subject (User ID)'), 'usr-42');
+    await user.type(dialog.getByLabelText('Client ID'), 'web-spa');
+    const scopeInput = dialog.getByPlaceholderText('e.g. openid');
+    await user.type(scopeInput, 'openid{Enter}');
+    await user.type(scopeInput, 'profile{Enter}');
+
+    await user.click(dialog.getByRole('button', { name: 'Remove openid' }));
+    await user.click(dialog.getByRole('button', { name: 'Grant Consent' }));
+
+    await waitFor(() => expect(createMutate).toHaveBeenCalledTimes(1));
+    expect(createMutate.mock.calls[0]![0]).toMatchObject({ scopes: ['profile'] });
+  });
+
+  it('shows a client-not-found toast when granting returns 404', async () => {
+    createMutate.mockRejectedValue({ response: { status: 404 } });
+    const { user } = renderWithProviders(<OidcAuthorizationsPage />);
+    await user.click(screen.getByRole('button', { name: /grant consent/i }));
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.type(dialog.getByLabelText('Subject (User ID)'), 'usr-42');
+    await user.type(dialog.getByLabelText('Client ID'), 'missing');
+    await user.click(dialog.getByRole('button', { name: 'Grant Consent' }));
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Client not found'));
+  });
+
+  it('shows a generic toast on a non-404 grant failure', async () => {
+    createMutate.mockRejectedValue({ response: { status: 500 } });
+    const { user } = renderWithProviders(<OidcAuthorizationsPage />);
+    await user.click(screen.getByRole('button', { name: /grant consent/i }));
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.type(dialog.getByLabelText('Subject (User ID)'), 'usr-42');
+    await user.type(dialog.getByLabelText('Client ID'), 'web-spa');
+    await user.click(dialog.getByRole('button', { name: 'Grant Consent' }));
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Failed to create authorization'));
+  });
+
+  it('cancels the grant dialog without calling the mutation', async () => {
+    const { user } = renderWithProviders(<OidcAuthorizationsPage />);
+    await user.click(screen.getByRole('button', { name: /grant consent/i }));
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.click(dialog.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(createMutate).not.toHaveBeenCalled();
+  });
+
+  it('revokes a single authorization', async () => {
+    authQuery = { data: mockOidcAuthorizations, isLoading: false };
+    const { user } = renderWithProviders(<OidcAuthorizationsPage />);
+    await user.click(screen.getAllByRole('button', { name: 'Revoke' })[0]!);
+
+    const dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByText('Revoke Authorization')).toBeInTheDocument();
+    await user.click(dialog.getByRole('button', { name: 'Revoke' }));
+
+    await waitFor(() => expect(revokeMutate).toHaveBeenCalledWith('auth_01HZ9KQX0000000000001'));
+    expect(toastSuccess).toHaveBeenCalledWith('Authorization revoked successfully');
+  });
+
+  it('shows an error toast when single revoke fails', async () => {
+    revokeMutate.mockRejectedValue(new Error('boom'));
+    authQuery = { data: mockOidcAuthorizations, isLoading: false };
+    const { user } = renderWithProviders(<OidcAuthorizationsPage />);
+    await user.click(screen.getAllByRole('button', { name: 'Revoke' })[0]!);
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.click(dialog.getByRole('button', { name: 'Revoke' }));
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Failed to revoke authorization'));
+  });
+
+  it('revokes all authorizations for a user', async () => {
+    authQuery = { data: mockOidcAuthorizations, isLoading: false };
+    const { user } = renderWithProviders(<OidcAuthorizationsPage />);
+    await user.click(screen.getAllByRole('button', { name: 'Revoke All' })[0]!);
+
+    const dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByText('Revoke User Authorizations')).toBeInTheDocument();
+    await user.click(dialog.getByRole('button', { name: 'Revoke All' }));
+
+    await waitFor(() => expect(revokeUserMutate).toHaveBeenCalledWith('usr_01HZ9KQX0000000000001'));
+    expect(toastSuccess).toHaveBeenCalledWith('User authorizations revoked successfully');
+  });
+
+  it('shows an error toast when revoke-all fails', async () => {
+    revokeUserMutate.mockRejectedValue(new Error('boom'));
+    authQuery = { data: mockOidcAuthorizations, isLoading: false };
+    const { user } = renderWithProviders(<OidcAuthorizationsPage />);
+    await user.click(screen.getAllByRole('button', { name: 'Revoke All' })[0]!);
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.click(dialog.getByRole('button', { name: 'Revoke All' }));
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith('Failed to revoke user authorizations')
+    );
   });
 });

--- a/packages/@granit/react-ui-openiddict-admin/src/__tests__/oidc-scopes-page.test.tsx
+++ b/packages/@granit/react-ui-openiddict-admin/src/__tests__/oidc-scopes-page.test.tsx
@@ -1,36 +1,61 @@
-import { screen } from '@testing-library/react';
+import { mockOidcScopes } from '@granit/react-openiddict-admin/testing';
+import { screen, waitFor, within } from '@testing-library/react';
 
 import { OidcScopesPage } from '../scopes/oidc-scopes-page';
 
 import { renderWithProviders } from './test-utils';
 
-const sampleScope = {
-  name: 'api',
-  displayName: 'API access',
-  description: 'Access to the protected API',
-  resources: ['api'],
+import type { AdminOidcScopeResponse } from '@granit/openiddict-admin';
+
+// A scope whose optional fields are all null/empty, to exercise the `?? '—'`
+// row fallbacks and the null-coalescing branches in openEdit/handleEdit.
+const nullScope: AdminOidcScopeResponse = {
+  name: 'sparse',
+  displayName: null,
+  description: null,
+  resources: null,
 };
 
-let scopesQuery: { data: readonly (typeof sampleScope)[]; isLoading: boolean } = {
+let scopesQuery: { data: readonly AdminOidcScopeResponse[]; isLoading: boolean } = {
   data: [],
   isLoading: false,
 };
 let canManage = true;
 
+const createMutate = vi.fn();
+const updateMutate = vi.fn();
+const deleteMutate = vi.fn();
+let pending = false;
+
 vi.mock('@granit/react-openiddict-admin', () => ({
   useOidcScopes: () => scopesQuery,
-  useCreateOidcScope: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useUpdateOidcScope: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useDeleteOidcScope: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useCreateOidcScope: () => ({ mutateAsync: createMutate, isPending: pending }),
+  useUpdateOidcScope: () => ({ mutateAsync: updateMutate, isPending: pending }),
+  useDeleteOidcScope: () => ({ mutateAsync: deleteMutate, isPending: pending }),
 }));
 
 vi.mock('@granit/react-authorization', () => ({
   usePermissions: () => ({ hasPermission: () => canManage, isLoading: false }),
 }));
 
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: (msg: string) => toastSuccess(msg),
+    error: (msg: string) => toastError(msg),
+  },
+}));
+
 beforeEach(() => {
   scopesQuery = { data: [], isLoading: false };
   canManage = true;
+  pending = false;
+  createMutate.mockReset().mockResolvedValue(undefined);
+  updateMutate.mockReset().mockResolvedValue(undefined);
+  deleteMutate.mockReset().mockResolvedValue(undefined);
+  toastSuccess.mockReset();
+  toastError.mockReset();
 });
 
 describe('OidcScopesPage', () => {
@@ -52,11 +77,12 @@ describe('OidcScopesPage', () => {
   });
 
   it('renders a row per scope with edit and delete actions', () => {
-    scopesQuery = { data: [sampleScope], isLoading: false };
+    scopesQuery = { data: mockOidcScopes, isLoading: false };
     renderWithProviders(<OidcScopesPage />);
-    expect(screen.getByText('API access')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+    expect(screen.getByText('OpenID')).toBeInTheDocument();
+    expect(screen.getByText('Granit Admin')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /edit/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: /delete/i }).length).toBeGreaterThan(0);
   });
 
   it('exposes the create action when the user can manage scopes', () => {
@@ -64,9 +90,204 @@ describe('OidcScopesPage', () => {
     expect(screen.getByRole('button', { name: /create scope/i })).toBeInTheDocument();
   });
 
-  it('hides the create action without the manage permission', () => {
+  it('hides the create action and row actions without the manage permission', () => {
     canManage = false;
+    scopesQuery = { data: mockOidcScopes, isLoading: false };
     renderWithProviders(<OidcScopesPage />);
     expect(screen.queryByRole('button', { name: /create scope/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+  });
+
+  it('creates a scope from the dialog and shows a success toast', async () => {
+    const { user } = renderWithProviders(<OidcScopesPage />);
+    await user.click(screen.getByRole('button', { name: /create scope/i }));
+
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.type(dialog.getByLabelText('Name'), 'api:read');
+    await user.type(dialog.getByLabelText('Display Name'), 'Read API');
+    await user.type(dialog.getByLabelText('Description'), 'Reads the API');
+    await user.type(dialog.getByLabelText('Resources'), 'api://one');
+
+    await user.click(dialog.getByRole('button', { name: 'Create Scope' }));
+
+    await waitFor(() => expect(createMutate).toHaveBeenCalledTimes(1));
+    expect(createMutate).toHaveBeenCalledWith({
+      name: 'api:read',
+      displayName: 'Read API',
+      description: 'Reads the API',
+      resources: ['api://one'],
+    });
+    expect(toastSuccess).toHaveBeenCalledWith('Scope created successfully');
+  });
+
+  it('shows an error toast when scope creation fails', async () => {
+    createMutate.mockRejectedValue(new Error('boom'));
+    const { user } = renderWithProviders(<OidcScopesPage />);
+    await user.click(screen.getByRole('button', { name: /create scope/i }));
+
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.type(dialog.getByLabelText('Name'), 'api:read');
+    await user.click(dialog.getByRole('button', { name: 'Create Scope' }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Failed to create scope'));
+  });
+
+  it('closes the create dialog on cancel without calling the mutation', async () => {
+    const { user } = renderWithProviders(<OidcScopesPage />);
+    await user.click(screen.getByRole('button', { name: /create scope/i }));
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.click(dialog.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(createMutate).not.toHaveBeenCalled();
+  });
+
+  it('edits a scope and shows a success toast', async () => {
+    scopesQuery = { data: mockOidcScopes, isLoading: false };
+    const { user } = renderWithProviders(<OidcScopesPage />);
+    await user.click(screen.getAllByRole('button', { name: /edit/i })[0]!);
+
+    const dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByText('Edit Scope')).toBeInTheDocument();
+    const displayName = dialog.getByLabelText('Display Name');
+    await user.clear(displayName);
+    await user.type(displayName, 'OpenID Connect');
+    await user.click(dialog.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    expect(updateMutate.mock.calls[0]![0]).toMatchObject({
+      scopeName: 'openid',
+      request: { displayName: 'OpenID Connect' },
+    });
+    expect(toastSuccess).toHaveBeenCalledWith('Scope updated successfully');
+  });
+
+  it('edits a scope description and resources', async () => {
+    scopesQuery = { data: mockOidcScopes, isLoading: false };
+    const { user } = renderWithProviders(<OidcScopesPage />);
+    // edit the scope that already has resources (granit:admin, index 3)
+    await user.click(screen.getAllByRole('button', { name: /edit/i })[3]!);
+
+    const dialog = within(await screen.findByRole('dialog'));
+    const description = dialog.getByLabelText('Description');
+    await user.clear(description);
+    await user.type(description, 'Updated description');
+
+    const resources = dialog.getByLabelText('Resources');
+    await user.clear(resources);
+    await user.type(resources, 'api://new-resource');
+
+    await user.click(dialog.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    expect(updateMutate.mock.calls[0]![0]).toMatchObject({
+      scopeName: 'granit:admin',
+      request: {
+        description: 'Updated description',
+        resources: ['api://new-resource'],
+      },
+    });
+  });
+
+  it('renders fallback dashes for a scope with no optional fields', () => {
+    scopesQuery = { data: [nullScope], isLoading: false };
+    renderWithProviders(<OidcScopesPage />);
+    expect(screen.getByText('sparse')).toBeInTheDocument();
+    // displayName / description / resources all render an em dash
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('edits a sparse scope, clearing display name to null', async () => {
+    scopesQuery = { data: [nullScope], isLoading: false };
+    const { user } = renderWithProviders(<OidcScopesPage />);
+    await user.click(screen.getByRole('button', { name: /edit/i }));
+
+    const dialog = within(await screen.findByRole('dialog'));
+    // fields start empty (null coalesced to ''); leave them empty and save
+    await user.click(dialog.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    expect(updateMutate.mock.calls[0]![0]).toMatchObject({
+      scopeName: 'sparse',
+      request: { displayName: null, description: null },
+    });
+  });
+
+  it('shows spinners and disables actions on every dialog while pending', async () => {
+    pending = true;
+    scopesQuery = { data: mockOidcScopes, isLoading: false };
+    const { user } = renderWithProviders(<OidcScopesPage />);
+
+    await user.click(screen.getByRole('button', { name: /create scope/i }));
+    let dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(dialog.getByRole('button', { name: 'Create Scope' })).toBeDisabled();
+    await user.keyboard('{Escape}');
+
+    await user.click(screen.getAllByRole('button', { name: /^edit/i })[0]!);
+    dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByRole('button', { name: 'Save' })).toBeDisabled();
+    await user.keyboard('{Escape}');
+
+    await user.click(screen.getAllByRole('button', { name: /^delete/i })[0]!);
+    dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByRole('button', { name: 'Delete' })).toBeDisabled();
+  });
+
+  it('creates a scope with no optional fields, sending undefined resources', async () => {
+    const { user } = renderWithProviders(<OidcScopesPage />);
+    await user.click(screen.getByRole('button', { name: /create scope/i }));
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.type(dialog.getByLabelText('Name'), 'minimal');
+    await user.click(dialog.getByRole('button', { name: 'Create Scope' }));
+    await waitFor(() => expect(createMutate).toHaveBeenCalledTimes(1));
+    expect(createMutate).toHaveBeenCalledWith({
+      name: 'minimal',
+      displayName: undefined,
+      description: undefined,
+      resources: undefined,
+    });
+  });
+
+  it('shows a not-found toast when editing returns 404', async () => {
+    updateMutate.mockRejectedValue({ response: { status: 404 } });
+    scopesQuery = { data: mockOidcScopes, isLoading: false };
+    const { user } = renderWithProviders(<OidcScopesPage />);
+    await user.click(screen.getAllByRole('button', { name: /edit/i })[0]!);
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.click(dialog.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Scope not found'));
+  });
+
+  it('shows a generic error toast on a non-404 edit failure', async () => {
+    updateMutate.mockRejectedValue({ response: { status: 500 } });
+    scopesQuery = { data: mockOidcScopes, isLoading: false };
+    const { user } = renderWithProviders(<OidcScopesPage />);
+    await user.click(screen.getAllByRole('button', { name: /edit/i })[0]!);
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.click(dialog.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Failed to update scope'));
+  });
+
+  it('deletes a scope and shows a success toast', async () => {
+    scopesQuery = { data: mockOidcScopes, isLoading: false };
+    const { user } = renderWithProviders(<OidcScopesPage />);
+    await user.click(screen.getAllByRole('button', { name: /delete/i })[0]!);
+
+    const dialog = within(await screen.findByRole('dialog'));
+    expect(dialog.getByText('Delete Scope')).toBeInTheDocument();
+    await user.click(dialog.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(deleteMutate).toHaveBeenCalledWith('openid'));
+    expect(toastSuccess).toHaveBeenCalledWith('Scope deleted successfully');
+  });
+
+  it('shows an error toast when deletion fails', async () => {
+    deleteMutate.mockRejectedValue(new Error('boom'));
+    scopesQuery = { data: mockOidcScopes, isLoading: false };
+    const { user } = renderWithProviders(<OidcScopesPage />);
+    await user.click(screen.getAllByRole('button', { name: /delete/i })[0]!);
+    const dialog = within(await screen.findByRole('dialog'));
+    await user.click(dialog.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith('Failed to delete scope'));
   });
 });

--- a/packages/@granit/react-ui-parties/src/__tests__/add-role-dialog.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/add-role-dialog.test.tsx
@@ -1,0 +1,103 @@
+import { screen, waitFor } from '@testing-library/react';
+
+import { AddRoleDialog } from '../components/add-role-dialog';
+
+import { renderWithProviders } from './test-utils';
+
+import type { PartyId } from '@granit/parties';
+
+const { mockAdd } = vi.hoisted(() => ({
+  mockAdd: { mutateAsync: vi.fn(), isPending: false },
+}));
+
+vi.mock('@granit/react-parties', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useAddPartyRoleMutation: () => mockAdd,
+  };
+});
+
+const partyId = 'party-1' as PartyId;
+
+describe('AddRoleDialog', () => {
+  beforeEach(() => {
+    mockAdd.mutateAsync.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('renders the dialog title when open', () => {
+    renderWithProviders(
+      <AddRoleDialog
+        partyId={partyId}
+        assignableRoles={['Customer', 'Supplier']}
+        open
+        onOpenChange={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Add role')).toBeInTheDocument();
+  });
+
+  it('disables the submit button until a role is selected', () => {
+    renderWithProviders(
+      <AddRoleDialog partyId={partyId} assignableRoles={['Customer']} open onOpenChange={vi.fn()} />
+    );
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+  });
+
+  it('selects a role and submits the mutation', async () => {
+    const onOpenChange = vi.fn();
+    const { user } = renderWithProviders(
+      <AddRoleDialog
+        partyId={partyId}
+        assignableRoles={['Customer', 'Supplier']}
+        open
+        onOpenChange={onOpenChange}
+      />
+    );
+    await user.click(screen.getByRole('combobox', { name: 'Role' }));
+    await user.click(await screen.findByRole('option', { name: 'Supplier' }));
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    await waitFor(() => {
+      expect(mockAdd.mutateAsync).toHaveBeenCalledWith({
+        id: partyId,
+        request: { role: 'Supplier' },
+      });
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('closes via the cancel button', async () => {
+    const onOpenChange = vi.fn();
+    const { user } = renderWithProviders(
+      <AddRoleDialog
+        partyId={partyId}
+        assignableRoles={['Customer']}
+        open
+        onOpenChange={onOpenChange}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('logs an error when the mutation rejects', async () => {
+    mockAdd.mutateAsync.mockRejectedValueOnce(new Error('boom'));
+    const { user } = renderWithProviders(
+      <AddRoleDialog partyId={partyId} assignableRoles={['Customer']} open onOpenChange={vi.fn()} />
+    );
+    await user.click(screen.getByRole('combobox', { name: 'Role' }));
+    await user.click(await screen.findByRole('option', { name: 'Customer' }));
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    await waitFor(() => {
+      expect(mockAdd.mutateAsync).toHaveBeenCalled();
+    });
+  });
+
+  it('falls back to all assignable roles when none are passed', async () => {
+    const { user } = renderWithProviders(
+      <AddRoleDialog partyId={partyId} assignableRoles={[]} open onOpenChange={vi.fn()} />
+    );
+    await user.click(screen.getByRole('combobox', { name: 'Role' }));
+    expect(await screen.findByRole('option', { name: 'Employee' })).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-parties/src/__tests__/addresses-tab.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/addresses-tab.test.tsx
@@ -1,0 +1,88 @@
+import { sampleParty } from '@granit/react-parties/testing';
+import { screen, waitFor } from '@testing-library/react';
+
+import { AddressesTab } from '../components/addresses-tab';
+
+import { renderWithProviders } from './test-utils';
+
+import type { PartyAddressResponse } from '@granit/parties';
+
+const { mockRemove, mockAdd } = vi.hoisted(() => ({
+  mockRemove: { mutateAsync: vi.fn(), isPending: false },
+  mockAdd: { mutateAsync: vi.fn(), isPending: false },
+}));
+
+vi.mock('@granit/react-parties', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useRemovePartyAddressMutation: () => mockRemove,
+    useAddPartyAddressMutation: () => mockAdd,
+  };
+});
+
+const partyId = sampleParty.id;
+const addresses = sampleParty.addresses as readonly PartyAddressResponse[];
+
+describe('AddressesTab', () => {
+  beforeEach(() => {
+    mockRemove.mutateAsync.mockReset().mockResolvedValue(undefined);
+    mockAdd.mutateAsync.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('renders the title and the address cards', () => {
+    renderWithProviders(<AddressesTab partyId={partyId} addresses={addresses} />);
+    expect(screen.getByText('Addresses')).toBeInTheDocument();
+    expect(screen.getByText('1 rue de la Loi')).toBeInTheDocument();
+    expect(screen.getByText('Acme Corp SA')).toBeInTheDocument();
+    expect(screen.getByText('Bât. 4')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no addresses', () => {
+    renderWithProviders(<AddressesTab partyId={partyId} addresses={[]} />);
+    expect(screen.getByText('No addresses on file.')).toBeInTheDocument();
+  });
+
+  it('removes an address via the mutation', async () => {
+    const { user } = renderWithProviders(<AddressesTab partyId={partyId} addresses={addresses} />);
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+    await waitFor(() => {
+      expect(mockRemove.mutateAsync).toHaveBeenCalledWith({
+        id: partyId,
+        addressId: addresses[0]!.id,
+      });
+    });
+  });
+
+  it('logs an error when the remove mutation rejects', async () => {
+    mockRemove.mutateAsync.mockRejectedValueOnce(new Error('boom'));
+    const { user } = renderWithProviders(<AddressesTab partyId={partyId} addresses={addresses} />);
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+    await waitFor(() => {
+      expect(mockRemove.mutateAsync).toHaveBeenCalled();
+    });
+  });
+
+  it('opens the add-address dialog', async () => {
+    const { user } = renderWithProviders(<AddressesTab partyId={partyId} addresses={addresses} />);
+    await user.click(screen.getByRole('button', { name: 'Add address' }));
+    expect(await screen.findByText('Add a new postal address for this party.')).toBeInTheDocument();
+  });
+
+  it('submits a new address through the add dialog', async () => {
+    const { user } = renderWithProviders(<AddressesTab partyId={partyId} addresses={[]} />);
+    await user.click(screen.getByRole('button', { name: 'Add address' }));
+    await user.type(await screen.findByLabelText('Address line 1'), '12 Main St');
+    await user.type(screen.getByLabelText('Postal code'), '1000');
+    await user.type(screen.getByLabelText('City'), 'Brussels');
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    await waitFor(() => {
+      expect(mockAdd.mutateAsync).toHaveBeenCalled();
+    });
+    const call = mockAdd.mutateAsync.mock.calls[0]![0] as {
+      request: { line1: string; country: string };
+    };
+    expect(call.request.line1).toBe('12 Main St');
+    expect(call.request.country).toBe('BE');
+  });
+});

--- a/packages/@granit/react-ui-parties/src/__tests__/create-conflict-dialog.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/create-conflict-dialog.test.tsx
@@ -136,4 +136,70 @@ describe('CreateConflictDialog', () => {
 
     expect(await screen.findByText(/wizard for existing-1 ← new-id/)).toBeInTheDocument();
   });
+
+  it('navigates to the survivor after a successful merge', async () => {
+    const onCreateAnyway = vi.fn().mockResolvedValue('new-id' as PartyId);
+    const onClose = vi.fn();
+    const { user } = renderWithProviders(
+      <CreateConflictDialog conflict={conflict} onCreateAnyway={onCreateAnyway} onClose={onClose} />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Merge into this one/i }));
+    await user.click(await screen.findByRole('button', { name: 'wizard-success' }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/parties/existing-1');
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('stays on the choose phase when force-create returns null', async () => {
+    const onCreateAnyway = vi.fn().mockResolvedValue(null);
+    const { user } = renderWithProviders(
+      <CreateConflictDialog conflict={conflict} onCreateAnyway={onCreateAnyway} onClose={vi.fn()} />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Create anyway/i }));
+
+    await waitFor(() => {
+      expect(onCreateAnyway).toHaveBeenCalled();
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(screen.getByText('Potential duplicate detected')).toBeInTheDocument();
+  });
+
+  it('recovers when force-create rejects', async () => {
+    const onCreateAnyway = vi.fn().mockRejectedValue(new Error('boom'));
+    const { user } = renderWithProviders(
+      <CreateConflictDialog conflict={conflict} onCreateAnyway={onCreateAnyway} onClose={vi.fn()} />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Create anyway/i }));
+
+    await waitFor(() => {
+      expect(onCreateAnyway).toHaveBeenCalled();
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('does not open the merge wizard when force-create returns null', async () => {
+    const onCreateAnyway = vi.fn().mockResolvedValue(null);
+    const { user } = renderWithProviders(
+      <CreateConflictDialog conflict={conflict} onCreateAnyway={onCreateAnyway} onClose={vi.fn()} />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Merge into this one/i }));
+
+    await waitFor(() => {
+      expect(onCreateAnyway).toHaveBeenCalled();
+    });
+    expect(screen.queryByText(/wizard for/)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing actionable when there is no conflict', () => {
+    renderWithProviders(
+      <CreateConflictDialog conflict={null} onCreateAnyway={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(screen.queryByText('Potential duplicate detected')).not.toBeInTheDocument();
+  });
 });

--- a/packages/@granit/react-ui-parties/src/__tests__/download-vcard-button.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/download-vcard-button.test.tsx
@@ -1,0 +1,73 @@
+import { screen, waitFor } from '@testing-library/react';
+
+import { DownloadVCardButton } from '../components/download-vcard-button';
+
+import { renderWithProviders } from './test-utils';
+
+import type { PartyId } from '@granit/parties';
+
+const { mockDownload } = vi.hoisted(() => ({ mockDownload: vi.fn() }));
+
+vi.mock('@granit/parties', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    downloadPartyVCard: (...args: unknown[]) => mockDownload(...args),
+  };
+});
+
+vi.mock('@granit/react-parties', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    usePartiesConfig: () => ({ client: {}, basePath: '/api/v1/parties' }),
+  };
+});
+
+const partyId = 'party-1' as PartyId;
+
+describe('DownloadVCardButton', () => {
+  beforeEach(() => {
+    mockDownload.mockReset();
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn(() => 'blob:fake'),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('renders the download button', () => {
+    renderWithProviders(<DownloadVCardButton partyId={partyId} partyName="Acme Corp" />);
+    expect(screen.getByRole('button', { name: 'Download vCard' })).toBeInTheDocument();
+  });
+
+  it('downloads the vCard and triggers the anchor click', async () => {
+    mockDownload.mockResolvedValue(new Blob(['BEGIN:VCARD'], { type: 'text/vcard' }));
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    const { user } = renderWithProviders(
+      <DownloadVCardButton partyId={partyId} partyName="Acme Corp!" />
+    );
+    await user.click(screen.getByRole('button', { name: 'Download vCard' }));
+
+    await waitFor(() => {
+      expect(mockDownload).toHaveBeenCalledWith({}, '/api/v1/parties', partyId);
+    });
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
+
+  it('surfaces an error toast when the download fails', async () => {
+    mockDownload.mockRejectedValue(new Error('network'));
+    const { user } = renderWithProviders(
+      <DownloadVCardButton partyId={partyId} partyName="Acme" />
+    );
+    await user.click(screen.getByRole('button', { name: 'Download vCard' }));
+    await waitFor(() => {
+      expect(mockDownload).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/@granit/react-ui-parties/src/__tests__/duplicates-inbox-page.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/duplicates-inbox-page.test.tsx
@@ -1,17 +1,23 @@
+import { sampleDuplicates } from '@granit/react-parties/testing';
 import { screen } from '@testing-library/react';
 
 import { DuplicatesInboxPage } from '../duplicates-inbox-page';
 
 import { renderWithProviders } from './test-utils';
 
+import type { PartyDuplicateCandidateResponse } from '@granit/parties';
+
+const candidate: PartyDuplicateCandidateResponse = sampleDuplicates[0]!;
+
 vi.mock('@granit/react-parties', () => ({
-  DuplicatesInbox: ({ onMerge }: { onMerge?: (row: unknown) => void }) => (
+  DuplicatesInbox: ({ onMerge }: { onMerge?: (row: PartyDuplicateCandidateResponse) => void }) => (
     <div data-slot="duplicates-inbox-stub">
-      <button type="button" onClick={() => onMerge?.({ id: 'cand-1' })}>
+      <button type="button" onClick={() => onMerge?.(candidate)}>
         stub-merge
       </button>
     </div>
   ),
+  MergeWizard: () => <div data-slot="merge-wizard-stub" />,
   usePartiesQuery: () => ({ data: [], isLoading: false }),
 }));
 
@@ -24,5 +30,11 @@ describe('DuplicatesInboxPage', () => {
   it('mounts the upstream <DuplicatesInbox> component', () => {
     renderWithProviders(<DuplicatesInboxPage />);
     expect(screen.getByRole('button', { name: 'stub-merge' })).toBeInTheDocument();
+  });
+
+  it('opens the survivor picker when a row requests a merge', async () => {
+    const { user } = renderWithProviders(<DuplicatesInboxPage />);
+    await user.click(screen.getByRole('button', { name: 'stub-merge' }));
+    expect(await screen.findByText('Pick the surviving party')).toBeInTheDocument();
   });
 });

--- a/packages/@granit/react-ui-parties/src/__tests__/emails-tab.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/emails-tab.test.tsx
@@ -1,0 +1,86 @@
+import { sampleParty } from '@granit/react-parties/testing';
+import { screen, waitFor } from '@testing-library/react';
+
+import { EmailsTab } from '../components/emails-tab';
+
+import { renderWithProviders } from './test-utils';
+
+import type { PartyEmailResponse } from '@granit/parties';
+
+const { mockRemove, mockAdd } = vi.hoisted(() => ({
+  mockRemove: { mutateAsync: vi.fn(), isPending: false },
+  mockAdd: { mutateAsync: vi.fn(), isPending: false },
+}));
+
+vi.mock('@granit/react-parties', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useRemovePartyEmailMutation: () => mockRemove,
+    useAddPartyEmailMutation: () => mockAdd,
+  };
+});
+
+const partyId = sampleParty.id;
+const emails = sampleParty.emails as readonly PartyEmailResponse[];
+
+describe('EmailsTab', () => {
+  beforeEach(() => {
+    mockRemove.mutateAsync.mockReset().mockResolvedValue(undefined);
+    mockAdd.mutateAsync.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('renders the title and the list of emails', () => {
+    renderWithProviders(<EmailsTab partyId={partyId} emails={emails} />);
+    expect(screen.getByText('Emails')).toBeInTheDocument();
+    expect(screen.getByText('billing@acme.example')).toBeInTheDocument();
+    expect(screen.getByText('support@acme.example')).toBeInTheDocument();
+    expect(screen.getByText('Primary')).toBeInTheDocument();
+    expect(screen.getByText('Billing')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no emails', () => {
+    renderWithProviders(<EmailsTab partyId={partyId} emails={[]} />);
+    expect(screen.getByText('No email addresses on file.')).toBeInTheDocument();
+  });
+
+  it('removes an email via the mutation', async () => {
+    const { user } = renderWithProviders(<EmailsTab partyId={partyId} emails={emails} />);
+    const removeButtons = screen.getAllByRole('button', { name: 'Delete' });
+    await user.click(removeButtons[0]!);
+    await waitFor(() => {
+      expect(mockRemove.mutateAsync).toHaveBeenCalledWith({
+        id: partyId,
+        emailId: emails[0]!.id,
+      });
+    });
+  });
+
+  it('logs an error when the remove mutation rejects', async () => {
+    mockRemove.mutateAsync.mockRejectedValueOnce(new Error('boom'));
+    const { user } = renderWithProviders(<EmailsTab partyId={partyId} emails={emails} />);
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+    await waitFor(() => {
+      expect(mockRemove.mutateAsync).toHaveBeenCalled();
+    });
+  });
+
+  it('opens the add-email dialog', async () => {
+    const { user } = renderWithProviders(<EmailsTab partyId={partyId} emails={emails} />);
+    await user.click(screen.getByRole('button', { name: 'Add email' }));
+    expect(await screen.findByText('Add a new email address for this party.')).toBeInTheDocument();
+  });
+
+  it('submits a new email through the add dialog', async () => {
+    const { user } = renderWithProviders(<EmailsTab partyId={partyId} emails={[]} />);
+    await user.click(screen.getByRole('button', { name: 'Add email' }));
+    await user.type(await screen.findByLabelText('Email'), 'new@acme.example');
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    await waitFor(() => {
+      expect(mockAdd.mutateAsync).toHaveBeenCalledWith({
+        id: partyId,
+        request: { address: 'new@acme.example', label: null, isPrimary: false },
+      });
+    });
+  });
+});

--- a/packages/@granit/react-ui-parties/src/__tests__/external-mappings-tab.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/external-mappings-tab.test.tsx
@@ -1,0 +1,97 @@
+import { sampleParty } from '@granit/react-parties/testing';
+import { screen, waitFor } from '@testing-library/react';
+
+import { ExternalMappingsTab } from '../components/external-mappings-tab';
+
+import { renderWithProviders } from './test-utils';
+
+import type { PartyExternalMappingResponse } from '@granit/parties';
+
+const { mockRemove, mockAdd } = vi.hoisted(() => ({
+  mockRemove: { mutateAsync: vi.fn(), isPending: false },
+  mockAdd: { mutateAsync: vi.fn(), isPending: false },
+}));
+
+vi.mock('@granit/react-parties', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useRemovePartyExternalMappingMutation: () => mockRemove,
+    useAddPartyExternalMappingMutation: () => mockAdd,
+  };
+});
+
+const partyId = sampleParty.id;
+const mappings = sampleParty.externalMappings as readonly PartyExternalMappingResponse[];
+
+describe('ExternalMappingsTab', () => {
+  beforeEach(() => {
+    mockRemove.mutateAsync.mockReset().mockResolvedValue(undefined);
+    mockAdd.mutateAsync.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('renders the title and the mapping list', () => {
+    renderWithProviders(<ExternalMappingsTab partyId={partyId} mappings={mappings} />);
+    expect(screen.getByText('External mappings')).toBeInTheDocument();
+    expect(screen.getByText('stripe')).toBeInTheDocument();
+    expect(screen.getByText('cus_AcmeBE')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no mappings', () => {
+    renderWithProviders(<ExternalMappingsTab partyId={partyId} mappings={[]} />);
+    expect(screen.getByText('No external mappings.')).toBeInTheDocument();
+  });
+
+  it('confirms then removes a mapping via the mutation', async () => {
+    const { user } = renderWithProviders(
+      <ExternalMappingsTab partyId={partyId} mappings={mappings} />
+    );
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+    expect(await screen.findByText('Remove external mapping?')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => {
+      expect(mockRemove.mutateAsync).toHaveBeenCalledWith({
+        id: partyId,
+        providerName: 'stripe',
+      });
+    });
+  });
+
+  it('cancels the remove confirmation', async () => {
+    const { user } = renderWithProviders(
+      <ExternalMappingsTab partyId={partyId} mappings={mappings} />
+    );
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+    await user.click(await screen.findByRole('button', { name: 'Cancel' }));
+    await waitFor(() => {
+      expect(screen.queryByText('Remove external mapping?')).not.toBeInTheDocument();
+    });
+    expect(mockRemove.mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('logs an error when the remove mutation rejects', async () => {
+    mockRemove.mutateAsync.mockRejectedValueOnce(new Error('boom'));
+    const { user } = renderWithProviders(
+      <ExternalMappingsTab partyId={partyId} mappings={mappings} />
+    );
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+    await user.click(await screen.findByRole('button', { name: 'Delete' }));
+    await waitFor(() => {
+      expect(mockRemove.mutateAsync).toHaveBeenCalled();
+    });
+  });
+
+  it('opens and submits the add-mapping dialog with a lowercased provider', async () => {
+    const { user } = renderWithProviders(<ExternalMappingsTab partyId={partyId} mappings={[]} />);
+    await user.click(screen.getByRole('button', { name: 'Add mapping' }));
+    await user.type(await screen.findByLabelText('Provider'), 'ODOO');
+    await user.type(screen.getByLabelText('External ID'), 'res.partner/99');
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    await waitFor(() => {
+      expect(mockAdd.mutateAsync).toHaveBeenCalledWith({
+        id: partyId,
+        request: { providerName: 'odoo', externalId: 'res.partner/99' },
+      });
+    });
+  });
+});

--- a/packages/@granit/react-ui-parties/src/__tests__/merge-action.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/merge-action.test.tsx
@@ -113,4 +113,34 @@ describe('MergeAction', () => {
       expect(mockNavigate).toHaveBeenCalledWith('/parties/s1');
     });
   });
+
+  it('returns to idle when the wizard is cancelled', async () => {
+    mockUsePartiesQuery.mockReturnValue({ data: [loserCandidate], isLoading: false });
+    const { user } = renderWithProviders(
+      <MergeAction survivorId={survivorId} survivorName="Acme" />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Merge with/i }));
+    await user.click(screen.getByRole('button', { name: /Globex Inc/ }));
+    await user.click(await screen.findByRole('button', { name: 'wizard-cancel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/wizard for/)).not.toBeInTheDocument();
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('closes the picker without selecting via cancel', async () => {
+    mockUsePartiesQuery.mockReturnValue({ data: [loserCandidate], isLoading: false });
+    const { user } = renderWithProviders(
+      <MergeAction survivorId={survivorId} survivorName="Acme" />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Merge with/i }));
+    await user.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Pick a party to merge into this one')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/@granit/react-ui-parties/src/__tests__/merge-from-candidate.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/merge-from-candidate.test.tsx
@@ -100,4 +100,14 @@ describe('MergeFromCandidate', () => {
       expect(mockNavigate).toHaveBeenCalledWith('/parties/p-a');
     });
   });
+
+  it('closes from the survivor picker via cancel', async () => {
+    const onClose = vi.fn();
+    const { user } = renderWithProviders(
+      <MergeFromCandidate candidate={candidate} onClose={onClose} />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onClose).toHaveBeenCalled();
+  });
 });

--- a/packages/@granit/react-ui-parties/src/__tests__/metadata-tab.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/metadata-tab.test.tsx
@@ -1,0 +1,87 @@
+import { screen, waitFor } from '@testing-library/react';
+
+import { MetadataTab } from '../components/metadata-tab';
+
+import { renderWithProviders } from './test-utils';
+
+import type { PartyId } from '@granit/parties';
+
+const { mockReplace } = vi.hoisted(() => ({
+  mockReplace: { mutateAsync: vi.fn(), isPending: false },
+}));
+
+vi.mock('@granit/react-parties', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useReplacePartyMetadataMutation: () => mockReplace,
+  };
+});
+
+const partyId = 'party-1' as PartyId;
+
+describe('MetadataTab', () => {
+  beforeEach(() => {
+    mockReplace.mutateAsync.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('renders existing metadata entries', () => {
+    renderWithProviders(<MetadataTab partyId={partyId} metadata={{ segment: 'enterprise' }} />);
+    expect(screen.getByText('Metadata')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('segment')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('enterprise')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there is no metadata', () => {
+    renderWithProviders(<MetadataTab partyId={partyId} metadata={{}} />);
+    expect(screen.getByText('No metadata entries.')).toBeInTheDocument();
+  });
+
+  it('adds, edits and saves an entry', async () => {
+    const { user } = renderWithProviders(<MetadataTab partyId={partyId} metadata={{}} />);
+    await user.click(screen.getByRole('button', { name: 'Add entry' }));
+    await user.type(screen.getByLabelText('Key'), 'region');
+    await user.type(screen.getByLabelText('Value'), 'EU');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => {
+      expect(mockReplace.mutateAsync).toHaveBeenCalledWith({
+        id: partyId,
+        request: { metadata: { region: 'EU' } },
+      });
+    });
+  });
+
+  it('removes an entry', async () => {
+    const { user } = renderWithProviders(<MetadataTab partyId={partyId} metadata={{ a: '1' }} />);
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(screen.queryByDisplayValue('a')).not.toBeInTheDocument();
+  });
+
+  it('blocks saving when keys are duplicated', async () => {
+    const { user } = renderWithProviders(<MetadataTab partyId={partyId} metadata={{ dup: '1' }} />);
+    await user.click(screen.getByRole('button', { name: 'Add entry' }));
+    const keyInputs = screen.getAllByLabelText('Key');
+    await user.type(keyInputs[1]!, 'dup');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    expect(await screen.findByText('Metadata keys must be unique.')).toBeInTheDocument();
+    expect(mockReplace.mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('shows the max-entries error when the cap is reached', async () => {
+    const full = Object.fromEntries(
+      Array.from({ length: 50 }, (_, i) => [`k${i}`, `v${i}`])
+    ) as Record<string, string>;
+    const { user } = renderWithProviders(<MetadataTab partyId={partyId} metadata={full} />);
+    await user.click(screen.getByRole('button', { name: 'Add entry' }));
+    expect(await screen.findByText('Maximum 50 metadata entries reached.')).toBeInTheDocument();
+  });
+
+  it('logs an error when the save mutation rejects', async () => {
+    mockReplace.mutateAsync.mockRejectedValueOnce(new Error('boom'));
+    const { user } = renderWithProviders(<MetadataTab partyId={partyId} metadata={{ a: '1' }} />);
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => {
+      expect(mockReplace.mutateAsync).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/@granit/react-ui-parties/src/__tests__/parties-list-page.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/parties-list-page.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 
 import { PartiesListPage } from '../parties-list-page';
 
@@ -55,5 +55,97 @@ describe('PartiesListPage', () => {
     renderWithProviders(<PartiesListPage />);
     expect(screen.getByText('Acme Corp')).toBeInTheDocument();
     expect(screen.getByText('billing@acme.example')).toBeInTheDocument();
+  });
+
+  it('renders skeletons while loading', () => {
+    mockUsePartiesQuery.mockReturnValue({ data: undefined, isLoading: true });
+    const { container } = renderWithProviders(<PartiesListPage />);
+    expect(container.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+  });
+
+  it('navigates to the create page', async () => {
+    mockUsePartiesQuery.mockReturnValue({ data: [], isLoading: false });
+    const { user } = renderWithProviders(<PartiesListPage />);
+    await user.click(screen.getByRole('button', { name: 'New party' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/parties/new');
+  });
+
+  it('filters the rows by the search term', async () => {
+    mockUsePartiesQuery.mockReturnValue({
+      data: [
+        {
+          id: 'p1',
+          tenantId: null,
+          kind: 'Company',
+          name: 'Acme Corp',
+          roles: 'Customer',
+          status: 'Active',
+          defaultCurrency: 'EUR',
+          primaryEmail: null,
+          primaryPhone: null,
+        },
+        {
+          id: 'p2',
+          tenantId: null,
+          kind: 'Company',
+          name: 'Globex Inc',
+          roles: 'Customer',
+          status: 'Active',
+          defaultCurrency: 'USD',
+          primaryEmail: null,
+          primaryPhone: null,
+        },
+      ],
+      isLoading: false,
+    });
+    const { user } = renderWithProviders(<PartiesListPage />);
+    await user.type(screen.getByLabelText('Search by name…'), 'globex');
+    expect(screen.getByText('Globex Inc')).toBeInTheDocument();
+    expect(screen.queryByText('Acme Corp')).not.toBeInTheDocument();
+  });
+
+  it('filters by status', async () => {
+    mockUsePartiesQuery.mockReturnValue({
+      data: [
+        {
+          id: 'p1',
+          tenantId: null,
+          kind: 'Company',
+          name: 'Acme Corp',
+          roles: 'Customer',
+          status: 'Active',
+          defaultCurrency: 'EUR',
+          primaryEmail: null,
+          primaryPhone: null,
+        },
+        {
+          id: 'p2',
+          tenantId: null,
+          kind: 'Company',
+          name: 'Old Co',
+          roles: 'Customer',
+          status: 'Archived',
+          defaultCurrency: 'EUR',
+          primaryEmail: null,
+          primaryPhone: null,
+        },
+      ],
+      isLoading: false,
+    });
+    const { user } = renderWithProviders(<PartiesListPage />);
+    await user.click(screen.getByRole('combobox', { name: 'Filter by status' }));
+    await user.click(await screen.findByRole('option', { name: 'Archived' }));
+    expect(screen.getByText('Old Co')).toBeInTheDocument();
+    expect(screen.queryByText('Acme Corp')).not.toBeInTheDocument();
+  });
+
+  it('requests the query scoped by the selected role filter', async () => {
+    mockUsePartiesQuery.mockReturnValue({ data: [], isLoading: false });
+    const { user } = renderWithProviders(<PartiesListPage />);
+    await user.click(screen.getByRole('combobox', { name: 'Filter by role' }));
+    await user.click(await screen.findByRole('option', { name: 'Supplier' }));
+    await waitFor(() => {
+      expect(mockUsePartiesQuery).toHaveBeenLastCalledWith({ role: 'Supplier' });
+    });
   });
 });

--- a/packages/@granit/react-ui-parties/src/__tests__/party-columns.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/party-columns.test.tsx
@@ -1,0 +1,61 @@
+import { sampleParties, toListItem } from '@granit/react-parties/testing';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { createPartyColumns } from '../components/party-columns';
+
+import { renderWithProviders } from './test-utils';
+
+import type { PartyId, PartyListItemResponse } from '@granit/parties';
+import type { CellContext } from '@tanstack/react-table';
+
+const t = ((key: string) => key) as never;
+
+function cellFor(id: string, row: PartyListItemResponse) {
+  const columns = createPartyColumns({ t, onViewDetail: vi.fn() });
+  const column = columns.find((c) => c.id === id)!;
+  const cell = column.cell as (ctx: CellContext<PartyListItemResponse, unknown>) => unknown;
+  return cell({ row: { original: row } } as never);
+}
+
+describe('createPartyColumns', () => {
+  const item = toListItem(sampleParties[0]!);
+
+  it('exposes the expected column ids', () => {
+    const ids = createPartyColumns({ t, onViewDetail: vi.fn() }).map((c) => c.id);
+    expect(ids).toEqual(['name', 'kind', 'roles', 'status', 'currency', 'primaryEmail', 'actions']);
+  });
+
+  it('renders the name cell', () => {
+    renderWithProviders(<>{cellFor('name', item) as never}</>);
+    expect(screen.getByText('Acme Corp')).toBeInTheDocument();
+  });
+
+  it('renders the roles, status and kind cells', () => {
+    renderWithProviders(
+      <>
+        {cellFor('kind', item) as never}
+        {cellFor('roles', item) as never}
+        {cellFor('status', item) as never}
+        {cellFor('currency', item) as never}
+      </>
+    );
+    expect(screen.getByText('Customer')).toBeInTheDocument();
+    expect(screen.getByText('EUR')).toBeInTheDocument();
+  });
+
+  it('renders an em dash when there is no primary email', () => {
+    renderWithProviders(<>{cellFor('primaryEmail', { ...item, primaryEmail: null }) as never}</>);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('fires onViewDetail from the actions cell', async () => {
+    const onViewDetail = vi.fn();
+    const columns = createPartyColumns({ t, onViewDetail });
+    const actions = columns.find((c) => c.id === 'actions')!;
+    const cell = actions.cell as (ctx: CellContext<PartyListItemResponse, unknown>) => unknown;
+    renderWithProviders(<>{cell({ row: { original: item } } as never) as never}</>);
+    await userEvent.setup({ delay: null }).click(screen.getByRole('button'));
+    expect(onViewDetail).toHaveBeenCalledWith(item.id as PartyId);
+  });
+});

--- a/packages/@granit/react-ui-parties/src/__tests__/party-create-form.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/party-create-form.test.tsx
@@ -59,6 +59,32 @@ describe('PartyCreateForm', () => {
     expect(values.defaultCurrency).toBe('EUR');
   });
 
+  it('submits the optional website, language and notes fields', async () => {
+    const onSubmit = vi.fn();
+    const { user } = renderWithProviders(
+      <PartyCreateForm onSubmit={onSubmit} onCancel={vi.fn()} isPending={false} />
+    );
+
+    await user.type(screen.getByLabelText('Name'), 'Acme Corp');
+    await user.type(screen.getByLabelText('Website'), 'https://acme.example');
+    await user.type(screen.getByLabelText('Language'), 'fr-BE');
+    await user.type(screen.getByLabelText('Internal notes'), 'VIP account');
+    await user.click(screen.getByRole('button', { name: 'Create party' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+    const [values] = onSubmit.mock.calls[0];
+    expect(values.website).toBe('https://acme.example');
+    expect(values.language).toBe('fr-BE');
+    expect(values.internalNotes).toBe('VIP account');
+  });
+
+  it('renders the loading label while pending', () => {
+    renderWithProviders(<PartyCreateForm onSubmit={vi.fn()} onCancel={vi.fn()} isPending />);
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
   it('calls onCancel when the cancel button is clicked', async () => {
     const onCancel = vi.fn();
     const { user } = renderWithProviders(

--- a/packages/@granit/react-ui-parties/src/__tests__/party-create-page.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/party-create-page.test.tsx
@@ -4,6 +4,9 @@ import { PartyCreatePage } from '../party-create-page';
 
 import { renderWithProviders } from './test-utils';
 
+import type { AxiosError } from '@granit/api-client';
+import type { PartyId } from '@granit/parties';
+
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
@@ -21,8 +24,27 @@ vi.mock('@granit/react-parties', async (importOriginal) => {
   return {
     ...actual,
     useCreatePartyMutation: () => ({ mutateAsync: mockMutateAsync, isPending: false }),
+    usePartyQuery: () => ({ data: undefined, isLoading: false }),
   };
 });
+
+function conflictError(): AxiosError {
+  const err = new Error('conflict') as AxiosError;
+  err.isAxiosError = true;
+  err.response = {
+    status: 409,
+    data: {
+      reason: 'Deterministic',
+      candidates: [
+        { candidateId: 'dup-1' as PartyId, score: 0.95, tier: 'Deterministic', signals: [] },
+      ],
+    },
+    statusText: 'Conflict',
+    headers: {},
+    config: {} as never,
+  };
+  return err;
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -62,5 +84,70 @@ describe('PartyCreatePage', () => {
     });
     expect(screen.getByText('Default currency')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create party' })).toBeInTheDocument();
+  });
+
+  it('creates a party and navigates to its detail page on success', async () => {
+    mockMutateAsync.mockResolvedValue({ id: 'new-party' });
+    const { user } = renderWithProviders(<PartyCreatePage />, { route: '/parties/new' });
+
+    await user.type(await screen.findByLabelText('Name'), 'Acme Corp');
+    await user.click(screen.getByRole('button', { name: 'Create party' }));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        request: expect.objectContaining({ name: 'Acme Corp', kind: 'Company' }),
+      });
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('/parties/new-party');
+  });
+
+  it('navigates to the list on cancel', async () => {
+    const { user } = renderWithProviders(<PartyCreatePage />, { route: '/parties/new' });
+    await user.click(await screen.findByRole('button', { name: 'Cancel' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/parties');
+  });
+
+  it('opens the conflict dialog on a 409 response', async () => {
+    mockMutateAsync.mockRejectedValueOnce(conflictError());
+    const { user } = renderWithProviders(<PartyCreatePage />, { route: '/parties/new' });
+
+    await user.type(await screen.findByLabelText('Name'), 'Acme Corp');
+    await user.click(screen.getByRole('button', { name: 'Create party' }));
+
+    expect(await screen.findByText('Potential duplicate detected')).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('force-creates the party from the conflict dialog', async () => {
+    mockMutateAsync.mockRejectedValueOnce(conflictError());
+    mockMutateAsync.mockResolvedValueOnce({ id: 'forced-party' });
+    const { user } = renderWithProviders(<PartyCreatePage />, { route: '/parties/new' });
+
+    await user.type(await screen.findByLabelText('Name'), 'Acme Corp');
+    await user.click(screen.getByRole('button', { name: 'Create party' }));
+
+    await user.click(await screen.findByRole('button', { name: 'Create anyway' }));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenLastCalledWith({
+        request: expect.objectContaining({ name: 'Acme Corp' }),
+        options: { force: true },
+      });
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('/parties/forced-party');
+  });
+
+  it('logs and stays on the page for a non-conflict error', async () => {
+    mockMutateAsync.mockRejectedValueOnce(new Error('boom'));
+    const { user } = renderWithProviders(<PartyCreatePage />, { route: '/parties/new' });
+
+    await user.type(await screen.findByLabelText('Name'), 'Acme Corp');
+    await user.click(screen.getByRole('button', { name: 'Create party' }));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalled();
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(screen.queryByText('Potential duplicate detected')).not.toBeInTheDocument();
   });
 });

--- a/packages/@granit/react-ui-parties/src/__tests__/party-detail-page.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/party-detail-page.test.tsx
@@ -41,10 +41,13 @@ const mockParty: PartyResponse = {
 // Mocks
 // ---------------------------------------------------------------------------
 
-const { mockUseParams } = vi.hoisted(() => ({ mockUseParams: vi.fn() }));
+const { mockUseParams, mockNavigate } = vi.hoisted(() => ({
+  mockUseParams: vi.fn(),
+  mockNavigate: vi.fn(),
+}));
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, useParams: mockUseParams, useNavigate: () => vi.fn() };
+  return { ...actual, useParams: mockUseParams, useNavigate: () => mockNavigate };
 });
 
 const { mockUsePartyQuery } = vi.hoisted(() => ({ mockUsePartyQuery: vi.fn() }));
@@ -130,5 +133,19 @@ describe('PartyDetailPage', () => {
     mockUsePartyQuery.mockReturnValue({ data: mockParty, isLoading: false });
     renderWithProviders(<PartyDetailPage />, { route: '/parties/party-1' });
     expect(document.querySelector('[data-slot="party-detail-page"]')).toBeInTheDocument();
+  });
+
+  it('navigates back to the list from the not-found state', async () => {
+    mockUsePartyQuery.mockReturnValue({ data: undefined, isLoading: false });
+    const { user } = renderWithProviders(<PartyDetailPage />, { route: '/parties/party-1' });
+    await user.click(screen.getByRole('button', { name: 'Back to parties' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/parties');
+  });
+
+  it('navigates back to the list from the detail header', async () => {
+    mockUsePartyQuery.mockReturnValue({ data: mockParty, isLoading: false });
+    const { user } = renderWithProviders(<PartyDetailPage />, { route: '/parties/party-1' });
+    await user.click(screen.getByRole('button', { name: 'Back to parties' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/parties');
   });
 });

--- a/packages/@granit/react-ui-parties/src/__tests__/party-identity-form.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/party-identity-form.test.tsx
@@ -1,0 +1,74 @@
+import { sampleParty } from '@granit/react-parties/testing';
+import { screen, waitFor } from '@testing-library/react';
+
+import { PartyIdentityForm } from '../components/party-identity-form';
+
+import { renderWithProviders } from './test-utils';
+
+const { mockUpdate } = vi.hoisted(() => ({
+  mockUpdate: { mutateAsync: vi.fn(), isPending: false },
+}));
+
+vi.mock('@granit/react-parties', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useUpdatePartyMutation: () => mockUpdate,
+  };
+});
+
+describe('PartyIdentityForm', () => {
+  beforeEach(() => {
+    mockUpdate.mutateAsync.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('renders the identity fields pre-filled from the party', () => {
+    renderWithProviders(<PartyIdentityForm party={sampleParty} />);
+    expect(screen.getByLabelText('Name')).toHaveValue('Acme Corp');
+  });
+
+  it('keeps the save button disabled until the form is dirty', () => {
+    renderWithProviders(<PartyIdentityForm party={sampleParty} />);
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('submits the updated identity', async () => {
+    const { user } = renderWithProviders(<PartyIdentityForm party={sampleParty} />);
+    const name = screen.getByLabelText('Name');
+    await user.clear(name);
+    await user.type(name, 'Acme Corporation');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => {
+      expect(mockUpdate.mutateAsync).toHaveBeenCalledWith({
+        id: sampleParty.id,
+        request: expect.objectContaining({ name: 'Acme Corporation' }),
+      });
+    });
+  });
+
+  it('submits an edited website, language and notes', async () => {
+    const { user } = renderWithProviders(<PartyIdentityForm party={sampleParty} />);
+    await user.type(screen.getByLabelText('Website'), '/extra');
+    await user.clear(screen.getByLabelText('Language'));
+    await user.type(screen.getByLabelText('Language'), 'en-GB');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => {
+      expect(mockUpdate.mutateAsync).toHaveBeenCalledWith({
+        id: sampleParty.id,
+        request: expect.objectContaining({ language: 'en-GB' }),
+      });
+    });
+  });
+
+  it('logs an error when the update mutation rejects', async () => {
+    mockUpdate.mutateAsync.mockRejectedValueOnce(new Error('boom'));
+    const { user } = renderWithProviders(<PartyIdentityForm party={sampleParty} />);
+    const name = screen.getByLabelText('Name');
+    await user.clear(name);
+    await user.type(name, 'Changed');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => {
+      expect(mockUpdate.mutateAsync).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/@granit/react-ui-parties/src/__tests__/party-picker-dialog.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/party-picker-dialog.test.tsx
@@ -1,0 +1,87 @@
+import { sampleParties, toListItem } from '@granit/react-parties/testing';
+import { screen, waitFor } from '@testing-library/react';
+
+import { PartyPickerDialog } from '../components/party-picker-dialog';
+
+import { renderWithProviders } from './test-utils';
+
+import type { PartyId, PartyListItemResponse } from '@granit/parties';
+
+const { mockUsePartiesQuery } = vi.hoisted(() => ({ mockUsePartiesQuery: vi.fn() }));
+
+vi.mock('@granit/react-parties', () => ({
+  usePartiesQuery: () => mockUsePartiesQuery(),
+}));
+
+const items: PartyListItemResponse[] = sampleParties.map(toListItem);
+const excludeId = sampleParties[0]!.id as PartyId;
+
+describe('PartyPickerDialog', () => {
+  beforeEach(() => {
+    mockUsePartiesQuery.mockReset();
+  });
+
+  it('shows the spinner while loading', () => {
+    mockUsePartiesQuery.mockReturnValue({ data: undefined, isLoading: true });
+    renderWithProviders(
+      <PartyPickerDialog open excludeId={excludeId} onOpenChange={vi.fn()} onSelect={vi.fn()} />
+    );
+    expect(screen.getByText('Pick a party to merge into this one')).toBeInTheDocument();
+  });
+
+  it('lists candidates excluding the survivor and archived parties', () => {
+    mockUsePartiesQuery.mockReturnValue({ data: items, isLoading: false });
+    renderWithProviders(
+      <PartyPickerDialog open excludeId={excludeId} onOpenChange={vi.fn()} onSelect={vi.fn()} />
+    );
+    expect(screen.queryByText('Acme Corp')).not.toBeInTheDocument();
+    expect(screen.getByText('Globex Inc')).toBeInTheDocument();
+    expect(screen.queryByText('Bob Dupont')).not.toBeInTheDocument();
+  });
+
+  it('filters candidates by the search term', async () => {
+    mockUsePartiesQuery.mockReturnValue({ data: items, isLoading: false });
+    const { user } = renderWithProviders(
+      <PartyPickerDialog open excludeId={excludeId} onOpenChange={vi.fn()} onSelect={vi.fn()} />
+    );
+    await user.type(screen.getByLabelText('Search by name…'), 'globex');
+    await waitFor(() => {
+      expect(screen.getByText('Globex Inc')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Initech BV')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state when nothing matches', async () => {
+    mockUsePartiesQuery.mockReturnValue({ data: items, isLoading: false });
+    const { user } = renderWithProviders(
+      <PartyPickerDialog open excludeId={excludeId} onOpenChange={vi.fn()} onSelect={vi.fn()} />
+    );
+    await user.type(screen.getByLabelText('Search by name…'), 'zzz-no-match');
+    expect(await screen.findByText('No active parties available to merge.')).toBeInTheDocument();
+  });
+
+  it('calls onSelect when a candidate is clicked', async () => {
+    mockUsePartiesQuery.mockReturnValue({ data: items, isLoading: false });
+    const onSelect = vi.fn();
+    const { user } = renderWithProviders(
+      <PartyPickerDialog open excludeId={excludeId} onOpenChange={vi.fn()} onSelect={onSelect} />
+    );
+    await user.click(screen.getByRole('button', { name: /Globex Inc/ }));
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ name: 'Globex Inc' }));
+  });
+
+  it('closes via the cancel button', async () => {
+    mockUsePartiesQuery.mockReturnValue({ data: items, isLoading: false });
+    const onOpenChange = vi.fn();
+    const { user } = renderWithProviders(
+      <PartyPickerDialog
+        open
+        excludeId={excludeId}
+        onOpenChange={onOpenChange}
+        onSelect={vi.fn()}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/@granit/react-ui-parties/src/__tests__/party-roles-badges.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/party-roles-badges.test.tsx
@@ -1,0 +1,31 @@
+import { screen } from '@testing-library/react';
+
+import { PartyRolesBadges } from '../components/party-roles-badges';
+import { PartyStatusBadge } from '../components/party-status-badge';
+
+import { renderWithProviders } from './test-utils';
+
+describe('PartyRolesBadges', () => {
+  it('renders a badge per parsed role', () => {
+    renderWithProviders(<PartyRolesBadges roles="Customer, Supplier" />);
+    expect(screen.getByText('Customer')).toBeInTheDocument();
+    expect(screen.getByText('Supplier')).toBeInTheDocument();
+  });
+
+  it('renders the None fallback when no roles are present', () => {
+    renderWithProviders(<PartyRolesBadges roles={null} />);
+    expect(screen.getByText('None')).toBeInTheDocument();
+  });
+
+  it('renders the None fallback for an empty string', () => {
+    renderWithProviders(<PartyRolesBadges roles="" />);
+    expect(screen.getByText('None')).toBeInTheDocument();
+  });
+});
+
+describe('PartyStatusBadge', () => {
+  it.each(['Active', 'Suspended', 'Archived'] as const)('renders the %s status', (status) => {
+    renderWithProviders(<PartyStatusBadge status={status} />);
+    expect(screen.getByText(status)).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-parties/src/__tests__/phones-tab.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/phones-tab.test.tsx
@@ -1,0 +1,86 @@
+import { sampleParty } from '@granit/react-parties/testing';
+import { screen, waitFor } from '@testing-library/react';
+
+import { PhonesTab } from '../components/phones-tab';
+
+import { renderWithProviders } from './test-utils';
+
+import type { PartyPhoneResponse } from '@granit/parties';
+
+const { mockRemove, mockAdd } = vi.hoisted(() => ({
+  mockRemove: { mutateAsync: vi.fn(), isPending: false },
+  mockAdd: { mutateAsync: vi.fn(), isPending: false },
+}));
+
+vi.mock('@granit/react-parties', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useRemovePartyPhoneMutation: () => mockRemove,
+    useAddPartyPhoneMutation: () => mockAdd,
+  };
+});
+
+const partyId = sampleParty.id;
+const phones = sampleParty.phones as readonly PartyPhoneResponse[];
+
+describe('PhonesTab', () => {
+  beforeEach(() => {
+    mockRemove.mutateAsync.mockReset().mockResolvedValue(undefined);
+    mockAdd.mutateAsync.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('renders the title and the formatted phone numbers', () => {
+    renderWithProviders(<PhonesTab partyId={partyId} phones={phones} />);
+    expect(screen.getByText('Phones')).toBeInTheDocument();
+    expect(screen.getByText('Work')).toBeInTheDocument();
+    expect(screen.getByText('Primary')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no phones', () => {
+    renderWithProviders(<PhonesTab partyId={partyId} phones={[]} />);
+    expect(screen.getByText('No phone numbers on file.')).toBeInTheDocument();
+  });
+
+  it('removes a phone via the mutation', async () => {
+    const { user } = renderWithProviders(<PhonesTab partyId={partyId} phones={phones} />);
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => {
+      expect(mockRemove.mutateAsync).toHaveBeenCalledWith({
+        id: partyId,
+        phoneId: phones[0]!.id,
+      });
+    });
+  });
+
+  it('logs an error when the remove mutation rejects', async () => {
+    mockRemove.mutateAsync.mockRejectedValueOnce(new Error('boom'));
+    const { user } = renderWithProviders(<PhonesTab partyId={partyId} phones={phones} />);
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => {
+      expect(mockRemove.mutateAsync).toHaveBeenCalled();
+    });
+  });
+
+  it('opens the add-phone dialog', async () => {
+    const { user } = renderWithProviders(<PhonesTab partyId={partyId} phones={phones} />);
+    await user.click(screen.getByRole('button', { name: 'Add phone' }));
+    expect(await screen.findByText('Add a new phone number for this party.')).toBeInTheDocument();
+  });
+
+  it('submits a new phone through the add dialog', async () => {
+    const { user } = renderWithProviders(<PhonesTab partyId={partyId} phones={[]} />);
+    await user.click(screen.getByRole('button', { name: 'Add phone' }));
+    await user.type(await screen.findByLabelText('Phone number'), '+32479123456');
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    await waitFor(() => {
+      expect(mockAdd.mutateAsync).toHaveBeenCalled();
+    });
+    const call = mockAdd.mutateAsync.mock.calls[0]![0] as {
+      id: string;
+      request: { kind: string; number: string };
+    };
+    expect(call.id).toBe(partyId);
+    expect(call.request.kind).toBe('Work');
+  });
+});

--- a/packages/@granit/react-ui-parties/src/__tests__/roles-tab.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/roles-tab.test.tsx
@@ -1,0 +1,69 @@
+import { sampleParty } from '@granit/react-parties/testing';
+import { screen, waitFor } from '@testing-library/react';
+
+import { RolesTab } from '../components/roles-tab';
+
+import { renderWithProviders } from './test-utils';
+
+const { mockRemove, mockAdd } = vi.hoisted(() => ({
+  mockRemove: { mutateAsync: vi.fn(), isPending: false },
+  mockAdd: { mutateAsync: vi.fn(), isPending: false },
+}));
+
+vi.mock('@granit/react-parties', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useRemovePartyRoleMutation: () => mockRemove,
+    useAddPartyRoleMutation: () => mockAdd,
+  };
+});
+
+const partyId = sampleParty.id;
+
+describe('RolesTab', () => {
+  beforeEach(() => {
+    mockRemove.mutateAsync.mockReset().mockResolvedValue(undefined);
+    mockAdd.mutateAsync.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('renders the assigned role badges', () => {
+    renderWithProviders(<RolesTab partyId={partyId} roles="Customer, Supplier" />);
+    expect(screen.getByText('Roles')).toBeInTheDocument();
+    expect(screen.getByText('Customer')).toBeInTheDocument();
+    expect(screen.getByText('Supplier')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when no roles are assigned', () => {
+    renderWithProviders(<RolesTab partyId={partyId} roles="" />);
+    expect(screen.getByText('No roles assigned.')).toBeInTheDocument();
+  });
+
+  it('disables the add button when all roles are assigned', () => {
+    renderWithProviders(<RolesTab partyId={partyId} roles="Customer, Supplier, Employee, Lead" />);
+    expect(screen.getByRole('button', { name: 'Add role' })).toBeDisabled();
+  });
+
+  it('removes a role via the mutation', async () => {
+    const { user } = renderWithProviders(<RolesTab partyId={partyId} roles="Customer" />);
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => {
+      expect(mockRemove.mutateAsync).toHaveBeenCalledWith({ id: partyId, role: 'Customer' });
+    });
+  });
+
+  it('logs an error when the remove mutation rejects', async () => {
+    mockRemove.mutateAsync.mockRejectedValueOnce(new Error('boom'));
+    const { user } = renderWithProviders(<RolesTab partyId={partyId} roles="Customer" />);
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => {
+      expect(mockRemove.mutateAsync).toHaveBeenCalled();
+    });
+  });
+
+  it('opens the add-role dialog', async () => {
+    const { user } = renderWithProviders(<RolesTab partyId={partyId} roles="Customer" />);
+    await user.click(screen.getByRole('button', { name: 'Add role' }));
+    expect(await screen.findByText('Grant a new business role to this party.')).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-parties/src/__tests__/tax-status-card.test.tsx
+++ b/packages/@granit/react-ui-parties/src/__tests__/tax-status-card.test.tsx
@@ -1,0 +1,97 @@
+import { screen, waitFor } from '@testing-library/react';
+
+import { TaxStatusCard } from '../components/tax-status-card';
+
+import { renderWithProviders } from './test-utils';
+
+import type { PartyId, PartyTaxStatusResponse } from '@granit/parties';
+
+const { mockClear, mockSet } = vi.hoisted(() => ({
+  mockClear: { mutateAsync: vi.fn(), isPending: false },
+  mockSet: { mutateAsync: vi.fn(), isPending: false },
+}));
+
+vi.mock('@granit/react-parties', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useClearPartyTaxStatusMutation: () => mockClear,
+    useSetPartyTaxStatusMutation: () => mockSet,
+  };
+});
+
+const partyId = 'party-1' as PartyId;
+const standard: PartyTaxStatusResponse = {
+  isExempt: false,
+  reverseCharge: false,
+  vatin: null,
+  evidenceBlobId: null,
+};
+const exempt: PartyTaxStatusResponse = {
+  isExempt: true,
+  reverseCharge: false,
+  vatin: 'BE0123456789',
+  evidenceBlobId: null,
+};
+
+describe('TaxStatusCard', () => {
+  beforeEach(() => {
+    mockClear.mutateAsync.mockReset().mockResolvedValue(undefined);
+    mockSet.mutateAsync.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('renders the standard taxation state and disables reset', () => {
+    renderWithProviders(<TaxStatusCard partyId={partyId} taxStatus={standard} />);
+    expect(screen.getByText('Standard taxation')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reset' })).toBeDisabled();
+  });
+
+  it('renders the exempt badge and the VATIN', () => {
+    renderWithProviders(<TaxStatusCard partyId={partyId} taxStatus={exempt} />);
+    expect(screen.getByText('VAT exempt')).toBeInTheDocument();
+    expect(screen.getByText('BE0123456789')).toBeInTheDocument();
+  });
+
+  it('clears the tax status via the mutation', async () => {
+    const { user } = renderWithProviders(<TaxStatusCard partyId={partyId} taxStatus={exempt} />);
+    await user.click(screen.getByRole('button', { name: 'Reset' }));
+    await waitFor(() => {
+      expect(mockClear.mutateAsync).toHaveBeenCalledWith(partyId);
+    });
+  });
+
+  it('logs an error when clearing rejects', async () => {
+    mockClear.mutateAsync.mockRejectedValueOnce(new Error('boom'));
+    const { user } = renderWithProviders(<TaxStatusCard partyId={partyId} taxStatus={exempt} />);
+    await user.click(screen.getByRole('button', { name: 'Reset' }));
+    await waitFor(() => {
+      expect(mockClear.mutateAsync).toHaveBeenCalled();
+    });
+  });
+
+  it('opens the edit dialog and saves new values', async () => {
+    const { user } = renderWithProviders(<TaxStatusCard partyId={partyId} taxStatus={standard} />);
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(await screen.findByText('Edit tax status')).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('VAT exempt'));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => {
+      expect(mockSet.mutateAsync).toHaveBeenCalledWith({
+        id: partyId,
+        request: { isExempt: true, reverseCharge: false, vatin: null, evidenceBlobId: null },
+      });
+    });
+  });
+
+  it('blocks saving when both exempt and reverse-charge are set', async () => {
+    const { user } = renderWithProviders(<TaxStatusCard partyId={partyId} taxStatus={standard} />);
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    await user.click(await screen.findByLabelText('VAT exempt'));
+    await user.click(screen.getByLabelText('Reverse charge'));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => {
+      expect(mockSet.mutateAsync).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/@granit/react-ui/src/__tests__/dropdown-menu.test.tsx
+++ b/packages/@granit/react-ui/src/__tests__/dropdown-menu.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '../dropdown-menu.js';
+
+function FullMenu() {
+  return (
+    <DropdownMenu defaultOpen>
+      <DropdownMenuTrigger>Open menu</DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuLabel>Account</DropdownMenuLabel>
+        <DropdownMenuLabel inset>Inset label</DropdownMenuLabel>
+        <DropdownMenuGroup>
+          <DropdownMenuItem>Profile</DropdownMenuItem>
+          <DropdownMenuItem inset>Inset item</DropdownMenuItem>
+          <DropdownMenuItem variant="destructive">
+            Delete
+            <DropdownMenuShortcut>⌫</DropdownMenuShortcut>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuCheckboxItem checked>Show toolbar</DropdownMenuCheckboxItem>
+        <DropdownMenuRadioGroup value="a">
+          <DropdownMenuRadioItem value="a">Option A</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="b">Option B</DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>More</DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            <DropdownMenuItem>Nested</DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger inset>Inset sub</DropdownMenuSubTrigger>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+describe('DropdownMenu', () => {
+  it('renders an open menu with every item kind and its data attributes', () => {
+    render(<FullMenu />);
+
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    expect(screen.getByText('Account')).toHaveAttribute('data-slot', 'dropdown-menu-label');
+
+    const destructive = screen.getByRole('menuitem', { name: /Delete/ });
+    expect(destructive).toHaveAttribute('data-variant', 'destructive');
+
+    const insetItem = screen.getByRole('menuitem', { name: 'Inset item' });
+    expect(insetItem).toHaveAttribute('data-inset', 'true');
+
+    expect(screen.getByText('⌫')).toHaveAttribute('data-slot', 'dropdown-menu-shortcut');
+    expect(screen.getByRole('menuitemcheckbox', { name: 'Show toolbar' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    expect(screen.getByRole('menuitemradio', { name: 'Option A' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    expect(screen.getByRole('menuitemradio', { name: 'Option B' })).toHaveAttribute(
+      'aria-checked',
+      'false'
+    );
+
+    const subTrigger = screen.getByText('More');
+    expect(subTrigger).toHaveAttribute('data-slot', 'dropdown-menu-sub-trigger');
+  });
+
+  it('opens the menu from a closed trigger on click', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Item</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(await screen.findByRole('menuitem', { name: 'Item' })).toBeInTheDocument();
+  });
+
+  it('invokes onSelect when an item is activated', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <DropdownMenu defaultOpen>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem onSelect={onSelect}>Click me</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+
+    await user.click(screen.getByRole('menuitem', { name: 'Click me' }));
+    expect(onSelect).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/@granit/react-ui/src/__tests__/fields.test.tsx
+++ b/packages/@granit/react-ui/src/__tests__/fields.test.tsx
@@ -1,0 +1,209 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { useForm } from 'react-hook-form';
+
+import { CheckboxField } from '../checkbox-field.js';
+import { Form } from '../form.js';
+import { SelectField } from '../select-field.js';
+import { TextField } from '../text-field.js';
+
+type Values = {
+  username: string;
+  fruit: string;
+  agree: boolean;
+};
+
+function Harness({
+  children,
+  defaultValues,
+}: {
+  children: (control: ReturnType<typeof useForm<Values>>['control']) => React.ReactNode;
+  defaultValues?: Partial<Values>;
+}) {
+  const form = useForm<Values>({
+    defaultValues: { username: '', fruit: '', agree: false, ...defaultValues },
+  });
+
+  return (
+    <Form {...form}>
+      <form>{children(form.control)}</form>
+    </Form>
+  );
+}
+
+describe('TextField', () => {
+  it('renders the label and an input wired to the field value', () => {
+    render(
+      <Harness defaultValues={{ username: 'alice' }}>
+        {(control) => <TextField control={control} name="username" label="Username" />}
+      </Harness>
+    );
+
+    expect(screen.getByText('Username')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toHaveValue('alice');
+  });
+
+  it('coerces a null field value to an empty string', () => {
+    render(
+      <Harness defaultValues={{ username: null as unknown as string }}>
+        {(control) => <TextField control={control} name="username" label="Username" />}
+      </Harness>
+    );
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+
+  it('forwards type, placeholder and maxLength props', () => {
+    render(
+      <Harness>
+        {(control) => (
+          <TextField
+            control={control}
+            name="username"
+            label="Username"
+            type="email"
+            placeholder="you@example.com"
+            maxLength={20}
+          />
+        )}
+      </Harness>
+    );
+
+    const input = screen.getByPlaceholderText('you@example.com');
+    expect(input).toHaveAttribute('type', 'email');
+    expect(input).toHaveAttribute('maxlength', '20');
+  });
+
+  it('applies the transform on every keystroke when provided', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Harness>
+        {(control) => (
+          <TextField
+            control={control}
+            name="username"
+            label="Username"
+            transform={(value) => value.toUpperCase()}
+          />
+        )}
+      </Harness>
+    );
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'abc');
+    expect(input).toHaveValue('ABC');
+  });
+
+  it('uses the default onChange path when no transform is given', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Harness>
+        {(control) => <TextField control={control} name="username" label="Username" />}
+      </Harness>
+    );
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'abc');
+    expect(input).toHaveValue('abc');
+  });
+});
+
+describe('SelectField', () => {
+  const options = [
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+  ] as const;
+
+  it('renders the label and a placeholder-backed trigger', () => {
+    render(
+      <Harness>
+        {(control) => (
+          <SelectField
+            control={control}
+            name="fruit"
+            label="Fruit"
+            options={options}
+            placeholder="Pick a fruit"
+          />
+        )}
+      </Harness>
+    );
+
+    expect(screen.getByText('Fruit')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByText('Pick a fruit')).toBeInTheDocument();
+  });
+
+  it('falls back to the label as placeholder when none is provided', () => {
+    render(
+      <Harness>
+        {(control) => (
+          <SelectField control={control} name="fruit" label="Fruit" options={options} />
+        )}
+      </Harness>
+    );
+
+    // Both the FormLabel and the SelectValue placeholder render "Fruit".
+    expect(screen.getAllByText('Fruit').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('opens the listbox and selects an option', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Harness>
+        {(control) => (
+          <SelectField control={control} name="fruit" label="Fruit" options={options} />
+        )}
+      </Harness>
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    expect(await screen.findByRole('option', { name: 'Banana' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('option', { name: 'Banana' }));
+    expect(screen.getByRole('combobox')).toHaveTextContent('Banana');
+  });
+});
+
+describe('CheckboxField', () => {
+  it('renders an unchecked checkbox bound to a false field value', () => {
+    render(
+      <Harness>
+        {(control) => <CheckboxField control={control} name="agree" label="I agree" />}
+      </Harness>
+    );
+
+    expect(screen.getByText('I agree')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+  });
+
+  it('reflects a checked default value', () => {
+    render(
+      <Harness defaultValues={{ agree: true }}>
+        {(control) => <CheckboxField control={control} name="agree" label="I agree" />}
+      </Harness>
+    );
+
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('toggles the field value on click', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Harness>
+        {(control) => <CheckboxField control={control} name="agree" label="I agree" />}
+      </Harness>
+    );
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+  });
+});

--- a/packages/@granit/react-ui/src/__tests__/misc-coverage.test.tsx
+++ b/packages/@granit/react-ui/src/__tests__/misc-coverage.test.tsx
@@ -1,0 +1,258 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from '../breadcrumb.js';
+import { CardAction, Card, CardContent, CardFooter, CardHeader } from '../card.js';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogTitle } from '../dialog.js';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '../select.js';
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from '../sheet.js';
+import { Toaster } from '../sonner.js';
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../table.js';
+
+describe('Toaster', () => {
+  beforeEach(() => {
+    // sonner reads window.matchMedia for theme detection; jsdom doesn't provide it.
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener() {},
+        removeListener() {},
+        addEventListener() {},
+        removeEventListener() {},
+        dispatchEvent: () => false,
+      }),
+    });
+  });
+
+  it('renders the sonner notifications region with the default system theme', () => {
+    render(<Toaster />);
+    expect(document.querySelector('section[aria-label^="Notifications"]')).toBeInTheDocument();
+  });
+
+  it('accepts an explicit theme override', () => {
+    render(<Toaster theme="dark" />);
+    expect(document.querySelector('section[aria-label^="Notifications"]')).toBeInTheDocument();
+  });
+});
+
+describe('Breadcrumb extras', () => {
+  it('renders a default chevron separator and an ellipsis', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator data-testid="sep" />
+          <BreadcrumbEllipsis />
+        </BreadcrumbList>
+      </Breadcrumb>
+    );
+
+    expect(screen.getByTestId('sep')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByText('More')).toBeInTheDocument();
+  });
+
+  it('renders a custom separator child when provided', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbSeparator>/</BreadcrumbSeparator>
+        </BreadcrumbList>
+      </Breadcrumb>
+    );
+
+    expect(screen.getByText('/')).toBeInTheDocument();
+  });
+
+  it('renders the link as a slotted child when asChild', () => {
+    render(
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <a href="/dash">Dashboard</a>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+    );
+
+    const link = screen.getByRole('link', { name: 'Dashboard' });
+    expect(link).toHaveAttribute('data-slot', 'breadcrumb-link');
+  });
+});
+
+describe('Card extras', () => {
+  it('renders header with an action, content and footer slots', () => {
+    render(
+      <Card>
+        <CardHeader>
+          <CardAction data-testid="action">Act</CardAction>
+        </CardHeader>
+        <CardContent>Body</CardContent>
+        <CardFooter data-testid="footer">Foot</CardFooter>
+      </Card>
+    );
+
+    expect(screen.getByTestId('action')).toHaveAttribute('data-slot', 'card-action');
+    expect(screen.getByText('Body')).toHaveAttribute('data-slot', 'card-content');
+    expect(screen.getByTestId('footer')).toHaveAttribute('data-slot', 'card-footer');
+  });
+});
+
+describe('Table extras', () => {
+  it('renders a footer and caption alongside header/body', () => {
+    render(
+      <Table>
+        <TableCaption>A list</TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>Alice</TableCell>
+          </TableRow>
+        </TableBody>
+        <TableFooter data-testid="foot">
+          <TableRow>
+            <TableCell>Total</TableCell>
+          </TableRow>
+        </TableFooter>
+      </Table>
+    );
+
+    expect(screen.getByText('A list')).toHaveAttribute('data-slot', 'table-caption');
+    expect(screen.getByTestId('foot')).toHaveAttribute('data-slot', 'table-footer');
+  });
+});
+
+describe('Dialog footer', () => {
+  it('renders a built-in close button when showCloseButton is set', async () => {
+    const user = userEvent.setup();
+    function Controlled() {
+      return (
+        <Dialog defaultOpen>
+          <DialogContent showCloseButton={false}>
+            <DialogTitle>Title</DialogTitle>
+            <DialogDescription>Body</DialogDescription>
+            <DialogFooter showCloseButton data-testid="footer">
+              Footer
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      );
+    }
+
+    render(<Controlled />);
+    // The content's own close button is disabled here, so the only "Close" button
+    // is the footer one.
+    const close = screen.getByRole('button', { name: 'Close' });
+    expect(close).toBeInTheDocument();
+
+    await user.click(close);
+    expect(screen.queryByText('Title')).not.toBeInTheDocument();
+  });
+
+  it('omits the footer close button by default', () => {
+    render(
+      <Dialog open>
+        <DialogContent showCloseButton={false}>
+          <DialogTitle>Title</DialogTitle>
+          <DialogDescription>Body</DialogDescription>
+          <DialogFooter>Footer</DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+
+    expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+  });
+});
+
+describe('Sheet sides', () => {
+  it.each(['top', 'right', 'bottom', 'left'] as const)(
+    'renders content for the %s side',
+    (side) => {
+      render(
+        <Sheet open>
+          <SheetContent side={side} data-testid="content">
+            <SheetTitle>Sheet</SheetTitle>
+            <SheetDescription>Desc</SheetDescription>
+          </SheetContent>
+        </Sheet>
+      );
+
+      expect(screen.getByTestId('content')).toHaveAttribute('data-slot', 'sheet-content');
+    }
+  );
+
+  it('omits the close button when showCloseButton is false', () => {
+    render(
+      <Sheet open>
+        <SheetContent showCloseButton={false}>
+          <SheetTitle>Sheet</SheetTitle>
+          <SheetDescription>Desc</SheetDescription>
+        </SheetContent>
+      </Sheet>
+    );
+
+    expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+  });
+});
+
+describe('Select extras', () => {
+  it('renders a small trigger plus grouped, labelled and separated items', async () => {
+    const user = userEvent.setup();
+    render(
+      <Select>
+        <SelectTrigger size="sm" aria-label="fruit" data-testid="trigger">
+          <SelectValue placeholder="Pick one" />
+        </SelectTrigger>
+        <SelectContent position="popper">
+          <SelectGroup>
+            <SelectLabel>Fruits</SelectLabel>
+            <SelectItem value="apple">Apple</SelectItem>
+            <SelectSeparator />
+            <SelectItem value="banana">Banana</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    );
+
+    expect(screen.getByTestId('trigger')).toHaveAttribute('data-size', 'sm');
+
+    await user.click(screen.getByRole('combobox', { name: 'fruit' }));
+    expect(await screen.findByText('Fruits')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Apple' })).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui/src/__tests__/overlays.test.tsx
+++ b/packages/@granit/react-ui/src/__tests__/overlays.test.tsx
@@ -1,0 +1,209 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+} from '../alert-dialog.js';
+import {
+  Avatar,
+  AvatarBadge,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  AvatarImage,
+} from '../avatar.js';
+import {
+  Command,
+  CommandDialog,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from '../command.js';
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from '../popover.js';
+
+describe('Avatar', () => {
+  it('defaults to size "default" and exposes the data-size attribute', () => {
+    render(
+      <Avatar data-testid="avatar">
+        <AvatarFallback>JF</AvatarFallback>
+      </Avatar>
+    );
+
+    expect(screen.getByTestId('avatar')).toHaveAttribute('data-size', 'default');
+  });
+
+  it.each(['sm', 'lg'] as const)('honours the %s size variant', (size) => {
+    render(
+      <Avatar data-testid="avatar" size={size}>
+        <AvatarFallback>JF</AvatarFallback>
+      </Avatar>
+    );
+
+    expect(screen.getByTestId('avatar')).toHaveAttribute('data-size', size);
+  });
+
+  it('renders image, badge, group and group-count slots', () => {
+    render(
+      <AvatarGroup data-testid="group">
+        <Avatar>
+          <AvatarImage src="https://example.com/a.png" alt="A" />
+          <AvatarFallback>A</AvatarFallback>
+          <AvatarBadge data-testid="badge" />
+        </Avatar>
+        <AvatarGroupCount data-testid="count">+3</AvatarGroupCount>
+      </AvatarGroup>
+    );
+
+    expect(screen.getByTestId('group')).toHaveAttribute('data-slot', 'avatar-group');
+    expect(screen.getByTestId('badge')).toHaveAttribute('data-slot', 'avatar-badge');
+    expect(screen.getByTestId('count')).toHaveAttribute('data-slot', 'avatar-group-count');
+  });
+});
+
+describe('Popover', () => {
+  it('renders header/title/description content when open', () => {
+    render(
+      <Popover open>
+        <PopoverAnchor />
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent>
+          <PopoverHeader>
+            <PopoverTitle>Title</PopoverTitle>
+            <PopoverDescription>Description</PopoverDescription>
+          </PopoverHeader>
+        </PopoverContent>
+      </Popover>
+    );
+
+    expect(screen.getByText('Title')).toHaveAttribute('data-slot', 'popover-title');
+    expect(screen.getByText('Description')).toHaveAttribute('data-slot', 'popover-description');
+  });
+
+  it('opens its content on trigger click', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent>Body</PopoverContent>
+      </Popover>
+    );
+
+    expect(screen.queryByText('Body')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(await screen.findByText('Body')).toBeInTheDocument();
+  });
+});
+
+describe('Command', () => {
+  it('renders groups, separators and shortcuts and filters on input', async () => {
+    const user = userEvent.setup();
+    render(
+      <Command>
+        <CommandInput placeholder="Search" />
+        <CommandList>
+          <CommandGroup heading="Fruits">
+            <CommandItem>
+              Apple
+              <CommandShortcut>⌘A</CommandShortcut>
+            </CommandItem>
+            <CommandItem>Banana</CommandItem>
+          </CommandGroup>
+          <CommandSeparator />
+          <CommandGroup heading="Veggies">
+            <CommandItem>Carrot</CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    );
+
+    expect(screen.getByText('Fruits')).toBeInTheDocument();
+    expect(screen.getByText('⌘A')).toHaveAttribute('data-slot', 'command-shortcut');
+
+    await user.type(screen.getByPlaceholderText('Search'), 'carr');
+    expect(screen.getByText('Carrot')).toBeInTheDocument();
+    expect(screen.queryByText('Apple')).not.toBeInTheDocument();
+  });
+
+  it('CommandDialog renders its title/description and content when open', () => {
+    render(
+      <CommandDialog open title="Palette" description="Type a command">
+        <CommandList>
+          <CommandItem>Run</CommandItem>
+        </CommandList>
+      </CommandDialog>
+    );
+
+    expect(screen.getByText('Palette')).toBeInTheDocument();
+    expect(screen.getByText('Type a command')).toBeInTheDocument();
+    expect(screen.getByText('Run')).toBeInTheDocument();
+  });
+
+  it('CommandDialog can hide the close button', () => {
+    render(
+      <CommandDialog open showCloseButton={false}>
+        <CommandList>
+          <CommandItem>Run</CommandItem>
+        </CommandList>
+      </CommandDialog>
+    );
+
+    expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+  });
+});
+
+describe('AlertDialog', () => {
+  it('renders content with media, footer and styled action/cancel buttons', () => {
+    render(
+      <AlertDialog open>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogMedia data-testid="media" />
+            <AlertDialogTitle>Confirm</AlertDialogTitle>
+            <AlertDialogDescription>Are you sure?</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="destructive">Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    expect(screen.getByTestId('media')).toHaveAttribute('data-slot', 'alert-dialog-media');
+    expect(screen.getByText('Cancel')).toHaveAttribute('data-variant', 'outline');
+    expect(screen.getByText('Delete')).toHaveAttribute('data-variant', 'destructive');
+  });
+
+  it('applies the small content size variant', () => {
+    render(
+      <AlertDialog open>
+        <AlertDialogContent size="sm" data-testid="content">
+          <AlertDialogTitle>Title</AlertDialogTitle>
+          <AlertDialogDescription>Body</AlertDialogDescription>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+
+    expect(screen.getByTestId('content')).toHaveAttribute('data-size', 'sm');
+  });
+});

--- a/packages/@granit/react-ui/src/__tests__/sidebar-components.test.tsx
+++ b/packages/@granit/react-ui/src/__tests__/sidebar-components.test.tsx
@@ -1,0 +1,299 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+} from '../sidebar.js';
+
+function stubMatchMedia(matches: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+function renderInProvider(
+  ui: React.ReactNode,
+  props?: React.ComponentProps<typeof SidebarProvider>
+) {
+  return render(<SidebarProvider {...props}>{ui}</SidebarProvider>);
+}
+
+describe('Sidebar layout components', () => {
+  beforeEach(() => {
+    stubMatchMedia(false);
+  });
+
+  it('renders the desktop sidebar with explicit variant/side/collapsible attributes', () => {
+    renderInProvider(
+      <Sidebar variant="floating" side="right" collapsible="icon">
+        <SidebarContent data-testid="content">Body</SidebarContent>
+      </Sidebar>
+    );
+
+    const inner = screen.getByText('Body').closest('[data-slot="sidebar"]');
+    expect(inner).toHaveAttribute('data-variant', 'floating');
+    expect(inner).toHaveAttribute('data-side', 'right');
+  });
+
+  it('renders a non-collapsible sidebar as a plain container', () => {
+    renderInProvider(
+      <Sidebar collapsible="none">
+        <span>Static</span>
+      </Sidebar>
+    );
+
+    expect(screen.getByText('Static')).toBeInTheDocument();
+    const root = screen.getByText('Static').closest('[data-slot="sidebar"]');
+    expect(root).not.toHaveAttribute('data-variant');
+  });
+
+  it('renders the inset variant gap for the desktop branch', () => {
+    renderInProvider(
+      <Sidebar variant="inset">
+        <SidebarContent>Inset body</SidebarContent>
+      </Sidebar>
+    );
+    expect(screen.getByText('Inset body')).toBeInTheDocument();
+  });
+
+  it('renders inside a Sheet (no desktop container) on a mobile viewport', () => {
+    stubMatchMedia(true);
+    Object.defineProperty(window, 'innerWidth', { value: 375, writable: true });
+    renderInProvider(
+      <Sidebar>
+        <SidebarContent>Mobile body</SidebarContent>
+      </Sidebar>
+    );
+
+    // On mobile the desktop container (the only element carrying data-state) is
+    // never rendered; the content lives in a closed Sheet portal instead.
+    expect(document.querySelector('[data-slot="sidebar"][data-state]')).toBeNull();
+    Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true });
+  });
+
+  it('renders header/footer/separator/input/inset/group slots', () => {
+    renderInProvider(
+      <>
+        <Sidebar>
+          <SidebarHeader data-testid="header">H</SidebarHeader>
+          <SidebarInput placeholder="Filter" />
+          <SidebarSeparator data-testid="sep" />
+          <SidebarGroup data-testid="group">
+            <SidebarGroupLabel>Label</SidebarGroupLabel>
+            <SidebarGroupAction aria-label="add">+</SidebarGroupAction>
+            <SidebarGroupContent data-testid="group-content">GC</SidebarGroupContent>
+          </SidebarGroup>
+          <SidebarFooter data-testid="footer">F</SidebarFooter>
+          <SidebarRail />
+        </Sidebar>
+        <SidebarInset data-testid="inset">Main</SidebarInset>
+      </>
+    );
+
+    expect(screen.getByTestId('header')).toHaveAttribute('data-sidebar', 'header');
+    expect(screen.getByPlaceholderText('Filter')).toHaveAttribute('data-sidebar', 'input');
+    expect(screen.getByTestId('sep')).toHaveAttribute('data-sidebar', 'separator');
+    expect(screen.getByText('Label')).toHaveAttribute('data-sidebar', 'group-label');
+    expect(screen.getByTestId('group-content')).toHaveAttribute('data-sidebar', 'group-content');
+    expect(screen.getByTestId('footer')).toHaveAttribute('data-sidebar', 'footer');
+    expect(screen.getByTestId('inset')).toHaveAttribute('data-slot', 'sidebar-inset');
+  });
+
+  it('renders group label and group action as slotted children when asChild', () => {
+    renderInProvider(
+      <Sidebar>
+        <SidebarGroup>
+          <SidebarGroupLabel asChild>
+            <h2>Slotted label</h2>
+          </SidebarGroupLabel>
+          <SidebarGroupAction asChild>
+            <a href="/add">Slotted action</a>
+          </SidebarGroupAction>
+        </SidebarGroup>
+      </Sidebar>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Slotted label' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Slotted action' })).toBeInTheDocument();
+  });
+
+  it('SidebarRail toggles the sidebar', async () => {
+    const user = userEvent.setup();
+    renderInProvider(
+      <Sidebar>
+        <SidebarRail />
+      </Sidebar>
+    );
+
+    const rail = screen.getByRole('button', { name: 'Toggle Sidebar' });
+    const sidebar = rail.closest('[data-state]');
+    expect(sidebar).toHaveAttribute('data-state', 'expanded');
+
+    await user.click(rail);
+    expect(sidebar).toHaveAttribute('data-state', 'collapsed');
+  });
+});
+
+describe('Sidebar menu components', () => {
+  beforeEach(() => {
+    stubMatchMedia(false);
+  });
+
+  it('renders a menu with items, actions, badges and a plain button', () => {
+    renderInProvider(
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton>Dashboard</SidebarMenuButton>
+          <SidebarMenuAction aria-label="more">…</SidebarMenuAction>
+          <SidebarMenuBadge data-testid="badge">9</SidebarMenuBadge>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    );
+
+    expect(screen.getByText('Dashboard')).toHaveAttribute('data-sidebar', 'menu-button');
+    expect(screen.getByLabelText('more')).toHaveAttribute('data-sidebar', 'menu-action');
+    expect(screen.getByTestId('badge')).toHaveAttribute('data-sidebar', 'menu-badge');
+  });
+
+  it('honours menu button variants, sizes and active state', () => {
+    renderInProvider(
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton variant="outline" size="lg" isActive>
+            Active
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    );
+
+    const button = screen.getByText('Active');
+    expect(button).toHaveAttribute('data-active', 'true');
+    expect(button).toHaveAttribute('data-size', 'lg');
+  });
+
+  it('renders the menu button as a slotted child when asChild', () => {
+    renderInProvider(
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton asChild>
+            <a href="/home">Home link</a>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    );
+
+    expect(screen.getByRole('link', { name: 'Home link' })).toHaveAttribute(
+      'data-sidebar',
+      'menu-button'
+    );
+  });
+
+  it('wraps the button in a tooltip when a string tooltip is supplied', () => {
+    renderInProvider(
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Helpful">Item</SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    );
+
+    expect(screen.getByText('Item')).toBeInTheDocument();
+  });
+
+  it('accepts an object tooltip configuration', () => {
+    renderInProvider(
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip={{ children: 'Configured' }}>Item</SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    );
+
+    expect(screen.getByText('Item')).toBeInTheDocument();
+  });
+
+  it('shows the menu action only on hover when configured', () => {
+    renderInProvider(
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuAction showOnHover aria-label="hover-action">
+            …
+          </SidebarMenuAction>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    );
+
+    expect(screen.getByLabelText('hover-action')).toBeInTheDocument();
+  });
+
+  it('renders sub-menu items and sub-buttons with sizes and active state', () => {
+    renderInProvider(
+      <SidebarMenuSub>
+        <SidebarMenuSubItem>
+          <SidebarMenuSubButton size="sm" isActive href="/a">
+            Small active
+          </SidebarMenuSubButton>
+        </SidebarMenuSubItem>
+        <SidebarMenuSubItem>
+          <SidebarMenuSubButton asChild>
+            <a href="/b">Slotted sub</a>
+          </SidebarMenuSubButton>
+        </SidebarMenuSubItem>
+      </SidebarMenuSub>
+    );
+
+    const small = screen.getByText('Small active');
+    expect(small).toHaveAttribute('data-size', 'sm');
+    expect(small).toHaveAttribute('data-active', 'true');
+    expect(screen.getByRole('link', { name: 'Slotted sub' })).toBeInTheDocument();
+  });
+
+  it('renders the skeleton with and without an icon', () => {
+    const { rerender } = renderInProvider(<SidebarMenuSkeleton data-testid="sk" />);
+    expect(screen.getByTestId('sk')).toHaveAttribute('data-sidebar', 'menu-skeleton');
+    expect(
+      screen.queryByTestId('sk')?.querySelector('[data-sidebar="menu-skeleton-icon"]')
+    ).toBeNull();
+
+    rerender(
+      <SidebarProvider>
+        <SidebarMenuSkeleton showIcon data-testid="sk" />
+      </SidebarProvider>
+    );
+    expect(
+      screen.getByTestId('sk').querySelector('[data-sidebar="menu-skeleton-icon"]')
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Coverage backfill for the packages introduced by **PR #744 (batch-8)** and **PR #745 (batch-9)**, bringing each above the 80% global Vitest threshold on all four metrics. (develop merged in to pick up the #745 packages.)

### Batch-8 (#744) — 5 packages
Foundation `react-ui` + `react-ui-admin-kit`, domain `react-ui-account`, `react-ui-openiddict-admin`, `react-ui-parties`.

| Metric | Before | After (combined, 2330 tests) |
|---|---|---|
| Statements | 62.2% | **95.0%** |
| Branches | 60.2% | **86.5%** |
| Functions | 59.0% | **95.4%** |
| Lines | 63.2% | **96.6%** |

### Batch-9 (#745) — 3 auth packages
Extracted from the showcase app-shell:
- `react-authentication-mock` (MockAuthProvider) — 0% → **100%**
- `react-ui-authentication-keycloak` (KeycloakAuthProvider) — 0% → **100%**
- `react-ui-authorization` (PermissionGuard, AccessDeniedPage, permission/role pages) — 80/67/72/80 → **100/88/100/100**

## Notes
- Domain packages reuse the shared `@granit/react-<module>/testing` fixtures (`sampleParty`, `mockProfile`/`mockPasskeys`, `mockOidcApplications`, `mockPermissionGroups`/`mockRoleGrants`, …). Foundation/provider packages with no domain fixtures use inline data + library mocks (BFF fetch / keycloak hook).
- Coverage measured **isolated per package** (path-filtered) — a safe lower bound for the full-suite CI threshold since isolated coverage ≤ full-suite.

## Verification
- All tests pass · `tsc --noEmit` 0 errors per package · ESLint `--max-warnings 0` clean.
- Test-files-only; no runtime/source changes; no source bugs found.