### PR TITLE
refactor(logging): centralise logger in src/logger.ts (4 special cases — migration complete)

### DIFF
--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -1,10 +1,14 @@
-import { createLogger, type Logger } from '@granit/logger';
 import axios, {
   type AxiosError,
   type AxiosInstance,
   type AxiosRequestConfig,
   type InternalAxiosRequestConfig,
 } from 'axios';
+
+import { logger as fallbackLogger } from './logger';
+
+import type { Logger } from '@granit/logger';
+
 
 /** Authentication mode for the API client. */
 export type ApiClientMode = 'bearer' | 'bff';
@@ -23,11 +27,6 @@ export type ApiClientTransport = 'xhr' | 'fetch';
  * silently clobber the request axios already built.
  */
 export type RequestFetchOptions = Omit<RequestInit, 'method' | 'body'>;
-
-// Fallback logger for the rare paths where no app logger is wired. Warnings
-// route through the @granit/logger façade (console transport in dev) rather
-// than the raw global console — keeps the no-console arch rule honest.
-const fallbackLogger = createLogger('api-client');
 
 /** Getter that returns the current CSRF token, or null if unavailable. */
 export type CsrfTokenGetter = () => string | null;

--- a/packages/@granit/api-client/src/logger.ts
+++ b/packages/@granit/api-client/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('api-client');

--- a/packages/@granit/react-bff/src/logger.ts
+++ b/packages/@granit/react-bff/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-bff');

--- a/packages/@granit/react-bff/src/providers/bff-provider.tsx
+++ b/packages/@granit/react-bff/src/providers/bff-provider.tsx
@@ -1,5 +1,4 @@
 import { CsrfManager, parseBffSessionResponse } from '@granit/bff';
-import { createLogger } from '@granit/logger';
 import {
   createContext,
   useCallback,
@@ -9,6 +8,8 @@ import {
   useRef,
   useState,
 } from 'react';
+
+import { logger as fallbackLogger } from '../logger';
 
 import type { BffConfig, BffUser } from '@granit/bff';
 import type { ReactNode } from 'react';
@@ -32,10 +33,6 @@ export interface BffContextType {
 }
 
 const BffContext = createContext<BffContextType | null>(null);
-
-// Fallback logger when the app wires no `config.logger`. Routes through the
-// @granit/logger façade (console transport in dev) instead of the raw console.
-const fallbackLogger = createLogger('react-bff');
 
 // Marks that a login redirect is in flight. Survives the full-page navigation
 // to the BFF/IdP and back (same-origin sessionStorage), so the first session

--- a/packages/@granit/react-entities/src/logger.ts
+++ b/packages/@granit/react-entities/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-entities');

--- a/packages/@granit/react-entities/src/providers/entity-renderer-provider.tsx
+++ b/packages/@granit/react-entities/src/providers/entity-renderer-provider.tsx
@@ -1,7 +1,10 @@
-import { createLogger, type Logger } from '@granit/logger';
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
 
+import { logger as consoleLogger } from '../logger';
+
 import { EMPTY_COMPONENT_CATALOG, type EntityComponentCatalog } from './component-catalog';
+
+import type { Logger } from '@granit/logger';
 
 /**
  * Resolves an i18n key (as carried by the manifest) into a localised
@@ -24,12 +27,6 @@ export interface EntityRendererContextValue {
    */
   readonly logger: Logger;
 }
-
-// Default logger used when no `@granit/logger` instance is wired into the
-// provider. Routes through the createLogger façade (console transport in dev)
-// so action failures still surface; production apps should wire a redacting
-// logger via `<EntityRendererProvider logger={…}>`.
-const consoleLogger: Logger = createLogger('react-entities');
 
 const EntityRendererContext = createContext<EntityRendererContextValue | null>(null);
 

--- a/packages/@granit/react-workflow/src/hooks/use-execute-transition.ts
+++ b/packages/@granit/react-workflow/src/hooks/use-execute-transition.ts
@@ -1,15 +1,15 @@
-import { createLogger } from '@granit/logger';
 import { executeStateMachineTransition } from '@granit/workflow';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
+import { logger as workflowLogger } from '../logger';
 import { useWorkflowConfig } from '../providers/workflow-provider';
 
 import { buildWorkflowQueryKey } from './query-keys';
 
 import type { WorkflowTransitionResult } from '@granit/workflow';
 
-const logger = createLogger('workflow:execute-transition');
+const logger = workflowLogger.child('execute-transition');
 
 export interface UseExecuteTransitionOptions {
   onSuccess?: (result: WorkflowTransitionResult) => void;

--- a/packages/@granit/react-workflow/src/logger.ts
+++ b/packages/@granit/react-workflow/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('workflow');


### PR DESCRIPTION
Final batch — the 4 non-standard call sites, completing the `src/logger.ts` convention rollout (audit checklist 5d).

## What
- **api-client** / **react-bff** — `const fallbackLogger = createLogger(…)` → `import { logger as fallbackLogger } from './logger'` (local name kept; api-client keeps its `import type { Logger }`).
- **react-entities** — `const consoleLogger: Logger = createLogger(…)` → `import { logger as consoleLogger }`; `Logger` type import retained.
- **react-workflow** — `createLogger('workflow:execute-transition')` → `createLogger('workflow')` + `logger.child('execute-transition')` (idiomatic sub-scope, prefix preserved as `workflow execute-transition`).

## Verified
`eslint --max-warnings 0`, `tsc --noEmit`, and all 4 test suites pass.

## Status
**Migration complete** — every @granit package now defines its logger once in `src/logger.ts`. Remaining logging work: debug/info enrichment of error/warn-only modules.