### PR TITLE
docs(audit-skill): 7g framework-agnostic seam / multi-platform readiness

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -222,7 +222,8 @@ HTTP-client conformity and endpoint drift), hooks, dependencies, cross-cutting
 concerns (including test data & mocks reuse, checklist 5e), module decomposition
 (backend bounded-context alignment), and finally the 3-tier layer separation
 (checklist 7 — core / headless / react-ui, including shadcn/ui UI-tier
-confinement, checklist 7e, and admin-UI composition, checklist 7f).
+confinement, checklist 7e, admin-UI composition, checklist 7f, and the
+framework-agnostic seam / multi-platform readiness, checklist 7g).
 
 For each finding, classify it:
 
@@ -446,6 +447,23 @@ When auditing all packages, perform these additional checks:
     # story coverage gap: component files vs stories per package
     for d in packages/@granit/react-ui-*; do c=$(find "$d/src" -name '*.tsx' ! -name '*.test.tsx' ! -name '*.stories.tsx' | wc -l); s=$(find "$d/src" -name '*.stories.tsx' | wc -l); echo "$(basename "$d"): $s stories / $c components"; done
     ```
+
+14. **Framework-agnostic seam (checklist 7g)**: keep the core portable so a future
+    non-React adapter can reuse it. R1/R3 are enforced by the `imports` arch-test;
+    R2 is a manual audit. Quick scans:
+
+    ```bash
+    # R1 — React ecosystem imported by a non-react (agnostic) package
+    for p in packages/@granit/*/package.json; do d=$(dirname "$p"); case "$d" in */react-*) continue;; esac
+      grep -rlnE "from 'react'|from 'react-dom'|from '@tanstack/react-query'" "$d/src" 2>/dev/null | grep -vE "/__tests__/|\.test\."
+    done
+    # R3 — react-ui pages importing a web router directly (ratchet baseline)
+    for f in $(grep -rlE "from 'react-router" packages/@granit/react-ui-*/src 2>/dev/null); do case "$f" in *test*|*stories*) continue;; esac; echo "$f"; done | sed -E 's|.*/(react-ui-[^/]+)/.*|@granit/\1|' | sort -u
+    # R2 — manual: a DOMAIN core touching a platform global it could inject
+    #   (skip the legitimate web abstractions: cookies, webauthn, oauth-redirect)
+    ```
+
+    Verify with `pnpm exec vitest run packages/@granit/arch-tests/src/__tests__/imports.test.ts`.
 
 ---
 

--- a/.claude/skills/audit/checklist.md
+++ b/.claude/skills/audit/checklist.md
@@ -511,6 +511,40 @@ foundation. Verify against the established patterns in `@granit/react-ui-parties
       is an INCONSISTENCY (`Fix: add aria-label / DialogTitle`). Audit statically —
       flag only clear omissions, not subjective contrast/landmark judgements.
 
+### 7g. Framework-agnostic seam — multi-platform readiness (--scope layers)
+
+The core/adapter split — framework-agnostic core `@granit/{module}` (types + api +
+permissions, NO framework runtime) + a thin `react-{module}` adapter — is what would
+let a future non-React adapter (`@granit/angular-{module}`, `@granit/{module}-native`)
+sit on the SAME core. Precedents already follow it: `validation` / `react-validation`,
+`query-engine` / `react-query-engine`, `entity-merge` / `react-entity-merge`. Do NOT
+build other adapters now (YAGNI) — just keep the seam clean so a port stays cheap.
+
+- [ ] **R1 — no React ecosystem in an agnostic core**: a package WITHOUT the
+      `react-` prefix must not import `react`, `react-dom`, or `@tanstack/react-query`.
+      The framework-neutral query core is `@tanstack/query-core` (React/Angular/Vue
+      layer their own adapters on top of it). Enforced by the `imports` arch-test
+      (`framework-agnostic packages do not import the React ecosystem`); current
+      allowlisted debt: `@granit/shell-core` (`src/query-client.ts` imports
+      `@tanstack/react-query` — migrate to `@tanstack/query-core`). BREAKING.
+- [ ] **R2 — no platform globals in a portable core**: a *domain* core that should be
+      portable avoids direct `window` / `document` / `localStorage` / `sessionStorage`
+      / `navigator` access; platform concerns (persistence, navigation, redirect) go
+      behind an injected port (web → `localStorage`, RN → `AsyncStorage`). **Audit
+      manually — there is no arch-test**: a regex can't separate runtime use from
+      JSDoc/string mentions without an AST, and several cores are *legitimately* web
+      platform abstractions, NOT violations — `@granit/cookies` (`document.cookie`),
+      WebAuthn passkeys (`navigator.credentials`), OAuth redirect (`window.location`).
+      Flag only a domain core reaching for a global it could have injected.
+      INCONSISTENCY.
+- [ ] **R3 — UI does not hard-bind a web router**: a `react-ui-{module}` page should
+      receive navigation via a thin port/props, not `import … from 'react-router-dom'`
+      / `'react-router'` directly, so React Native (react-navigation) or Angular Router
+      can substitute. Enforced as a **ratchet** by the `imports` arch-test (`react-ui
+      packages do not add NEW direct web-router imports`): the current offenders are
+      baselined (`UI_ROUTER_BASELINE`); no NEW `react-ui-*` may add a direct router
+      import, and the baseline should SHRINK as pages migrate. INCONSISTENCY.
+
 ---
 
 ## Suppressions — DO NOT flag


### PR DESCRIPTION
Follow-up to #750 (the 7g commit raced the squash-merge of #750 and landed after
it — re-applied here cleanly on top of develop).

## Why

Protect the core/adapter seam that would let a future non-React adapter (Angular,
React Native) reuse the framework-agnostic core, without building anything now.

## What — checklist section 7g (Framework-agnostic seam)

- **R1** — no React ecosystem (`react` / `react-dom` / `@tanstack/react-query`) in
  an unprefixed core; the neutral query core is `@tanstack/query-core`. Enforced by
  an `imports` arch-test (lands in a separate code PR); current allowlisted debt:
  `@granit/shell-core`.
- **R2** — no platform globals (`window`/`document`/`localStorage`/`navigator`) in a
  *portable domain* core; injected ports instead. Manual audit only (a regex can't
  tell runtime use from JSDoc without an AST; `@granit/cookies`, WebAuthn, OAuth
  redirect are legitimate web abstractions, not violations).
- **R3** — `react-ui-*` pages don't hard-bind `react-router-dom`; navigation via a
  thin port/props so RN/Angular routers can substitute. Enforced as a **ratchet**
  arch-test (separate PR): current offenders baselined, no new ones, shrink over time.

SKILL.md: Step 3 reference + cross-package scan #14.

## Notes

- Docs-only. `markdownlint-cli2` clean. The R1/R3 arch-tests follow in a code PR.