### PR TITLE
fix: unbreak develop CI (lockfile + latent lint/arch failures from #765)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -8929,6 +8929,88 @@
       ]
     },
     {
+      "name": "@granit/react-ui-error-boundary",
+      "description": "Granit admin error UI — the visible fallback, route-error and not-found pages that pair with the headless @granit/react-error-boundary. App-agnostic: each page takes an optional layout slot and ships its own Errors.* translations.",
+      "exports": [
+        {
+          "name": "ErrorFallback",
+          "kind": "function",
+          "signature": "function ErrorFallback("
+        },
+        {
+          "name": "ErrorFallbackProps",
+          "kind": "interface",
+          "signature": "interface ErrorFallbackProps",
+          "members": [
+            {
+              "name": "error",
+              "kind": "property",
+              "signature": "error: Error"
+            },
+            {
+              "name": "onReset",
+              "kind": "method",
+              "signature": "onReset: () => void"
+            },
+            {
+              "name": "layout",
+              "kind": "property",
+              "signature": "layout?: ComponentType<{ children: ReactNode }>"
+            },
+            {
+              "name": "showErrorDetail",
+              "kind": "property",
+              "signature": "showErrorDetail?: boolean"
+            }
+          ]
+        },
+        {
+          "name": "ErrorPage",
+          "kind": "function",
+          "signature": "function ErrorPage("
+        },
+        {
+          "name": "ErrorPageProps",
+          "kind": "interface",
+          "signature": "interface ErrorPageProps",
+          "members": [
+            {
+              "name": "layout",
+              "kind": "property",
+              "signature": "layout?: ComponentType<{ children: ReactNode }>"
+            },
+            {
+              "name": "onError",
+              "kind": "method",
+              "signature": "onError?: (error: unknown) => void"
+            },
+            {
+              "name": "showErrorDetail",
+              "kind": "property",
+              "signature": "showErrorDetail?: boolean"
+            }
+          ]
+        },
+        {
+          "name": "NotFoundPage",
+          "kind": "function",
+          "signature": "function NotFoundPage("
+        },
+        {
+          "name": "NotFoundPageProps",
+          "kind": "interface",
+          "signature": "interface NotFoundPageProps",
+          "members": [
+            {
+              "name": "layout",
+              "kind": "property",
+              "signature": "layout?: ComponentType<{ children: ReactNode }>"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "@granit/react-ui-features",
       "description": "Granit admin UI for the Features module — the feature-flag listing (grouped, collapsible), value badges, the per-feature detail page and the set/remove-override dialog. Composes @granit/react-features (headless) with the foundation UI packages.",
       "exports": [
@@ -9207,6 +9289,11 @@
           "name": "LanguageList",
           "kind": "function",
           "signature": "function LanguageList()"
+        },
+        {
+          "name": "LanguageSwitcher",
+          "kind": "function",
+          "signature": "function LanguageSwitcher()"
         },
         {
           "name": "createLocalizationColumns",

--- a/packages/@granit/arch-tests/src/__tests__/helpers.ts
+++ b/packages/@granit/arch-tests/src/__tests__/helpers.ts
@@ -115,6 +115,7 @@ export const UI_ROUTER_BASELINE: ReadonlyArray<string> = [
   '@granit/react-ui-cms-sites',
   '@granit/react-ui-dashboards',
   '@granit/react-ui-documents',
+  '@granit/react-ui-error-boundary',
   '@granit/react-ui-features',
   '@granit/react-ui-hostnames',
   '@granit/react-ui-identity',

--- a/packages/@granit/react-ui-admin-kit/src/layout/top-progress-bar.tsx
+++ b/packages/@granit/react-ui-admin-kit/src/layout/top-progress-bar.tsx
@@ -1,7 +1,6 @@
-import * as React from 'react';
-
 import { cn } from '@granit/utils';
 import { useIsFetching, useIsMutating } from '@tanstack/react-query';
+import * as React from 'react';
 
 let suspenseCount = 0;
 const listeners = new Set<() => void>();
@@ -44,7 +43,6 @@ export function TopProgressBar() {
 
   React.useEffect(() => {
     if (active && state === 'idle') {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- sync progress to external query/mutation activity
       setState('loading');
       setProgress(8);
     } else if (!active && state === 'loading') {

--- a/packages/@granit/react-ui-error-boundary/src/__tests__/error-fallback.test.tsx
+++ b/packages/@granit/react-ui-error-boundary/src/__tests__/error-fallback.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 
 import { ErrorFallback } from '../error-fallback';
+
 import { renderWithI18n } from './test-utils';
 
 import type { ReactNode } from 'react';

--- a/packages/@granit/react-ui-error-boundary/src/__tests__/error-page.test.tsx
+++ b/packages/@granit/react-ui-error-boundary/src/__tests__/error-page.test.tsx
@@ -3,6 +3,7 @@ import { I18nextProvider } from 'react-i18next';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 
 import { ErrorPage } from '../error-page';
+
 import { testI18n } from './test-utils';
 
 import type { ReactElement } from 'react';

--- a/packages/@granit/react-ui-error-boundary/src/__tests__/not-found-page.test.tsx
+++ b/packages/@granit/react-ui-error-boundary/src/__tests__/not-found-page.test.tsx
@@ -3,6 +3,7 @@ import { I18nextProvider } from 'react-i18next';
 import { MemoryRouter } from 'react-router-dom';
 
 import { NotFoundPage } from '../not-found-page';
+
 import { testI18n } from './test-utils';
 
 describe('NotFoundPage', () => {

--- a/packages/@granit/react-ui-error-boundary/src/error-fallback.tsx
+++ b/packages/@granit/react-ui-error-boundary/src/error-fallback.tsx
@@ -1,8 +1,7 @@
-import { useState, type ComponentType, type ReactNode } from 'react';
-
 import { useTranslation } from '@granit/react-localization';
 import { Button } from '@granit/react-ui';
 import { AlertTriangle, Check, Copy } from 'lucide-react';
+import { useState, type ComponentType, type ReactNode } from 'react';
 
 export interface ErrorFallbackProps {
   error: Error;

--- a/packages/@granit/react-ui-error-boundary/src/error-page.tsx
+++ b/packages/@granit/react-ui-error-boundary/src/error-page.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useState, type ComponentType, type ReactNode } from 'react';
-
 import { useTranslation } from '@granit/react-localization';
 import { Button } from '@granit/react-ui';
 import { AlertTriangle, Check, Copy, ServerCrash } from 'lucide-react';
+import { useEffect, useState, type ComponentType, type ReactNode } from 'react';
 import { isRouteErrorResponse, Link, useRouteError } from 'react-router-dom';
 
 export interface ErrorPageProps {

--- a/packages/@granit/react-ui-error-boundary/src/not-found-page.tsx
+++ b/packages/@granit/react-ui-error-boundary/src/not-found-page.tsx
@@ -1,8 +1,7 @@
-import { type ComponentType, type ReactNode } from 'react';
-
 import { useTranslation } from '@granit/react-localization';
 import { Button } from '@granit/react-ui';
 import { AlertTriangle } from 'lucide-react';
+import { type ComponentType, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 
 export interface NotFoundPageProps {

--- a/packages/@granit/react-ui-localization/src/components/language-switcher.stories.tsx
+++ b/packages/@granit/react-ui-localization/src/components/language-switcher.stories.tsx
@@ -1,6 +1,7 @@
 import { mockLanguages } from '@granit/react-localization/testing';
 
 import { LanguagesContext } from '../languages-context';
+
 import { LanguageSwitcher } from './language-switcher';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5185,6 +5185,39 @@ importers:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
+  packages/@granit/react-ui-error-boundary:
+    devDependencies:
+      '@granit/react-localization':
+        specifier: workspace:*
+        version: link:../react-localization
+      '@granit/react-ui':
+        specifier: workspace:*
+        version: link:../react-ui
+      '@storybook/react-vite':
+        specifier: ^10.4.6
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(yaml@2.9.0))
+      i18next:
+        specifier: ^26.0.0
+        version: 26.3.1(typescript@6.0.3)
+      lucide-react:
+        specifier: ^1.21.0
+        version: 1.21.0(react@19.2.7)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+      react-i18next:
+        specifier: ^17.0.0
+        version: 17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+      react-router-dom:
+        specifier: ^7.18.0
+        version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook:
+        specifier: ^10.4.6
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
   packages/@granit/react-ui-features:
     dependencies:
       lucide-react:


### PR DESCRIPTION
## Problem

`develop` CI is fully red (lint + typecheck + all 4 test shards). PR #765 was merged with red CI — `pnpm install --frozen-lockfile` failed, so lint/test/typecheck never actually ran and several latent failures landed on `develop`:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml
is not up to date with packages/@granit/react-ui-error-boundary/package.json
```

## Fixes (all version-independent — verified green under develop's current deps)

1. **Lockfile** — `pnpm install --lockfile-only` adds the missing `react-ui-error-boundary` importer (the 10 dev/peer deps #765 added). Restores `--frozen-lockfile`.
2. **react-ui-error-boundary import order** — `react` groups with the external imports, ordered after `lucide-react` (`import-x/order`).
3. **Router arch baseline** — `react-ui-error-boundary` legitimately uses `useRouteError`/`isRouteErrorResponse`/`Link`, so it's added to `UI_ROUTER_BASELINE` (the 'no NEW direct web-router import' ratchet).
4. **top-progress-bar.tsx / language-switcher.stories.tsx** — pre-existing `import-x/order` breakage + an orphan `eslint-disable react-hooks/set-state-in-effect` (no react-hooks plugin is registered in `eslint.config.js`, so the directive referenced an unknown rule).

## Verification

`pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm tsc`, and the full `pnpm test run` all green locally.