### PR TITLE
feat(react-ui-timeline): new package — entity activity feed

### DIFF
--- a/packages/@granit/react-ui-timeline/README.md
+++ b/packages/@granit/react-ui-timeline/README.md
@@ -1,0 +1,27 @@
+# @granit/react-ui-timeline
+
+Admin UI for the Granit Timeline module — the entity activity feed: a paginated
+stream of timeline entries, a composer with @-mention autocomplete and emoji
+reactions. The UI counterpart to the headless
+[`@granit/react-timeline`](../react-timeline) (provider + hooks).
+
+## Components
+
+- **`EntityTimeline`** — the page-level feed for one entity (`entityType` +
+  `entityId`): composer on top, paginated stream below.
+- `TimelineStream`, `TimelineEntry`, `TimelineComposer`, `ReactionStrip`,
+  `MentionEditor`, `EmojiPicker`, `TwemojiImage` — the building blocks.
+
+## App-agnostic by design
+
+`EntityTimeline` stays neutral so stories/tests can mount it without the auth,
+identity or query stacks. Hosts inject from their own context at the call site:
+
+- `currentUserId` — `useAuth().user?.sub` (drives author-only edit gating);
+- `canReact` — `usePermissions().hasPermission('Timeline.Reactions.React')`;
+- `searchMentions` — a `(query) => Promise<MentionSuggestion[]>` over the host's
+  identity client.
+
+The `TimelineProvider` (from `@granit/react-timeline`, wired with the host's API
+client) is mounted by the app, not this package. The `Timeline.*` strings ship
+in `timelineAdminTranslationsEn` / `timelineAdminTranslationsFr`.

--- a/packages/@granit/react-ui-timeline/package.json
+++ b/packages/@granit/react-ui-timeline/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@granit/react-ui-timeline",
+  "description": "Granit admin UI for the Timeline module — the entity activity feed (stream, entries, composer with @-mentions, emoji reactions). Composes the headless @granit/react-timeline (provider, hooks) with the foundation UI packages. App-agnostic: auth/permission/mention data are injected as props.",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@emoji-mart/data": "^1.2.1",
+    "@emoji-mart/react": "^1.1.1",
+    "@granit/api-client": "workspace:*",
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-timeline": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/timeline": "workspace:*",
+    "@granit/types": "workspace:*",
+    "@granit/utils": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "@tiptap/extension-mention": "^3.27.1",
+    "@tiptap/extension-placeholder": "^3.27.1",
+    "@tiptap/react": "^3.27.1",
+    "@tiptap/starter-kit": "^3.27.1",
+    "lucide-react": "^1.21.0",
+    "next-themes": "^0.4.6",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.18.0",
+    "sonner": "^2.0.7",
+    "tippy.js": "^6.3.7"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@emoji-mart/data": "^1.2.1",
+    "@emoji-mart/react": "^1.1.1",
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-timeline": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/timeline": "workspace:*",
+    "@granit/types": "workspace:*",
+    "@granit/utils": "workspace:*",
+    "@storybook/react-vite": "^10.4.6",
+    "@tanstack/react-query": "^5.0.0",
+    "@tiptap/extension-mention": "^3.27.1",
+    "@tiptap/extension-placeholder": "^3.27.1",
+    "@tiptap/react": "^3.27.1",
+    "@tiptap/starter-kit": "^3.27.1",
+    "i18next": "^26.0.0",
+    "lucide-react": "^1.21.0",
+    "next-themes": "^0.4.6",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-i18next": "^17.0.0",
+    "react-router-dom": "^7.18.0",
+    "sonner": "^2.0.7",
+    "storybook": "^10.4.6",
+    "tippy.js": "^6.3.7"
+  }
+}

--- a/packages/@granit/react-ui-timeline/src/__tests__/entity-timeline.test.tsx
+++ b/packages/@granit/react-ui-timeline/src/__tests__/entity-timeline.test.tsx
@@ -1,0 +1,142 @@
+import { screen } from '@testing-library/react';
+
+import { renderWithProviders } from './test-utils';
+
+import { EntityTimeline } from '../entity-timeline';
+
+// Mock @granit/react-timeline (hooks + provider)
+const { mockUseTimeline, mockUseTimelineActions, mockUseTimelineFollowers } = vi.hoisted(() => ({
+  mockUseTimeline: vi.fn(),
+  mockUseTimelineActions: vi.fn(),
+  mockUseTimelineFollowers: vi.fn(),
+}));
+
+vi.mock('@granit/react-timeline', () => ({
+  useTimeline: mockUseTimeline,
+  useTimelineActions: mockUseTimelineActions,
+  useTimelineFollowers: mockUseTimelineFollowers,
+  useToggleReaction: () => ({ mutate: vi.fn() }),
+  useUpdateEntryBody: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+  applyToggleResult: vi.fn((reactions: unknown, _result: unknown) => reactions),
+}));
+
+vi.mock('@granit/timeline', () => ({
+  TimelineEntryType: { Comment: 'Comment', InternalNote: 'InternalNote', SystemLog: 'SystemLog' },
+  TimelineEntryOrigin: { Native: 'Native', External: 'External' },
+}));
+
+const defaultTimeline = {
+  entries: [],
+  totalCount: 0,
+  loading: false,
+  loadingMore: false,
+  error: null,
+  hasMore: false,
+  loadMore: vi.fn(),
+  refresh: vi.fn(),
+  addOptimisticEntry: vi.fn(),
+  removeOptimisticEntry: vi.fn(),
+  patchEntry: vi.fn(),
+  degradedSources: [],
+};
+
+const defaultActions = {
+  postEntry: vi.fn().mockResolvedValue({ id: 'new' }),
+  removeEntry: vi.fn().mockResolvedValue(undefined),
+  posting: false,
+  deleting: false,
+  error: null,
+};
+
+const defaultFollowers = {
+  followers: [],
+  isFollowing: false,
+  loading: false,
+  follow: vi.fn().mockResolvedValue(undefined),
+  unfollow: vi.fn().mockResolvedValue(undefined),
+};
+
+describe('EntityTimeline', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('should display the Timeline title', () => {
+    mockUseTimeline.mockReturnValue(defaultTimeline);
+    mockUseTimelineActions.mockReturnValue(defaultActions);
+    mockUseTimelineFollowers.mockReturnValue(defaultFollowers);
+    renderWithProviders(<EntityTimeline entityType="User" entityId="u-1" />);
+    expect(screen.getByText('Timeline')).toBeInTheDocument();
+  });
+
+  it('should display the empty message when there are no entries', () => {
+    mockUseTimeline.mockReturnValue(defaultTimeline);
+    mockUseTimelineActions.mockReturnValue(defaultActions);
+    mockUseTimelineFollowers.mockReturnValue(defaultFollowers);
+    renderWithProviders(<EntityTimeline entityType="User" entityId="u-1" />);
+    expect(screen.getByText('No timeline entries yet.')).toBeInTheDocument();
+  });
+
+  it('should display the error state when loading fails', () => {
+    mockUseTimeline.mockReturnValue({
+      ...defaultTimeline,
+      error: new Error('Network error'),
+    });
+    mockUseTimelineActions.mockReturnValue(defaultActions);
+    mockUseTimelineFollowers.mockReturnValue(defaultFollowers);
+    renderWithProviders(<EntityTimeline entityType="User" entityId="u-1" />);
+    expect(screen.getByText('Failed to load timeline')).toBeInTheDocument();
+  });
+
+  it('should display the spinner during initial loading', () => {
+    mockUseTimeline.mockReturnValue({ ...defaultTimeline, loading: true });
+    mockUseTimelineActions.mockReturnValue(defaultActions);
+    mockUseTimelineFollowers.mockReturnValue(defaultFollowers);
+    renderWithProviders(<EntityTimeline entityType="User" entityId="u-1" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('should display the timeline entries', () => {
+    mockUseTimeline.mockReturnValue({
+      ...defaultTimeline,
+      entries: [
+        {
+          id: 'e-1',
+          body: 'First comment',
+          entryType: 'Comment',
+          authorName: 'Admin',
+          occurredAt: '2026-01-01T00:00:00Z',
+          entityType: 'User',
+          entityId: 'u-1',
+          authorId: 'a-1',
+          parentEntryId: null,
+          attachments: [],
+        },
+      ],
+      totalCount: 1,
+    });
+    mockUseTimelineActions.mockReturnValue(defaultActions);
+    mockUseTimelineFollowers.mockReturnValue(defaultFollowers);
+    renderWithProviders(<EntityTimeline entityType="User" entityId="u-1" />);
+    expect(screen.getByText('First comment')).toBeInTheDocument();
+  });
+
+  it('should pass entityType and entityId to hooks', () => {
+    mockUseTimeline.mockReturnValue(defaultTimeline);
+    mockUseTimelineActions.mockReturnValue(defaultActions);
+    mockUseTimelineFollowers.mockReturnValue(defaultFollowers);
+    renderWithProviders(<EntityTimeline entityType="User" entityId="u-1" />);
+    expect(mockUseTimeline).toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: 'User', entityId: 'u-1' })
+    );
+    expect(mockUseTimelineActions).toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: 'User', entityId: 'u-1' })
+    );
+  });
+
+  it('should have the data-slot attribute', () => {
+    mockUseTimeline.mockReturnValue(defaultTimeline);
+    mockUseTimelineActions.mockReturnValue(defaultActions);
+    mockUseTimelineFollowers.mockReturnValue(defaultFollowers);
+    renderWithProviders(<EntityTimeline entityType="User" entityId="u-1" />);
+    expect(document.querySelector('[data-slot="entity-timeline"]')).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-timeline/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-ui-timeline/src/__tests__/test-utils.tsx
@@ -1,0 +1,56 @@
+import { TooltipProvider } from '@granit/react-ui';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import i18next from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { MemoryRouter } from 'react-router-dom';
+
+import { timelineAdminTranslationsEn } from '../locales';
+
+import type { ReactElement, ReactNode } from 'react';
+
+// Render helper for the timeline UI: the package's own flat Timeline.* bundle in
+// context (separators disabled, dotted keys verbatim), plus a QueryClient,
+// TooltipProvider and router — the components use react-query, tooltips and
+// <Link>. Tests that exercise EntityTimeline mock @granit/react-timeline, so no
+// real TimelineProvider/API client is needed here.
+const testI18n = i18next.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  ns: ['translation'],
+  defaultNS: 'translation',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: {
+    en: { translation: { ...timelineAdminTranslationsEn } },
+  },
+  interpolation: { escapeValue: false },
+});
+
+export { testI18n };
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+export function renderWithProviders(ui: ReactElement) {
+  const queryClient = makeQueryClient();
+  return {
+    ...render(ui, {
+      wrapper: ({ children }: { readonly children: ReactNode }) => (
+        <I18nextProvider i18n={testI18n}>
+          <QueryClientProvider client={queryClient}>
+            <TooltipProvider>
+              <MemoryRouter>{children}</MemoryRouter>
+            </TooltipProvider>
+          </QueryClientProvider>
+        </I18nextProvider>
+      ),
+    }),
+    user: userEvent.setup({ delay: null }),
+  };
+}

--- a/packages/@granit/react-ui-timeline/src/emoji-picker.stories.tsx
+++ b/packages/@granit/react-ui-timeline/src/emoji-picker.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { EmojiPicker } from './emoji-picker';
+
+const meta = {
+  title: 'Timeline/EmojiPicker',
+  component: EmojiPicker,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    onSelect: fn(),
+    onClose: fn(),
+  },
+} satisfies Meta<typeof EmojiPicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Default (with close callback)',
+};
+
+export const WithoutCloseCallback: Story = {
+  name: 'Without close callback',
+  args: {
+    onClose: undefined,
+  },
+};

--- a/packages/@granit/react-ui-timeline/src/emoji-picker.tsx
+++ b/packages/@granit/react-ui-timeline/src/emoji-picker.tsx
@@ -1,0 +1,106 @@
+import { lazy, Suspense, useEffect, type ReactNode } from 'react';
+
+import { useTranslation } from '@granit/react-localization';
+import { useTheme } from 'next-themes';
+
+interface EmojiMartSelection {
+  readonly native: string;
+  readonly unified?: string;
+  readonly shortcodes?: string;
+  readonly name?: string;
+}
+
+interface EmojiMartProps {
+  readonly set?: 'twitter' | 'apple' | 'google' | 'facebook' | 'native';
+  readonly onEmojiSelect?: (emoji: EmojiMartSelection) => void;
+  readonly autoFocus?: boolean;
+  readonly theme?: 'auto' | 'light' | 'dark';
+  readonly locale?: string;
+  readonly previewPosition?: 'top' | 'bottom' | 'none';
+  readonly skinTonePosition?: 'preview' | 'search' | 'none';
+  readonly perLine?: number;
+  readonly maxFrequentRows?: number;
+}
+
+// Dynamic-import the emoji-mart picker + the **Twitter** data bundle.
+// `@emoji-mart/data`'s default export is `sets/15/native.json`, which
+// strips the `x`/`y` sprite coordinates emoji-mart needs to position
+// each glyph on the Twemoji spritesheet — combining the default data
+// with `set="twitter"` produces a broken picker where every cell
+// renders as `#️⃣` (the (0,0) cell). Loading the Twitter set directly
+// ships the coordinates so the picker aligns with the chip rendering
+// (which uses Twemoji via `<TwemojiImage>`).
+//
+// Code-split so the ~200 KB cost is paid only the first time the
+// picker is opened.
+const Picker = lazy(async () => {
+  const [{ default: PickerComponent }, dataModule] = await Promise.all([
+    import('@emoji-mart/react'),
+    import('@emoji-mart/data/sets/15/twitter.json'),
+  ]);
+  return {
+    default: function ConfiguredPicker(props: EmojiMartProps): ReactNode {
+      return <PickerComponent data={dataModule.default} {...props} />;
+    },
+  };
+});
+
+export interface EmojiPickerProps {
+  /** Fires with the literal emoji grapheme (`native`) on user pick. */
+  readonly onSelect: (emoji: string) => void;
+  /** Optional dismiss callback — `Escape` is the default. */
+  readonly onClose?: () => void;
+}
+
+// Open-catalog emoji picker built on emoji-mart, configured to:
+//  - emit Twemoji codepoints so picked glyphs round-trip cleanly
+//    through `<TwemojiImage>` regardless of the user's OS,
+//  - mirror the app theme (next-themes → light / dark / auto),
+//  - localise category names via i18next's current language.
+//
+// First mount is async — emoji-mart + its data module are dynamic
+// imports. A `null` fallback keeps the parent popover stable while
+// the chunk loads (popovers compute their own placement so a
+// momentarily empty content doesn't jump).
+export function EmojiPicker({ onSelect, onClose }: EmojiPickerProps) {
+  const { resolvedTheme } = useTheme();
+  const { i18n } = useTranslation();
+
+  useEffect(() => {
+    if (!onClose) return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    globalThis.addEventListener('keydown', handler);
+    return () => globalThis.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const theme: EmojiMartProps['theme'] = resolveTheme(resolvedTheme);
+
+  // The picker is mounted inside a Radix Popover which already provides
+  // dialog semantics — adding `role="dialog"` here would duplicate them
+  // (and trips eslint-plugin-jsx-a11y's "prefer <dialog>" rule).
+  return (
+    <div data-slot="emoji-picker">
+      <Suspense fallback={null}>
+        <Picker
+          set="twitter"
+          theme={theme}
+          locale={i18n.language.split('-')[0]}
+          autoFocus
+          previewPosition="none"
+          skinTonePosition="search"
+          perLine={8}
+          maxFrequentRows={1}
+          onEmojiSelect={(emoji) => onSelect(emoji.native)}
+        />
+      </Suspense>
+    </div>
+  );
+}
+
+function resolveTheme(resolvedTheme: string | undefined): EmojiMartProps['theme'] {
+  if (resolvedTheme === 'dark') return 'dark';
+  if (resolvedTheme === 'light') return 'light';
+  return 'auto';
+}

--- a/packages/@granit/react-ui-timeline/src/entity-timeline.stories.tsx
+++ b/packages/@granit/react-ui-timeline/src/entity-timeline.stories.tsx
@@ -1,0 +1,58 @@
+import { createApiClient } from '@granit/api-client';
+import { TimelineProvider } from '@granit/react-timeline';
+import { createTimelineHandlers } from '@granit/react-timeline/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { EntityTimeline } from './entity-timeline';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const storyTimelineConfig = { client: createApiClient({ baseURL: '' }), basePath: '/api/v1/timeline' };
+
+const meta: Meta<typeof EntityTimeline> = {
+  title: 'Timeline/EntityTimeline',
+  component: EntityTimeline,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    msw: {
+      handlers: createTimelineHandlers(),
+    },
+  },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <TimelineProvider config={storyTimelineConfig}>
+          <Story />
+        </TimelineProvider>
+      </QueryClientProvider>
+    ),
+  ],
+  argTypes: {
+    entityType: { control: 'text' },
+    entityId: { control: 'text' },
+    pageSize: { control: 'number' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EntityTimeline>;
+
+export const Default: Story = {
+  args: {
+    entityType: 'User',
+    entityId: 'user-001',
+  },
+};
+
+export const CustomPageSize: Story = {
+  args: {
+    entityType: 'User',
+    entityId: 'user-001',
+    pageSize: 10,
+  },
+};

--- a/packages/@granit/react-ui-timeline/src/entity-timeline.tsx
+++ b/packages/@granit/react-ui-timeline/src/entity-timeline.tsx
@@ -1,0 +1,556 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { useTranslation } from '@granit/react-localization';
+import {
+  applyToggleResult,
+  useTimeline,
+  useTimelineActions,
+  useTimelineFollowers,
+  useUpdateEntryBody,
+} from '@granit/react-timeline';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Spinner,
+} from '@granit/react-ui';
+import {
+  TimelineEntryNotEditableReason,
+  TimelineEntryOrigin,
+  TimelineEntryType,
+} from '@granit/timeline';
+import type {
+  PostTimelineEntryRequest,
+  MentionSuggestion,
+  ReactionToggleResponse,
+  TimelineStreamEntryResponse,
+  TimelineEntryId,
+  TimelineEntryNotEditableReasonValue,
+} from '@granit/timeline';
+import { isAxiosError } from '@granit/api-client';
+import { AlertCircle, AlertTriangle, Bell, BellOff, MessageSquare, Plus } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import { TimelineComposer } from './timeline-composer';
+import { TimelineStream } from './timeline-stream';
+import { cn } from '@granit/utils';
+
+// Single-pass tokenizer for the timeline body. Branch 1 is the canonical
+// mention payload (`@[Name](user:guid)`) emitted by `<TimelineComposer>`
+// and parsed server-side by `Granit.Timeline.Internal.MentionParser`.
+// Branch 2 matches autolinked URLs typed in prose — `http(s)://…` until
+// whitespace or angle bracket; trailing prose punctuation is trimmed in
+// JS (regex lookbehind would lock us into modern engines unnecessarily).
+// The GUID shape uses a compact `[0-9a-f-]{36}` class (case-insensitive flag)
+// to keep regex complexity below SonarJS's threshold — exact RFC 4122
+// validation happens server-side.
+const BODY_TOKEN_REGEX = /@\[([^\]]+)\]\(user:([0-9a-f-]{36})\)|(https?:\/\/[^\s<>]+)/gi;
+
+// Characters that typically belong to surrounding prose rather than the
+// URL itself (sentence-ending punctuation, closing brackets, quotes).
+// Stripped repeatedly so e.g. `(https://example.com).` keeps both the
+// `.` and `)` outside the link.
+const TRAILING_URL_CHARS = new Set(['.', ',', ';', ':', '!', '?', ')', ']', '"', "'"]);
+
+function trimTrailingPunctuation(url: string): { url: string; trailing: string } {
+  let end = url.length;
+  while (end > 0 && TRAILING_URL_CHARS.has(url.charAt(end - 1))) end--;
+  return { url: url.slice(0, end), trailing: url.slice(end) };
+}
+
+// Same-origin URLs stay in-app via React Router so SPA state survives
+// the navigation; cross-origin URLs open in a new tab with the standard
+// reverse-tabnabbing protection (`noopener` strips `window.opener`,
+// `noreferrer` drops the Referer header).
+function renderUrlLink(href: string, key: string): React.ReactNode {
+  let parsed: URL;
+  try {
+    parsed = new URL(href);
+  } catch {
+    return href;
+  }
+  const sameOrigin = parsed.origin === globalThis.location?.origin;
+  if (sameOrigin) {
+    return (
+      <Link
+        key={key}
+        to={`${parsed.pathname}${parsed.search}${parsed.hash}`}
+        className="text-primary underline-offset-2 hover:underline"
+        data-testid="timeline-url-link"
+      >
+        {href}
+      </Link>
+    );
+  }
+  return (
+    <a
+      key={key}
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-primary underline-offset-2 hover:underline"
+      data-testid="timeline-url-link"
+      data-external=""
+    >
+      {href}
+    </a>
+  );
+}
+
+// Default body renderer: walks the body once, producing a mix of text
+// segments, mention `<Link>`s, and URL anchors. Hosts can override the
+// whole renderer via the `renderBody` prop if they need different
+// routing (e.g. tenant-scoped) or richer markdown.
+function renderBodyWithMentions(body: string): React.ReactNode {
+  const nodes: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  BODY_TOKEN_REGEX.lastIndex = 0;
+  while ((match = BODY_TOKEN_REGEX.exec(body)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(body.slice(lastIndex, match.index));
+    }
+    const [whole, displayName, userId, urlMatch] = match;
+    if (urlMatch === undefined) {
+      nodes.push(
+        <Link
+          key={`mention-${match.index}-${userId}`}
+          to={`/identity/users/${userId}`}
+          className="rounded px-1 py-0.5 font-medium text-primary hover:bg-primary/10"
+          data-testid="timeline-mention-link"
+        >
+          @{displayName}
+        </Link>
+      );
+    } else {
+      const { url, trailing } = trimTrailingPunctuation(urlMatch);
+      nodes.push(renderUrlLink(url, `url-${match.index}`));
+      if (trailing) nodes.push(trailing);
+    }
+    lastIndex = match.index + whole.length;
+  }
+  if (lastIndex < body.length) {
+    nodes.push(body.slice(lastIndex));
+  }
+  return nodes.length === 0 ? body : nodes;
+}
+
+/** Default edit window — matches the backend's `TimelineOptions.EditWindow` default (15 min). */
+const EDIT_WINDOW_MS = 15 * 60 * 1000;
+
+/**
+ * Maps the RFC 7807 `timeline-entry-not-editable` rejection (returned
+ * by the PATCH endpoint when one of the four edit gates fires) to a
+ * localised toast. Falls through to a generic error toast for any
+ * other failure shape.
+ */
+function handleEditRejection(err: unknown, t: ReturnType<typeof useTranslation>['t']): void {
+  if (isAxiosError(err) && err.response?.status === 403) {
+    const data = err.response.data as
+      | { type?: string; extensions?: { reason?: string } }
+      | undefined;
+    if (data?.type === 'timeline-entry-not-editable') {
+      const reason = data.extensions?.reason as TimelineEntryNotEditableReasonValue | undefined;
+      const fallbacks: Record<TimelineEntryNotEditableReasonValue, string> = {
+        [TimelineEntryNotEditableReason.ExternalOrigin]:
+          'This entry comes from an external source and cannot be edited here.',
+        [TimelineEntryNotEditableReason.SystemLog]: 'System log entries are immutable.',
+        [TimelineEntryNotEditableReason.NotAuthor]: 'You can only edit entries you authored.',
+        [TimelineEntryNotEditableReason.WindowExpired]:
+          'The edit window for this entry has expired.',
+      };
+      const key = reason ? `Timeline.EditReject.${reason}` : 'Timeline.EditReject.Unknown';
+      const fallback = (reason && fallbacks[reason]) ?? 'This entry cannot be edited.';
+      // 403 rejections are excluded from the global MutationCache.onError toast,
+      // so this domain-specific message is the only one surfaced to the user.
+      toast.error(t(key, { defaultValue: fallback }));
+    }
+  }
+  // Any other failure shape is surfaced by the global MutationCache.onError toast.
+}
+
+export interface EntityTimelineProps {
+  entityType: string;
+  entityId: string;
+  /** Entry types available in the composer. Default: [Comment, InternalNote] */
+  entryTypes?: TimelineEntryType[];
+  /** Number of entries per page. Default: 20 */
+  pageSize?: number;
+  /**
+   * Forwarded to each `<TimelineStreamEntryResponse>`'s reaction bar. Hosts compute it
+   * via `usePermissions().hasPermission('Timeline.Reactions.React')` at the call
+   * site so this component stays QueryClient-free for stories / tests
+   * that don't need the auth stack mounted. Default: `false`.
+   */
+  canReact?: boolean;
+  /**
+   * Forwarded to `<TimelineComposer>` to drive @-mention autocomplete.
+   * Kept page-level so this component stays Identity-stack-agnostic
+   * (stories/tests can mount without `IdentityProvider`).
+   */
+  searchMentions?: (query: string) => Promise<MentionSuggestion[]>;
+  /**
+   * Id of the signed-in user (`user.sub`). Hosts read it from
+   * `useAuth()` at the call site so this neutral component stays
+   * Identity-stack-agnostic — same rationale as `canReact` /
+   * `searchMentions`. Drives author-only edit gating; `undefined`
+   * disables editing.
+   */
+  currentUserId?: string;
+  className?: string;
+}
+
+function EntityTimelineInner({
+  entityType,
+  entityId,
+  // Admin: InternalNote visible in composer (hidden in patient-facing front).
+  // The stream renders ALL entry types unfiltered (Comment, InternalNote, SystemLog).
+  entryTypes = [TimelineEntryType.Comment, TimelineEntryType.InternalNote],
+  pageSize = 20,
+  canReact = false,
+  searchMentions,
+  currentUserId,
+  className,
+}: Readonly<EntityTimelineProps>) {
+  const { t } = useTranslation();
+  const [replyTo, setReplyTo] = useState<string | undefined>(undefined);
+  const [composerOpen, setComposerOpen] = useState(false);
+  const [editingEntry, setEditingEntry] = useState<{
+    readonly id: TimelineEntryId;
+    readonly originalBody: string;
+    readonly originalEntryType: TimelineEntryType;
+  } | null>(null);
+
+  const {
+    entries,
+    loading,
+    loadingMore,
+    hasMore,
+    loadMore,
+    error,
+    addOptimisticEntry,
+    removeOptimisticEntry,
+    patchEntry,
+    degradedSources,
+  } = useTimeline({ entityType, entityId, pageSize });
+
+  const updateBody = useUpdateEntryBody();
+
+  const {
+    followers,
+    isFollowing,
+    loading: followersLoading,
+    follow,
+    unfollow,
+  } = useTimelineFollowers({ entityType, entityId, currentUserId });
+
+  const handleFollowToggle = useCallback(() => {
+    const action = isFollowing ? unfollow : follow;
+    action().catch(() => {}); // errors already surfaced via hook's internal logger
+  }, [isFollowing, follow, unfollow]);
+
+  const { postEntry, removeEntry } = useTimelineActions({
+    entityType,
+    entityId,
+    onEntryCreated: addOptimisticEntry,
+    onEntryDeleted: removeOptimisticEntry,
+  });
+
+  const handleSubmit = useCallback(
+    async (request: PostTimelineEntryRequest) => {
+      await postEntry(request);
+      setReplyTo(undefined);
+      setComposerOpen(false);
+    },
+    [postEntry]
+  );
+
+  const handleReply = useCallback((entryId: string) => {
+    setReplyTo(entryId);
+    setComposerOpen(true);
+  }, []);
+
+  const handleComposerOpenChange = useCallback((open: boolean) => {
+    setComposerOpen(open);
+    if (!open) setReplyTo(undefined);
+  }, []);
+
+  const handleDelete = useCallback(
+    async (entryId: string) => {
+      await removeEntry(entryId);
+    },
+    [removeEntry]
+  );
+
+  const handleEdit = useCallback(
+    (entryId: TimelineEntryId, currentBody: string, originalEntryType: TimelineEntryType) => {
+      setEditingEntry({ id: entryId, originalBody: currentBody, originalEntryType });
+    },
+    []
+  );
+
+  const closeEdit = useCallback(() => {
+    setEditingEntry(null);
+  }, []);
+
+  // `request` shape comes from `<TimelineComposer>`'s create contract;
+  // we only care about `body` here — entryType isn't reclassified on
+  // edit (the selector is hidden) and parentEntryId is N/A for edits.
+  const handleEditSubmit = useCallback(
+    async (request: PostTimelineEntryRequest) => {
+      if (!editingEntry) return;
+      const trimmed = request.body.trim();
+      if (!trimmed || trimmed === editingEntry.originalBody) {
+        closeEdit();
+        return;
+      }
+      try {
+        await updateBody.mutateAsync({
+          entityType,
+          entityId,
+          entryId: editingEntry.id,
+          body: trimmed,
+        });
+        const nowIso = new Date().toISOString();
+        patchEntry(editingEntry.id, (entry) => ({
+          ...entry,
+          body: trimmed,
+          editedAt: nowIso as TimelineStreamEntryResponse['editedAt'],
+        }));
+        closeEdit();
+      } catch (err) {
+        handleEditRejection(err, t);
+      }
+    },
+    [editingEntry, updateBody, entityType, entityId, patchEntry, closeEdit, t]
+  );
+
+  const canEditEntry = useCallback(
+    (entry: TimelineStreamEntryResponse): boolean => {
+      if (!currentUserId) return false;
+      if ((entry.origin ?? TimelineEntryOrigin.Native) !== TimelineEntryOrigin.Native) return false;
+      if (entry.entryType === TimelineEntryType.SystemLog) return false;
+      if (entry.authorId !== currentUserId) return false;
+      const age = Date.now() - new Date(entry.occurredAt).getTime();
+      return age < EDIT_WINDOW_MS;
+    },
+    [currentUserId]
+  );
+
+  const handleReactionToggled = useCallback(
+    (entryId: TimelineEntryId, result: ReactionToggleResponse) => {
+      patchEntry(entryId, (entry) => ({
+        ...entry,
+        reactions: applyToggleResult(entry.reactions, result),
+      }));
+    },
+    [patchEntry]
+  );
+
+  const degradedLabel = useMemo(
+    () => (degradedSources.length > 0 ? degradedSources.join(', ') : null),
+    [degradedSources]
+  );
+
+  // API errors (incl. the 400 timeline-depth-exceeded problem) are surfaced by
+  // the global QueryCache.onError toast.
+
+  if (loading && entries.length === 0) {
+    return (
+      <Card className={className} data-slot="entity-timeline">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <MessageSquare className="h-5 w-5" />
+            {t('Timeline.Title')}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex justify-center py-8">
+          <Spinner size="md" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error && entries.length === 0) {
+    return (
+      <Card className={className} data-slot="entity-timeline">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <MessageSquare className="h-5 w-5" />
+            {t('Timeline.Title')}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col items-center gap-2 py-8 text-center">
+            <AlertCircle className="h-8 w-8 text-muted-foreground/70" />
+            <p className="text-sm font-medium text-foreground">{t('Timeline.ErrorTitle')}</p>
+            <p className="text-sm text-muted-foreground">{t('Timeline.ErrorMessage')}</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={cn(className)} data-slot="entity-timeline">
+      <CardHeader className="flex flex-col gap-3">
+        <div className="flex w-full flex-row items-center justify-between gap-2">
+          <CardTitle className="flex min-w-0 items-center gap-2">
+            <MessageSquare className="h-5 w-5 shrink-0" />
+            <span className="truncate">{t('Timeline.Title')}</span>
+          </CardTitle>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={handleFollowToggle}
+            disabled={followersLoading}
+            aria-pressed={isFollowing}
+            aria-label={
+              isFollowing
+                ? t('Timeline.Unfollow', { defaultValue: 'Unfollow' })
+                : t('Timeline.Follow', { defaultValue: 'Follow' })
+            }
+            data-testid="timeline-follow-button"
+            className="shrink-0"
+          >
+            {isFollowing ? (
+              <BellOff className="mr-1 h-4 w-4" aria-hidden />
+            ) : (
+              <Bell className="mr-1 h-4 w-4" aria-hidden />
+            )}
+            {isFollowing
+              ? t('Timeline.Unfollow', { defaultValue: 'Unfollow' })
+              : t('Timeline.Follow', { defaultValue: 'Follow' })}
+            {followers.length > 0 && (
+              <span className="ml-1 tabular-nums text-xs text-muted-foreground">
+                ({followers.length})
+              </span>
+            )}
+          </Button>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={() => setComposerOpen(true)}
+          aria-label={t('Timeline.AddEntry', { defaultValue: 'Add entry' })}
+          data-testid="timeline-add-button"
+          className="w-full"
+        >
+          <Plus className="mr-1 h-4 w-4" aria-hidden />
+          {t('Common.Add')}
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {degradedLabel && (
+          <output
+            data-testid="timeline-degraded-banner"
+            className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+          >
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+            <span>
+              {t('Timeline.PartialData', {
+                defaultValue: `Partial data — these sources are unavailable: ${degradedLabel}.`,
+                sources: degradedLabel,
+              })}
+            </span>
+          </output>
+        )}
+
+        <TimelineStream
+          entries={entries}
+          entityType={entityType}
+          entityId={entityId}
+          canReact={canReact}
+          loading={loading}
+          loadingMore={loadingMore}
+          hasMore={hasMore}
+          onLoadMore={loadMore}
+          onReply={handleReply}
+          onDelete={handleDelete}
+          onEdit={currentUserId ? handleEdit : undefined}
+          canEdit={canEditEntry}
+          onReactionToggled={handleReactionToggled}
+          renderBody={renderBodyWithMentions}
+          emptyMessage={t('Timeline.Empty')}
+        />
+      </CardContent>
+
+      <Dialog open={composerOpen} onOpenChange={handleComposerOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {replyTo
+                ? t('Timeline.ReplyDialogTitle', { defaultValue: 'Reply to entry' })
+                : t('Timeline.AddDialogTitle', { defaultValue: 'Add timeline entry' })}
+            </DialogTitle>
+            <DialogDescription>
+              {replyTo
+                ? t('Timeline.ReplyingTo')
+                : t('Timeline.AddDialogDescription', {
+                    defaultValue: 'Write a comment or internal note.',
+                  })}
+            </DialogDescription>
+          </DialogHeader>
+          <TimelineComposer
+            onSubmit={handleSubmit}
+            parentEntryId={replyTo}
+            entryTypes={entryTypes}
+            searchMentions={searchMentions}
+            placeholder={t('Timeline.AddComment')}
+            submitLabel={t('Timeline.Send')}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={editingEntry !== null}
+        onOpenChange={(open) => {
+          if (!open) closeEdit();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {t('Timeline.EditDialogTitle', { defaultValue: 'Edit entry' })}
+            </DialogTitle>
+            <DialogDescription>
+              {t('Timeline.EditDialogHint', {
+                defaultValue: 'You can edit your own entries within 15 minutes of posting.',
+              })}
+            </DialogDescription>
+          </DialogHeader>
+          {/* `key` forces remount when switching between entries so the */}
+          {/* composer's internal body state is re-seeded from `initialBody`. */}
+          <TimelineComposer
+            key={editingEntry?.id ?? 'edit'}
+            onSubmit={handleEditSubmit}
+            initialBody={editingEntry?.originalBody}
+            initialEntryType={editingEntry?.originalEntryType}
+            entryTypes={entryTypes}
+            searchMentions={searchMentions}
+            placeholder={t('Timeline.AddComment')}
+            submitLabel={t('Timeline.SaveEdit', { defaultValue: 'Save' })}
+          />
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}
+
+/**
+ * Entity timeline component. Requires a `<TimelineProvider>` ancestor
+ * (both App.tsx files mount one at the app level via `timelineConfig`).
+ */
+export function EntityTimeline(props: Readonly<EntityTimelineProps>) {
+  return <EntityTimelineInner {...props} />;
+}

--- a/packages/@granit/react-ui-timeline/src/index.ts
+++ b/packages/@granit/react-ui-timeline/src/index.ts
@@ -1,0 +1,9 @@
+export { EntityTimeline, type EntityTimelineProps } from './entity-timeline';
+export { TimelineStream, type TimelineStreamProps } from './timeline-stream';
+export { TimelineStreamEntryResponse, type TimelineEntryProps } from './timeline-entry';
+export { TimelineComposer, type TimelineComposerProps } from './timeline-composer';
+export { ReactionStrip, type ReactionStripProps } from './reaction-strip';
+export { MentionEditor, type MentionEditorProps } from './mention-editor';
+export { EmojiPicker, type EmojiPickerProps } from './emoji-picker';
+export { TwemojiImage, emojiToTwemojiCodepoints, type TwemojiImageProps } from './twemoji-image';
+export { timelineAdminTranslationsEn, timelineAdminTranslationsFr } from './locales';

--- a/packages/@granit/react-ui-timeline/src/locales/en.ts
+++ b/packages/@granit/react-ui-timeline/src/locales/en.ts
@@ -1,0 +1,22 @@
+/**
+ * English strings for the Timeline UI. Flat `Timeline.*` keys in the
+ * `translation` namespace (the host registers them with separators disabled,
+ * so the dotted keys are looked up verbatim). Named with the `timelineAdmin`
+ * prefix to avoid colliding with the headless `@granit/react-timeline`
+ * `timelineTranslations*` exports.
+ */
+export const timelineAdminTranslationsEn = {
+  'Timeline.AddComment': 'Add a comment...',
+  'Timeline.AddDialogDescription': 'Write a comment or internal note.',
+  'Timeline.AddDialogTitle': 'Add timeline entry',
+  'Timeline.AddEntry': 'Add entry',
+  'Timeline.AddReaction': 'Add reaction',
+  'Timeline.CancelReply': 'Cancel',
+  'Timeline.Empty': 'No timeline entries yet.',
+  'Timeline.ErrorMessage': 'Could not load timeline entries.',
+  'Timeline.ErrorTitle': 'Failed to load timeline',
+  'Timeline.ReplyDialogTitle': 'Reply to entry',
+  'Timeline.ReplyingTo': 'Replying to a comment',
+  'Timeline.Send': 'Send',
+  'Timeline.Title': 'Timeline',
+} as const;

--- a/packages/@granit/react-ui-timeline/src/locales/fr.ts
+++ b/packages/@granit/react-ui-timeline/src/locales/fr.ts
@@ -1,0 +1,18 @@
+/**
+ * French strings for the Timeline UI. See {@link timelineAdminTranslationsEn}.
+ */
+export const timelineAdminTranslationsFr = {
+  'Timeline.AddComment': 'Ajouter un commentaire...',
+  'Timeline.AddDialogDescription': 'Rédigez un commentaire ou une note interne.',
+  'Timeline.AddDialogTitle': 'Ajouter une entrée',
+  'Timeline.AddEntry': 'Ajouter',
+  'Timeline.AddReaction': 'Ajouter une réaction',
+  'Timeline.CancelReply': 'Annuler',
+  'Timeline.Empty': 'Aucune entrée dans la timeline.',
+  'Timeline.ErrorMessage': 'Impossible de charger les entrées de la timeline.',
+  'Timeline.ErrorTitle': 'Échec du chargement de la timeline',
+  'Timeline.ReplyDialogTitle': 'Répondre à une entrée',
+  'Timeline.ReplyingTo': 'Réponse à un commentaire',
+  'Timeline.Send': 'Envoyer',
+  'Timeline.Title': 'Timeline',
+} as const;

--- a/packages/@granit/react-ui-timeline/src/locales/index.ts
+++ b/packages/@granit/react-ui-timeline/src/locales/index.ts
@@ -1,0 +1,2 @@
+export { timelineAdminTranslationsEn } from './en';
+export { timelineAdminTranslationsFr } from './fr';

--- a/packages/@granit/react-ui-timeline/src/mention-editor.stories.tsx
+++ b/packages/@granit/react-ui-timeline/src/mention-editor.stories.tsx
@@ -1,0 +1,56 @@
+import type { MentionSuggestion } from '@granit/timeline';
+import { fn } from 'storybook/test';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { MentionEditor } from './mention-editor';
+
+const mockSuggestions: MentionSuggestion[] = [
+  { id: '11111111-1111-1111-1111-111111111111', displayName: 'Jane Dupont' },
+  { id: '22222222-2222-2222-2222-222222222222', displayName: 'System Admin' },
+  { id: '33333333-3333-3333-3333-333333333333', displayName: 'Security Officer' },
+];
+
+const searchMentions = async (query: string): Promise<MentionSuggestion[]> => {
+  const q = query.toLowerCase();
+  return mockSuggestions.filter((s) => s.displayName.toLowerCase().includes(q));
+};
+
+const meta = {
+  title: 'Timeline/MentionEditor',
+  component: MentionEditor,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    onChange: fn(),
+    searchMentions,
+    placeholder: 'Write a comment… use @ to mention someone',
+  },
+} satisfies Meta<typeof MentionEditor>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithInitialBody: Story = {
+  args: {
+    initialBody: 'Thanks @[Jane Dupont](user:11111111-1111-1111-1111-111111111111), reviewing now.',
+  },
+};
+
+export const NoMentionLookup: Story = {
+  args: {
+    searchMentions: undefined,
+    placeholder: 'Plain comment, no mentions',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    initialBody: 'This editor is read-only.',
+    disabled: true,
+  },
+};

--- a/packages/@granit/react-ui-timeline/src/mention-editor.tsx
+++ b/packages/@granit/react-ui-timeline/src/mention-editor.tsx
@@ -1,0 +1,384 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
+
+import type { MentionSuggestion } from '@granit/timeline';
+import Mention from '@tiptap/extension-mention';
+import Placeholder from '@tiptap/extension-placeholder';
+import { EditorContent, ReactRenderer, useEditor, type Editor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import tippy, { type Instance, type Props as TippyProps } from 'tippy.js';
+
+import { cn } from '@granit/utils';
+
+import 'tippy.js/dist/tippy.css';
+
+// Same canonical wire format the backend's `MentionParser` consumes and
+// the timeline body renderer parses for `<Link>` chips:
+// `@[Display Name](user:<guid>)`.
+const MENTION_REGEX =
+  /@\[([^\]]+)\]\(user:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\)/g;
+
+interface MentionInlineNode {
+  readonly type: 'text' | 'mention';
+  readonly text?: string;
+  readonly attrs?: { readonly id: string; readonly label: string };
+}
+
+interface MentionParagraphNode {
+  readonly type: 'paragraph';
+  // TipTap's `Content` type requires mutable arrays; this doc is built locally
+  // and handed straight to useEditor, so the immutability would only block the
+  // call site without giving us a real guarantee.
+  content?: MentionInlineNode[];
+}
+
+interface MentionDoc {
+  readonly type: 'doc';
+  content: MentionParagraphNode[];
+}
+
+// Parse one logical line of markdown into ProseMirror inline nodes.
+// Plain segments become `text`; every `@[Name](user:guid)` match becomes
+// a `mention` atom. Everything outside the regex is preserved verbatim.
+function parseInline(line: string): MentionInlineNode[] {
+  const result: MentionInlineNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  MENTION_REGEX.lastIndex = 0;
+  while ((match = MENTION_REGEX.exec(line)) !== null) {
+    if (match.index > lastIndex) {
+      result.push({ type: 'text', text: line.slice(lastIndex, match.index) });
+    }
+    result.push({ type: 'mention', attrs: { id: match[2] ?? '', label: match[1] ?? '' } });
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < line.length) {
+    result.push({ type: 'text', text: line.slice(lastIndex) });
+  }
+  return result;
+}
+
+// Initial seed: turn the markdown body into a ProseMirror JSON doc the
+// editor can hydrate from. Each `\n` becomes a fresh paragraph; mentions
+// are materialised as atomic `mention` nodes so the editor treats them
+// as a single deletable chip.
+function markdownToDoc(markdown: string): MentionDoc {
+  if (!markdown) {
+    return { type: 'doc', content: [{ type: 'paragraph' }] };
+  }
+  const paragraphs = markdown.split('\n').map<MentionParagraphNode>((line) => {
+    const inline = parseInline(line);
+    return inline.length > 0 ? { type: 'paragraph', content: inline } : { type: 'paragraph' };
+  });
+  return { type: 'doc', content: paragraphs };
+}
+
+// Reverse pass: serialise the editor's current document back to the
+// markdown shape the backend expects. Mention chips re-emerge as
+// `@[label](user:id)` so the wire format is round-trip stable.
+function docToMarkdown(editor: Editor): string {
+  const json = editor.getJSON() as MentionDoc;
+  const lines: string[] = [];
+  for (const block of json.content ?? []) {
+    if (block.type !== 'paragraph') continue;
+    const parts: string[] = [];
+    for (const node of block.content ?? []) {
+      if (node.type === 'text') {
+        parts.push(node.text ?? '');
+      } else if (node.type === 'mention' && node.attrs) {
+        parts.push(`@[${node.attrs.label}](user:${node.attrs.id})`);
+      }
+    }
+    lines.push(parts.join(''));
+  }
+  return lines.join('\n');
+}
+
+interface MentionListItemRef {
+  readonly onKeyDown: (event: KeyboardEvent) => boolean;
+}
+
+interface MentionListProps {
+  readonly items: readonly MentionSuggestion[];
+  readonly command: (item: { id: string; label: string }) => void;
+}
+
+const MentionList = forwardRef<MentionListItemRef, MentionListProps>(function MentionList(
+  { items, command },
+  ref
+) {
+  // Track previous items via a state pair so we can reset the highlight
+  // on identity change without writing to a ref during render (lint
+  // forbids that) and without an effect (cascading renders).
+  const [prevItems, setPrevItems] = useState(items);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  if (prevItems !== items) {
+    setPrevItems(items);
+    setSelectedIndex(0);
+  }
+
+  const selectItem = (index: number) => {
+    const item = items[index];
+    if (item) command({ id: item.id, label: item.displayName });
+  };
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      onKeyDown: (event: KeyboardEvent): boolean => {
+        if (event.key === 'ArrowDown') {
+          setSelectedIndex((i) => (i + 1) % Math.max(items.length, 1));
+          return true;
+        }
+        if (event.key === 'ArrowUp') {
+          setSelectedIndex((i) => (i - 1 + items.length) % Math.max(items.length, 1));
+          return true;
+        }
+        if (event.key === 'Enter') {
+          selectItem(selectedIndex);
+          return true;
+        }
+        return false;
+      },
+    }),
+    // selectItem closes over the latest selectedIndex/items via state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [items, selectedIndex]
+  );
+
+  if (items.length === 0) return null;
+
+  // Each row is a real <button> so it's natively interactive (the
+  // browser routes Enter/Space to the click handler and a11y tooling
+  // recognises it without ARIA roles). The TipTap suggestion plugin
+  // still owns arrow-key navigation while focus stays in the editor
+  // (see `onKeyDown` plumbing in the suggestion render() above); the
+  // click path is just the pointer fallback.
+  return (
+    <ul
+      data-slot="mention-editor"
+      data-testid="mention-editor-listbox"
+      className="max-h-60 w-64 overflow-auto rounded-md border border-border bg-popover py-1 text-sm text-popover-foreground shadow-md"
+    >
+      {items.map((item, index) => {
+        const active = index === selectedIndex;
+        return (
+          <li key={item.id}>
+            <button
+              type="button"
+              data-testid="mention-editor-option"
+              data-active={active ? '' : undefined}
+              aria-pressed={active}
+              // `mousedown` preventDefault keeps focus in the editor —
+              // letting it shift to the popup would tear down the
+              // suggestion plugin before the click completes.
+              // The actual selection runs on `click` so the user's
+              // mouse-up still has somewhere to land.
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={(e) => {
+                e.preventDefault();
+                selectItem(index);
+              }}
+              onMouseEnter={() => setSelectedIndex(index)}
+              className={cn(
+                'block w-full cursor-pointer truncate px-3 py-1.5 text-left',
+                active ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/60'
+              )}
+            >
+              {item.displayName}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+});
+
+export interface MentionEditorProps {
+  /** Markdown body — only consumed on mount. */
+  readonly initialBody?: string;
+  /** Fires on every keystroke with the markdown-serialised body. */
+  readonly onChange: (markdown: string) => void;
+  /** Async source for `@`-mention suggestions. Disabling = no autocomplete. */
+  readonly searchMentions?: (query: string) => Promise<MentionSuggestion[]>;
+  readonly placeholder?: string;
+  readonly disabled?: boolean;
+  /** Optional Enter handler (Shift+Enter still adds a paragraph break). */
+  readonly onSubmit?: () => void;
+  readonly className?: string;
+}
+
+// TipTap-backed composer surface. Renders mentions as atomic chips
+// (deletable as one unit) and gets a Tippy-driven suggestion popup
+// anchored at the caret. Output is round-trip-stable with the
+// `@[Name](user:guid)` markdown the backend stores.
+export function MentionEditor({
+  initialBody = '',
+  onChange,
+  searchMentions,
+  placeholder,
+  disabled = false,
+  onSubmit,
+  className,
+}: MentionEditorProps) {
+  // Tracks whether the mention suggestion popup is currently mounted.
+  // We can't query the DOM reliably (Tippy keeps a hidden root between
+  // shows, and the listbox is empty while items are loading), so we
+  // hook the suggestion lifecycle directly.
+  const popupOpenRef = useRef(false);
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        // Strip features the timeline body doesn't carry over the wire:
+        // anything beyond text + mention + paragraph breaks would silently
+        // be lost during markdown serialisation.
+        bold: false,
+        italic: false,
+        strike: false,
+        code: false,
+        codeBlock: false,
+        heading: false,
+        bulletList: false,
+        orderedList: false,
+        listItem: false,
+        blockquote: false,
+        horizontalRule: false,
+      }),
+      Placeholder.configure({ placeholder: placeholder ?? '' }),
+      Mention.configure({
+        HTMLAttributes: {
+          class:
+            'inline-flex items-center rounded px-1 py-0.5 font-medium text-primary bg-primary/10',
+          'data-testid': 'mention-editor-chip',
+        },
+        renderText({ node }) {
+          // What we copy/paste; the on-screen chip uses HTMLAttributes.
+          return `@${node.attrs.label}`;
+        },
+        suggestion: {
+          char: '@',
+          // Empty query is forwarded so the popup opens immediately on `@`.
+          items: async ({ query }) => {
+            if (!searchMentions) return [];
+            return await searchMentions(query);
+          },
+          render: () => {
+            let component: ReactRenderer<MentionListItemRef, MentionListProps>;
+            let popup: Instance<TippyProps>[];
+
+            return {
+              onStart: (props) => {
+                popupOpenRef.current = true;
+                component = new ReactRenderer(MentionList, {
+                  props: {
+                    items: props.items as readonly MentionSuggestion[],
+                    command: props.command,
+                  },
+                  editor: props.editor,
+                });
+                if (!props.clientRect) return;
+                popup = tippy('body', {
+                  getReferenceClientRect: props.clientRect as () => DOMRect,
+                  appendTo: () => document.body,
+                  content: component.element,
+                  showOnCreate: true,
+                  interactive: true,
+                  trigger: 'manual',
+                  placement: 'bottom-start',
+                  // Strip Tippy's default theme — we ship our own styling
+                  // on the listbox so it inherits design tokens.
+                  arrow: false,
+                  offset: [0, 4],
+                });
+              },
+              onUpdate(props) {
+                component.updateProps({
+                  items: props.items as readonly MentionSuggestion[],
+                  command: props.command,
+                });
+                // Guard: `onUpdate` can race with `onExit` (e.g. when
+                // the user clears the trigger char by deleting); calling
+                // `setProps` on a destroyed Tippy instance prints a
+                // "memory leak" warning in dev.
+                if (!props.clientRect) return;
+                const instance = popup?.[0];
+                if (!instance || instance.state.isDestroyed) return;
+                instance.setProps({
+                  getReferenceClientRect: props.clientRect as () => DOMRect,
+                });
+              },
+              onKeyDown(props) {
+                if (props.event.key === 'Escape') {
+                  const instance = popup?.[0];
+                  if (instance && !instance.state.isDestroyed) instance.hide();
+                  return true;
+                }
+                return component.ref?.onKeyDown(props.event) ?? false;
+              },
+              onExit() {
+                popupOpenRef.current = false;
+                const instance = popup?.[0];
+                if (instance && !instance.state.isDestroyed) instance.destroy();
+                component.destroy();
+              },
+            };
+          },
+        },
+      }),
+    ],
+    content: markdownToDoc(initialBody),
+    editable: !disabled,
+    // Defer creation under React 19 StrictMode (double-invocation would
+    // otherwise leave a destroyed editor instance behind).
+    immediatelyRender: false,
+    onUpdate: ({ editor: ed }) => {
+      onChange(docToMarkdown(ed));
+    },
+  });
+
+  useEffect(() => {
+    if (editor && !editor.isDestroyed) editor.setEditable(!disabled);
+  }, [editor, disabled]);
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey && onSubmit) {
+      // While the mention popup is open, Enter belongs to it (selects
+      // the highlighted suggestion via the plugin's own keydown). We
+      // stopPropagation as well so the outer form's submit handler
+      // never sees a synthetic Enter on a focused button or input.
+      if (popupOpenRef.current) {
+        event.stopPropagation();
+        return;
+      }
+      event.preventDefault();
+      onSubmit();
+    }
+  };
+
+  return (
+    <EditorContent
+      editor={editor}
+      onKeyDown={handleKeyDown}
+      data-testid="mention-editor"
+      className={cn(
+        'min-h-[5rem] w-full rounded-md border-0 bg-transparent px-3 py-2 text-sm',
+        // Style the editable surface itself (TipTap renders into a child div).
+        '[&_.ProseMirror]:min-h-[4rem] [&_.ProseMirror]:outline-none',
+        // Placeholder text (the empty-doc decoration injected by the extension).
+        '[&_.ProseMirror_p.is-editor-empty:first-child]:before:pointer-events-none',
+        '[&_.ProseMirror_p.is-editor-empty:first-child]:before:float-left',
+        '[&_.ProseMirror_p.is-editor-empty:first-child]:before:h-0',
+        '[&_.ProseMirror_p.is-editor-empty:first-child]:before:text-muted-foreground',
+        '[&_.ProseMirror_p.is-editor-empty:first-child]:before:content-[attr(data-placeholder)]',
+        className
+      )}
+    />
+  );
+}

--- a/packages/@granit/react-ui-timeline/src/reaction-strip.stories.tsx
+++ b/packages/@granit/react-ui-timeline/src/reaction-strip.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import { toReactionEmoji } from '@granit/timeline';
+import { toEntityId } from '@granit/types';
+
+import { ReactionStrip } from './reaction-strip';
+
+import type { ReactionMap, TimelineEntryId } from '@granit/timeline';
+
+const entryId = toEntityId<'TimelineStreamEntryResponse'>('tl-1') as TimelineEntryId;
+
+const THUMBS_UP = toReactionEmoji('👍');
+const PARTY = toReactionEmoji('🎉');
+const HEART = toReactionEmoji('❤️');
+
+const reactionsWithMix: ReactionMap = {
+  [THUMBS_UP]: { count: 3, displayEmoji: THUMBS_UP, byCurrentUser: true },
+  [PARTY]: { count: 1, displayEmoji: PARTY, byCurrentUser: false },
+  [HEART]: { count: 2, displayEmoji: HEART, byCurrentUser: false },
+};
+
+const reactionsSingle: ReactionMap = {
+  [THUMBS_UP]: { count: 1, displayEmoji: THUMBS_UP, byCurrentUser: true },
+};
+
+const meta = {
+  title: 'Timeline/ReactionStrip',
+  component: ReactionStrip,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    entryId,
+    onToggle: fn(),
+  },
+} satisfies Meta<typeof ReactionStrip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Interactive — multiple reactions',
+  args: {
+    reactions: reactionsWithMix,
+  },
+};
+
+export const SingleReaction: Story = {
+  name: 'Interactive — single reaction',
+  args: {
+    reactions: reactionsSingle,
+  },
+};
+
+export const NoReactionsInteractive: Story = {
+  name: 'Interactive — no reactions yet (shows picker only)',
+  args: {
+    reactions: {},
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Read-only — multiple reactions',
+  args: {
+    reactions: reactionsWithMix,
+    onToggle: undefined,
+  },
+};
+
+export const ReadOnlyEmpty: Story = {
+  name: 'Read-only — empty (renders nothing)',
+  args: {
+    reactions: {},
+    onToggle: undefined,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When read-only and there are no reactions, the component returns null and renders nothing.',
+      },
+    },
+  },
+};

--- a/packages/@granit/react-ui-timeline/src/reaction-strip.tsx
+++ b/packages/@granit/react-ui-timeline/src/reaction-strip.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+
+import { useTranslation } from '@granit/react-localization';
+import { Popover, PopoverContent, PopoverTrigger } from '@granit/react-ui';
+import {
+  parseReactionEmoji,
+  type ReactionAggregateResponse,
+  type ReactionEmoji,
+  type ReactionMap,
+  type TimelineEntryId,
+} from '@granit/timeline';
+import { SmilePlus } from 'lucide-react';
+
+import { cn } from '@granit/utils';
+
+import { EmojiPicker } from './emoji-picker';
+import { TwemojiImage } from './twemoji-image';
+
+export interface ReactionStripProps {
+  readonly entryId: TimelineEntryId;
+  readonly reactions: ReactionMap | undefined;
+  /** Toggle handler. When undefined, the strip renders read-only (no picker, no chip clicks). */
+  readonly onToggle?: (args: { entryId: TimelineEntryId; emoji: ReactionEmoji }) => void;
+  readonly className?: string;
+}
+
+// Teams / Slack-style reaction strip:
+//  - chips render only emojis present in `entry.reactions` (count > 0),
+//    keyed by literal Unicode grapheme (👍, 👍🏽, 👨‍👩‍👧, …),
+//  - glyphs use `<TwemojiImage>` for cross-OS-consistent rendering,
+//  - a discrete `<SmilePlus />` button opens an `<EmojiPicker>` popover
+//    backed by emoji-mart (full Unicode catalog, lazy-loaded),
+//  - read-only viewers (no `onToggle`) see no picker and chips are
+//    non-clickable; the whole strip is hidden when reactions are empty.
+export function ReactionStrip({ entryId, reactions, onToggle, className }: ReactionStripProps) {
+  const { t } = useTranslation();
+  const [pickerOpen, setPickerOpen] = React.useState(false);
+  const isInteractive = onToggle != null;
+
+  const present = Object.entries(reactions ?? {}) as readonly [string, ReactionAggregateResponse][];
+
+  if (present.length === 0 && !isInteractive) return null;
+
+  const handlePick = (native: string) => {
+    setPickerOpen(false);
+    const branded = parseReactionEmoji(native);
+    if (!branded || !onToggle) return;
+    onToggle({ entryId, emoji: branded });
+  };
+
+  return (
+    <div
+      data-slot="reaction-strip"
+      data-granit-reaction-strip=""
+      data-entry-id={entryId}
+      className={cn('flex flex-wrap items-center gap-1', className)}
+    >
+      {present.map(([emoji, aggregate]) => {
+        const hasReacted = aggregate.byCurrentUser;
+        return (
+          <button
+            key={emoji}
+            type="button"
+            data-emoji={emoji}
+            data-has-reacted={hasReacted ? '' : undefined}
+            aria-pressed={hasReacted}
+            aria-label={t('Timeline.Reaction.AriaLabel', {
+              defaultValue: `React with {{emoji}}`,
+              emoji: aggregate.displayEmoji,
+            })}
+            disabled={!isInteractive}
+            onClick={
+              isInteractive
+                ? () => {
+                    const branded = parseReactionEmoji(emoji);
+                    if (branded) onToggle({ entryId, emoji: branded });
+                  }
+                : undefined
+            }
+            className={cn(
+              'inline-flex h-6 items-center gap-1 rounded-full border px-2 text-xs transition-colors',
+              hasReacted
+                ? 'border-primary/40 bg-primary/10 text-foreground'
+                : 'border-border bg-muted/40 text-muted-foreground hover:bg-muted',
+              !isInteractive && 'cursor-default opacity-80'
+            )}
+          >
+            <TwemojiImage emoji={aggregate.displayEmoji} size={14} />
+            <span className="font-medium tabular-nums">{aggregate.count}</span>
+          </button>
+        );
+      })}
+
+      {isInteractive && (
+        <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              data-granit-reaction-strip-picker=""
+              aria-label={t('Timeline.AddReaction', { defaultValue: 'Add reaction' })}
+              title={t('Timeline.AddReaction', { defaultValue: 'Add reaction' })}
+              className="inline-flex h-6 w-6 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <SmilePlus className="h-3.5 w-3.5" aria-hidden />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            side="top"
+            align="start"
+            className="w-auto border-0 bg-transparent p-0 shadow-none"
+          >
+            <EmojiPicker onSelect={handlePick} onClose={() => setPickerOpen(false)} />
+          </PopoverContent>
+        </Popover>
+      )}
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-timeline/src/timeline-composer.stories.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-composer.stories.tsx
@@ -1,0 +1,62 @@
+import type { MentionSuggestion, PostTimelineEntryRequest } from '@granit/timeline';
+import { TimelineEntryType } from '@granit/timeline';
+import { fn } from 'storybook/test';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { TimelineComposer } from './timeline-composer';
+
+const mockSuggestions: MentionSuggestion[] = [
+  { id: '11111111-1111-1111-1111-111111111111', displayName: 'Jane Dupont' },
+  { id: '22222222-2222-2222-2222-222222222222', displayName: 'System Admin' },
+];
+
+const searchMentions = async (query: string): Promise<MentionSuggestion[]> => {
+  const q = query.toLowerCase();
+  return mockSuggestions.filter((s) => s.displayName.toLowerCase().includes(q));
+};
+
+const onSubmit = (request: PostTimelineEntryRequest): Promise<void> => {
+  fn()(request);
+  return Promise.resolve();
+};
+
+const meta = {
+  title: 'Timeline/TimelineComposer',
+  component: TimelineComposer,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    onSubmit,
+    searchMentions,
+  },
+} satisfies Meta<typeof TimelineComposer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const SingleEntryType: Story = {
+  args: {
+    entryTypes: [TimelineEntryType.Comment],
+    placeholder: 'Add a comment…',
+  },
+};
+
+export const InternalNotePreselected: Story = {
+  args: {
+    entryTypes: [TimelineEntryType.Comment, TimelineEntryType.InternalNote],
+    initialEntryType: TimelineEntryType.InternalNote,
+  },
+};
+
+export const EditMode: Story = {
+  args: {
+    initialBody: 'An existing note being edited.',
+    hideEntryTypeSelector: true,
+    submitLabel: 'Save',
+  },
+};

--- a/packages/@granit/react-ui-timeline/src/timeline-composer.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-composer.tsx
@@ -1,0 +1,188 @@
+import type { FormEvent } from 'react';
+import { useCallback, useState } from 'react';
+
+import { useTranslation } from '@granit/react-localization';
+import { Button } from '@granit/react-ui';
+import { TimelineEntryType } from '@granit/timeline';
+import type { PostTimelineEntryRequest, MentionSuggestion } from '@granit/timeline';
+import { Lock, MessageSquare } from 'lucide-react';
+
+import { cn } from '@granit/utils';
+
+import { MentionEditor } from './mention-editor';
+
+export interface TimelineComposerProps {
+  onSubmit: (request: PostTimelineEntryRequest) => Promise<void>;
+  parentEntryId?: string;
+  entryTypes?: TimelineEntryType[];
+  searchMentions?: (query: string) => Promise<MentionSuggestion[]>;
+  placeholder?: string;
+  submitLabel?: string;
+  /**
+   * Pre-fill the editor — used by edit flows that re-mount the composer
+   * with an existing body. Only consumed on mount; subsequent prop
+   * changes are ignored to avoid clobbering the user's keystrokes.
+   */
+  initialBody?: string;
+  /**
+   * Pre-select the entry type. Defaults to `entryTypes[0]`. Edit flows
+   * pass the original entry's type so the selector reflects what the
+   * user is editing (e.g. "Internal note" stays selected).
+   */
+  initialEntryType?: TimelineEntryType;
+  /**
+   * Hide the entry-type selector regardless of `entryTypes` length.
+   * Edit flows don't let the user reclassify an entry.
+   */
+  hideEntryTypeSelector?: boolean;
+  className?: string;
+}
+
+function pickEntryTypeLabel(
+  type: (typeof TimelineEntryType)[keyof typeof TimelineEntryType],
+  t: ReturnType<typeof useTranslation>['t']
+): string {
+  if (type === TimelineEntryType.InternalNote) {
+    return t('Components.Timeline.Composer.InternalNote');
+  }
+  if (type === TimelineEntryType.SystemLog) {
+    return t('Components.Timeline.Composer.SystemLog');
+  }
+  return t('Components.Timeline.Composer.Comment');
+}
+
+export function TimelineComposer({
+  onSubmit,
+  parentEntryId,
+  entryTypes = [TimelineEntryType.Comment, TimelineEntryType.InternalNote],
+  searchMentions,
+  placeholder = 'Write a comment…',
+  submitLabel = 'Send',
+  initialBody = '',
+  initialEntryType,
+  hideEntryTypeSelector = false,
+  className,
+}: Readonly<TimelineComposerProps>) {
+  const { t } = useTranslation();
+  const [body, setBody] = useState(initialBody);
+  // Resilience: if `initialEntryType` isn't in the allowed list (happens
+  // when backend's `TimelineStreamEntryType` wire enum diverges from
+  // domain `TimelineEntryType` — InternalNote arrives as `1` which
+  // would map to SystemLog on the frontend), fall back to the first
+  // type so the radiogroup always has a selected option. Tracked
+  // upstream in granit-dotnet.
+  const [entryType, setEntryType] = useState<TimelineEntryType>(
+    initialEntryType !== undefined && entryTypes.includes(initialEntryType)
+      ? initialEntryType
+      : entryTypes[0]!
+  );
+  const [submitting, setSubmitting] = useState(false);
+
+  const submitBody = useCallback(async () => {
+    const trimmed = body.trim();
+    if (!trimmed || submitting) return;
+
+    setSubmitting(true);
+    try {
+      await onSubmit({
+        entryType,
+        body: trimmed,
+        parentEntryId,
+      });
+      setBody('');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [body, entryType, parentEntryId, submitting, onSubmit]);
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      await submitBody();
+    },
+    [submitBody]
+  );
+
+  const isInternalNote = entryType === TimelineEntryType.InternalNote;
+
+  return (
+    <form
+      data-slot="timeline-composer"
+      onSubmit={(e) => {
+        handleSubmit(e).catch(() => {});
+      }}
+      className={cn(
+        'rounded-lg border border-border bg-card shadow-sm transition-colors',
+        'focus-within:border-ring focus-within:ring-1 focus-within:ring-ring/30',
+        isInternalNote && 'border-primary/30 bg-primary/5',
+        className
+      )}
+      data-testid="timeline-composer"
+    >
+      <MentionEditor
+        initialBody={initialBody}
+        onChange={setBody}
+        searchMentions={searchMentions}
+        placeholder={placeholder}
+        disabled={submitting}
+        onSubmit={() => {
+          submitBody().catch(() => {});
+        }}
+      />
+
+      <div
+        className="flex flex-wrap items-center justify-between gap-2 border-t border-border/60 px-2 py-1.5"
+        data-testid="timeline-composer-footer"
+      >
+        {!hideEntryTypeSelector && entryTypes.length > 1 ? (
+          <div
+            role="radiogroup"
+            aria-label={t('Components.Timeline.Composer.EntryType')}
+            className="inline-flex items-center gap-0.5 rounded-md bg-muted/50 p-0.5"
+            data-testid="timeline-composer-type-selector"
+          >
+            {entryTypes.map((type) => {
+              const active = entryType === type;
+              const Icon = type === TimelineEntryType.InternalNote ? Lock : MessageSquare;
+              const label = pickEntryTypeLabel(type, t);
+              return (
+                <button
+                  key={type}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  onClick={() => setEntryType(type)}
+                  className={cn(
+                    'inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium transition-colors',
+                    // Bumped active styling: `bg-background` alone barely
+                    // shows over the `bg-muted/50` container — especially
+                    // in dark mode where both tokens collapse onto similar
+                    // shades. A primary-tinted ring + bg makes the
+                    // selected pill unambiguous in both themes.
+                    active
+                      ? 'bg-background text-foreground shadow-sm ring-1 ring-primary/40'
+                      : 'text-muted-foreground hover:text-foreground'
+                  )}
+                >
+                  <Icon className="h-3.5 w-3.5" aria-hidden />
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <div />
+        )}
+
+        <Button
+          type="submit"
+          size="sm"
+          disabled={!body.trim() || submitting}
+          data-testid="timeline-composer-submit"
+        >
+          {submitting ? t('Components.Timeline.Composer.Sending') : submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/packages/@granit/react-ui-timeline/src/timeline-entry.stories.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-entry.stories.tsx
@@ -1,0 +1,180 @@
+import { TimelineProvider } from '@granit/react-timeline';
+import { createTimelineHandlers } from '@granit/react-timeline/testing';
+import { TimelineEntryType } from '@granit/timeline';
+import type { ReactionEmoji, TimelineStreamEntryResponse } from '@granit/timeline';
+import { toEntityId, toISODateString } from '@granit/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fn } from 'storybook/test';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { createApiClient } from '@granit/api-client';
+
+import { TimelineStreamEntryResponse as TimelineEntryComponent } from './timeline-entry';
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const storyTimelineConfig = { client: createApiClient({ baseURL: '' }), basePath: '/api/v1/timeline' };
+
+const commentEntry: TimelineStreamEntryResponse = {
+  id: toEntityId<'TimelineStreamEntryResponse'>('tl-1'),
+  entryType: TimelineEntryType.Comment,
+  body: 'Account created and initial roles assigned. Please review and confirm.',
+  authorId: toEntityId<'User'>('admin-001'),
+  authorName: 'System Admin',
+  parentEntryId: null,
+  occurredAt: toISODateString('2026-05-10T09:30:00Z'),
+  attachments: [],
+};
+
+const internalNoteEntry: TimelineStreamEntryResponse = {
+  id: toEntityId<'TimelineStreamEntryResponse'>('tl-2'),
+  entryType: TimelineEntryType.InternalNote,
+  body: 'Reviewed user access — confirmed granit-showcase-admin role required for project onboarding.',
+  authorId: toEntityId<'User'>('admin-002'),
+  authorName: 'Security Officer',
+  parentEntryId: null,
+  occurredAt: toISODateString('2026-06-01T14:15:00Z'),
+  attachments: [],
+};
+
+const systemLogEntry: TimelineStreamEntryResponse = {
+  id: toEntityId<'TimelineStreamEntryResponse'>('tl-3'),
+  entryType: TimelineEntryType.SystemLog,
+  body: 'Role granit-showcase-readonly removed by admin.',
+  authorId: toEntityId<'User'>('system'),
+  authorName: 'System',
+  parentEntryId: null,
+  occurredAt: toISODateString('2026-06-05T11:00:00Z'),
+  attachments: [],
+};
+
+const editedEntry: TimelineStreamEntryResponse = {
+  id: toEntityId<'TimelineStreamEntryResponse'>('tl-4'),
+  entryType: TimelineEntryType.Comment,
+  body: 'This comment was updated after the initial submission.',
+  authorId: toEntityId<'User'>('admin-001'),
+  authorName: 'System Admin',
+  parentEntryId: null,
+  occurredAt: toISODateString('2026-05-20T10:00:00Z'),
+  editedAt: toISODateString('2026-05-20T10:45:00Z'),
+  attachments: [],
+};
+
+const entryWithReactions: TimelineStreamEntryResponse = {
+  id: toEntityId<'TimelineStreamEntryResponse'>('tl-5'),
+  entryType: TimelineEntryType.Comment,
+  body: 'Great progress on this feature! The implementation looks solid.',
+  authorId: toEntityId<'User'>('admin-003'),
+  authorName: 'Jane Dupont',
+  parentEntryId: null,
+  occurredAt: toISODateString('2026-06-07T08:00:00Z'),
+  attachments: [],
+  reactions: {
+    ['👍' as ReactionEmoji]: { count: 3, byCurrentUser: true, displayEmoji: '👍' },
+    ['🎉' as ReactionEmoji]: { count: 1, byCurrentUser: false, displayEmoji: '🎉' },
+  },
+};
+
+const meta: Meta<typeof TimelineEntryComponent> = {
+  title: 'Timeline/TimelineEntry',
+  component: TimelineEntryComponent,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+  },
+  argTypes: {
+    depth: { control: { type: 'range', min: 0, max: 4, step: 1 } },
+    canReact: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TimelineEntryComponent>;
+
+export const Default: Story = {
+  args: {
+    entry: commentEntry,
+    onReply: fn(),
+    onEdit: fn(),
+    onDelete: fn(),
+  },
+};
+
+export const InternalNote: Story = {
+  args: {
+    entry: internalNoteEntry,
+    onReply: fn(),
+    onDelete: fn(),
+  },
+};
+
+export const SystemLog: Story = {
+  args: {
+    entry: systemLogEntry,
+  },
+};
+
+export const Edited: Story = {
+  args: {
+    entry: editedEntry,
+    onReply: fn(),
+    onEdit: fn(),
+    onDelete: fn(),
+  },
+};
+
+export const WithReactions: Story = {
+  args: {
+    entry: entryWithReactions,
+    onReply: fn(),
+  },
+};
+
+export const NestedReply: Story = {
+  args: {
+    entry: {
+      ...commentEntry,
+      id: toEntityId<'TimelineStreamEntryResponse'>('tl-nested'),
+      body: 'This is a nested reply to the original comment.',
+      authorName: 'Jane Dupont',
+      authorId: toEntityId<'User'>('user-042'),
+    },
+    depth: 2,
+    onReply: fn(),
+    onDelete: fn(),
+  },
+};
+
+export const InteractiveReactions: Story = {
+  parameters: {
+    msw: {
+      handlers: createTimelineHandlers(),
+    },
+  },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <TimelineProvider config={storyTimelineConfig}>
+          <Story />
+        </TimelineProvider>
+      </QueryClientProvider>
+    ),
+  ],
+  args: {
+    entry: entryWithReactions,
+    entityType: 'User',
+    entityId: 'user-001',
+    canReact: true,
+    onReply: fn(),
+    onReactionToggled: fn(),
+  },
+};
+
+export const ReadOnlyNoActions: Story = {
+  args: {
+    entry: commentEntry,
+  },
+};

--- a/packages/@granit/react-ui-timeline/src/timeline-entry.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-entry.tsx
@@ -1,0 +1,300 @@
+import { useCallback, useMemo } from 'react';
+
+import { useDateFormatter, useTranslation } from '@granit/react-localization';
+import { useAnchorEntry, useToggleReaction } from '@granit/react-timeline';
+import { Button, Avatar, AvatarFallback } from '@granit/react-ui';
+import { TimelineEntryOrigin, TimelineEntryType } from '@granit/timeline';
+import type {
+  ReactionEmoji,
+  ReactionToggleResponse,
+  TimelineStreamEntryResponse,
+  TimelineEntryId,
+} from '@granit/timeline';
+
+import { cn } from '@granit/utils';
+
+import { ReactionStrip } from './reaction-strip';
+
+export interface TimelineEntryProps {
+  entry: TimelineStreamEntryResponse;
+  /**
+   * Surrounding stream's entity context. Required for reactions
+   * (`useToggleReaction` scopes its optimistic patches by stream).
+   * Optional only to keep legacy non-reaction usages compatible.
+   */
+  entityType?: string;
+  entityId?: string;
+  /**
+   * Whether the viewer holds the `Timeline.Reactions.React` permission. Hosts read
+   * this from their auth provider and pass it down — keeps `TimelineStreamEntryResponse`
+   * QueryClient-free so it can be unit-tested without mounting the
+   * authorization stack. Defaults to `false` (read-only reactions).
+   */
+  canReact?: boolean;
+  depth?: number;
+  onReply?: (entryId: string) => void;
+  onDelete?: (entryId: string) => void;
+  /**
+   * Invoked when the user clicks "Edit". When omitted, the action is
+   * not rendered. Hosts compute eligibility (native origin + Comment
+   * or InternalNote + authorship + within edit window) and only pass
+   * this callback for entries the current user can actually edit. The
+   * callback receives the current body so the host can pre-fill its
+   * editor; the host owns the form lifecycle.
+   */
+  onEdit?: (
+    entryId: TimelineEntryId,
+    currentBody: string,
+    entryType: TimelineStreamEntryResponse['entryType']
+  ) => void;
+  /**
+   * Invoked with the server's authoritative result after a reaction
+   * toggle resolves. Hosts wire this to `useTimeline().patchEntry`
+   * (via {@link applyToggleResult}) so only the affected entry's
+   * `reactions` map updates — no full stream refetch. `useTimeline`
+   * keeps entries in `useState` (not React Query), so the toggle
+   * hook's React Query cache patches don't reach this consumer.
+   */
+  onReactionToggled?: (entryId: TimelineEntryId, result: ReactionToggleResponse) => void;
+  renderBody?: (body: string) => React.ReactNode;
+  className?: string;
+}
+
+const ENTRY_TYPE_LABELS: Record<TimelineEntryType, string> = {
+  [TimelineEntryType.Comment]: 'comment',
+  [TimelineEntryType.InternalNote]: 'internal-note',
+  [TimelineEntryType.SystemLog]: 'system-log',
+};
+
+/* Closed palette of semantic tokens used for avatar tinting. CLAUDE.md
+ * forbids raw color utilities outside `components/ui/`, so we pick from
+ * four neutral-friendly slots and hash the authorId into one of them
+ * for a deterministic but varied result. */
+const AVATAR_PALETTE = [
+  'bg-primary/10 text-primary',
+  'bg-secondary text-secondary-foreground',
+  'bg-accent text-accent-foreground',
+  'bg-muted text-muted-foreground',
+] as const;
+
+function getInitials(name: string | null | undefined): string {
+  if (!name) return '?';
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0]!.charAt(0).toUpperCase();
+  const last = parts.at(-1) ?? '';
+  return (parts[0]!.charAt(0) + last.charAt(0)).toUpperCase();
+}
+
+function getAvatarTintClass(authorId: string | null | undefined): string {
+  if (!authorId) return AVATAR_PALETTE[3];
+  let hash = 0;
+  for (let i = 0; i < authorId.length; i++) {
+    hash = Math.trunc(hash * 31 + (authorId.codePointAt(i) ?? 0));
+  }
+  return AVATAR_PALETTE[Math.abs(hash) % AVATAR_PALETTE.length]!;
+}
+
+export function TimelineStreamEntryResponse({
+  entry,
+  entityType,
+  entityId,
+  canReact = false,
+  depth = 0,
+  onReply,
+  onDelete,
+  onEdit,
+  onReactionToggled,
+  renderBody,
+  className,
+}: Readonly<TimelineEntryProps>) {
+  const { formatDateTime, formatTimeAgo } = useDateFormatter();
+  const { t } = useTranslation();
+  const reactionsEnabled = canReact && Boolean(entityType && entityId);
+  const handleReply = useCallback(() => {
+    onReply?.(entry.id);
+  }, [onReply, entry.id]);
+
+  const handleDelete = useCallback(() => {
+    onDelete?.(entry.id);
+  }, [onDelete, entry.id]);
+
+  const handleEdit = useCallback(() => {
+    onEdit?.(entry.id, entry.body, entry.entryType);
+  }, [onEdit, entry.id, entry.body, entry.entryType]);
+
+  const entryTypeClass = ENTRY_TYPE_LABELS[entry.entryType] ?? 'unknown';
+  const isSystemLog = entry.entryType === TimelineEntryType.SystemLog;
+  const initials = useMemo(() => getInitials(entry.authorName), [entry.authorName]);
+  const avatarTint = useMemo(() => getAvatarTintClass(entry.authorId), [entry.authorId]);
+
+  return (
+    <article
+      className={cn('flex gap-3', className)}
+      data-testid="timeline-entry"
+      data-entry-type={entryTypeClass}
+      data-depth={depth}
+      style={depth > 0 ? { marginLeft: `${depth * 24}px` } : undefined}
+      aria-label={`${entryTypeClass} by ${entry.authorName}`}
+    >
+      <Avatar size="sm" aria-hidden="true" data-testid="timeline-entry-avatar">
+        <AvatarFallback className={cn('text-xs font-semibold', avatarTint)}>
+          {initials}
+        </AvatarFallback>
+      </Avatar>
+
+      <div className="min-w-0 flex-1">
+        <header
+          data-testid="timeline-entry-header"
+          className="flex flex-wrap items-baseline gap-x-2 text-sm"
+        >
+          <span data-testid="timeline-entry-author" className="font-medium text-foreground">
+            {entry.authorName ?? 'System'}
+          </span>
+          <time
+            dateTime={entry.occurredAt}
+            title={formatDateTime(entry.occurredAt)}
+            data-testid="timeline-entry-time"
+            className="text-xs text-muted-foreground"
+          >
+            {formatTimeAgo(entry.occurredAt)}
+          </time>
+          {entry.editedAt ? (
+            <span
+              data-testid="timeline-entry-edited-badge"
+              title={`${t('Timeline.Edited', { defaultValue: 'Edited' })}: ${formatDateTime(entry.editedAt)}`}
+              className="text-xs italic text-muted-foreground"
+            >
+              ({t('Timeline.EditedShort', { defaultValue: 'edited' })})
+            </span>
+          ) : null}
+        </header>
+
+        <div data-testid="timeline-entry-body" className="mt-1 text-sm text-foreground">
+          {renderBody ? renderBody(entry.body) : entry.body}
+        </div>
+
+        {!isSystemLog &&
+          (reactionsEnabled && entityType && entityId ? (
+            <InteractiveReactionBar
+              entry={entry}
+              entityType={entityType}
+              entityId={entityId}
+              onToggled={onReactionToggled}
+            />
+          ) : (
+            <ReactionStrip
+              entryId={entry.id}
+              reactions={entry.reactions ?? undefined}
+              className="mt-1"
+            />
+          ))}
+
+        {!isSystemLog && (
+          <footer data-testid="timeline-entry-actions" className="mt-1 flex items-center gap-1">
+            {onReply && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleReply}
+                data-testid="timeline-reply-btn"
+              >
+                {t('Timeline.Reply', { defaultValue: 'Reply' })}
+              </Button>
+            )}
+            {onEdit && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleEdit}
+                data-testid="timeline-edit-btn"
+              >
+                {t('Timeline.Edit', { defaultValue: 'Edit' })}
+              </Button>
+            )}
+            {onDelete && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleDelete}
+                data-testid="timeline-delete-btn"
+              >
+                {t('Timeline.Delete', { defaultValue: 'Delete' })}
+              </Button>
+            )}
+          </footer>
+        )}
+      </div>
+    </article>
+  );
+}
+
+// Sub-component that owns the `useToggleReaction` hook (and thus the
+// `useMutation` → `useQueryClient` chain). Mounting it conditionally
+// keeps the parent `<TimelineStreamEntryResponse>` mountable without a
+// `<QueryClientProvider>` for any non-reacting scenario (read-only
+// users, unit tests, stories without auth wiring).
+interface InteractiveReactionBarProps {
+  readonly entry: TimelineStreamEntryResponse;
+  readonly entityType: string;
+  readonly entityId: string;
+  readonly onToggled?: (entryId: TimelineEntryId, result: ReactionToggleResponse) => void;
+}
+
+function InteractiveReactionBar({
+  entry,
+  entityType,
+  entityId,
+  onToggled,
+}: InteractiveReactionBarProps) {
+  const toggleReaction = useToggleReaction();
+  const anchorEntry = useAnchorEntry();
+  const needsAnchor =
+    (entry.origin ?? TimelineEntryOrigin.Native) === TimelineEntryOrigin.External &&
+    typeof entry.sourceKey === 'string' &&
+    entry.sourceKey.length > 0 &&
+    typeof entry.sourceId === 'string' &&
+    entry.sourceId.length > 0;
+
+  const handleToggle = useCallback(
+    ({ entryId, emoji }: { entryId: TimelineEntryId; emoji: ReactionEmoji }) => {
+      // For external-origin entries the reaction endpoint only accepts
+      // the native shadow id, so we materialise (or recover) it first
+      // via the deterministic v5 anchor — idempotent, repeated clicks
+      // converge on the same id. The local cache is patched against
+      // the *original* (projected) entryId so the visible row updates;
+      // a subsequent stream refresh will swap the id to the shadow.
+      const cascade = async () => {
+        const sourceKey = entry.sourceKey;
+        const sourceId = entry.sourceId;
+        const targetId =
+          needsAnchor && sourceKey && sourceId
+            ? await anchorEntry.mutateAsync({ entityType, entityId, sourceKey, sourceId })
+            : entryId;
+        toggleReaction.mutate(
+          { entityType, entityId, entryId: targetId, emoji },
+          { onSuccess: (result) => onToggled?.(entryId, result) }
+        );
+      };
+      void cascade();
+    },
+    [
+      toggleReaction,
+      anchorEntry,
+      entityType,
+      entityId,
+      needsAnchor,
+      entry.sourceKey,
+      entry.sourceId,
+      onToggled,
+    ]
+  );
+  return (
+    <ReactionStrip
+      entryId={entry.id}
+      reactions={entry.reactions ?? undefined}
+      onToggle={handleToggle}
+      className="mt-1"
+    />
+  );
+}

--- a/packages/@granit/react-ui-timeline/src/timeline-stream.stories.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-stream.stories.tsx
@@ -1,0 +1,122 @@
+import { TimelineProvider } from '@granit/react-timeline';
+import { createTimelineHandlers } from '@granit/react-timeline/testing';
+import { TimelineEntryType } from '@granit/timeline';
+import type { TimelineStreamEntryResponse } from '@granit/timeline';
+import { toEntityId, toISODateString } from '@granit/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fn } from 'storybook/test';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { createApiClient } from '@granit/api-client';
+
+import { TimelineStream } from './timeline-stream';
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const storyTimelineConfig = { client: createApiClient({ baseURL: '' }), basePath: '/api/v1/timeline' };
+
+const rootComment: TimelineStreamEntryResponse = {
+  id: toEntityId<'TimelineStreamEntryResponse'>('tl-1'),
+  entryType: TimelineEntryType.Comment,
+  body: 'Account created and initial roles assigned. Please review and confirm.',
+  authorId: toEntityId<'User'>('admin-001'),
+  authorName: 'System Admin',
+  parentEntryId: null,
+  occurredAt: toISODateString('2026-05-10T09:30:00Z'),
+  attachments: [],
+};
+
+const reply: TimelineStreamEntryResponse = {
+  id: toEntityId<'TimelineStreamEntryResponse'>('tl-2'),
+  entryType: TimelineEntryType.Comment,
+  body: 'Confirmed — roles look correct.',
+  authorId: toEntityId<'User'>('user-042'),
+  authorName: 'Jane Dupont',
+  parentEntryId: toEntityId<'TimelineStreamEntryResponse'>('tl-1'),
+  occurredAt: toISODateString('2026-05-10T10:05:00Z'),
+  attachments: [],
+};
+
+const internalNote: TimelineStreamEntryResponse = {
+  id: toEntityId<'TimelineStreamEntryResponse'>('tl-3'),
+  entryType: TimelineEntryType.InternalNote,
+  body: 'Reviewed access — granit-showcase-admin required for onboarding.',
+  authorId: toEntityId<'User'>('admin-002'),
+  authorName: 'Security Officer',
+  parentEntryId: null,
+  occurredAt: toISODateString('2026-06-01T14:15:00Z'),
+  attachments: [],
+};
+
+const entries: TimelineStreamEntryResponse[] = [rootComment, reply, internalNote];
+
+const meta: Meta<typeof TimelineStream> = {
+  title: 'Timeline/TimelineStream',
+  component: TimelineStream,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    msw: {
+      handlers: createTimelineHandlers(),
+    },
+  },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <TimelineProvider config={storyTimelineConfig}>
+          <Story />
+        </TimelineProvider>
+      </QueryClientProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof TimelineStream>;
+
+export const Default: Story = {
+  args: {
+    entries,
+    entityType: 'User',
+    entityId: 'user-001',
+    onReply: fn(),
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    entries: [],
+    loading: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    entries: [],
+    emptyMessage: 'No timeline entries yet.',
+  },
+};
+
+export const WithLoadMore: Story = {
+  args: {
+    entries,
+    hasMore: true,
+    onLoadMore: fn(),
+    onReply: fn(),
+  },
+};
+
+export const Interactive: Story = {
+  args: {
+    entries,
+    entityType: 'User',
+    entityId: 'user-001',
+    canReact: true,
+    onReply: fn(),
+    onDelete: fn(),
+    onReactionToggled: fn(),
+  },
+};

--- a/packages/@granit/react-ui-timeline/src/timeline-stream.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-stream.tsx
@@ -1,0 +1,181 @@
+import { useCallback, useMemo } from 'react';
+
+import { useTranslation } from '@granit/react-localization';
+import { Button, Spinner } from '@granit/react-ui';
+import type {
+  ReactionToggleResponse,
+  TimelineStreamEntryResponse as TimelineEntryType,
+  TimelineEntryId,
+} from '@granit/timeline';
+
+import { cn } from '@granit/utils';
+
+import { TimelineStreamEntryResponse } from './timeline-entry.js';
+
+import type { TimelineEntryProps } from './timeline-entry.js';
+
+export interface TimelineStreamProps {
+  entries: readonly TimelineEntryType[];
+  /**
+   * Stream's entity context — threaded into each `<TimelineStreamEntryResponse>` so
+   * reactions (`useToggleReaction`) can scope their cache patches by
+   * stream.
+   */
+  entityType?: string;
+  entityId?: string;
+  /** Forwarded to each `<TimelineStreamEntryResponse>` — gates the reaction bar's interactive mode. */
+  canReact?: boolean;
+  loading?: boolean;
+  loadingMore?: boolean;
+  hasMore?: boolean;
+  onLoadMore?: () => void;
+  onReply?: (entryId: string) => void;
+  onDelete?: (entryId: string) => void;
+  /** Forwarded to each entry — see {@link TimelineEntryProps.onEdit}. */
+  onEdit?: (
+    entryId: TimelineEntryId,
+    currentBody: string,
+    entryType: TimelineEntryType['entryType']
+  ) => void;
+  /**
+   * Per-entry edit eligibility predicate. When provided, the stream
+   * only forwards {@link onEdit} to entries for which `canEdit(entry)`
+   * returns true — others render no edit action. Without a predicate,
+   * `onEdit` (if present) is forwarded to every entry. Hosts typically
+   * encode the four edit gates here (native origin, type, authorship,
+   * within edit window) so the button only shows for actionable rows.
+   */
+  canEdit?: (entry: TimelineEntryType) => boolean;
+  /** Forwarded to each interactive reaction bar — see TimelineEntryProps. */
+  onReactionToggled?: (entryId: TimelineEntryId, result: ReactionToggleResponse) => void;
+  renderEntry?: (props: TimelineEntryProps) => React.ReactNode;
+  renderBody?: (body: string) => React.ReactNode;
+  className?: string;
+  emptyMessage?: string;
+}
+
+interface ThreadedEntry {
+  entry: TimelineEntryType;
+  depth: number;
+}
+
+function buildThreadedList(entries: readonly TimelineEntryType[]): ThreadedEntry[] {
+  const rootEntries: TimelineEntryType[] = [];
+  const childrenMap = new Map<string, TimelineEntryType[]>();
+
+  for (const entry of entries) {
+    if (entry.parentEntryId) {
+      const siblings = childrenMap.get(entry.parentEntryId) ?? [];
+      siblings.push(entry);
+      childrenMap.set(entry.parentEntryId, siblings);
+    } else {
+      rootEntries.push(entry);
+    }
+  }
+
+  const result: ThreadedEntry[] = [];
+
+  function addWithChildren(entry: TimelineEntryType, depth: number) {
+    result.push({ entry, depth });
+    const children = childrenMap.get(entry.id);
+    if (children) {
+      for (const child of children) {
+        addWithChildren(child, depth + 1);
+      }
+    }
+  }
+
+  for (const root of rootEntries) {
+    addWithChildren(root, 0);
+  }
+
+  return result;
+}
+
+export function TimelineStream({
+  entries,
+  entityType,
+  entityId,
+  canReact = false,
+  loading = false,
+  loadingMore = false,
+  hasMore = false,
+  onLoadMore,
+  onReply,
+  onDelete,
+  onEdit,
+  canEdit,
+  onReactionToggled,
+  renderEntry,
+  renderBody,
+  className,
+  emptyMessage = 'No entries yet.',
+}: Readonly<TimelineStreamProps>) {
+  const { t } = useTranslation();
+  const threadedEntries = useMemo(() => buildThreadedList(entries), [entries]);
+
+  const handleLoadMore = useCallback(() => {
+    onLoadMore?.();
+  }, [onLoadMore]);
+
+  if (loading) {
+    return (
+      <output className={className} aria-label="Loading timeline">
+        <Spinner data-testid="timeline-loading" />
+      </output>
+    );
+  }
+
+  if (threadedEntries.length === 0) {
+    return (
+      <div className={className} data-testid="timeline-empty">
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  return (
+    <section
+      className={cn('space-y-4', className)}
+      aria-label="Timeline"
+      data-testid="timeline-stream"
+    >
+      {threadedEntries.map(({ entry, depth }) => {
+        const entryProps: TimelineEntryProps = {
+          entry,
+          entityType,
+          entityId,
+          canReact,
+          depth,
+          onReply,
+          onDelete,
+          onEdit: onEdit && (!canEdit || canEdit(entry)) ? onEdit : undefined,
+          onReactionToggled,
+          renderBody,
+        };
+
+        return renderEntry ? (
+          <div key={entry.id}>{renderEntry(entryProps)}</div>
+        ) : (
+          <TimelineStreamEntryResponse key={entry.id} {...entryProps} />
+        );
+      })}
+
+      {hasMore && (
+        <div data-testid="timeline-load-more">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleLoadMore}
+            disabled={loadingMore}
+            data-testid="timeline-load-more-btn"
+          >
+            {loadingMore
+              ? t('Timeline.LoadingMore', { defaultValue: 'Loading…' })
+              : t('Timeline.LoadMore', { defaultValue: 'Load more' })}
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/@granit/react-ui-timeline/src/tippy-css.d.ts
+++ b/packages/@granit/react-ui-timeline/src/tippy-css.d.ts
@@ -1,0 +1,3 @@
+// Side-effect import declaration for the Tippy.js stylesheet. Bundlers consume
+// the CSS via their asset pipeline; this just satisfies the type-checker.
+declare module 'tippy.js/dist/tippy.css';

--- a/packages/@granit/react-ui-timeline/src/twemoji-image.stories.tsx
+++ b/packages/@granit/react-ui-timeline/src/twemoji-image.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { TwemojiImage } from './twemoji-image';
+
+const meta = {
+  title: 'Timeline/TwemojiImage',
+  component: TwemojiImage,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof TwemojiImage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    emoji: '👍',
+    size: 18,
+  },
+};
+
+export const Large: Story = {
+  args: {
+    emoji: '🎉',
+    size: 48,
+  },
+};
+
+export const SkinToneModifier: Story = {
+  args: {
+    emoji: '👍🏽',
+    size: 32,
+  },
+};
+
+export const ZwjSequence: Story = {
+  args: {
+    emoji: '👨‍👩‍👧',
+    size: 32,
+  },
+};
+
+export const KeycapSequence: Story = {
+  args: {
+    emoji: '1️⃣',
+    size: 24,
+  },
+};
+
+export const EmojiStrip: Story = {
+  args: { emoji: '👍' },
+  render: () => (
+    <div className="flex items-center gap-2">
+      {['👍', '❤️', '😂', '😮', '😢', '🎉', '🔥', '✅'].map((emoji) => (
+        <TwemojiImage key={emoji} emoji={emoji} size={24} />
+      ))}
+    </div>
+  ),
+};

--- a/packages/@granit/react-ui-timeline/src/twemoji-image.tsx
+++ b/packages/@granit/react-ui-timeline/src/twemoji-image.tsx
@@ -1,0 +1,97 @@
+import { useState, type CSSProperties } from 'react';
+
+import { cn } from '@granit/utils';
+
+// Pinned jsdelivr CDN. Twemoji 14.x is the last "official" Twitter
+// drop; jdecked/twemoji is the community-maintained successor that
+// tracks new Unicode emoji versions.
+const CDN_BASE = 'https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/svg';
+
+const ZWJ = '‍';
+const VS16 = '️';
+
+// Mirror jdecked/twemoji's `grabTheRightIcon`:
+//  - VS-16 (U+FE0F) is stripped from sequences WITHOUT a ZWJ.
+//  - It must be PRESERVED when a ZWJ is present (otherwise families
+//    like `👨‍👩‍👧` map to the wrong asset).
+//  - Surrogate pairs fold back into astral codepoints via the
+//    `for…of` iteration on strings.
+//
+// Examples:
+//   '👍'              → '1f44d'
+//   '1️⃣'             → '31-20e3'
+//   '👨‍👩‍👧'       → '1f468-200d-1f469-200d-1f467'
+//   '👍🏽'            → '1f44d-1f3fd'
+//
+// Exported for test access only.
+// eslint-disable-next-line react-refresh/only-export-components
+export function emojiToTwemojiCodepoints(emoji: string): string {
+  const normalized = emoji.includes(ZWJ) ? emoji : emoji.replaceAll(VS16, '');
+  const out: string[] = [];
+  for (const ch of normalized) {
+    const cp = ch.codePointAt(0);
+    if (cp !== undefined) out.push(cp.toString(16));
+  }
+  return out.join('-');
+}
+
+export interface TwemojiImageProps {
+  /** Literal emoji glyph — any well-formed Extended_Pictographic sequence. */
+  readonly emoji: string;
+  /** Side length in CSS pixels (square). Defaults to `18`. */
+  readonly size?: number;
+  readonly className?: string;
+  readonly style?: CSSProperties;
+}
+
+// Render an emoji as a Twemoji SVG image served from the jdecked/twemoji
+// jsdelivr CDN. Cross-OS-consistent glyph rendering without bundling
+// the sprite. The `<img>` tag uses native lazy decoding so a strip of
+// many reactions doesn't block paint.
+//
+// Fallback: the CDN occasionally lacks an asset (notably for ZWJ
+// sequences that ship from the backend stripped of VS-16 — the
+// `NormalizeForAggregate` rule on `EmojiValidator` collapses skin-tone
+// and presentation-selector variants for aggregation, but Twemoji's
+// filenames use the fully-qualified RGI form). When the SVG 404s,
+// swap to native glyph rendering inline so the user never sees a
+// broken-image icon.
+//
+// CSP requirement: the app must allow `img-src https://cdn.jsdelivr.net`.
+// No `connect-src` needed — `<img>` doesn't use fetch.
+export function TwemojiImage({ emoji, size = 18, className, style }: TwemojiImageProps) {
+  const [errored, setErrored] = useState(false);
+
+  if (errored) {
+    return (
+      <span
+        role="img"
+        data-slot="twemoji-image"
+        aria-label={emoji}
+        data-emoji={emoji}
+        className={cn('inline-block select-none align-text-bottom leading-none', className)}
+        style={{ fontSize: size, lineHeight: `${size}px`, ...style }}
+      >
+        {emoji}
+      </span>
+    );
+  }
+
+  const codepoints = emojiToTwemojiCodepoints(emoji);
+  return (
+    <img
+      src={`${CDN_BASE}/${codepoints}.svg`}
+      alt={emoji}
+      role="img"
+      width={size}
+      height={size}
+      loading="lazy"
+      decoding="async"
+      draggable={false}
+      data-emoji={emoji}
+      onError={() => setErrored(true)}
+      className={cn('inline-block select-none align-text-bottom', className)}
+      style={style}
+    />
+  );
+}

--- a/packages/@granit/react-ui-timeline/tsconfig.json
+++ b/packages/@granit/react-ui-timeline/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": [
+    "src/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.stories.ts",
+    "src/**/*.stories.tsx"
+  ]
+}

--- a/packages/@granit/react-ui-timeline/tsup.config.ts
+++ b/packages/@granit/react-ui-timeline/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();


### PR DESCRIPTION
New package: the **UI counterpart** to the headless `@granit/react-timeline` (provider + hooks). The entity activity feed — a paginated stream, a composer with @-mention autocomplete and emoji reactions.

## Components
`EntityTimeline` (page-level feed) + `TimelineStream`, `TimelineEntry`, `TimelineComposer`, `ReactionStrip`, `MentionEditor`, `EmojiPicker`, `TwemojiImage`.

## App-agnostic by design
`EntityTimeline` stays neutral (no auth/identity/query stack required to mount). Hosts inject at the call site:
- `currentUserId` ← `useAuth().user?.sub` (author-only edit gating)
- `canReact` ← `usePermissions().hasPermission('Timeline.Reactions.React')`
- `searchMentions` ← `(query) => Promise<MentionSuggestion[]>` over the host identity client

The `TimelineProvider` (wired with the host API client) is mounted by the app. Ships its own `Timeline.*` bundle (`timelineAdminTranslationsEn/Fr`).

## Validation
Full arch-tests pass (2938). EntityTimeline test (7 cases) + 8 stories (storybook-vitest coverage). Consumed source-direct by the showcase (lint + tsc + unit green).

Extracted from the showcase; `isAxiosError` routed through `@granit/api-client`, strict-tsc null-guards applied.