### PR TITLE
feat(bff): add @granit/react-ui-bff auth provider

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -8363,6 +8363,23 @@
       ]
     },
     {
+      "name": "@granit/react-ui-bff",
+      "description": "BFF auth provider for Granit apps — wraps @granit/react-bff's BffProvider, adapts its session to the app's auth context, wires the 401→login bridge and CSRF manager, and renders init / backend-unavailable states. Companion to react-ui-authentication-keycloak and react-authentication-mock.",
+      "exports": [
+        {
+          "name": "BffAuthProvider",
+          "kind": "function",
+          "signature": "function BffAuthProvider("
+        },
+        {
+          "name": "BffAuthProviderProps",
+          "kind": "interface",
+          "signature": "interface BffAuthProviderProps",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/react-ui-blob-storage",
       "description": "Granit admin UI for the Blob Storage module — the blobs list (query-driven grid with status pills, size formatting and per-row download/delete actions) plus the orphan-cleanup and crypto-shred delete dialogs. Composes @granit/react-blob-storage (headless) with the foundation UI packages.",
       "exports": [

--- a/packages/@granit/arch-tests/src/__tests__/helpers.ts
+++ b/packages/@granit/arch-tests/src/__tests__/helpers.ts
@@ -53,6 +53,7 @@ export function toModules(pkgs: ReadonlyArray<PackageInfo>): Module[] {
 export const FETCH_ALLOWLIST: ReadonlyArray<string> = [
   '@granit/bff',
   '@granit/react-bff',
+  '@granit/react-ui-bff',
   '@granit/logger-otlp',
   '@granit/react-tracing',
   '@granit/notifications-sse',

--- a/packages/@granit/react-ui-bff/README.md
+++ b/packages/@granit/react-ui-bff/README.md
@@ -1,0 +1,33 @@
+# @granit/react-ui-bff
+
+The **BFF auth provider** for Granit apps — the UI companion to the headless
+[`@granit/react-bff`](../react-bff), mirroring the backend's top-level **Bff**
+module. Wraps `BffProvider`, adapts the BFF session to the app's auth context,
+wires the 401→login bridge and the CSRF manager, and renders the init spinner /
+backend-unavailable retry screen.
+
+Companion to [`@granit/react-ui-authentication-keycloak`](../react-ui-authentication-keycloak)
+and [`@granit/react-authentication-mock`](../react-authentication-mock).
+
+## Usage
+
+```tsx
+import { BffAuthProvider } from '@granit/react-ui-bff';
+
+import { AuthContext } from './auth-context'; // your createAuthContext() instance
+import { PublicLayout } from './public-layout';
+import { setCsrfManager } from './api'; // your axios CSRF wiring
+
+<BffAuthProvider
+  context={AuthContext}
+  config={{ pathPrefix: BFF_PREFIX }}
+  layout={PublicLayout}
+  onCsrfManager={setCsrfManager}
+>
+  <App />
+</BffAuthProvider>;
+```
+
+The host owns its context instance, BFF path prefix, public layout and the
+API-client CSRF wiring; the package owns the BFF↔auth-context bridge. The 401
+handler uses `setOnUnauthorized` from `@granit/api-client`.

--- a/packages/@granit/react-ui-bff/package.json
+++ b/packages/@granit/react-ui-bff/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@granit/react-ui-bff",
+  "description": "BFF auth provider for Granit apps — wraps @granit/react-bff's BffProvider, adapts its session to the app's auth context, wires the 401→login bridge and CSRF manager, and renders init / backend-unavailable states. Companion to react-ui-authentication-keycloak and react-authentication-mock.",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/authentication": "workspace:*",
+    "@granit/authentication-keycloak": "workspace:*",
+    "@granit/bff": "workspace:*",
+    "@granit/logger": "workspace:*",
+    "@granit/react-bff": "workspace:*",
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "lucide-react": "^1.21.0",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/authentication": "workspace:*",
+    "@granit/authentication-keycloak": "workspace:*",
+    "@granit/bff": "workspace:*",
+    "@granit/logger": "workspace:*",
+    "@granit/react-bff": "workspace:*",
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*"
+  }
+}

--- a/packages/@granit/react-ui-bff/src/bff-auth-provider.tsx
+++ b/packages/@granit/react-ui-bff/src/bff-auth-provider.tsx
@@ -1,0 +1,217 @@
+import { setOnUnauthorized } from '@granit/api-client';
+import { BffProvider, useBffConfig } from '@granit/react-bff';
+import { useTranslation } from '@granit/react-localization';
+import { Button, Spinner } from '@granit/react-ui';
+import { AlertTriangle } from 'lucide-react';
+import * as React from 'react';
+
+import { logger } from './logger';
+
+import type { KeycloakAuthContextType, KeycloakUserInfo } from '@granit/authentication-keycloak';
+import type { BffConfig, BffUser, CsrfManager } from '@granit/bff';
+import type { Context, ReactNode } from 'react';
+
+// Module-level guard: `setOnUnauthorized` warns on re-registration. Under React
+// StrictMode (dev) the bridge mounts → unmounts → remounts, which would trip the
+// warning. The latest `login` callback lives on `bffLatestLogin` so the one-shot
+// handler always invokes the current value; `bffIsAuthenticated` mirrors the auth
+// state so the handler skips redirects when the user is not authenticated yet
+// (e.g. on /login), which would otherwise loop on 401s.
+let bffOnUnauthorizedWired = false;
+let bffLatestLogin: (() => void) | null = null;
+let bffIsAuthenticated = false;
+let bffCsrfManagerWired = false;
+
+/** Pre-flight: verify the BFF endpoint is reachable before redirecting. */
+async function isBffReachable(pathPrefix: string): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5000);
+    // Intentional native fetch: an interceptor-free liveness probe. Routing this
+    // through the Axios client would trip the 401→login redirect handler and loop.
+    // eslint-disable-next-line no-restricted-globals
+    const response = await fetch(`${pathPrefix}/bff/user`, {
+      method: 'GET',
+      credentials: 'include',
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    return response.status !== 502 && response.status !== 503;
+  } catch {
+    return false;
+  }
+}
+
+/** Map BFF user claims to the auth context's user shape. */
+function toBffUserInfo(user: BffUser): KeycloakUserInfo {
+  const parts = user.name.split(' ');
+  return {
+    sub: user.sub,
+    email: user.email,
+    name: user.name,
+    preferred_username: user.email,
+    given_name: parts[0],
+    family_name: parts.slice(1).join(' '),
+  };
+}
+
+interface BffAuthBridgeProps {
+  readonly context: Context<KeycloakAuthContextType | undefined>;
+  readonly pathPrefix: string;
+  readonly layout: React.ComponentType<{ readonly children: ReactNode }>;
+  readonly onCsrfManager?: (manager: CsrfManager) => void;
+  readonly children: ReactNode;
+}
+
+/** Inner bridge: reads BFF context and provides the app-level auth context. */
+function BffAuthBridge({
+  context: AuthContext,
+  pathPrefix,
+  layout: Layout,
+  onCsrfManager,
+  children,
+}: BffAuthBridgeProps) {
+  const { user, isAuthenticated, isLoading, login, logout, csrfManager } = useBffConfig();
+  const { t } = useTranslation();
+  const [backendDown, setBackendDown] = React.useState(false);
+
+  // Wire the CsrfManager into the host's API client (host-provided setter).
+  React.useEffect(() => {
+    onCsrfManager?.(csrfManager);
+    if (!bffCsrfManagerWired) {
+      bffCsrfManagerWired = true;
+      logger.debug('[BffAuth] CsrfManager wired to API client');
+    }
+  }, [csrfManager, onCsrfManager]);
+
+  React.useEffect(() => {
+    bffLatestLogin = login;
+  }, [login]);
+  React.useEffect(() => {
+    bffIsAuthenticated = isAuthenticated;
+  }, [isAuthenticated]);
+  React.useEffect(() => {
+    if (bffOnUnauthorizedWired) return;
+    bffOnUnauthorizedWired = true;
+    setOnUnauthorized(() => {
+      // Skip redirect when not authenticated: the user is already on an auth page
+      // (e.g. /login) and 401s there are expected; redirecting would loop.
+      if (!bffIsAuthenticated) {
+        logger.warn('[BffAuth] Unauthorized while not authenticated — skipping BFF redirect');
+        return;
+      }
+      logger.warn('[BffAuth] Unauthorized — redirecting to BFF login');
+      bffLatestLogin?.();
+    });
+  }, []);
+
+  const mappedUser = React.useMemo(() => (user ? toBffUserInfo(user) : null), [user]);
+
+  // Safe login: check backend reachability before redirecting.
+  const safeLogin = React.useCallback(async () => {
+    const reachable = await isBffReachable(pathPrefix);
+    if (reachable) {
+      login();
+    } else {
+      logger.error('[BffAuth] Backend unreachable — cannot redirect to login');
+      setBackendDown(true);
+    }
+  }, [login, pathPrefix]);
+
+  const value = React.useMemo<KeycloakAuthContextType>(
+    () => ({
+      keycloak: null,
+      authenticated: isAuthenticated,
+      loading: isLoading,
+      user: mappedUser,
+      login: safeLogin,
+      logout,
+    }),
+    [isAuthenticated, isLoading, mappedUser, safeLogin, logout]
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-background">
+        <div className="flex flex-col items-center">
+          <Spinner size="lg" className="mb-4" />
+          <p className="text-sm font-medium text-muted-foreground">
+            {t('Auth.Initializing', 'Initializing…')}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (backendDown) {
+    return (
+      <Layout>
+        <div className="text-center">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+            <AlertTriangle className="h-6 w-6 text-destructive" aria-hidden="true" />
+          </div>
+          <h2 className="mb-2 text-lg font-semibold text-foreground">
+            {t('Auth.BackendUnavailable.Title', 'Service unavailable')}
+          </h2>
+          <p className="mb-6 text-sm text-muted-foreground">
+            {t(
+              'Auth.BackendUnavailable.Message',
+              'The authentication server is not responding. Please try again later or contact your administrator.'
+            )}
+          </p>
+          <Button
+            onClick={() => {
+              setBackendDown(false);
+              safeLogin().catch(() => undefined);
+            }}
+          >
+            {t('Auth.BackendUnavailable.Retry', 'Retry')}
+          </Button>
+        </div>
+      </Layout>
+    );
+  }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+const Passthrough = ({ children }: { readonly children: ReactNode }) => <>{children}</>;
+
+export interface BffAuthProviderProps {
+  /** The app's auth context (from `createAuthContext`). */
+  readonly context: Context<KeycloakAuthContextType | undefined>;
+  /** BFF config (`pathPrefix` + optional logger). */
+  readonly config: BffConfig;
+  /** Host layout wrapper for the backend-unavailable screen. Defaults to a passthrough. */
+  readonly layout?: React.ComponentType<{ readonly children: ReactNode }>;
+  /** Wire the BFF `CsrfManager` into the host's API client (CSRF interceptor). */
+  readonly onCsrfManager?: (manager: CsrfManager) => void;
+  readonly children: ReactNode;
+}
+
+/**
+ * BFF auth provider — wraps `@granit/react-bff`'s `BffProvider` and adapts its
+ * session to the app's auth context, wiring the 401→login bridge and the CSRF
+ * manager, and rendering init / backend-unavailable states. The host owns its
+ * context instance, BFF config, layout and API-client CSRF wiring.
+ */
+export function BffAuthProvider({
+  context,
+  config,
+  layout = Passthrough,
+  onCsrfManager,
+  children,
+}: BffAuthProviderProps) {
+  return (
+    <BffProvider config={config}>
+      <BffAuthBridge
+        context={context}
+        pathPrefix={config.pathPrefix}
+        layout={layout}
+        onCsrfManager={onCsrfManager}
+      >
+        {children}
+      </BffAuthBridge>
+    </BffProvider>
+  );
+}

--- a/packages/@granit/react-ui-bff/src/index.ts
+++ b/packages/@granit/react-ui-bff/src/index.ts
@@ -1,0 +1,1 @@
+export { BffAuthProvider, type BffAuthProviderProps } from './bff-auth-provider';

--- a/packages/@granit/react-ui-bff/src/logger.ts
+++ b/packages/@granit/react-ui-bff/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-ui-bff');

--- a/packages/@granit/react-ui-bff/tsconfig.json
+++ b/packages/@granit/react-ui-bff/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/@granit/react-ui-bff/tsup.config.ts
+++ b/packages/@granit/react-ui-bff/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4141,6 +4141,40 @@ importers:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
+  packages/@granit/react-ui-bff:
+    dependencies:
+      lucide-react:
+        specifier: ^1.21.0
+        version: 1.21.0(react@19.2.7)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/authentication':
+        specifier: workspace:*
+        version: link:../authentication
+      '@granit/authentication-keycloak':
+        specifier: workspace:*
+        version: link:../authentication-keycloak
+      '@granit/bff':
+        specifier: workspace:*
+        version: link:../bff
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@granit/react-bff':
+        specifier: workspace:*
+        version: link:../react-bff
+      '@granit/react-localization':
+        specifier: workspace:*
+        version: link:../react-localization
+      '@granit/react-ui':
+        specifier: workspace:*
+        version: link:../react-ui
+
   packages/@granit/react-ui-blob-storage:
     dependencies:
       lucide-react:


### PR DESCRIPTION
## What

Extracts the **BFF auth provider** from the showcase app-shell into `@granit/react-ui-bff` —
the UI companion to the headless `@granit/react-bff`, mirroring the backend's top-level **Bff**
module (named `react-ui-bff`, not `react-ui-authentication-bff`, for that reason).

Completes the auth-provider symmetry:
- `MockAuthProvider` → `@granit/react-authentication-mock`
- `KeycloakAuthProvider` → `@granit/react-ui-authentication-keycloak`
- **`BffAuthProvider` → `@granit/react-ui-bff`** (this PR)

## Injection (app-shell stays host)

`BffAuthProvider({ context, config, layout?, onCsrfManager? })`:
- `context` — the app's `createAuthContext()` instance.
- `config` — BFF `pathPrefix` (+ logger).
- `layout` — host public layout for the backend-unavailable screen (defaults to passthrough).
- `onCsrfManager` — wires the BFF `CsrfManager` into the host's Axios CSRF interceptor.

The 401→login bridge uses `setOnUnauthorized` from `@granit/api-client`. The liveness probe is an
intentional interceptor-free `fetch` (routing it through Axios would trip the 401 redirect and
loop) — `@granit/react-ui-bff` is added to the arch-test `FETCH_ALLOWLIST` alongside `@granit/react-bff`.

## Verification

- `tsc --noEmit` clean. `eslint --max-warnings 0` clean. Arch-tests: **2853 passed**.

The showcase MR re-points `bff-auth-provider` to a thin wrapper over this package.