### PR TITLE
docs(audit-skill): logging hygiene (one logger/package + dev observability)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -465,6 +465,23 @@ When auditing all packages, perform these additional checks:
 
     Verify with `pnpm exec vitest run packages/@granit/arch-tests/src/__tests__/imports.test.ts`.
 
+15. **Logging hygiene (checklist 5d)**: one logger instance per package, and enough
+    dev-time observability. Scans:
+
+    ```bash
+    # packages with >1 createLogger() call site (duplicate instances — centralize in logger.ts)
+    for p in $(grep -rl "createLogger(" packages/@granit/*/src 2>/dev/null | sed -E 's|/src/.*||' | sort -u); do
+      n=$(grep -rhoE "createLogger\(" "$p/src" | wc -l); [ "$n" -gt 1 ] && echo "$n  $p"
+    done
+    # logging packages that emit ONLY warn/error (no debug/info → poor dev observability)
+    for p in $(grep -rl "from '@granit/logger'" packages/@granit/*/src 2>/dev/null | sed -E 's|/src/.*||' | sort -u); do
+      di=$(grep -rhoE "\.(debug|info)\(" "$p/src" | wc -l); [ "$di" -eq 0 ] && echo "ONLY warn/error: $p"
+    done
+    ```
+
+    The `>1 createLogger` rule is enforced by an arch-test; the debug/info coverage is
+    a GAP heuristic (don't over-log, no PII).
+
 ---
 
 ## PR Mode (`/audit pr`)

--- a/.claude/skills/audit/checklist.md
+++ b/.claude/skills/audit/checklist.md
@@ -282,6 +282,23 @@ the rule — extend the arch-test rather than duplicating an ad-hoc check.
 
 - [ ] **Logging façade**: runtime code uses `@granit/logger` (`createLogger`),
       never `console.*`
+- [ ] **One logger per package**: a package creates its logger ONCE, in a dedicated
+      `src/logger.ts` (`export const logger = createLogger('<pkg-name>')`), and every
+      other file imports that instance — like `@granit/react-ui-bff`. Repeating
+      `const logger = createLogger('<pkg>')` inline in several files builds duplicate
+      instances of the same prefix; flag as INCONSISTENCY (`Fix: move to src/logger.ts
+      and import it`). Use `logger.child('Feature')` for sub-scopes instead of a manual
+      `'[Feature] …'` string prefix. Enforced by the `>1 createLogger` arch-test.
+- [ ] **Dev observability (debug/info)**: the default log level is `DEBUG` in dev
+      and `WARN` in prod (`resolveLogLevelName`), so `debug`/`info` are free to a
+      developer and silent in production. Key flows SHOULD emit them, not just
+      `warn`/`error`: `info` on provider init and successful mutations (`X created
+      id=…`); `debug` on API calls in hooks (`fetching X` / `X loaded {count}`),
+      query-key invalidations, and gating/branching decisions. A domain
+      `react-{module}` whose only logs are `error`/`warn` (no `debug`/`info` on its
+      hooks/providers) is a GAP — a developer running the app sees nothing of the
+      module's behaviour. Do NOT over-log (no per-render spam, no PII — use the
+      `redact*` helpers); judge by whether the logs would help diagnose a flow in dev.
 - [ ] **CSP / Trusted Types**: any package that writes to a DOM script sink
       (`.innerHTML`, `.outerHTML`, `.insertAdjacentHTML`, direct `.src =` or
       `setAttribute('src', …)` on `iframe`/`script`) MUST expose a `<pkg>/csp`


### PR DESCRIPTION
Extends audit checklist 5d with two logging rules, prompted by the clean `react-ui-bff/src/logger.ts` pattern.

## What
- **One logger per package**: create the logger once in `src/logger.ts` (`export const logger = createLogger('<pkg>')`) and import it everywhere — like `@granit/react-ui-bff`. Inline `createLogger('<pkg>')` repeated across files builds duplicate same-prefix instances (INCONSISTENCY). Use `logger.child('Feature')` for sub-scopes.
- **Dev observability (debug/info)**: default level is `DEBUG` in dev / `WARN` in prod, so debug/info cost nothing in prod and make dev observable. Key flows (provider init, API calls in hooks, mutations, query-key invalidations) SHOULD emit `info`/`debug`; a module logging only `warn`/`error` is a GAP. No over-logging, no PII (use `redact*`).

## Why now
Survey of the 51 logging packages: **36 emit only warn/error** (zero debug/info), and 7 duplicate their logger instance across files. The infra already defaults to DEBUG in dev — the observability is just unused.

SKILL.md: cross-package scan #15. Enforcement arch-test (>1 createLogger) + the inline→logger.ts migration follow in code PRs. Docs-only; markdownlint clean.