### PR TITLE
feat(react-ui-admin-kit): TopProgressBar + colocate FormDialog story

### DIFF
--- a/packages/@granit/arch-tests/src/__tests__/patterns.test.ts
+++ b/packages/@granit/arch-tests/src/__tests__/patterns.test.ts
@@ -54,7 +54,13 @@ describe('patterns (delegated to kit)', () => {
     expect(
       scanUseFormResolver({
         ...ctx,
-        allowedFiles: ['react-entities/src/hooks/use-entity-form.ts'],
+        allowedFiles: [
+          'react-entities/src/hooks/use-entity-form.ts',
+          // Storybook demo: FormDialog is form-agnostic (the host owns the
+          // form); the story wires a throwaway useForm purely to render the
+          // dialog chrome, so it needs no validation contract.
+          'react-ui-admin-kit/src/form-dialog/form-dialog.stories.tsx',
+        ],
       })
     ).toEqual([]);
   });

--- a/packages/@granit/react-ui-admin-kit/src/form-dialog/form-dialog.stories.tsx
+++ b/packages/@granit/react-ui-admin-kit/src/form-dialog/form-dialog.stories.tsx
@@ -1,0 +1,82 @@
+import { Button, TextField } from '@granit/react-ui';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import { FormDialog } from './form-dialog';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+interface DemoValues {
+  name: string;
+  email: string;
+}
+
+/**
+ * Hosts own the form instance, the open state and the submit handler — the
+ * dialog only provides the chrome. This demo wires a minimal `react-hook-form`
+ * instance so the fields and Cancel/Submit footer are interactive.
+ */
+function FormDialogDemo({
+  isSubmitting = false,
+  submitVariant = 'default',
+}: {
+  readonly isSubmitting?: boolean;
+  readonly submitVariant?: 'default' | 'destructive';
+}) {
+  const [open, setOpen] = useState(true);
+  const form = useForm<DemoValues>({ defaultValues: { name: '', email: '' } });
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open dialog</Button>
+      <FormDialog
+        open={open}
+        onOpenChange={setOpen}
+        form={form}
+        onSubmit={() => setOpen(false)}
+        title="Create user"
+        description="Fill in the details below."
+        submitLabel="Create"
+        busyLabel="Creating…"
+        isSubmitting={isSubmitting}
+        submitVariant={submitVariant}
+      >
+        <TextField control={form.control} name="name" label="Name" placeholder="Jane Doe" />
+        <TextField
+          control={form.control}
+          name="email"
+          label="Email"
+          type="email"
+          placeholder="jane@example.com"
+        />
+      </FormDialog>
+    </>
+  );
+}
+
+const meta = {
+  title: 'Admin Kit/FormDialog',
+  component: FormDialog,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof FormDialog<DemoValues>>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Default form-in-a-dialog with two fields. */
+export const Default: Story = {
+  render: () => <FormDialogDemo />,
+};
+
+/** Submitting state: both footer buttons disabled, busy label shown. */
+export const Submitting: Story = {
+  render: () => <FormDialogDemo isSubmitting />,
+};
+
+/** Destructive submit variant (e.g. a confirm-and-delete form). */
+export const Destructive: Story = {
+  render: () => <FormDialogDemo submitVariant="destructive" />,
+};

--- a/packages/@granit/react-ui-admin-kit/src/index.ts
+++ b/packages/@granit/react-ui-admin-kit/src/index.ts
@@ -6,6 +6,7 @@ export * from './data-table/manual-data-table';
 export * from './form-dialog/form-dialog';
 export * from './hooks/use-operator-labels';
 export * from './layout/detail-aside-layout';
+export * from './layout/top-progress-bar';
 export * from './hooks/use-smart-filter-sync';
 export * from './querying/bulk-actions';
 export * from './querying/column-visibility';

--- a/packages/@granit/react-ui-admin-kit/src/layout/top-progress-bar.stories.tsx
+++ b/packages/@granit/react-ui-admin-kit/src/layout/top-progress-bar.stories.tsx
@@ -1,0 +1,98 @@
+import { Button } from '@granit/react-ui';
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import * as React from 'react';
+
+import { RouteSuspenseSignal, TopProgressBar } from './top-progress-bar';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof TopProgressBar> = {
+  title: 'Admin Kit/TopProgressBar',
+  component: TopProgressBar,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'GitHub-style thin progress bar fixed to the top of the viewport. Tracks React Query fetching/mutations and lazy route chunk loading via `<RouteSuspenseSignal />`.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function withQueryClient(Story: React.ComponentType) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={client}>
+      <Story />
+    </QueryClientProvider>
+  );
+}
+
+function DemoQueryTrigger() {
+  const [enabled, setEnabled] = React.useState(false);
+  useQuery({
+    queryKey: ['demo', enabled],
+    queryFn: () => new Promise((resolve) => globalThis.setTimeout(() => resolve('done'), 1500)),
+    enabled,
+  });
+  return (
+    <div className="flex flex-col items-start gap-3 p-8">
+      <p className="text-muted-foreground text-sm">
+        Click to trigger a 1.5s query and watch the bar animate.
+      </p>
+      <Button
+        onClick={() => {
+          setEnabled(false);
+          globalThis.setTimeout(() => setEnabled(true), 50);
+        }}
+      >
+        Trigger query
+      </Button>
+    </div>
+  );
+}
+
+export const WithQuery: Story = {
+  decorators: [withQueryClient],
+  render: () => (
+    <>
+      <TopProgressBar />
+      <DemoQueryTrigger />
+    </>
+  ),
+};
+
+function DemoSuspenseTrigger() {
+  const [showSignal, setShowSignal] = React.useState(false);
+  return (
+    <div className="flex flex-col items-start gap-3 p-8">
+      <p className="text-muted-foreground text-sm">
+        Simulates a lazy route chunk load via <code>RouteSuspenseSignal</code>.
+      </p>
+      <Button
+        onClick={() => {
+          setShowSignal(true);
+          globalThis.setTimeout(() => setShowSignal(false), 1500);
+        }}
+      >
+        Simulate route chunk load
+      </Button>
+      {showSignal && <RouteSuspenseSignal />}
+    </div>
+  );
+}
+
+export const WithRouteChunk: Story = {
+  decorators: [withQueryClient],
+  render: () => (
+    <>
+      <TopProgressBar />
+      <DemoSuspenseTrigger />
+    </>
+  ),
+};

--- a/packages/@granit/react-ui-admin-kit/src/layout/top-progress-bar.tsx
+++ b/packages/@granit/react-ui-admin-kit/src/layout/top-progress-bar.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+
+import { cn } from '@granit/utils';
+import { useIsFetching, useIsMutating } from '@tanstack/react-query';
+
+let suspenseCount = 0;
+const listeners = new Set<() => void>();
+
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+const getSuspenseCount = () => suspenseCount;
+
+const notify = () => {
+  for (const listener of listeners) listener();
+};
+
+export function RouteSuspenseSignal() {
+  React.useEffect(() => {
+    suspenseCount += 1;
+    notify();
+    return () => {
+      suspenseCount -= 1;
+      notify();
+    };
+  }, []);
+  return null;
+}
+
+type ProgressState = 'idle' | 'loading' | 'done';
+
+export function TopProgressBar() {
+  const isFetching = useIsFetching();
+  const isMutating = useIsMutating();
+  const suspended = React.useSyncExternalStore(subscribe, getSuspenseCount, getSuspenseCount);
+  const active = isFetching + isMutating + suspended > 0;
+
+  const [state, setState] = React.useState<ProgressState>('idle');
+  const [progress, setProgress] = React.useState(0);
+
+  React.useEffect(() => {
+    if (active && state === 'idle') {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- sync progress to external query/mutation activity
+      setState('loading');
+      setProgress(8);
+    } else if (!active && state === 'loading') {
+      setState('done');
+      setProgress(100);
+    }
+  }, [active, state]);
+
+  React.useEffect(() => {
+    if (state === 'loading') {
+      const id = globalThis.setInterval(() => {
+        setProgress((p) => (p < 90 ? p + (90 - p) * 0.1 : p));
+      }, 200);
+      return () => globalThis.clearInterval(id);
+    }
+    if (state === 'done') {
+      const id = globalThis.setTimeout(() => {
+        setState('idle');
+        setProgress(0);
+      }, 350);
+      return () => globalThis.clearTimeout(id);
+    }
+    return undefined;
+  }, [state]);
+
+  const visible = state !== 'idle';
+
+  return (
+    // Custom top-loading bar (nProgress-style). `<progress>` would be
+    // ideal but its native styling cannot be themed reliably across
+    // browsers; the visual fill is a child div animating its width.
+    // NOSONAR(jsx-a11y/prefer-tag-over-role)
+    <div
+      data-slot="top-progress-bar"
+      role="progressbar"
+      aria-hidden={!visible}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round(progress)}
+      className={cn(
+        'pointer-events-none fixed inset-x-0 top-0 z-[60] h-0.5 transition-opacity duration-300',
+        visible ? 'opacity-100' : 'opacity-0'
+      )}
+    >
+      <div
+        className="bg-primary h-full transition-[width] duration-300 ease-out"
+        style={{
+          width: `${progress}%`,
+          boxShadow:
+            '0 0 10px var(--color-primary, currentColor), 0 0 4px var(--color-primary, currentColor)',
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Two foundation-completion changes for `@granit/react-ui-admin-kit`, extracted from the showcase shell.

## TopProgressBar
GitHub-style top loading bar tracking React Query fetching/mutations plus lazy route chunk loading via `RouteSuspenseSignal`. Generic (only `@tanstack/react-query` + `cn`). Lives under `src/layout/`.

## FormDialog story
The component (and its test) already lived here; the story lived in the showcase. Colocated next to the component for parity with the other admin-kit stories. Imports the component relatively and `Button`/`TextField` from the `@granit/react-ui` peer.

## arch-tests
Added a documented `allowedFiles` entry for the FormDialog story: a Storybook demo deliberately wiring a throwaway `useForm` to render the dialog chrome has no validation contract, so `use-form-needs-resolver` legitimately doesn't apply.

## Validation
Full arch-tests pass (2905). Consumed source-direct by the showcase (lint + tsc + unit green).