### PR TITLE
refactor(react-presence): centralise logger + debug observability (reference)

### DIFF
--- a/packages/@granit/react-presence/src/hooks/use-heartbeat.ts
+++ b/packages/@granit/react-presence/src/hooks/use-heartbeat.ts
@@ -1,16 +1,14 @@
-import { createLogger } from '@granit/logger';
 import { pollMyPresence } from '@granit/presence';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 
 import { DEFAULT_HEARTBEAT_INTERVAL_MS } from '../constants';
+import { logger } from '../logger';
 import { buildPresenceQueryKey, usePresenceConfig } from '../providers/presence-provider';
 
 import { presenceKeys } from './query-keys';
 
 import type { PresenceResponse } from '@granit/presence';
-
-const logger = createLogger('react-presence');
 
 export interface UseHeartbeatOptions {
   /** Polling interval in ms while the tab is visible. Default: 30 000. */
@@ -83,6 +81,7 @@ export function useHeartbeat(options: UseHeartbeatOptions = {}): void {
           // tick. This races on initial mount and on every tab re-focus.
           await queryClient.cancelQueries({ queryKey });
           queryClient.setQueryData<PresenceResponse>(queryKey, data);
+          logger.debug('Presence heartbeat sent', { idleSeconds });
         }
       } catch {
         // Heartbeat failures are non-critical — keep polling.

--- a/packages/@granit/react-presence/src/hooks/use-resource-presence.ts
+++ b/packages/@granit/react-presence/src/hooks/use-resource-presence.ts
@@ -1,4 +1,3 @@
-import { createLogger } from '@granit/logger';
 import { joinResourceRoom, leaveResourceRoom } from '@granit/presence';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -6,11 +5,10 @@ import {
   DEFAULT_RESOURCE_HEARTBEAT_INTERVAL_MS,
   DEFAULT_RESOURCE_STALE_THRESHOLD_MS,
 } from '../constants';
+import { logger } from '../logger';
 import { usePresenceConfig } from '../providers/presence-provider';
 
 import type { ResourcePresenceParticipantResponse, ResourceRoomResponse } from '@granit/presence';
-
-const logger = createLogger('react-presence');
 
 export interface UseResourcePresenceOptions {
   /** Heartbeat cadence ms. Default: 15 000. */
@@ -186,6 +184,11 @@ export function useResourcePresence(
           setParticipants(applyStaleFilter(data, staleThresholdRef.current));
           setIsJoining(false);
           setError(null);
+          logger.debug('Resource presence heartbeat', {
+            kind,
+            id,
+            participants: data.participants.length,
+          });
         }
       } catch (err) {
         if (!cancelled && !ac.signal.aborted) {

--- a/packages/@granit/react-presence/src/logger.ts
+++ b/packages/@granit/react-presence/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-presence');


### PR DESCRIPTION
Reference implementation of the logging-hygiene convention (audit checklist 5d, #755) — the template for migrating the other inline-logger packages.

## What
- **Centralise the logger**: new `src/logger.ts` (`export const logger = createLogger('react-presence')`), imported by both hooks. Previously `createLogger('react-presence')` was duplicated inline in `use-heartbeat.ts` and `use-resource-presence.ts` (same prefix, two instances).
- **Dev observability**: add `logger.debug` on the heartbeat ticks (`idleSeconds`, participant count). Default dev level is DEBUG, prod WARN — free in dev, silent in prod.

## Verified
`tsc --noEmit` + `eslint` clean; react-presence now has exactly one `createLogger` call (shrinks the one-logger arch-test baseline in #754).

## Context
Pattern to replicate across the remaining inline-logger packages (see follow-up plan).