### PR TITLE
feat(react-parties): debug observability on party lifecycle + merge

### DIFF
--- a/packages/@granit/react-parties/package.json
+++ b/packages/@granit/react-parties/package.json
@@ -17,6 +17,7 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/entity-merge": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/parties": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
@@ -55,6 +56,7 @@
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/entity-merge": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-entity-merge": "workspace:*",
     "@granit/react-testing": "workspace:*",

--- a/packages/@granit/react-parties/src/hooks/use-parties.ts
+++ b/packages/@granit/react-parties/src/hooks/use-parties.ts
@@ -22,6 +22,7 @@ import {
 } from '@granit/parties';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
+import { logger } from '../logger';
 import { buildPartiesQueryKey, usePartiesConfig } from '../providers/parties-provider';
 
 import type {
@@ -138,7 +139,10 @@ export function useCreatePartyMutation(): UseMutationResult<
   return useMutation({
     mutationFn: ({ request, options }: CreatePartyMutationVariables) =>
       createParty(config.client, basePath, request, options),
-    onSuccess: () => invalidateList(),
+    onSuccess: (data) => {
+      logger.debug('Party created', { id: data.id });
+      invalidateList();
+    },
   });
 }
 
@@ -154,7 +158,10 @@ export function useUpdatePartyMutation(): UseMutationResult<
 
   return useMutation({
     mutationFn: ({ id, request }) => updateParty(config.client, basePath, id, request),
-    onSuccess: (_data, { id }) => invalidateAll(id),
+    onSuccess: (_data, { id }) => {
+      logger.debug('Party updated', { id });
+      invalidateAll(id);
+    },
   });
 }
 
@@ -172,7 +179,10 @@ export function useSuspendPartyMutation(): UseMutationResult<
 
   return useMutation({
     mutationFn: ({ id, request }) => suspendParty(config.client, basePath, id, request),
-    onSuccess: (_data, { id }) => invalidateAll(id),
+    onSuccess: (_data, { id }) => {
+      logger.debug('Party suspended', { id });
+      invalidateAll(id);
+    },
   });
 }
 
@@ -184,7 +194,10 @@ export function useActivatePartyMutation(): UseMutationResult<void, Error, Party
 
   return useMutation({
     mutationFn: (id: PartyId) => activateParty(config.client, basePath, id),
-    onSuccess: (_data, id) => invalidateAll(id),
+    onSuccess: (_data, id) => {
+      logger.debug('Party activated', { id });
+      invalidateAll(id);
+    },
   });
 }
 
@@ -196,7 +209,10 @@ export function useArchivePartyMutation(): UseMutationResult<void, Error, PartyI
 
   return useMutation({
     mutationFn: (id: PartyId) => archiveParty(config.client, basePath, id),
-    onSuccess: (_data, id) => invalidateAll(id),
+    onSuccess: (_data, id) => {
+      logger.debug('Party archived', { id });
+      invalidateAll(id);
+    },
   });
 }
 

--- a/packages/@granit/react-parties/src/hooks/use-party-merge.ts
+++ b/packages/@granit/react-parties/src/hooks/use-party-merge.ts
@@ -2,6 +2,7 @@ import { generateMergeIdempotencyKey } from '@granit/entity-merge';
 import { mergeParty, previewPartyMerge } from '@granit/parties';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
+import { logger } from '../logger';
 import { buildPartiesQueryKey, usePartiesConfig } from '../providers/parties-provider';
 
 import type { PartyId, PartyMergeRequest, PartyMergeResponse } from '@granit/parties';
@@ -79,6 +80,7 @@ export function useMergePartyMutation(
       // Live merges only — dry-runs never commit so don't invalidate caches.
       if (request.dryRun) return;
 
+      logger.debug('Party merged', { survivorId, loserId: request.loserId });
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: buildPartiesQueryKey(config, 'list'),

--- a/packages/@granit/react-parties/src/logger.ts
+++ b/packages/@granit/react-parties/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-parties');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2858,6 +2858,9 @@ importers:
       '@granit/entity-merge':
         specifier: workspace:*
         version: link:../entity-merge
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/react-api-client':
         specifier: workspace:*
         version: link:../react-api-client


### PR DESCRIPTION
Enrichment batch 2 (audit checklist 5d "dev observability", #755). `@granit/react-parties` had **no logging at all**, so this also wires the logger.

## What
- New `src/logger.ts` + `@granit/logger` peer/dev dep (lockfile regenerated in the same commit).
- `logger.debug` on the party lifecycle mutations: create / update / suspend / activate / archive, and live party merge.

Default level is `DEBUG` in dev / `WARN` in prod — free locally, silent in production. No PII (party ids only). The noisy per-contact CRUD (address/email/phone) is intentionally left unlogged.

## Verified (worktree install)
`eslint --max-warnings 0`, `tsc --noEmit`, **69 tests** pass.

## Pattern note
For packages that already import `@granit/logger` (the 36 warn/error-only ones), enrichment is just adding `debug` calls. Silent packages like this one additionally need the dep + `logger.ts` + lockfile.