### PR TITLE
feat(react-ui-localization): add LanguageSwitcher component

### DIFF
--- a/packages/@granit/react-ui-localization/src/components/language-switcher.stories.tsx
+++ b/packages/@granit/react-ui-localization/src/components/language-switcher.stories.tsx
@@ -1,0 +1,55 @@
+import { mockLanguages } from '@granit/react-localization/testing';
+
+import { LanguagesContext } from '../languages-context';
+import { LanguageSwitcher } from './language-switcher';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof LanguageSwitcher> = {
+  title: 'Features/Localization/LanguageSwitcher',
+  component: LanguageSwitcher,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <LanguagesContext.Provider value={mockLanguages}>
+        <div className="w-48 rounded-md border p-4">
+          <Story />
+        </div>
+      </LanguagesContext.Provider>
+    ),
+  ],
+};
+
+export const SingleLanguage: Story = {
+  decorators: [
+    (Story) => (
+      <LanguagesContext.Provider value={[mockLanguages[0]]}>
+        <div className="w-48 rounded-md border p-4">
+          <Story />
+        </div>
+      </LanguagesContext.Provider>
+    ),
+  ],
+};
+
+export const NoLanguages: Story = {
+  decorators: [
+    (Story) => (
+      <LanguagesContext.Provider value={[]}>
+        <div className="w-48 rounded-md border p-4">
+          <p className="text-muted-foreground text-xs">(component renders nothing when empty)</p>
+          <Story />
+        </div>
+      </LanguagesContext.Provider>
+    ),
+  ],
+};

--- a/packages/@granit/react-ui-localization/src/components/language-switcher.tsx
+++ b/packages/@granit/react-ui-localization/src/components/language-switcher.tsx
@@ -1,0 +1,30 @@
+import { useLocale } from '@granit/react-localization';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@granit/react-ui';
+import { Globe } from 'lucide-react';
+
+import { useLanguages } from '../languages-context';
+
+export function LanguageSwitcher() {
+  const languages = useLanguages();
+  const { locale, setLocale } = useLocale();
+
+  if (languages.length === 0) return null;
+
+  return (
+    <div data-slot="language-switcher" className="mt-6 flex justify-center">
+      <Select value={locale} onValueChange={setLocale}>
+        <SelectTrigger className="h-8 w-auto gap-2 border-none bg-transparent text-xs text-muted-foreground shadow-none">
+          <Globe className="size-3.5" />
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent position="popper" className="min-w-36">
+          {languages.map((lang) => (
+            <SelectItem key={lang.cultureName} value={lang.cultureName}>
+              {lang.displayName}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-localization/src/index.ts
+++ b/packages/@granit/react-ui-localization/src/index.ts
@@ -1,6 +1,7 @@
 export { LanguageListPage } from './language-list-page';
 export { LocalizationOverrideListPage } from './localization-override-list-page';
 export { LanguageList } from './components/language-list';
+export { LanguageSwitcher } from './components/language-switcher';
 export { createLocalizationColumns } from './components/localization-columns';
 export { TranslationCreateDialog } from './components/translation-create-dialog';
 export { TranslationEditDialog } from './components/translation-edit-dialog';


### PR DESCRIPTION
Extracts the compact `LanguageSwitcher` from the showcase public layout into `@granit/react-ui-localization`, next to `LanguagesContext`/`useLanguages` which it consumes.

A `Select` sourced from `LanguagesContext`, switching the locale via `useLocale`. Deps (`@granit/react-localization`, `@granit/react-ui`, `lucide-react`) already declared.

## Validation
Full arch-tests pass (2905). Consumed source-direct by the showcase (lint + tsc + unit green).