### PR TITLE
feat(react-notifications): debug observability on inbox + subscription flows

### DIFF
--- a/packages/@granit/react-notifications/src/hooks/use-notification-subscriptions.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-notification-subscriptions.ts
@@ -10,6 +10,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { API_BASE_PATH } from '../constants';
+import { logger } from '../logger';
 import { useNotificationConfig } from '../providers/notification-provider';
 
 import type {
@@ -78,7 +79,8 @@ export function useSubscribeToNotificationType(): UseMutationResult<void, Error,
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (typeName) => subscribeToNotificationType(config.apiClient, basePath, typeName),
-    onSuccess: () => {
+    onSuccess: (_data, typeName) => {
+      logger.debug('Subscribed to notification type', { typeName });
       queryClient.invalidateQueries({ queryKey: SUBSCRIPTIONS_KEY });
     },
   });
@@ -95,7 +97,8 @@ export function useUnsubscribeFromNotificationType(): UseMutationResult<void, Er
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (typeName) => unsubscribeFromNotificationType(config.apiClient, basePath, typeName),
-    onSuccess: () => {
+    onSuccess: (_data, typeName) => {
+      logger.debug('Unsubscribed from notification type', { typeName });
       queryClient.invalidateQueries({ queryKey: SUBSCRIPTIONS_KEY });
     },
   });
@@ -124,6 +127,7 @@ export function useFollowEntity(): UseMutationResult<void, Error, EntityFollowVa
     mutationFn: ({ entityType, entityId }) =>
       followEntity(config.apiClient, basePath, entityType, entityId),
     onSuccess: (_data, { entityType, entityId }) => {
+      logger.debug('Followed entity', { entityType, entityId });
       queryClient.invalidateQueries({ queryKey: ENTITY_FOLLOWERS_KEY(entityType, entityId) });
     },
   });
@@ -142,6 +146,7 @@ export function useUnfollowEntity(): UseMutationResult<void, Error, EntityFollow
     mutationFn: ({ entityType, entityId }) =>
       unfollowEntity(config.apiClient, basePath, entityType, entityId),
     onSuccess: (_data, { entityType, entityId }) => {
+      logger.debug('Unfollowed entity', { entityType, entityId });
       queryClient.invalidateQueries({ queryKey: ENTITY_FOLLOWERS_KEY(entityType, entityId) });
     },
   });

--- a/packages/@granit/react-notifications/src/hooks/use-notifications.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-notifications.ts
@@ -4,6 +4,7 @@ import { toISODateString } from '@granit/types';
 import { useCallback } from 'react';
 
 import { API_BASE_PATH } from '../constants';
+import { logger } from '../logger';
 import { useNotificationConfig } from '../providers/notification-provider';
 
 import type { UserNotification, UserNotificationPage } from '@granit/notifications';
@@ -59,6 +60,7 @@ export function useNotifications(options: UseNotificationsOptions = {}): UseNoti
   const markRead = useCallback(
     async (id: string) => {
       await markAsRead(config.apiClient, basePath, id);
+      logger.debug('Marked notification as read', { id });
       setNotifications((prev: readonly UserNotification[]) =>
         prev.map((n: UserNotification) =>
           n.id === id
@@ -73,6 +75,7 @@ export function useNotifications(options: UseNotificationsOptions = {}): UseNoti
 
   const markAllRead = useCallback(async () => {
     await markAllAsRead(config.apiClient, basePath);
+    logger.debug('Marked all notifications as read');
     setNotifications((prev: readonly UserNotification[]) =>
       prev.map((n: UserNotification) => ({
         ...n,


### PR DESCRIPTION
First enrichment batch (audit checklist 5d "dev observability", #755) — reference for adding `debug`/`info` to error/warn-only modules.

## What
`logger.debug` on the user-facing mutations of `@granit/react-notifications`:
- mark notification read / mark all read
- subscribe / unsubscribe to a notification type
- follow / unfollow an entity

These flows previously emitted nothing in dev. The default level is `DEBUG` in dev / `WARN` in prod, so the logs are free locally and silent in production. Complements the provider's existing `info` logs (real-time transport connect/disconnect). No PII (only ids/type names).

## Verified
`eslint --max-warnings 0`, `tsc --noEmit`, **59 tests** pass.

## Remaining
~35 other error/warn-only modules to enrich, domain by domain.