### PR TITLE
feat(react-ui-error-boundary): new package — error/404 fallback pages

### DIFF
--- a/packages/@granit/react-ui-error-boundary/README.md
+++ b/packages/@granit/react-ui-error-boundary/README.md
@@ -1,0 +1,40 @@
+# @granit/react-ui-error-boundary
+
+Visible error UI for Granit admin apps — the fallback, route-error and
+not-found pages that pair with the headless
+[`@granit/react-error-boundary`](../react-error-boundary).
+
+The headless package owns the _mechanism_ (`GranitErrorBoundary` catches render
+errors and delegates UI via `renderFallback`); this package owns the _pages_.
+
+## Components
+
+- **`ErrorFallback`** — rendered by a boundary's `renderFallback`; shows the
+  error, a retry button, and (in dev) a copyable detail block.
+- **`ErrorPage`** — a React Router `errorElement`; distinguishes 404 from other
+  route errors and links back home.
+- **`NotFoundPage`** — a standalone 404 page.
+
+Each page is app-agnostic:
+
+- pass an optional `layout` slot (e.g. your public/centered layout) — without
+  it the page renders bare;
+- `ErrorPage` accepts an `onError` callback so the host can log via its own
+  logger;
+- the `Errors.*` strings ship in `errorBoundaryTranslationsEn` /
+  `errorBoundaryTranslationsFr`; register them in your i18n instance.
+
+## Usage
+
+```tsx
+import { GranitErrorBoundary } from '@granit/react-error-boundary';
+import { ErrorFallback } from '@granit/react-ui-error-boundary';
+
+<GranitErrorBoundary
+  renderFallback={(error, reset) => (
+    <ErrorFallback error={error} onReset={reset} layout={PublicLayout} />
+  )}
+>
+  <App />
+</GranitErrorBoundary>;
+```

--- a/packages/@granit/react-ui-error-boundary/package.json
+++ b/packages/@granit/react-ui-error-boundary/package.json
@@ -34,9 +34,11 @@
     "@granit/react-localization": "workspace:*",
     "@granit/react-ui": "workspace:*",
     "@storybook/react-vite": "^10.4.6",
+    "i18next": "^26.0.0",
     "lucide-react": "^1.21.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-i18next": "^17.0.0",
     "react-router-dom": "^7.18.0",
     "storybook": "^10.4.6"
   }

--- a/packages/@granit/react-ui-error-boundary/package.json
+++ b/packages/@granit/react-ui-error-boundary/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@granit/react-ui-error-boundary",
+  "description": "Granit admin error UI — the visible fallback, route-error and not-found pages that pair with the headless @granit/react-error-boundary. App-agnostic: each page takes an optional layout slot and ships its own Errors.* translations.",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "lucide-react": "^1.21.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.18.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@storybook/react-vite": "^10.4.6",
+    "lucide-react": "^1.21.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.18.0",
+    "storybook": "^10.4.6"
+  }
+}

--- a/packages/@granit/react-ui-error-boundary/src/__tests__/error-fallback.test.tsx
+++ b/packages/@granit/react-ui-error-boundary/src/__tests__/error-fallback.test.tsx
@@ -1,0 +1,48 @@
+import { screen } from '@testing-library/react';
+
+import { ErrorFallback } from '../error-fallback';
+import { renderWithI18n } from './test-utils';
+
+import type { ReactNode } from 'react';
+
+describe('ErrorFallback', () => {
+  const error = new Error('Test error message');
+
+  it('renders the error heading and message', () => {
+    renderWithI18n(<ErrorFallback error={error} onReset={() => undefined} />);
+
+    expect(screen.getByText('Unexpected Error')).toBeInTheDocument();
+    expect(screen.getByText(/try again/i)).toBeInTheDocument();
+  });
+
+  it('hides the error detail block by default', () => {
+    renderWithI18n(<ErrorFallback error={error} onReset={() => undefined} />);
+
+    expect(screen.queryByText('Error detail')).not.toBeInTheDocument();
+  });
+
+  it('shows the copyable error detail when showErrorDetail is set', () => {
+    renderWithI18n(<ErrorFallback error={error} onReset={() => undefined} showErrorDetail />);
+
+    expect(screen.getByText('Error detail')).toBeInTheDocument();
+    expect(screen.getByText(/Test error message/)).toBeInTheDocument();
+  });
+
+  it('calls onReset when the retry button is clicked', async () => {
+    const onReset = vi.fn();
+    const { user } = renderWithI18n(<ErrorFallback error={error} onReset={onReset} />);
+
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+
+    expect(onReset).toHaveBeenCalledOnce();
+  });
+
+  it('wraps its content in the provided layout slot', () => {
+    function Layout({ children }: Readonly<{ children: ReactNode }>) {
+      return <div data-testid="layout">{children}</div>;
+    }
+    renderWithI18n(<ErrorFallback error={error} onReset={() => undefined} layout={Layout} />);
+
+    expect(screen.getByTestId('layout')).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-error-boundary/src/__tests__/error-page.test.tsx
+++ b/packages/@granit/react-ui-error-boundary/src/__tests__/error-page.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+
+import { ErrorPage } from '../error-page';
+import { testI18n } from './test-utils';
+
+import type { ReactElement } from 'react';
+
+function renderRoute(errorElement: ReactElement, thrown: unknown) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/',
+        loader: () => {
+          throw thrown;
+        },
+        element: <div />,
+        errorElement,
+        hydrateFallbackElement: <div />,
+      },
+    ],
+    { initialEntries: ['/'] }
+  );
+  return render(
+    <I18nextProvider i18n={testI18n}>
+      <RouterProvider router={router} />
+    </I18nextProvider>
+  );
+}
+
+describe('ErrorPage', () => {
+  it('renders a generic error with a back-home link', async () => {
+    renderRoute(<ErrorPage />, new Error('boom'));
+
+    expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /back to home/i })).toHaveAttribute('href', '/');
+  });
+
+  it('renders the 404 variant for a 404 response', async () => {
+    renderRoute(<ErrorPage />, new Response(null, { status: 404 }));
+
+    expect(await screen.findByText('Page not found')).toBeInTheDocument();
+  });
+
+  it('shows the error detail when showErrorDetail is set', async () => {
+    renderRoute(<ErrorPage showErrorDetail />, new Error('database down'));
+
+    expect(await screen.findByText('Error detail')).toBeInTheDocument();
+    expect(screen.getByText(/database down/)).toBeInTheDocument();
+  });
+
+  it('calls onError with the caught error', async () => {
+    const onError = vi.fn();
+    const err = new Error('boom');
+    renderRoute(<ErrorPage onError={onError} />, err);
+
+    await screen.findByText('Something went wrong');
+    expect(onError).toHaveBeenCalledWith(err);
+  });
+});

--- a/packages/@granit/react-ui-error-boundary/src/__tests__/not-found-page.test.tsx
+++ b/packages/@granit/react-ui-error-boundary/src/__tests__/not-found-page.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import { MemoryRouter } from 'react-router-dom';
+
+import { NotFoundPage } from '../not-found-page';
+import { testI18n } from './test-utils';
+
+describe('NotFoundPage', () => {
+  it('renders the 404 message and a back-home link', () => {
+    render(
+      <I18nextProvider i18n={testI18n}>
+        <MemoryRouter>
+          <NotFoundPage />
+        </MemoryRouter>
+      </I18nextProvider>
+    );
+
+    expect(screen.getByText('Page not found')).toBeInTheDocument();
+    expect(screen.getByText(/does not exist/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /back to home/i })).toHaveAttribute('href', '/');
+  });
+});

--- a/packages/@granit/react-ui-error-boundary/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-ui-error-boundary/src/__tests__/test-utils.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import i18next from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+
+import { errorBoundaryTranslationsEn } from '../locales';
+
+import type { ReactElement, ReactNode } from 'react';
+
+// Local render helper: the error pages only need the package's own flat
+// Errors.* bundle in context (the host registers them with separators
+// disabled, so dotted keys are looked up verbatim). Router-dependent cases
+// build their own MemoryRouter; this just supplies i18n.
+const testI18n = i18next.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  ns: ['translation'],
+  defaultNS: 'translation',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: {
+    en: { translation: { ...errorBoundaryTranslationsEn } },
+  },
+  interpolation: { escapeValue: false },
+});
+
+export { testI18n };
+
+export function renderWithI18n(ui: ReactElement) {
+  return {
+    ...render(ui, {
+      wrapper: ({ children }: { readonly children: ReactNode }) => (
+        <I18nextProvider i18n={testI18n}>{children}</I18nextProvider>
+      ),
+    }),
+    user: userEvent.setup({ delay: null }),
+  };
+}

--- a/packages/@granit/react-ui-error-boundary/src/error-fallback.stories.tsx
+++ b/packages/@granit/react-ui-error-boundary/src/error-fallback.stories.tsx
@@ -1,0 +1,27 @@
+import { ErrorFallback } from './error-fallback';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  title: 'Error Boundary/ErrorFallback',
+  component: ErrorFallback,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    error: new Error('Cannot read properties of undefined (reading "id")'),
+    onReset: () => undefined,
+  },
+} satisfies Meta<typeof ErrorFallback>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Default fallback shown by a boundary's `renderFallback`. */
+export const Default: Story = {};
+
+/** Dev mode: the copyable error-detail block is visible. */
+export const WithErrorDetail: Story = {
+  args: { showErrorDetail: true },
+};

--- a/packages/@granit/react-ui-error-boundary/src/error-fallback.tsx
+++ b/packages/@granit/react-ui-error-boundary/src/error-fallback.tsx
@@ -1,0 +1,76 @@
+import { useState, type ComponentType, type ReactNode } from 'react';
+
+import { useTranslation } from '@granit/react-localization';
+import { Button } from '@granit/react-ui';
+import { AlertTriangle, Check, Copy } from 'lucide-react';
+
+export interface ErrorFallbackProps {
+  error: Error;
+  onReset: () => void;
+  /** Optional wrapper (e.g. a public/centered layout). Without it the page renders bare. */
+  layout?: ComponentType<{ children: ReactNode }>;
+  /** Show the copyable error-detail block (typically the host's dev flag). */
+  showErrorDetail?: boolean;
+}
+
+/**
+ * Visible fallback for a caught render error — pair with the headless
+ * `GranitErrorBoundary` from `@granit/react-error-boundary` via its
+ * `renderFallback` slot.
+ */
+export function ErrorFallback({
+  error,
+  onReset,
+  layout: Layout,
+  showErrorDetail = false,
+}: Readonly<ErrorFallbackProps>) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  const errorDetail = error.toString();
+
+  function handleCopy() {
+    void navigator.clipboard.writeText(errorDetail).then(() => {
+      setCopied(true);
+      globalThis.setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  const content = (
+    <div data-slot="error-fallback" className="text-center">
+      <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-accent">
+        <AlertTriangle className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
+      </div>
+      <h1 className="mb-4 text-2xl font-semibold text-foreground">
+        {t('Errors.UnexpectedError', 'An unexpected error occurred')}
+      </h1>
+      {showErrorDetail && (
+        <div className="mb-6 rounded-md border border-destructive/20 bg-destructive/5 p-4 text-left">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="text-xs font-medium text-destructive/70">Error detail</span>
+            <button
+              type="button"
+              onClick={handleCopy}
+              aria-label="Copy error"
+              className="flex items-center gap-1.5 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              {copied ? (
+                <Check className="h-3.5 w-3.5 text-success-600 dark:text-success-500" />
+              ) : (
+                <Copy className="h-3.5 w-3.5" />
+              )}
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+          <pre className="overflow-auto text-xs text-destructive">{errorDetail}</pre>
+        </div>
+      )}
+      <p className="mb-4 text-muted-foreground">
+        {t('Errors.UnexpectedErrorMessage', 'Please try again or contact support.')}
+      </p>
+      <Button onClick={onReset}>{t('Errors.Retry', 'Retry')}</Button>
+    </div>
+  );
+
+  return Layout ? <Layout>{content}</Layout> : content;
+}

--- a/packages/@granit/react-ui-error-boundary/src/error-page.stories.tsx
+++ b/packages/@granit/react-ui-error-boundary/src/error-page.stories.tsx
@@ -1,0 +1,40 @@
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+
+import { ErrorPage } from './error-page';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof ErrorPage> = {
+  title: 'Error Boundary/ErrorPage',
+  component: ErrorPage,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function throwingRouter(thrown: unknown) {
+  return createMemoryRouter([
+    {
+      path: '/',
+      loader: () => {
+        throw thrown;
+      },
+      element: <div />,
+      errorElement: <ErrorPage showErrorDetail />,
+    },
+  ]);
+}
+
+/** A route that resolves to a 404 — links back home. */
+export const NotFound: Story = {
+  render: () => <RouterProvider router={throwingRouter(new Response(null, { status: 404 }))} />,
+};
+
+/** A route that throws an unexpected error. */
+export const Generic: Story = {
+  render: () => <RouterProvider router={throwingRouter(new Error('Database connection failed'))} />,
+};

--- a/packages/@granit/react-ui-error-boundary/src/error-page.tsx
+++ b/packages/@granit/react-ui-error-boundary/src/error-page.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState, type ComponentType, type ReactNode } from 'react';
+
+import { useTranslation } from '@granit/react-localization';
+import { Button } from '@granit/react-ui';
+import { AlertTriangle, Check, Copy, ServerCrash } from 'lucide-react';
+import { isRouteErrorResponse, Link, useRouteError } from 'react-router-dom';
+
+export interface ErrorPageProps {
+  /** Optional wrapper (e.g. a public/centered layout). Without it the page renders bare. */
+  layout?: ComponentType<{ children: ReactNode }>;
+  /** Called once with the caught route error so the host can log it. */
+  onError?: (error: unknown) => void;
+  /** Show the copyable error-detail block (typically the host's dev flag). */
+  showErrorDetail?: boolean;
+}
+
+function resolveErrorDetail(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (isRouteErrorResponse(error)) return error.statusText;
+  if (error === null || error === undefined) return '';
+  if (typeof error === 'object') return JSON.stringify(error);
+  return String(error);
+}
+
+/**
+ * React Router `errorElement` — distinguishes a 404 from other route errors and
+ * links back home. Pass `onError` to log via the host's logger.
+ */
+export function ErrorPage({ layout: Layout, onError, showErrorDetail = false }: Readonly<ErrorPageProps>) {
+  const { t } = useTranslation();
+  const error = useRouteError();
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (error) onError?.(error);
+  }, [error, onError]);
+
+  const isNotFound = isRouteErrorResponse(error) && error.status === 404;
+  const Icon = isNotFound ? AlertTriangle : ServerCrash;
+  const title = isNotFound ? t('Errors.NotFound') : t('Errors.Generic');
+  const message = isNotFound ? t('Errors.NotFoundMessage') : t('Errors.GenericMessage');
+
+  const errorDetail = resolveErrorDetail(error);
+
+  function handleCopy() {
+    void navigator.clipboard.writeText(errorDetail).then(() => {
+      setCopied(true);
+      globalThis.setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  const content = (
+    <div data-slot="error-page" className="text-center">
+      <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-accent">
+        <Icon className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
+      </div>
+      <h1 className="mb-4 text-2xl font-semibold text-foreground">{title}</h1>
+      {showErrorDetail && errorDetail && (
+        <div className="mb-6 rounded-md border border-destructive/20 bg-destructive/5 p-4 text-left">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="text-xs font-medium text-destructive/70">Error detail</span>
+            <button
+              type="button"
+              onClick={handleCopy}
+              aria-label="Copy error"
+              className="flex items-center gap-1.5 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              {copied ? (
+                <Check className="h-3.5 w-3.5 text-success-600 dark:text-success-500" />
+              ) : (
+                <Copy className="h-3.5 w-3.5" />
+              )}
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+          <pre className="overflow-auto text-sm text-destructive">{errorDetail}</pre>
+        </div>
+      )}
+      <p className="mb-8 text-muted-foreground">{message}</p>
+      <Button asChild>
+        <Link to="/">{t('Errors.BackToHome')}</Link>
+      </Button>
+    </div>
+  );
+
+  return Layout ? <Layout>{content}</Layout> : content;
+}

--- a/packages/@granit/react-ui-error-boundary/src/index.ts
+++ b/packages/@granit/react-ui-error-boundary/src/index.ts
@@ -1,0 +1,4 @@
+export { ErrorFallback, type ErrorFallbackProps } from './error-fallback';
+export { ErrorPage, type ErrorPageProps } from './error-page';
+export { NotFoundPage, type NotFoundPageProps } from './not-found-page';
+export { errorBoundaryTranslationsEn, errorBoundaryTranslationsFr } from './locales';

--- a/packages/@granit/react-ui-error-boundary/src/locales/en.ts
+++ b/packages/@granit/react-ui-error-boundary/src/locales/en.ts
@@ -1,0 +1,16 @@
+/**
+ * English strings for the error UI. Flat `Errors.*` keys in the `translation`
+ * namespace (the host registers them with separators disabled, so the dotted
+ * keys are looked up verbatim). Named with the `errorBoundary` prefix to avoid
+ * colliding with other packages' translation symbols.
+ */
+export const errorBoundaryTranslationsEn = {
+  'Errors.BackToHome': 'Back to home',
+  'Errors.Generic': 'Something went wrong',
+  'Errors.GenericMessage': 'An unexpected error occurred. Please try again.',
+  'Errors.NotFound': 'Page not found',
+  'Errors.NotFoundMessage': 'The page you are looking for does not exist.',
+  'Errors.Retry': 'Retry',
+  'Errors.UnexpectedError': 'Unexpected Error',
+  'Errors.UnexpectedErrorMessage': 'An unexpected error occurred. Please try again.',
+} as const;

--- a/packages/@granit/react-ui-error-boundary/src/locales/fr.ts
+++ b/packages/@granit/react-ui-error-boundary/src/locales/fr.ts
@@ -1,0 +1,13 @@
+/**
+ * French strings for the error UI. See {@link errorBoundaryTranslationsEn}.
+ */
+export const errorBoundaryTranslationsFr = {
+  'Errors.BackToHome': "Retour à l'accueil",
+  'Errors.Generic': "Une erreur s'est produite",
+  'Errors.GenericMessage': 'Une erreur inattendue s’est produite. Veuillez réessayer.',
+  'Errors.NotFound': 'Page introuvable',
+  'Errors.NotFoundMessage': "La page que vous recherchez n'existe pas.",
+  'Errors.Retry': 'Réessayer',
+  'Errors.UnexpectedError': 'Erreur inattendue',
+  'Errors.UnexpectedErrorMessage': 'Une erreur inattendue s’est produite. Veuillez réessayer.',
+} as const;

--- a/packages/@granit/react-ui-error-boundary/src/locales/index.ts
+++ b/packages/@granit/react-ui-error-boundary/src/locales/index.ts
@@ -1,0 +1,2 @@
+export { errorBoundaryTranslationsEn } from './en';
+export { errorBoundaryTranslationsFr } from './fr';

--- a/packages/@granit/react-ui-error-boundary/src/not-found-page.stories.tsx
+++ b/packages/@granit/react-ui-error-boundary/src/not-found-page.stories.tsx
@@ -1,0 +1,26 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import { NotFoundPage } from './not-found-page';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof NotFoundPage> = {
+  title: 'Error Boundary/NotFoundPage',
+  component: NotFoundPage,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/packages/@granit/react-ui-error-boundary/src/not-found-page.tsx
+++ b/packages/@granit/react-ui-error-boundary/src/not-found-page.tsx
@@ -1,0 +1,36 @@
+import { type ComponentType, type ReactNode } from 'react';
+
+import { useTranslation } from '@granit/react-localization';
+import { Button } from '@granit/react-ui';
+import { AlertTriangle } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+export interface NotFoundPageProps {
+  /** Optional wrapper (e.g. a public/centered layout). Without it the page renders bare. */
+  layout?: ComponentType<{ children: ReactNode }>;
+}
+
+/** Standalone 404 page. */
+export function NotFoundPage({ layout: Layout }: Readonly<NotFoundPageProps>) {
+  const { t } = useTranslation();
+
+  const content = (
+    <div
+      data-slot="not-found-page"
+      className="flex min-h-[calc(100vh-theme(spacing.16))] items-center justify-center px-4"
+    >
+      <div className="text-center">
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-accent">
+          <AlertTriangle className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
+        </div>
+        <h1 className="mb-2 text-2xl font-semibold text-foreground">{t('Errors.NotFound')}</h1>
+        <p className="mb-8 text-muted-foreground">{t('Errors.NotFoundMessage')}</p>
+        <Button asChild>
+          <Link to="/">{t('Errors.BackToHome')}</Link>
+        </Button>
+      </div>
+    </div>
+  );
+
+  return Layout ? <Layout>{content}</Layout> : content;
+}

--- a/packages/@granit/react-ui-error-boundary/tsconfig.json
+++ b/packages/@granit/react-ui-error-boundary/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": [
+    "src/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.stories.ts",
+    "src/**/*.stories.tsx"
+  ]
+}

--- a/packages/@granit/react-ui-error-boundary/tsup.config.ts
+++ b/packages/@granit/react-ui-error-boundary/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();


### PR DESCRIPTION
New package: the **UI counterpart** to the headless `@granit/react-error-boundary`. The headless package owns the mechanism (`GranitErrorBoundary` catches render errors and delegates UI via `renderFallback`); this package owns the **pages**.

## Components
- **`ErrorFallback`** — rendered by a boundary's `renderFallback`; error heading, retry button, optional copyable detail block.
- **`ErrorPage`** — React Router `errorElement`; distinguishes 404 from other route errors, links home.
- **`NotFoundPage`** — standalone 404.

## App-agnostic design
- optional `layout` slot (renders bare without it);
- `ErrorPage` takes an `onError` callback for host-side logging;
- the dev error-detail block is gated by a `showErrorDetail` prop (host passes its dev flag) — no `import.meta.env` coupling;
- ships its own `Errors.*` bundle (`errorBoundaryTranslationsEn/Fr`).

Extracted from the showcase, which now keeps only thin host wrappers injecting `PublicLayout` + logger.

## Validation
Full arch-tests pass (2918). 10 component tests (layout/onError/showErrorDetail slots, 404 vs generic). Consumed source-direct by the showcase (lint + tsc + unit green).