### PR TITLE
refactor(logging): centralise logger in src/logger.ts (6 duplicators)

### DIFF
--- a/packages/@granit/localization/src/apply-translations.ts
+++ b/packages/@granit/localization/src/apply-translations.ts
@@ -1,9 +1,7 @@
-import { createLogger } from '@granit/logger';
+import { logger } from './logger';
 
 import type { ApplicationLocalizationResponse } from './types/index';
 import type { i18n } from 'i18next';
-
-const logger = createLogger('localization');
 
 /**
  * Apply backend localization response to the i18next instance.

--- a/packages/@granit/localization/src/create-localization.ts
+++ b/packages/@granit/localization/src/create-localization.ts
@@ -1,10 +1,9 @@
-import { createLogger } from '@granit/logger';
 import { createInstance } from 'i18next';
+
+import { logger } from './logger';
 
 import type { LocalizationConfig } from './types/index';
 import type { i18n } from 'i18next';
-
-const logger = createLogger('localization');
 
 /**
  * Create an isolated i18next instance with Digital Dynamics defaults.

--- a/packages/@granit/localization/src/logger.ts
+++ b/packages/@granit/localization/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('localization');

--- a/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
@@ -1,5 +1,4 @@
 import { SEND_MESSAGE_LIMITS } from '@granit/ai-chat';
-import { createLogger } from '@granit/logger';
 import { cn } from '@granit/utils';
 import { ArrowUp, Paperclip, Sparkles, Square } from 'lucide-react';
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
@@ -7,6 +6,7 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { MENTION_SEARCH_DEBOUNCE_MS } from '../constants';
 import { useDefaultMentionSearch } from '../hooks/use-default-mention-search';
 import { defaultChatLabels } from '../locales/index';
+import { logger } from '../logger';
 
 import { AttachmentChips } from './attachment-chips';
 import { CHIP_SLOT, createChipElement, isEditorEmpty, serializeEditor } from './composer-content';
@@ -34,8 +34,6 @@ import type {
   MouseEvent,
   ReactNode,
 } from 'react';
-
-const logger = createLogger('react-ai-chat');
 
 /** Caret-moving keys that should re-evaluate the `/` `@` trigger on key-up. */
 const CARET_KEYS = new Set(['ArrowLeft', 'ArrowRight', 'Home', 'End']);

--- a/packages/@granit/react-ai-chat/src/hooks/use-chat-stream.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-chat-stream.ts
@@ -3,16 +3,14 @@ import {
   CHAT_STREAM_EVENT_TYPES,
   streamConversationMessage,
 } from '@granit/ai-chat';
-import { createLogger } from '@granit/logger';
 import { toEntityId, toISODateString } from '@granit/types';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { logger } from '../logger';
 import { useAIChatConfig } from '../providers/ai-chat-provider';
 
 import { conversationKeys } from './query-keys';
-
-const logger = createLogger('react-ai-chat');
 
 import type { MessagesPageParam } from './use-conversation-messages';
 import type {

--- a/packages/@granit/react-ai-chat/src/logger.ts
+++ b/packages/@granit/react-ai-chat/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-ai-chat');

--- a/packages/@granit/react-localization/src/date-locale.ts
+++ b/packages/@granit/react-localization/src/date-locale.ts
@@ -1,10 +1,9 @@
-import { createLogger } from '@granit/logger';
 import { enUS } from 'date-fns/locale';
 import { useEffect, useState } from 'react';
 
-import type { Locale } from 'date-fns/locale';
+import { logger } from './logger';
 
-const logger = createLogger('react-localization');
+import type { Locale } from 'date-fns/locale';
 
 /** Alias for i18n codes that don't have a matching date-fns locale file. */
 const LOCALE_ALIAS: Record<string, string> = {

--- a/packages/@granit/react-localization/src/logger.ts
+++ b/packages/@granit/react-localization/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-localization');

--- a/packages/@granit/react-localization/src/use-locale.ts
+++ b/packages/@granit/react-localization/src/use-locale.ts
@@ -1,10 +1,9 @@
 import { LOCALE_STORAGE_KEY } from '@granit/localization';
-import { createLogger } from '@granit/logger';
 import { createStorage } from '@granit/storage';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const logger = createLogger('react-localization');
+import { logger } from './logger';
 
 export interface UseLocaleOptions {
   /** Called after locale is changed — use to persist to backend (e.g. settings API). */

--- a/packages/@granit/react-notifications/src/hooks/use-unread-count.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-unread-count.ts
@@ -1,11 +1,9 @@
-import { createLogger } from '@granit/logger';
 import { getUnreadCount } from '@granit/notifications';
 import { useCallback, useEffect, useRef } from 'react';
 
 import { API_BASE_PATH } from '../constants';
+import { logger } from '../logger';
 import { useNotificationConfig } from '../providers/notification-provider';
-
-const logger = createLogger('react-notifications');
 
 export interface UseUnreadCountOptions {
   /** Polling interval in ms. Set to 0 to disable polling. Default: 60 000 */

--- a/packages/@granit/react-notifications/src/logger.ts
+++ b/packages/@granit/react-notifications/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-notifications');

--- a/packages/@granit/react-notifications/src/providers/notification-provider.tsx
+++ b/packages/@granit/react-notifications/src/providers/notification-provider.tsx
@@ -1,5 +1,6 @@
-import { createLogger } from '@granit/logger';
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+import { logger } from '../logger';
 
 import type {
   ConnectionState,
@@ -21,8 +22,6 @@ interface NotificationContextValue {
 }
 
 const NotificationContext = createContext<NotificationContextValue | null>(null);
-
-const logger = createLogger('react-notifications');
 
 // ---------------------------------------------------------------------------
 // Hook

--- a/packages/@granit/react-timeline/src/hooks/use-timeline-actions.ts
+++ b/packages/@granit/react-timeline/src/hooks/use-timeline-actions.ts
@@ -1,12 +1,12 @@
-import { createLogger } from '@granit/logger';
 import { createEntry, deleteEntry } from '@granit/timeline';
 import { useCallback, useState } from 'react';
 
+import { logger as timelineLogger } from '../logger';
 import { useTimelineConfig } from '../providers/timeline-provider';
 
 import type { PostTimelineEntryRequest, TimelineStreamEntryResponse } from '@granit/timeline';
 
-const logger = createLogger('timeline:actions');
+const logger = timelineLogger.child('actions');
 
 export interface UseTimelineActionsOptions {
   entityType: string;

--- a/packages/@granit/react-timeline/src/hooks/use-timeline-followers.ts
+++ b/packages/@granit/react-timeline/src/hooks/use-timeline-followers.ts
@@ -1,10 +1,10 @@
-import { createLogger } from '@granit/logger';
 import { getFollowers, followEntity, unfollowEntity } from '@granit/timeline';
 import { useCallback, useEffect, useState } from 'react';
 
+import { logger as timelineLogger } from '../logger';
 import { useTimelineConfig } from '../providers/timeline-provider';
 
-const logger = createLogger('timeline:followers');
+const logger = timelineLogger.child('followers');
 
 export interface UseTimelineFollowersOptions {
   entityType: string;

--- a/packages/@granit/react-timeline/src/logger.ts
+++ b/packages/@granit/react-timeline/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('timeline');

--- a/packages/@granit/react-validation/src/logger.ts
+++ b/packages/@granit/react-validation/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-validation');

--- a/packages/@granit/react-validation/src/use-server-validation-batch.ts
+++ b/packages/@granit/react-validation/src/use-server-validation-batch.ts
@@ -1,13 +1,12 @@
-import { createLogger } from '@granit/logger';
 import { isEmptyFieldValue, validateField, validateFieldsBatch } from '@granit/validation';
 import { useEffect, useRef, useState } from 'react';
+
+import { logger } from './logger';
 
 import type { TranslateFunction } from './create-constraints-resolver';
 import type { ServerValidationState } from './use-server-validation';
 import type { AxiosInstance } from '@granit/api-client';
 import type { FieldConstraint } from '@granit/validation';
-
-const logger = createLogger('react-validation');
 
 export interface BatchFieldSpec {
   readonly name: string;

--- a/packages/@granit/react-validation/src/use-server-validation.ts
+++ b/packages/@granit/react-validation/src/use-server-validation.ts
@@ -1,12 +1,11 @@
-import { createLogger } from '@granit/logger';
 import { isEmptyFieldValue, validateField, validateFieldServer } from '@granit/validation';
 import { useEffect, useRef, useState } from 'react';
+
+import { logger } from './logger';
 
 import type { TranslateFunction } from './create-constraints-resolver';
 import type { AxiosInstance } from '@granit/api-client';
 import type { FieldConstraint } from '@granit/validation';
-
-const logger = createLogger('react-validation');
 
 export interface ServerValidationState {
   readonly status: 'idle' | 'validating' | 'valid' | 'invalid' | 'error';


### PR DESCRIPTION
Batch 1 of the logger-centralisation work (audit checklist 5d, #755) — the 6 packages that duplicated their `createLogger` instance across files, following the #756 react-presence template.

## What
Each package created `createLogger('<pkg>')` inline in two files. Moved to a single `src/logger.ts` (`export const logger = createLogger('<pkg>')`) imported by both.

- **localization, react-ai-chat, react-localization, react-notifications, react-validation** — plain duplicates → single instance.
- **react-timeline** — used two *distinct* sub-prefixes (`timeline:actions` / `timeline:followers`); now `createLogger('timeline')` + `logger.child('actions')` / `logger.child('followers')` (the idiomatic sub-scope API).

Each package now has exactly one `createLogger` call → they can be removed from `LOGGER_MULTI_INSTANCE_BASELINE` (#754) once both merge (harmless stale entries until then).

## Verified
`tsc --noEmit`, `eslint --max-warnings 0`, and all 6 test suites (**353 tests**) pass.

## Next
Remaining backlog: ~26 single-inline packages to move to `logger.ts`, plus debug/info enrichment of the error/warn-only modules.