### PR TITLE
feat(react-documents): debug observability on document lifecycle

### DIFF
--- a/packages/@granit/react-documents/package.json
+++ b/packages/@granit/react-documents/package.json
@@ -17,6 +17,7 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/documents": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
@@ -47,6 +48,7 @@
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/documents": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",

--- a/packages/@granit/react-documents/src/hooks/use-document-mutations.ts
+++ b/packages/@granit/react-documents/src/hooks/use-document-mutations.ts
@@ -11,6 +11,7 @@ import {
 } from '@granit/documents';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { logger } from '../logger';
 import { buildDocumentsQueryKey, useDocumentsConfig } from '../providers/documents-provider';
 
 import type { ResolvedDocumentsConfig } from '../providers/documents-provider';
@@ -110,7 +111,8 @@ export function useFinalizeUpload(): UseMutationResult<
   return useMutation({
     mutationFn: (request: FinalizeUploadRequest) =>
       finalizeUpload(config.client, config.basePath, request),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      logger.debug('Document upload finalized', { id: data.id });
       invalidateAllFolders(queryClient, config);
       invalidateQuota(queryClient, config);
     },
@@ -129,7 +131,8 @@ export function useRenameDocument(): UseMutationResult<
   return useMutation({
     mutationFn: ({ id, request }: DocumentIdMutationArgs<RenameDocumentRequest>) =>
       renameDocument(config.client, config.basePath, id, request),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      logger.debug('Document renamed', { id: data.id });
       invalidateAllDocuments(queryClient, config);
     },
   });
@@ -147,7 +150,8 @@ export function useMoveDocument(): UseMutationResult<
   return useMutation({
     mutationFn: ({ id, request }: DocumentIdMutationArgs<MoveDocumentRequest>) =>
       moveDocument(config.client, config.basePath, id, request),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      logger.debug('Document moved', { id: data.id });
       invalidateAllDocuments(queryClient, config);
     },
   });
@@ -169,7 +173,8 @@ export function useTransferDocumentOwner(): UseMutationResult<
   return useMutation({
     mutationFn: ({ id, request }: DocumentIdMutationArgs<TransferOwnerRequest>) =>
       transferDocumentOwner(config.client, config.basePath, id, request),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      logger.debug('Document owner transferred', { id: data.id });
       invalidateAllDocuments(queryClient, config);
     },
   });
@@ -182,7 +187,8 @@ export function useTrashDocument(): UseMutationResult<DocumentResponse, Error, s
 
   return useMutation({
     mutationFn: (id: string) => trashDocument(config.client, config.basePath, id),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      logger.debug('Document trashed', { id: data.id });
       invalidateAllDocuments(queryClient, config);
       invalidateTrashedDocuments(queryClient, config);
       invalidateQuota(queryClient, config);
@@ -197,7 +203,8 @@ export function useRestoreDocument(): UseMutationResult<DocumentResponse, Error,
 
   return useMutation({
     mutationFn: (id: string) => restoreDocument(config.client, config.basePath, id),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      logger.debug('Document restored', { id: data.id });
       invalidateAllDocuments(queryClient, config);
       invalidateTrashedDocuments(queryClient, config);
       invalidateQuota(queryClient, config);
@@ -212,7 +219,8 @@ export function usePermanentlyDeleteDocument(): UseMutationResult<void, Error, s
 
   return useMutation({
     mutationFn: (id: string) => permanentlyDeleteDocument(config.client, config.basePath, id),
-    onSuccess: () => {
+    onSuccess: (_data, id) => {
+      logger.debug('Document permanently deleted', { id });
       invalidateAllDocuments(queryClient, config);
       invalidateTrashedDocuments(queryClient, config);
       invalidateQuota(queryClient, config);
@@ -236,6 +244,7 @@ export function useAppendDocumentVersion(): UseMutationResult<
     mutationFn: ({ id, request }: DocumentIdMutationArgs<AppendVersionRequest>) =>
       appendDocumentVersion(config.client, config.basePath, id, request),
     onSuccess: (_data, { id }) => {
+      logger.debug('Document version appended', { id });
       invalidateDocumentVersions(queryClient, config, id);
       invalidateDocumentDetail(queryClient, config, id);
       invalidateQuota(queryClient, config);

--- a/packages/@granit/react-documents/src/logger.ts
+++ b/packages/@granit/react-documents/src/logger.ts
@@ -1,0 +1,3 @@
+import { createLogger } from '@granit/logger';
+
+export const logger = createLogger('react-documents');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2223,6 +2223,9 @@ importers:
       '@granit/documents':
         specifier: workspace:*
         version: link:../documents
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine


### PR DESCRIPTION
Enrichment batch 3 (audit checklist 5d, #755). `@granit/react-documents` had no logging, so this also wires the logger.

## What
- New `src/logger.ts` + `@granit/logger` peer/dev dep (lockfile regenerated same commit).
- `logger.debug` on the 8 document-lifecycle mutations: upload finalize, rename, move, transfer-owner, trash, restore, permanently-delete, append-version.

Default level `DEBUG` dev / `WARN` prod. No PII (document ids only). The smaller mutation files (shares, tags, public-links, folders) left for a follow-up.

## Verified (worktree install)
`eslint --max-warnings 0`, `tsc --noEmit`, **252 tests** pass.