### PR TITLE
feat(authentication-federated): add @granit/react-ui-authentication-federated

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -8155,6 +8155,23 @@
       ]
     },
     {
+      "name": "@granit/react-ui-authentication-federated",
+      "description": "Federated (external-IdP) login landing page for Granit apps — provider-agnostic 'sign in' screen that triggers the IdP redirect, surfaces auth-error query params, and redirects when already authenticated. The federated parallel to @granit/react-ui-authentication-local (which carries the local OpenIddict login forms).",
+      "exports": [
+        {
+          "name": "FederatedLoginPage",
+          "kind": "function",
+          "signature": "function FederatedLoginPage("
+        },
+        {
+          "name": "FederatedLoginPageProps",
+          "kind": "interface",
+          "signature": "interface FederatedLoginPageProps",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/react-ui-authentication-keycloak",
       "description": "Keycloak auth provider for Granit apps — wires @granit/react-authentication-keycloak's useKeycloakInit into the app's auth context, with locale-aware login and an init loading state. The Keycloak parallel to @granit/react-ui-authentication-local (which carries OpenIddict login pages; Keycloak hosts its own login, so this ships only the provider).",
       "exports": [

--- a/packages/@granit/react-ui-authentication-federated/README.md
+++ b/packages/@granit/react-ui-authentication-federated/README.md
@@ -1,0 +1,30 @@
+# @granit/react-ui-authentication-federated
+
+The **federated (external-IdP) login landing** for Granit apps — the provider-agnostic
+"sign in" screen shown before redirecting to the IdP. The federated parallel to
+[`@granit/react-ui-authentication-local`](../react-ui-authentication-local) (which carries the
+_local_ OpenIddict login forms).
+
+It does **not** render a credentials form (the IdP owns that). It shows a branded sign-in button
+that calls `login()`, surfaces an `?error=<code>` auth error, and redirects home when already
+authenticated.
+
+## Usage
+
+```tsx
+import {
+  FederatedLoginPage,
+  authFederatedTranslationsEn,
+} from '@granit/react-ui-authentication-federated';
+
+i18n.addResourceBundle('en', 'translation', authFederatedTranslationsEn, true, true);
+
+// Host wrapper injects the auth state + public layout:
+const { login, loading, authenticated } = useAuth();
+<FederatedLoginPage
+  login={login}
+  loading={loading}
+  authenticated={authenticated}
+  layout={PublicLayout}
+/>;
+```

--- a/packages/@granit/react-ui-authentication-federated/package.json
+++ b/packages/@granit/react-ui-authentication-federated/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@granit/react-ui-authentication-federated",
+  "description": "Federated (external-IdP) login landing page for Granit apps — provider-agnostic 'sign in' screen that triggers the IdP redirect, surfaces auth-error query params, and redirects when already authenticated. The federated parallel to @granit/react-ui-authentication-local (which carries the local OpenIddict login forms).",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "lucide-react": "^1.21.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.18.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/testing": "workspace:*",
+    "@storybook/react-vite": "^10.4.6",
+    "i18next": "^26.0.0",
+    "react-i18next": "^17.0.0",
+    "storybook": "^10.4.6"
+  }
+}

--- a/packages/@granit/react-ui-authentication-federated/src/__tests__/federated-login-page.test.tsx
+++ b/packages/@granit/react-ui-authentication-federated/src/__tests__/federated-login-page.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nextProvider } from 'react-i18next';
+import { MemoryRouter } from 'react-router-dom';
+
+import { FederatedLoginPage } from '../federated-login-page';
+
+import { testI18n } from './test-utils';
+
+import type { ReactElement } from 'react';
+
+function renderPage(ui: ReactElement, route = '/login') {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <I18nextProvider i18n={testI18n}>{ui}</I18nextProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('FederatedLoginPage', () => {
+  it('renders the subtitle and sign-in button, and calls login on click', async () => {
+    const login = vi.fn();
+    renderPage(<FederatedLoginPage login={login} loading={false} authenticated={false} />);
+    expect(screen.getByText(/Sign in with your administrator account/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+    expect(login).toHaveBeenCalledOnce();
+  });
+
+  it('disables the button and shows signing-in text while loading', () => {
+    renderPage(<FederatedLoginPage login={vi.fn()} loading authenticated={false} />);
+    expect(screen.getByRole('button', { name: /signing in/i })).toBeDisabled();
+  });
+
+  it('surfaces the auth error from the ?error= query param', () => {
+    renderPage(
+      <FederatedLoginPage login={vi.fn()} loading={false} authenticated={false} />,
+      '/login?error=server_error'
+    );
+    expect(screen.getByText(/authentication server encountered an error/i)).toBeInTheDocument();
+  });
+
+  it('redirects away when already authenticated (no sign-in button)', () => {
+    renderPage(<FederatedLoginPage login={vi.fn()} loading={false} authenticated />);
+    expect(screen.queryByRole('button', { name: 'Sign in' })).not.toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-authentication-federated/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-ui-authentication-federated/src/__tests__/test-utils.tsx
@@ -1,0 +1,16 @@
+import i18next from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import { authFederatedTranslationsEn } from '../locales';
+
+export const testI18n = i18next.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  ns: ['translation'],
+  defaultNS: 'translation',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: { ...authFederatedTranslationsEn } } },
+  interpolation: { escapeValue: false },
+});

--- a/packages/@granit/react-ui-authentication-federated/src/federated-login-page.tsx
+++ b/packages/@granit/react-ui-authentication-federated/src/federated-login-page.tsx
@@ -1,0 +1,68 @@
+import { useTranslation } from '@granit/react-localization';
+import { Alert, AlertDescription, AlertTitle, Button } from '@granit/react-ui';
+import { AlertCircle } from 'lucide-react';
+import { Navigate, useSearchParams } from 'react-router-dom';
+
+import type { ComponentType, ReactNode } from 'react';
+
+export interface FederatedLoginPageProps {
+  /** Triggers the IdP login redirect (the host's auth `login`). */
+  readonly login: () => void;
+  /** Whether a login/init is in flight (disables the button). */
+  readonly loading: boolean;
+  /** Whether the user is already authenticated (redirects to `/`). */
+  readonly authenticated: boolean;
+  /**
+   * Host public-page layout (logo / centered card). Defaults to a passthrough.
+   * Receives an optional `footer` node.
+   */
+  readonly layout?: ComponentType<{ readonly children: ReactNode; readonly footer?: ReactNode }>;
+}
+
+const Passthrough = ({ children }: { readonly children: ReactNode }) => <>{children}</>;
+
+/**
+ * Federated (external-IdP) login landing. Provider-agnostic: it does not render a
+ * credentials form (the IdP owns that) — it shows a branded "sign in" button that
+ * calls `login()` to start the redirect, surfaces an `?error=<code>` auth error,
+ * and redirects home when already authenticated. The host injects the auth state
+ * and its public layout.
+ */
+export function FederatedLoginPage({
+  login,
+  loading,
+  authenticated,
+  layout: Layout = Passthrough,
+}: FederatedLoginPageProps) {
+  const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const error = searchParams.get('error');
+
+  if (authenticated) {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <Layout
+      footer={
+        <p className="mt-6 text-center text-xs text-muted-foreground/70">
+          {t('Auth.LoginPage.Restricted')}
+        </p>
+      }
+    >
+      {error && (
+        <Alert variant="destructive" className="mb-6">
+          <AlertCircle className="size-4" />
+          <AlertTitle>{t('Auth.AccessDenied.Title')}</AlertTitle>
+          <AlertDescription>{t(`Auth.AccessDenied.${error}`)}</AlertDescription>
+        </Alert>
+      )}
+      <p className="mb-6 text-center text-sm text-muted-foreground">
+        {t('Auth.LoginPage.Subtitle')}
+      </p>
+      <Button className="w-full" onClick={() => login()} disabled={loading}>
+        {loading ? t('Auth.SigningIn') : t('Auth.Login')}
+      </Button>
+    </Layout>
+  );
+}

--- a/packages/@granit/react-ui-authentication-federated/src/index.ts
+++ b/packages/@granit/react-ui-authentication-federated/src/index.ts
@@ -1,0 +1,2 @@
+export { FederatedLoginPage, type FederatedLoginPageProps } from './federated-login-page';
+export { authFederatedTranslationsEn, authFederatedTranslationsFr } from './locales';

--- a/packages/@granit/react-ui-authentication-federated/src/locales/en.ts
+++ b/packages/@granit/react-ui-authentication-federated/src/locales/en.ts
@@ -1,0 +1,15 @@
+export const authFederatedTranslationsEn = {
+  'Auth.AccessDenied.Title': 'Access Denied',
+  'Auth.AccessDenied.access_denied':
+    'Your login request was denied. Please try again or contact your administrator.',
+  'Auth.AccessDenied.invalid_state':
+    'The authentication session is invalid or has expired. Please try again.',
+  'Auth.AccessDenied.login_required': 'Your session has expired. Please log in again.',
+  'Auth.AccessDenied.server_error':
+    'The authentication server encountered an error. Please try again later.',
+  'Auth.AccessDenied.token_exchange_failed': 'Authentication failed. Please try again.',
+  'Auth.Login': 'Sign in',
+  'Auth.LoginPage.Restricted': 'Access restricted to authorised administrators',
+  'Auth.LoginPage.Subtitle': 'Sign in with your administrator account to access the console.',
+  'Auth.SigningIn': 'Signing in...',
+} as const;

--- a/packages/@granit/react-ui-authentication-federated/src/locales/fr.ts
+++ b/packages/@granit/react-ui-authentication-federated/src/locales/fr.ts
@@ -1,0 +1,16 @@
+export const authFederatedTranslationsFr = {
+  'Auth.AccessDenied.Title': 'Accès refusé',
+  'Auth.AccessDenied.access_denied':
+    'Votre demande de connexion a été refusée. Veuillez réessayer ou contacter votre administrateur.',
+  'Auth.AccessDenied.invalid_state':
+    'La session d’authentification est invalide ou a expiré. Veuillez réessayer.',
+  'Auth.AccessDenied.login_required': 'Votre session a expiré. Veuillez vous reconnecter.',
+  'Auth.AccessDenied.server_error':
+    'Le serveur d’authentification a rencontré une erreur. Veuillez réessayer plus tard.',
+  'Auth.AccessDenied.token_exchange_failed': 'L’authentification a échoué. Veuillez réessayer.',
+  'Auth.Login': 'Se connecter',
+  'Auth.LoginPage.Restricted': 'Accès réservé aux administrateurs autorisés',
+  'Auth.LoginPage.Subtitle':
+    'Connectez-vous avec votre compte administrateur pour accéder à la console.',
+  'Auth.SigningIn': 'Connexion en cours...',
+} as const;

--- a/packages/@granit/react-ui-authentication-federated/src/locales/index.ts
+++ b/packages/@granit/react-ui-authentication-federated/src/locales/index.ts
@@ -1,0 +1,2 @@
+export { authFederatedTranslationsEn } from './en';
+export { authFederatedTranslationsFr } from './fr';

--- a/packages/@granit/react-ui-authentication-federated/tsconfig.json
+++ b/packages/@granit/react-ui-authentication-federated/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/@granit/react-ui-authentication-federated/tsup.config.ts
+++ b/packages/@granit/react-ui-authentication-federated/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3933,6 +3933,43 @@ importers:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
+  packages/@granit/react-ui-authentication-federated:
+    dependencies:
+      lucide-react:
+        specifier: ^1.21.0
+        version: 1.21.0(react@19.2.7)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+      react-router-dom:
+        specifier: ^7.18.0
+        version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    devDependencies:
+      '@granit/react-localization':
+        specifier: workspace:*
+        version: link:../react-localization
+      '@granit/react-ui':
+        specifier: workspace:*
+        version: link:../react-ui
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@storybook/react-vite':
+        specifier: ^10.4.6
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(yaml@2.9.0))
+      i18next:
+        specifier: ^26.0.0
+        version: 26.3.1(typescript@6.0.3)
+      react-i18next:
+        specifier: ^17.0.0
+        version: 17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+      storybook:
+        specifier: ^10.4.6
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
   packages/@granit/react-ui-authentication-keycloak:
     dependencies:
       react:


### PR DESCRIPTION
## What

Extracts the **federated (external-IdP) login landing page** from the showcase app-shell into
`@granit/react-ui-authentication-federated` — the federated parallel to
`@granit/react-ui-authentication-local` (which carries the *local* OpenIddict login forms).

## Layering (no overlap with the keycloak provider)

This is the **login UI**, not a session provider — orthogonal to
`@granit/react-ui-authentication-keycloak` (the Keycloak *provider*):
- **Login UI**: `-local` (credentials form) | `-federated` (this — IdP redirect button)
- **Session provider**: `bff` | `keycloak` | `mock`

It is provider-agnostic: it imports nothing Keycloak-specific, just calls the injected `login()`.
A second federated IdP needs no change here.

## Injection

`FederatedLoginPage({ login, loading, authenticated, layout? })` — the host injects its auth state
and public layout; the page does the IdP redirect button, the `?error=<code>` alert, and the
already-authenticated redirect. Ships its `Auth.LoginPage.*` / `Auth.AccessDenied.*` strings.

## Verification

- `tsc --noEmit` clean. `eslint --max-warnings 0` clean. Arch-tests: **2866 passed**. Page test: **4 passing**.