### PR TITLE
feat(arch-tests): enforce framework-agnostic seam (R1 + R3 ratchet)

### DIFF
--- a/packages/@granit/arch-tests/src/__tests__/helpers.ts
+++ b/packages/@granit/arch-tests/src/__tests__/helpers.ts
@@ -77,3 +77,60 @@ export const CONSOLE_ALLOWLIST: ReadonlyArray<string> = [
  *   grep -rhoE "@granit/react-[a-z0-9-]+" ~/dev/granit-fx/granit-cms-renderer/{app,src}
  */
 export const RSC_PACKAGES: ReadonlyArray<string> = ['@granit/react-cms'];
+
+/**
+ * R1 (checklist 7g) — framework-agnostic (non-`react-`) packages must not import the
+ * React ecosystem (`react`, `react-dom`, `@tanstack/react-query`) so a future
+ * non-React adapter can reuse the core. The framework-neutral query core is
+ * `@tanstack/query-core`. Allowlisted debt:
+ *   @granit/shell-core — `src/query-client.ts` still imports `@tanstack/react-query`
+ *   (migrate to `@tanstack/query-core`).
+ */
+export const REACT_ECOSYSTEM_CORE_ALLOWLIST: ReadonlyArray<string> = ['@granit/shell-core'];
+
+/**
+ * R3 (checklist 7g) — `react-ui-*` packages that currently import a web router
+ * (`react-router` / `react-router-dom`) directly in runtime code. This is a RATCHET
+ * baseline: no NEW package may be added, and it should SHRINK as pages move
+ * navigation behind a port/props so React Native (react-navigation) or Angular
+ * Router can substitute. Regenerate from the R3 scan in checklist 7g: grep the
+ * `react-router` imports under each `react-ui-` package src (excluding test and
+ * stories files), map each hit to its `@granit/react-ui-…` package name, sort -u.
+ */
+export const UI_ROUTER_BASELINE: ReadonlyArray<string> = [
+  '@granit/react-ui-account',
+  '@granit/react-ui-ai',
+  '@granit/react-ui-ai-chat',
+  '@granit/react-ui-auditing',
+  '@granit/react-ui-authentication-api-keys',
+  '@granit/react-ui-authentication-local',
+  '@granit/react-ui-catalog',
+  '@granit/react-ui-cms-hostnames',
+  '@granit/react-ui-cms-menus',
+  '@granit/react-ui-cms-pages',
+  '@granit/react-ui-cms-redirects',
+  '@granit/react-ui-cms-releases',
+  '@granit/react-ui-cms-seo',
+  '@granit/react-ui-cms-sites',
+  '@granit/react-ui-dashboards',
+  '@granit/react-ui-documents',
+  '@granit/react-ui-features',
+  '@granit/react-ui-hostnames',
+  '@granit/react-ui-identity',
+  '@granit/react-ui-invoicing',
+  '@granit/react-ui-metering',
+  '@granit/react-ui-multi-tenancy',
+  '@granit/react-ui-notifications',
+  '@granit/react-ui-openiddict-admin',
+  '@granit/react-ui-parties',
+  '@granit/react-ui-payments',
+  '@granit/react-ui-privacy',
+  '@granit/react-ui-reference-data',
+  '@granit/react-ui-scheduling',
+  '@granit/react-ui-shell-admin',
+  '@granit/react-ui-subscriptions',
+  '@granit/react-ui-tax',
+  '@granit/react-ui-taxonomy',
+  '@granit/react-ui-templating',
+  '@granit/react-ui-webhooks',
+];

--- a/packages/@granit/arch-tests/src/__tests__/imports.test.ts
+++ b/packages/@granit/arch-tests/src/__tests__/imports.test.ts
@@ -15,7 +15,9 @@ import {
   AXIOS_ALLOWLIST,
   CONSOLE_ALLOWLIST,
   FETCH_ALLOWLIST,
+  REACT_ECOSYSTEM_CORE_ALLOWLIST,
   REPO_ROOT,
+  UI_ROUTER_BASELINE,
   listPackages,
   toModules,
 } from './helpers';
@@ -125,5 +127,51 @@ describe('imports — granit-specific rules', () => {
 
     for (const n of graph.keys()) if ((color.get(n) ?? WHITE) === WHITE) dfs(n);
     expect(cycles).toEqual([]);
+  });
+
+  // R1 (checklist 7g) — keep the framework-agnostic core portable for a future
+  // non-React adapter (Angular, React Native): the neutral query core is
+  // @tanstack/query-core, not the React binding.
+  it('framework-agnostic (non-react) packages do not import the React ecosystem', () => {
+    const offenders: string[] = [];
+    for (const pkg of packages) {
+      if (pkg.isReact) continue;
+      if (REACT_ECOSYSTEM_CORE_ALLOWLIST.includes(pkg.name)) continue;
+      for (const f of walkSourceFiles(pkg.srcDir, (file) => !isTestFile(file))) {
+        for (const spec of collectImports(f)) {
+          if (/^(react|react-dom|@tanstack\/react-query)$/.test(spec)) {
+            offenders.push(`${rel(f, REPO_ROOT)} :: ${spec}`);
+          }
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  // R3 (checklist 7g) — ratchet: react-ui pages should receive navigation via a
+  // thin port/props so a non-web router (react-navigation / Angular Router) can
+  // substitute. No NEW package may import a web router directly; UI_ROUTER_BASELINE
+  // is the frozen set of current offenders and should shrink over time.
+  it('react-ui packages do not add NEW direct web-router imports', () => {
+    const offenders = new Set<string>();
+    for (const pkg of packages) {
+      if (!pkg.dirName.startsWith('react-ui-')) continue;
+      const notTestSupport = (file: string): boolean =>
+        !isTestFile(file) &&
+        !isTestingDir(file) &&
+        !/[\\/]__tests__[\\/]/.test(file) &&
+        !/test-utils\.tsx?$/.test(file) &&
+        !/\.stories\.tsx?$/.test(file);
+      for (const f of walkSourceFiles(pkg.srcDir, notTestSupport)) {
+        for (const spec of collectImports(f)) {
+          if (/^react-router(-dom)?$/.test(spec)) {
+            offenders.add(pkg.name);
+            break;
+          }
+        }
+      }
+    }
+    const newOffenders = [...offenders].filter((n) => !UI_ROUTER_BASELINE.includes(n)).sort();
+    expect(newOffenders).toEqual([]);
   });
 });


### PR DESCRIPTION
Enforcement half of the framework-agnostic seam rules documented in checklist 7g
(audit-skill guidance in #752). Keeps the core/adapter split clean so a future
non-React adapter (Angular, React Native) can reuse the framework-agnostic core,
without building anything now.

## What

Two new rules in `arch-tests/src/__tests__/imports.test.ts` (+ allowlists in `helpers.ts`):

- **R1 — `framework-agnostic (non-react) packages do not import the React ecosystem`**
  Bans `react` / `react-dom` / `@tanstack/react-query` in any package without the
  `react-` prefix. The framework-neutral query core is `@tanstack/query-core`.
  Allowlisted debt: `@granit/shell-core` (`query-client.ts` — migrate to query-core).
- **R3 — `react-ui packages do not add NEW direct web-router imports`** (ratchet)
  `react-ui-*` pages should receive navigation via a thin port/props so a non-web
  router (react-navigation / Angular Router) can substitute. The current 35
  offenders are frozen in `UI_ROUTER_BASELINE`; the test fails on any NEW one, and
  the baseline should shrink as pages migrate.

R2 (no platform globals in a portable core) stays a **manual** audit in 7g — a regex
can't separate runtime use from JSDoc without an AST, and several cores are
legitimately web platform abstractions (cookies, WebAuthn, OAuth redirect).

## Verification

Run locally (temp-applied in a node_modules-backed tree):

- `vitest run …/imports.test.ts` → **9 passed** (7 existing + 2 new)
- `tsc --noEmit` → clean
- `eslint` → clean

## Notes

Depends conceptually on #752 (checklist 7g). Both can merge independently.