### PR TITLE
refactor(logging): centralise logger in src/logger.ts (21 packages) + close ratchet

### DIFF
--- a/packages/@granit/ai-chat/src/api/conversations-api.ts
+++ b/packages/@granit/ai-chat/src/api/conversations-api.ts
@@ -4,7 +4,7 @@
 // stream. Routes are relative to `basePath` (the `/conversations` prefix).
 // ---------------------------------------------------------------------------
 
-import { createLogger } from '@granit/logger';
+import { logger } from '../logger';
 
 import type {
   ChatStreamEvent,
@@ -22,8 +22,6 @@ import type {
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 import type { PagedResult } from '@granit/query-engine';
-
-const logger = createLogger('ai-chat');
 
 /**
  * List the current user's conversations, newest first, without their messages.

--- a/packages/@granit/ai-chat/src/logger.ts
+++ b/packages/@granit/ai-chat/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('ai-chat');

--- a/packages/@granit/ai/src/api/ai-chat-api.ts
+++ b/packages/@granit/ai/src/api/ai-chat-api.ts
@@ -3,8 +3,7 @@
 // Mirrors Granit.AI.Endpoints chat endpoints (sync + SSE stream).
 // ---------------------------------------------------------------------------
 
-import { createLogger } from '@granit/logger';
-
+import { logger } from '../logger';
 import { AI_STREAM_DONE_MARKER } from '../types/index';
 
 import type {
@@ -15,8 +14,6 @@ import type {
   AIChatStreamUsage,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
-
-const logger = createLogger('ai');
 
 /**
  * Send a chat completion request and return the full response.

--- a/packages/@granit/ai/src/logger.ts
+++ b/packages/@granit/ai/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('ai');

--- a/packages/@granit/arch-tests/src/__tests__/helpers.ts
+++ b/packages/@granit/arch-tests/src/__tests__/helpers.ts
@@ -189,19 +189,11 @@ export const STORYBOOK_PAGE_BUDGET: Readonly<Record<string, number>> = {
 };
 
 /**
- * Logging hygiene (checklist 5d) — packages that currently call `createLogger()` more
- * than once, building duplicate instances of the same prefix. The convention is ONE
- * logger per package in `src/logger.ts`, imported everywhere (see `@granit/react-ui-bff`).
- * Ratchet baseline: no NEW package may have >1 `createLogger()` call; this set must
- * SHRINK as packages centralise their logger. Regenerate by counting `createLogger(`
- * per package (excluding `@granit/logger` itself).
+ * Logging hygiene (checklist 5d) — packages allowed to call `createLogger()` more than
+ * once (duplicate instances of the same prefix). The convention is ONE logger per
+ * package in `src/logger.ts`, imported everywhere (see `@granit/react-ui-bff`). This
+ * ratchet is now EMPTY — every package has a single logger; no NEW package may
+ * reintroduce a duplicate. Keep it empty unless a deliberate, documented exception
+ * arises.
  */
-export const LOGGER_MULTI_INSTANCE_BASELINE: ReadonlyArray<string> = [
-  '@granit/localization',
-  '@granit/react-ai-chat',
-  '@granit/react-localization',
-  '@granit/react-notifications',
-  '@granit/react-presence',
-  '@granit/react-timeline',
-  '@granit/react-validation',
-];
+export const LOGGER_MULTI_INSTANCE_BASELINE: ReadonlyArray<string> = [];

--- a/packages/@granit/bff/src/csrf/csrf-manager.ts
+++ b/packages/@granit/bff/src/csrf/csrf-manager.ts
@@ -7,11 +7,9 @@
 // auto-injects it on mutation methods.
 // ---------------------------------------------------------------------------
 
-import { createLogger } from '@granit/logger';
+import { logger } from '../logger';
 
 import type { BffCsrfTokenResponse } from '../types/index';
-
-const logger = createLogger('bff');
 
 const MUTATION_METHODS = new Set(['POST', 'PUT', 'DELETE', 'PATCH']);
 

--- a/packages/@granit/bff/src/logger.ts
+++ b/packages/@granit/bff/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('bff');

--- a/packages/@granit/cookies/src/cookie-store.ts
+++ b/packages/@granit/cookies/src/cookie-store.ts
@@ -1,8 +1,6 @@
-import { createLogger } from '@granit/logger';
+import { logger } from './logger';
 
 import type { CookieCategory, ConsentState } from './types/index';
-
-const logger = createLogger('cookies');
 
 /**
  * Attributes applied when writing a cookie via {@link setConsentedCookie} or

--- a/packages/@granit/cookies/src/logger.ts
+++ b/packages/@granit/cookies/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('cookies');

--- a/packages/@granit/dashboards/src/logger.ts
+++ b/packages/@granit/dashboards/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('dashboards');

--- a/packages/@granit/dashboards/src/types/widget-bridge.ts
+++ b/packages/@granit/dashboards/src/types/widget-bridge.ts
@@ -21,13 +21,11 @@
 // shaped against the persistence view. This module is the round-trip
 // bridge between the two — pure data transformation, no React deps.
 
-import { createLogger } from '@granit/logger';
+import { logger } from '../logger';
 
 import type { DashboardDetailResponse } from './dashboard-detail-response';
 import type { AddWidgetRequest, UpdateWidgetRequest, WidgetInstanceResponse } from './index';
 import type { DashboardDefinition, WidgetDefinition, WidgetDefinitionBase } from '../types/index';
-
-const logger = createLogger('dashboards');
 
 /**
  * The five structural fields that live outside `configJson` because the

--- a/packages/@granit/notifications-sse/src/logger.ts
+++ b/packages/@granit/notifications-sse/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('notifications-sse');

--- a/packages/@granit/notifications-sse/src/transports/create-sse-transport.ts
+++ b/packages/@granit/notifications-sse/src/transports/create-sse-transport.ts
@@ -1,10 +1,9 @@
-import { createLogger } from '@granit/logger';
 import { createTransportListeners } from '@granit/notifications';
 import { EventStreamContentType, fetchEventSource } from '@microsoft/fetch-event-source';
 
-import type { NotificationTransportMessage, NotificationTransport } from '@granit/notifications';
+import { logger } from '../logger';
 
-const logger = createLogger('notifications-sse');
+import type { NotificationTransportMessage, NotificationTransport } from '@granit/notifications';
 
 export interface SseTransportConfig {
   /** SSE endpoint URL, e.g. '/api/v1/notifications/stream'. */

--- a/packages/@granit/react-ai/src/hooks/use-ai-chat-stream.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-chat-stream.ts
@@ -1,12 +1,10 @@
 import { chatStream } from '@granit/ai';
-import { createLogger } from '@granit/logger';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { logger } from '../logger';
 import { useAIConfig } from '../providers/ai-provider';
 
 import type { AIChatRequest, AIChatStreamUsage } from '@granit/ai';
-
-const logger = createLogger('react-ai');
 
 export interface UseAIChatStreamReturn {
   /**

--- a/packages/@granit/react-ai/src/logger.ts
+++ b/packages/@granit/react-ai/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-ai');

--- a/packages/@granit/react-authentication-cognito/src/hooks/use-cognito-init.ts
+++ b/packages/@granit/react-authentication-cognito/src/hooks/use-cognito-init.ts
@@ -1,8 +1,8 @@
 import { setTokenGetter, setOnUnauthorized } from '@granit/api-client';
-import { createLogger } from '@granit/logger';
 import { CognitoUserPool } from 'amazon-cognito-identity-js';
 import * as React from 'react';
 
+import { logger } from '../logger';
 import {
   buildCognitoAuthorizeUrl,
   generatePkce,
@@ -13,8 +13,6 @@ import {
 import type { LoginOptions, LogoutOptions, OidcUserInfo } from '@granit/authentication';
 import type { CognitoAuthContextType, CognitoCoreConfig } from '@granit/authentication-cognito';
 import type { ICognitoStorage } from 'amazon-cognito-identity-js';
-
-const logger = createLogger('react-authentication-cognito');
 
 /**
  * In-memory implementation of the Cognito SDK storage contract. Tokens live

--- a/packages/@granit/react-authentication-cognito/src/logger.ts
+++ b/packages/@granit/react-authentication-cognito/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-authentication-cognito');

--- a/packages/@granit/react-authentication-entraid/src/hooks/use-entraid-init.ts
+++ b/packages/@granit/react-authentication-entraid/src/hooks/use-entraid-init.ts
@@ -1,12 +1,11 @@
 import { PublicClientApplication, InteractionRequiredAuthError } from '@azure/msal-browser';
 import { setTokenGetter, setOnUnauthorized } from '@granit/api-client';
-import { createLogger } from '@granit/logger';
 import * as React from 'react';
+
+import { logger } from '../logger';
 
 import type { LoginOptions, LogoutOptions, OidcUserInfo } from '@granit/authentication';
 import type { EntraIdAuthContextType, EntraIdCoreConfig } from '@granit/authentication-entraid';
-
-const logger = createLogger('authentication-entraid');
 
 export interface EntraIdCoreResult extends EntraIdAuthContextType {
   /** Direct ref to the MSAL PublicClientApplication instance. */

--- a/packages/@granit/react-authentication-entraid/src/logger.ts
+++ b/packages/@granit/react-authentication-entraid/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('authentication-entraid');

--- a/packages/@granit/react-authentication-google-cloud/src/hooks/use-google-cloud-init.ts
+++ b/packages/@granit/react-authentication-google-cloud/src/hooks/use-google-cloud-init.ts
@@ -1,5 +1,4 @@
 import { setTokenGetter, setOnUnauthorized } from '@granit/api-client';
-import { createLogger } from '@granit/logger';
 import { initializeApp } from 'firebase/app';
 import {
   initializeAuth,
@@ -13,14 +12,14 @@ import {
 } from 'firebase/auth';
 import * as React from 'react';
 
+import { logger } from '../logger';
+
 import type { LoginOptions, LogoutOptions, OidcUserInfo } from '@granit/authentication';
 import type {
   GoogleCloudAuthContextType,
   GoogleCloudCoreConfig,
 } from '@granit/authentication-google-cloud';
 import type { Auth, Persistence, User } from 'firebase/auth';
-
-const logger = createLogger('react-authentication-google-cloud');
 
 /** Resolve the Firebase persistence from the configured posture (default: memory). */
 function resolvePersistence(tokenStorage: GoogleCloudCoreConfig['tokenStorage']): Persistence {

--- a/packages/@granit/react-authentication-google-cloud/src/logger.ts
+++ b/packages/@granit/react-authentication-google-cloud/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-authentication-google-cloud');

--- a/packages/@granit/react-authentication-keycloak/src/hooks/use-keycloak-core.ts
+++ b/packages/@granit/react-authentication-keycloak/src/hooks/use-keycloak-core.ts
@@ -1,7 +1,8 @@
 import { setTokenGetter, setOnUnauthorized } from '@granit/api-client';
-import { createLogger } from '@granit/logger';
 import Keycloak from 'keycloak-js';
 import * as React from 'react';
+
+import { logger } from '../logger';
 
 import type { LoginOptions, LogoutOptions } from '@granit/authentication';
 import type {
@@ -34,8 +35,6 @@ export interface KeycloakCoreResult extends KeycloakAuthContextType {
   /** Decoded JWT payload — undefined before authentication. */
   tokenParsed: Record<string, unknown> | undefined;
 }
-
-const logger = createLogger('react-authentication-keycloak');
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/@granit/react-authentication-keycloak/src/logger.ts
+++ b/packages/@granit/react-authentication-keycloak/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-authentication-keycloak');

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-upload.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-upload.ts
@@ -1,15 +1,13 @@
 import { cancelPendingUpload, confirmUpload, initiateUpload } from '@granit/blob-storage';
-import { createLogger } from '@granit/logger';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useRef, useState } from 'react';
 
+import { logger } from '../logger';
 import { useBlobStorageConfig } from '../providers/blob-storage-provider';
 
 import { blobListQueryKey, blobStorageKeys } from './query-keys';
 
 import type { BlobConfirmUploadResponse } from '@granit/blob-storage';
-
-const logger = createLogger('react-blob-storage');
 
 /** Upload progress phase. */
 export type BlobUploadPhase =

--- a/packages/@granit/react-blob-storage/src/logger.ts
+++ b/packages/@granit/react-blob-storage/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-blob-storage');

--- a/packages/@granit/react-cms/src/logger.ts
+++ b/packages/@granit/react-cms/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-cms');

--- a/packages/@granit/react-cms/src/puck/catalog-to-config.tsx
+++ b/packages/@granit/react-cms/src/puck/catalog-to-config.tsx
@@ -1,11 +1,9 @@
-import { createLogger } from '@granit/logger';
-
 import { BLOCK_COMPONENTS } from '../blocks/registry';
+import { logger } from '../logger';
+
 
 import type { BlockCatalogResponse, BlockFieldDescriptor, BlockFieldKind } from '@granit/cms';
 import type { Config, ExternalField, Fields } from '@puckeditor/core';
-
-const logger = createLogger('react-cms');
 
 /**
  * Callback supplied by the renderer to resolve live data for a data-bound block.

--- a/packages/@granit/react-cookies/src/logger.ts
+++ b/packages/@granit/react-cookies/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('cookies');

--- a/packages/@granit/react-cookies/src/providers/cookie-consent-provider.tsx
+++ b/packages/@granit/react-cookies/src/providers/cookie-consent-provider.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import { defaultConsentState } from '@granit/cookies';
-import { createLogger } from '@granit/logger';
 import { createContext, useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+
+import { logger } from '../logger';
 
 import type { CookieConsentContextValue } from '../types/index';
 import type { CookieCategory, CookieConsentAdapter, ConsentState } from '@granit/cookies';
-
-const logger = createLogger('cookies');
 
 export const CookieConsentContext = createContext<CookieConsentContextValue | null>(null);
 

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-stream.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-stream.ts
@@ -1,6 +1,6 @@
-import { createLogger } from '@granit/logger';
 import { useEffect } from 'react';
 
+import { logger } from '../logger';
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
 import type {
@@ -8,8 +8,6 @@ import type {
   RefreshHint,
   WidgetSnapshotStatus,
 } from '@granit/dashboards';
-
-const logger = createLogger('react-dashboards');
 
 /**
  * Wire shape of an `event: snapshot` frame on the dashboard SSE

--- a/packages/@granit/react-dashboards/src/logger.ts
+++ b/packages/@granit/react-dashboards/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-dashboards');

--- a/packages/@granit/react-data-exchange/src/export/hooks/use-export-job.ts
+++ b/packages/@granit/react-data-exchange/src/export/hooks/use-export-job.ts
@@ -1,8 +1,8 @@
 import { createExportJob, downloadExportFile, getExportJobStatus } from '@granit/data-exchange';
-import { createLogger } from '@granit/logger';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { logger } from '../../logger';
 import { buildExportQueryKey, useExportConfig } from '../providers/export-provider';
 
 import type {
@@ -10,8 +10,6 @@ import type {
   ExportJobResponse,
   ExportJobStatus,
 } from '@granit/data-exchange';
-
-const logger = createLogger('react-data-exchange');
 
 export interface UseExportJobReturn {
   /** Start a new export job. */

--- a/packages/@granit/react-data-exchange/src/logger.ts
+++ b/packages/@granit/react-data-exchange/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-data-exchange');

--- a/packages/@granit/react-notifications-mobile-push/src/hooks/use-mobile-push.ts
+++ b/packages/@granit/react-notifications-mobile-push/src/hooks/use-mobile-push.ts
@@ -1,13 +1,11 @@
 import { PushNotifications } from '@capacitor/push-notifications';
-import { createLogger } from '@granit/logger';
 import { registerDeviceToken, unregisterDeviceToken } from '@granit/notifications-mobile-push';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { logger } from '../logger';
 import { useMobilePushConfig } from '../providers/mobile-push-provider';
 
 import type { MobilePlatform } from '@granit/notifications-mobile-push';
-
-const logger = createLogger('react-notifications-mobile-push');
 
 /**
  * Returns a promise that resolves with the device token once Capacitor

--- a/packages/@granit/react-notifications-mobile-push/src/logger.ts
+++ b/packages/@granit/react-notifications-mobile-push/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-notifications-mobile-push');

--- a/packages/@granit/react-notifications-web-push/src/hooks/use-web-push.ts
+++ b/packages/@granit/react-notifications-web-push/src/hooks/use-web-push.ts
@@ -1,4 +1,3 @@
-import { createLogger } from '@granit/logger';
 import {
   registerPushSubscription,
   unregisterPushSubscription,
@@ -6,9 +5,8 @@ import {
 } from '@granit/notifications-web-push';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { logger } from '../logger';
 import { useWebPushConfig } from '../providers/web-push-provider';
-
-const logger = createLogger('react-notifications-web-push');
 
 export interface UseWebPushReturn {
   /** Whether the browser supports Web Push. */

--- a/packages/@granit/react-notifications-web-push/src/logger.ts
+++ b/packages/@granit/react-notifications-web-push/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-notifications-web-push');

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-device-verification.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-device-verification.ts
@@ -1,9 +1,7 @@
-import { createLogger } from '@granit/logger';
 import { useState } from 'react';
 
+import { logger } from '../logger';
 import { useAdminConfig } from '../providers/openiddict-admin-provider';
-
-const logger = createLogger('react-openiddict-admin');
 
 export type DeviceVerificationStatus = 'idle' | 'pending' | 'success' | 'error';
 

--- a/packages/@granit/react-openiddict-admin/src/logger.ts
+++ b/packages/@granit/react-openiddict-admin/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-openiddict-admin');

--- a/packages/@granit/react-tracing/src/logger.ts
+++ b/packages/@granit/react-tracing/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-tracing');

--- a/packages/@granit/react-tracing/src/providers/tracing-provider.tsx
+++ b/packages/@granit/react-tracing/src/providers/tracing-provider.tsx
@@ -1,4 +1,3 @@
-import { createLogger } from '@granit/logger';
 import { type Tracer, trace } from '@opentelemetry/api';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
@@ -9,6 +8,8 @@ import { resourceFromAttributes } from '@opentelemetry/resources';
 import { BatchSpanProcessor, WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 import * as React from 'react';
+
+import { logger } from '../logger';
 
 import type { TracingProviderProps } from '../types/index';
 import type { TracingExporterConfig } from '@granit/tracing';
@@ -22,8 +23,6 @@ import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-web';
 
 // ExportResultCode.SUCCESS = 0 (from @opentelemetry/core, not a direct dependency)
 const EXPORT_SUCCESS = { code: 0 as const };
-
-const logger = createLogger('react-tracing');
 
 function createGatedExporter(exporterConfig: TracingExporterConfig): SpanExporter {
   let delegate: OTLPTraceExporter | null = null;

--- a/packages/@granit/react-ui-dashboards/src/dashboard-edit-page.tsx
+++ b/packages/@granit/react-ui-dashboards/src/dashboard-edit-page.tsx
@@ -4,7 +4,6 @@ import {
   type DashboardDefinition,
   type WidgetDefinition,
 } from '@granit/dashboards';
-import { createLogger } from '@granit/logger';
 import {
   analyticsWidgetCatalog,
   analyticsWidgetConfigFormRegistry,
@@ -55,7 +54,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
-const logger = createLogger('react-ui-dashboards');
+import { logger } from './logger';
 
 type PendingEditAction = 'delete-widget' | 'discard';
 

--- a/packages/@granit/react-ui-dashboards/src/logger.ts
+++ b/packages/@granit/react-ui-dashboards/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-ui-dashboards');


### PR DESCRIPTION
Batch 2 — completes the `src/logger.ts` convention rollout (audit checklist 5d, #755).

## What
Moves the inline `createLogger()` of **21 single-instance packages** into a dedicated `src/logger.ts` imported by the former call site. Existing log prefixes preserved verbatim (e.g. `react-authentication-entraid` keeps `'authentication-entraid'`).

Also **closes the ratchet**: `LOGGER_MULTI_INSTANCE_BASELINE` is now empty — every package has exactly one logger, so the one-logger arch-test admits no exceptions.

## Note
These 21 were single-instance already (1 `createLogger` call), so this is the *file-convention* rollout, not a duplicate fix. 4 non-standard cases deferred (api-client/react-bff `fallbackLogger`, react-entities `consoleLogger: Logger`, react-workflow sub-prefix) — they need bespoke handling.

## Verified (against develop tree)
`eslint --max-warnings 0` (42 files), `tsc --noEmit` (21 pkgs), and **853 tests** across 107 files pass.

## Remaining
4 special-case migrations + debug/info enrichment of error/warn-only modules.