### PR TITLE
fix: unbreak develop CI (react-ui-timeline #767 latent failures)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -10287,6 +10287,369 @@
       ]
     },
     {
+      "name": "@granit/react-ui-timeline",
+      "description": "Granit admin UI for the Timeline module — the entity activity feed (stream, entries, composer with @-mentions, emoji reactions). Composes the headless @granit/react-timeline (provider, hooks) with the foundation UI packages. App-agnostic: auth/permission/mention data are injected as props.",
+      "exports": [
+        {
+          "name": "EntityTimeline",
+          "kind": "function",
+          "signature": "function EntityTimeline(props: Readonly<EntityTimelineProps>)"
+        },
+        {
+          "name": "EntityTimelineProps",
+          "kind": "interface",
+          "signature": "interface EntityTimelineProps",
+          "members": [
+            {
+              "name": "entityType",
+              "kind": "property",
+              "signature": "entityType: string"
+            },
+            {
+              "name": "entityId",
+              "kind": "property",
+              "signature": "entityId: string"
+            },
+            {
+              "name": "entryTypes",
+              "kind": "property",
+              "signature": "entryTypes?: TimelineEntryType[]"
+            },
+            {
+              "name": "pageSize",
+              "kind": "property",
+              "signature": "pageSize?: number"
+            },
+            {
+              "name": "canReact",
+              "kind": "property",
+              "signature": "canReact?: boolean"
+            },
+            {
+              "name": "searchMentions",
+              "kind": "method",
+              "signature": "searchMentions?: (query: string) => Promise<MentionSuggestion[]>"
+            },
+            {
+              "name": "currentUserId",
+              "kind": "property",
+              "signature": "currentUserId?: string"
+            },
+            {
+              "name": "className",
+              "kind": "property",
+              "signature": "className?: string"
+            }
+          ]
+        },
+        {
+          "name": "TimelineStream",
+          "kind": "function",
+          "signature": "function TimelineStream("
+        },
+        {
+          "name": "TimelineStreamProps",
+          "kind": "interface",
+          "signature": "interface TimelineStreamProps",
+          "members": [
+            {
+              "name": "entries",
+              "kind": "property",
+              "signature": "entries: readonly TimelineEntryType[]"
+            },
+            {
+              "name": "entityType",
+              "kind": "property",
+              "signature": "entityType?: string"
+            },
+            {
+              "name": "entityId",
+              "kind": "property",
+              "signature": "entityId?: string"
+            },
+            {
+              "name": "canReact",
+              "kind": "property",
+              "signature": "canReact?: boolean"
+            },
+            {
+              "name": "loading",
+              "kind": "property",
+              "signature": "loading?: boolean"
+            },
+            {
+              "name": "loadingMore",
+              "kind": "property",
+              "signature": "loadingMore?: boolean"
+            },
+            {
+              "name": "hasMore",
+              "kind": "property",
+              "signature": "hasMore?: boolean"
+            },
+            {
+              "name": "onLoadMore",
+              "kind": "method",
+              "signature": "onLoadMore?: () => void"
+            },
+            {
+              "name": "onReply",
+              "kind": "method",
+              "signature": "onReply?: (entryId: string) => void"
+            },
+            {
+              "name": "onDelete",
+              "kind": "method",
+              "signature": "onDelete?: (entryId: string) => void"
+            },
+            {
+              "name": "onEdit",
+              "kind": "method",
+              "signature": "onEdit?: ("
+            },
+            {
+              "name": "entryId",
+              "kind": "property",
+              "signature": "entryId: TimelineEntryId,"
+            },
+            {
+              "name": "currentBody",
+              "kind": "property",
+              "signature": "currentBody: string,"
+            },
+            {
+              "name": "entryType",
+              "kind": "property",
+              "signature": "entryType: TimelineEntryType['entryType']"
+            },
+            {
+              "name": "canEdit",
+              "kind": "method",
+              "signature": "canEdit?: (entry: TimelineEntryType) => boolean"
+            },
+            {
+              "name": "onReactionToggled",
+              "kind": "method",
+              "signature": "onReactionToggled?: (entryId: TimelineEntryId, result: ReactionToggleResponse) => void"
+            },
+            {
+              "name": "renderEntry",
+              "kind": "method",
+              "signature": "renderEntry?: (props: TimelineEntryProps) => React.ReactNode"
+            },
+            {
+              "name": "renderBody",
+              "kind": "method",
+              "signature": "renderBody?: (body: string) => React.ReactNode"
+            },
+            {
+              "name": "className",
+              "kind": "property",
+              "signature": "className?: string"
+            },
+            {
+              "name": "emptyMessage",
+              "kind": "property",
+              "signature": "emptyMessage?: string"
+            }
+          ]
+        },
+        {
+          "name": "TimelineStreamEntryResponse",
+          "kind": "function",
+          "signature": "function TimelineStreamEntryResponse("
+        },
+        {
+          "name": "TimelineEntryProps",
+          "kind": "interface",
+          "signature": "interface TimelineEntryProps",
+          "members": [
+            {
+              "name": "entry",
+              "kind": "property",
+              "signature": "entry: TimelineStreamEntryResponse"
+            },
+            {
+              "name": "entityType",
+              "kind": "property",
+              "signature": "entityType?: string"
+            },
+            {
+              "name": "entityId",
+              "kind": "property",
+              "signature": "entityId?: string"
+            },
+            {
+              "name": "canReact",
+              "kind": "property",
+              "signature": "canReact?: boolean"
+            },
+            {
+              "name": "depth",
+              "kind": "property",
+              "signature": "depth?: number"
+            },
+            {
+              "name": "onReply",
+              "kind": "method",
+              "signature": "onReply?: (entryId: string) => void"
+            },
+            {
+              "name": "onDelete",
+              "kind": "method",
+              "signature": "onDelete?: (entryId: string) => void"
+            },
+            {
+              "name": "onEdit",
+              "kind": "method",
+              "signature": "onEdit?: ("
+            },
+            {
+              "name": "entryId",
+              "kind": "property",
+              "signature": "entryId: TimelineEntryId,"
+            },
+            {
+              "name": "currentBody",
+              "kind": "property",
+              "signature": "currentBody: string,"
+            },
+            {
+              "name": "entryType",
+              "kind": "property",
+              "signature": "entryType: TimelineStreamEntryResponse['entryType']"
+            },
+            {
+              "name": "onReactionToggled",
+              "kind": "method",
+              "signature": "onReactionToggled?: (entryId: TimelineEntryId, result: ReactionToggleResponse) => void"
+            },
+            {
+              "name": "renderBody",
+              "kind": "method",
+              "signature": "renderBody?: (body: string) => React.ReactNode"
+            },
+            {
+              "name": "className",
+              "kind": "property",
+              "signature": "className?: string"
+            }
+          ]
+        },
+        {
+          "name": "TimelineComposer",
+          "kind": "function",
+          "signature": "function TimelineComposer("
+        },
+        {
+          "name": "TimelineComposerProps",
+          "kind": "interface",
+          "signature": "interface TimelineComposerProps",
+          "members": [
+            {
+              "name": "onSubmit",
+              "kind": "method",
+              "signature": "onSubmit: (request: PostTimelineEntryRequest) => Promise<void>"
+            },
+            {
+              "name": "parentEntryId",
+              "kind": "property",
+              "signature": "parentEntryId?: string"
+            },
+            {
+              "name": "entryTypes",
+              "kind": "property",
+              "signature": "entryTypes?: TimelineEntryType[]"
+            },
+            {
+              "name": "searchMentions",
+              "kind": "method",
+              "signature": "searchMentions?: (query: string) => Promise<MentionSuggestion[]>"
+            },
+            {
+              "name": "placeholder",
+              "kind": "property",
+              "signature": "placeholder?: string"
+            },
+            {
+              "name": "submitLabel",
+              "kind": "property",
+              "signature": "submitLabel?: string"
+            },
+            {
+              "name": "initialBody",
+              "kind": "property",
+              "signature": "initialBody?: string"
+            },
+            {
+              "name": "initialEntryType",
+              "kind": "property",
+              "signature": "initialEntryType?: TimelineEntryType"
+            },
+            {
+              "name": "hideEntryTypeSelector",
+              "kind": "property",
+              "signature": "hideEntryTypeSelector?: boolean"
+            },
+            {
+              "name": "className",
+              "kind": "property",
+              "signature": "className?: string"
+            }
+          ]
+        },
+        {
+          "name": "ReactionStrip",
+          "kind": "function",
+          "signature": "function ReactionStrip("
+        },
+        {
+          "name": "ReactionStripProps",
+          "kind": "interface",
+          "signature": "interface ReactionStripProps",
+          "members": []
+        },
+        {
+          "name": "MentionEditor",
+          "kind": "function",
+          "signature": "function MentionEditor("
+        },
+        {
+          "name": "MentionEditorProps",
+          "kind": "interface",
+          "signature": "interface MentionEditorProps",
+          "members": []
+        },
+        {
+          "name": "EmojiPicker",
+          "kind": "function",
+          "signature": "function EmojiPicker("
+        },
+        {
+          "name": "EmojiPickerProps",
+          "kind": "interface",
+          "signature": "interface EmojiPickerProps",
+          "members": []
+        },
+        {
+          "name": "TwemojiImage",
+          "kind": "function",
+          "signature": "function TwemojiImage("
+        },
+        {
+          "name": "emojiToTwemojiCodepoints",
+          "kind": "function",
+          "signature": "function emojiToTwemojiCodepoints(emoji: string): string"
+        },
+        {
+          "name": "TwemojiImageProps",
+          "kind": "interface",
+          "signature": "interface TwemojiImageProps",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/react-ui-webhooks",
       "description": "Granit admin UI for the Webhooks module — the subscriptions list, the create wizard (with the one-time signing-secret reveal) and the per-subscription detail view (lifecycle actions, delivery history, signing-key rotation, test ping and live stats dashboard). Composes @granit/react-webhooks (headless) with the foundation UI packages.",
       "exports": [

--- a/packages/@granit/arch-tests/src/__tests__/helpers.ts
+++ b/packages/@granit/arch-tests/src/__tests__/helpers.ts
@@ -134,6 +134,7 @@ export const UI_ROUTER_BASELINE: ReadonlyArray<string> = [
   '@granit/react-ui-tax',
   '@granit/react-ui-taxonomy',
   '@granit/react-ui-templating',
+  '@granit/react-ui-timeline',
   '@granit/react-ui-webhooks',
 ];
 

--- a/packages/@granit/react-ui-timeline/src/__tests__/entity-timeline.test.tsx
+++ b/packages/@granit/react-ui-timeline/src/__tests__/entity-timeline.test.tsx
@@ -1,8 +1,9 @@
 import { screen } from '@testing-library/react';
 
+import { EntityTimeline } from '../entity-timeline';
+
 import { renderWithProviders } from './test-utils';
 
-import { EntityTimeline } from '../entity-timeline';
 
 // Mock @granit/react-timeline (hooks + provider)
 const { mockUseTimeline, mockUseTimelineActions, mockUseTimelineFollowers } = vi.hoisted(() => ({

--- a/packages/@granit/react-ui-timeline/src/emoji-picker.stories.tsx
+++ b/packages/@granit/react-ui-timeline/src/emoji-picker.stories.tsx
@@ -1,7 +1,8 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
 import { EmojiPicker } from './emoji-picker';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta = {
   title: 'Timeline/EmojiPicker',

--- a/packages/@granit/react-ui-timeline/src/emoji-picker.tsx
+++ b/packages/@granit/react-ui-timeline/src/emoji-picker.tsx
@@ -1,7 +1,6 @@
-import { lazy, Suspense, useEffect, type ReactNode } from 'react';
-
 import { useTranslation } from '@granit/react-localization';
 import { useTheme } from 'next-themes';
+import { lazy, Suspense, useEffect, type ReactNode } from 'react';
 
 interface EmojiMartSelection {
   readonly native: string;

--- a/packages/@granit/react-ui-timeline/src/entity-timeline.tsx
+++ b/packages/@granit/react-ui-timeline/src/entity-timeline.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
-
+import { isAxiosError } from '@granit/api-client';
 import { useTranslation } from '@granit/react-localization';
 import {
   applyToggleResult,
@@ -26,6 +25,16 @@ import {
   TimelineEntryOrigin,
   TimelineEntryType,
 } from '@granit/timeline';
+import { cn } from '@granit/utils';
+import { AlertCircle, AlertTriangle, Bell, BellOff, MessageSquare, Plus } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { toast } from 'sonner';
+
+
+import { TimelineComposer } from './timeline-composer';
+import { TimelineStream } from './timeline-stream';
+
 import type {
   PostTimelineEntryRequest,
   MentionSuggestion,
@@ -34,14 +43,7 @@ import type {
   TimelineEntryId,
   TimelineEntryNotEditableReasonValue,
 } from '@granit/timeline';
-import { isAxiosError } from '@granit/api-client';
-import { AlertCircle, AlertTriangle, Bell, BellOff, MessageSquare, Plus } from 'lucide-react';
-import { Link } from 'react-router-dom';
-import { toast } from 'sonner';
 
-import { TimelineComposer } from './timeline-composer';
-import { TimelineStream } from './timeline-stream';
-import { cn } from '@granit/utils';
 
 // Single-pass tokenizer for the timeline body. Branch 1 is the canonical
 // mention payload (`@[Name](user:guid)`) emitted by `<TimelineComposer>`

--- a/packages/@granit/react-ui-timeline/src/mention-editor.stories.tsx
+++ b/packages/@granit/react-ui-timeline/src/mention-editor.stories.tsx
@@ -1,9 +1,10 @@
-import type { MentionSuggestion } from '@granit/timeline';
 import { fn } from 'storybook/test';
 
+import { MentionEditor } from './mention-editor';
+
+import type { MentionSuggestion } from '@granit/timeline';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { MentionEditor } from './mention-editor';
 
 const mockSuggestions: MentionSuggestion[] = [
   { id: '11111111-1111-1111-1111-111111111111', displayName: 'Jane Dupont' },

--- a/packages/@granit/react-ui-timeline/src/mention-editor.tsx
+++ b/packages/@granit/react-ui-timeline/src/mention-editor.tsx
@@ -1,3 +1,8 @@
+import { cn } from '@granit/utils';
+import Mention from '@tiptap/extension-mention';
+import Placeholder from '@tiptap/extension-placeholder';
+import { EditorContent, ReactRenderer, useEditor, type Editor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
 import {
   forwardRef,
   useEffect,
@@ -6,15 +11,9 @@ import {
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
-
-import type { MentionSuggestion } from '@granit/timeline';
-import Mention from '@tiptap/extension-mention';
-import Placeholder from '@tiptap/extension-placeholder';
-import { EditorContent, ReactRenderer, useEditor, type Editor } from '@tiptap/react';
-import StarterKit from '@tiptap/starter-kit';
 import tippy, { type Instance, type Props as TippyProps } from 'tippy.js';
 
-import { cn } from '@granit/utils';
+import type { MentionSuggestion } from '@granit/timeline';
 
 import 'tippy.js/dist/tippy.css';
 
@@ -148,7 +147,6 @@ const MentionList = forwardRef<MentionListItemRef, MentionListProps>(function Me
       },
     }),
     // selectItem closes over the latest selectedIndex/items via state.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [items, selectedIndex]
   );
 

--- a/packages/@granit/react-ui-timeline/src/reaction-strip.stories.tsx
+++ b/packages/@granit/react-ui-timeline/src/reaction-strip.stories.tsx
@@ -1,11 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
-import { fn } from 'storybook/test';
 import { toReactionEmoji } from '@granit/timeline';
 import { toEntityId } from '@granit/types';
+import { fn } from 'storybook/test';
 
 import { ReactionStrip } from './reaction-strip';
 
 import type { ReactionMap, TimelineEntryId } from '@granit/timeline';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const entryId = toEntityId<'TimelineStreamEntryResponse'>('tl-1') as TimelineEntryId;
 

--- a/packages/@granit/react-ui-timeline/src/reaction-strip.tsx
+++ b/packages/@granit/react-ui-timeline/src/reaction-strip.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { useTranslation } from '@granit/react-localization';
 import { Popover, PopoverContent, PopoverTrigger } from '@granit/react-ui';
 import {
@@ -9,9 +7,9 @@ import {
   type ReactionMap,
   type TimelineEntryId,
 } from '@granit/timeline';
-import { SmilePlus } from 'lucide-react';
-
 import { cn } from '@granit/utils';
+import { SmilePlus } from 'lucide-react';
+import * as React from 'react';
 
 import { EmojiPicker } from './emoji-picker';
 import { TwemojiImage } from './twemoji-image';

--- a/packages/@granit/react-ui-timeline/src/timeline-composer.stories.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-composer.stories.tsx
@@ -1,10 +1,11 @@
-import type { MentionSuggestion, PostTimelineEntryRequest } from '@granit/timeline';
 import { TimelineEntryType } from '@granit/timeline';
 import { fn } from 'storybook/test';
 
-import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { TimelineComposer } from './timeline-composer';
+
+import type { MentionSuggestion, PostTimelineEntryRequest } from '@granit/timeline';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const mockSuggestions: MentionSuggestion[] = [
   { id: '11111111-1111-1111-1111-111111111111', displayName: 'Jane Dupont' },

--- a/packages/@granit/react-ui-timeline/src/timeline-composer.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-composer.tsx
@@ -1,15 +1,14 @@
-import type { FormEvent } from 'react';
-import { useCallback, useState } from 'react';
-
 import { useTranslation } from '@granit/react-localization';
 import { Button } from '@granit/react-ui';
 import { TimelineEntryType } from '@granit/timeline';
-import type { PostTimelineEntryRequest, MentionSuggestion } from '@granit/timeline';
-import { Lock, MessageSquare } from 'lucide-react';
-
 import { cn } from '@granit/utils';
+import { Lock, MessageSquare } from 'lucide-react';
+import { useCallback, useState } from 'react';
 
 import { MentionEditor } from './mention-editor';
+
+import type { PostTimelineEntryRequest, MentionSuggestion } from '@granit/timeline';
+import type { FormEvent } from 'react';
 
 export interface TimelineComposerProps {
   onSubmit: (request: PostTimelineEntryRequest) => Promise<void>;

--- a/packages/@granit/react-ui-timeline/src/timeline-entry.stories.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-entry.stories.tsx
@@ -1,16 +1,17 @@
+import { createApiClient } from '@granit/api-client';
 import { TimelineProvider } from '@granit/react-timeline';
 import { createTimelineHandlers } from '@granit/react-timeline/testing';
 import { TimelineEntryType } from '@granit/timeline';
-import type { ReactionEmoji, TimelineStreamEntryResponse } from '@granit/timeline';
 import { toEntityId, toISODateString } from '@granit/types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fn } from 'storybook/test';
 
-import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { createApiClient } from '@granit/api-client';
 
 import { TimelineStreamEntryResponse as TimelineEntryComponent } from './timeline-entry';
+
+import type { ReactionEmoji, TimelineStreamEntryResponse } from '@granit/timeline';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false }, mutations: { retry: false } },

--- a/packages/@granit/react-ui-timeline/src/timeline-entry.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-entry.tsx
@@ -1,19 +1,18 @@
-import { useCallback, useMemo } from 'react';
-
 import { useDateFormatter, useTranslation } from '@granit/react-localization';
 import { useAnchorEntry, useToggleReaction } from '@granit/react-timeline';
 import { Button, Avatar, AvatarFallback } from '@granit/react-ui';
 import { TimelineEntryOrigin, TimelineEntryType } from '@granit/timeline';
+import { cn } from '@granit/utils';
+import { useCallback, useMemo } from 'react';
+
+import { ReactionStrip } from './reaction-strip';
+
 import type {
   ReactionEmoji,
   ReactionToggleResponse,
   TimelineStreamEntryResponse,
   TimelineEntryId,
 } from '@granit/timeline';
-
-import { cn } from '@granit/utils';
-
-import { ReactionStrip } from './reaction-strip';
 
 export interface TimelineEntryProps {
   entry: TimelineStreamEntryResponse;

--- a/packages/@granit/react-ui-timeline/src/timeline-stream.stories.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-stream.stories.tsx
@@ -1,16 +1,17 @@
+import { createApiClient } from '@granit/api-client';
 import { TimelineProvider } from '@granit/react-timeline';
 import { createTimelineHandlers } from '@granit/react-timeline/testing';
 import { TimelineEntryType } from '@granit/timeline';
-import type { TimelineStreamEntryResponse } from '@granit/timeline';
 import { toEntityId, toISODateString } from '@granit/types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fn } from 'storybook/test';
 
-import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { createApiClient } from '@granit/api-client';
 
 import { TimelineStream } from './timeline-stream';
+
+import type { TimelineStreamEntryResponse } from '@granit/timeline';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false }, mutations: { retry: false } },

--- a/packages/@granit/react-ui-timeline/src/timeline-stream.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-stream.tsx
@@ -1,18 +1,16 @@
-import { useCallback, useMemo } from 'react';
-
 import { useTranslation } from '@granit/react-localization';
 import { Button, Spinner } from '@granit/react-ui';
+import { cn } from '@granit/utils';
+import { useCallback, useMemo } from 'react';
+
+import { TimelineStreamEntryResponse } from './timeline-entry.js';
+
+import type { TimelineEntryProps } from './timeline-entry.js';
 import type {
   ReactionToggleResponse,
   TimelineStreamEntryResponse as TimelineEntryType,
   TimelineEntryId,
 } from '@granit/timeline';
-
-import { cn } from '@granit/utils';
-
-import { TimelineStreamEntryResponse } from './timeline-entry.js';
-
-import type { TimelineEntryProps } from './timeline-entry.js';
 
 export interface TimelineStreamProps {
   entries: readonly TimelineEntryType[];

--- a/packages/@granit/react-ui-timeline/src/twemoji-image.stories.tsx
+++ b/packages/@granit/react-ui-timeline/src/twemoji-image.stories.tsx
@@ -1,6 +1,7 @@
+import { TwemojiImage } from './twemoji-image';
+
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { TwemojiImage } from './twemoji-image';
 
 const meta = {
   title: 'Timeline/TwemojiImage',

--- a/packages/@granit/react-ui-timeline/src/twemoji-image.tsx
+++ b/packages/@granit/react-ui-timeline/src/twemoji-image.tsx
@@ -1,6 +1,6 @@
+import { cn } from '@granit/utils';
 import { useState, type CSSProperties } from 'react';
 
-import { cn } from '@granit/utils';
 
 // Pinned jsdelivr CDN. Twemoji 14.x is the last "official" Twitter
 // drop; jdecked/twemoji is the community-maintained successor that
@@ -24,7 +24,6 @@ const VS16 = '️';
 //   '👍🏽'            → '1f44d-1f3fd'
 //
 // Exported for test access only.
-// eslint-disable-next-line react-refresh/only-export-components
 export function emojiToTwemojiCodepoints(emoji: string): string {
   const normalized = emoji.includes(ZWJ) ? emoji : emoji.replaceAll(VS16, '');
   const out: string[] = [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6668,6 +6668,87 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
 
+  packages/@granit/react-ui-timeline:
+    devDependencies:
+      '@emoji-mart/data':
+        specifier: ^1.2.1
+        version: 1.2.1
+      '@emoji-mart/react':
+        specifier: ^1.1.1
+        version: 1.1.1(emoji-mart@5.6.0)(react@19.2.7)
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-localization':
+        specifier: workspace:*
+        version: link:../react-localization
+      '@granit/react-timeline':
+        specifier: workspace:*
+        version: link:../react-timeline
+      '@granit/react-ui':
+        specifier: workspace:*
+        version: link:../react-ui
+      '@granit/timeline':
+        specifier: workspace:*
+        version: link:../timeline
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
+      '@granit/utils':
+        specifier: workspace:*
+        version: link:../utils
+      '@storybook/react-vite':
+        specifier: ^10.4.6
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(yaml@2.9.0))
+      '@tanstack/react-query':
+        specifier: 5.101.0
+        version: 5.101.0(react@19.2.7)
+      '@tiptap/extension-mention':
+        specifier: ^3.27.1
+        version: 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/suggestion@3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
+      '@tiptap/extension-placeholder':
+        specifier: ^3.27.1
+        version: 3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
+      '@tiptap/react':
+        specifier: ^3.27.1
+        version: 3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tiptap/starter-kit':
+        specifier: ^3.27.1
+        version: 3.27.1
+      i18next:
+        specifier: ^26.0.0
+        version: 26.3.1(typescript@6.0.3)
+      lucide-react:
+        specifier: ^1.21.0
+        version: 1.21.0(react@19.2.7)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+      react-i18next:
+        specifier: ^17.0.0
+        version: 17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+      react-router-dom:
+        specifier: ^7.18.0
+        version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook:
+        specifier: ^10.4.6
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      tippy.js:
+        specifier: ^6.3.7
+        version: 6.3.7
+
   packages/@granit/react-ui-webhooks:
     devDependencies:
       '@granit/api-client':
@@ -7458,6 +7539,15 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emoji-mart/data@1.2.1':
+    resolution: {integrity: sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==}
+
+  '@emoji-mart/react@1.1.1':
+    resolution: {integrity: sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==}
+    peerDependencies:
+      emoji-mart: ^5.2
+      react: 19.2.7
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -8601,6 +8691,9 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
   '@preact/signals-core@1.14.3':
     resolution: {integrity: sha512-m0K3vnbSLC5rHs2ZVfeAMvBtT1zIyq4mxx5OlNncSgMj5Iz6W5Rn3kPrDxAC+iIKmiVe0lSl6U37t5ZkEWoVAw==}
@@ -9911,6 +10004,13 @@ packages:
       '@tiptap/core': 3.27.1
       '@tiptap/pm': 3.27.1
 
+  '@tiptap/extension-mention@3.27.1':
+    resolution: {integrity: sha512-QfaKdl8PET01JvEFrIjMcOC1iYrBm2tsZEn07J1AaCqClW9iWcg/nCAdkdFhVir1fC54SLuaui43xslBawQRFg==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+      '@tiptap/pm': 3.27.1
+      '@tiptap/suggestion': 3.27.1
+
   '@tiptap/extension-ordered-list@3.27.1':
     resolution: {integrity: sha512-GYrKqD//9nHJ2r80uXqbDMzRnFpGzbaEQRTSGaO/SH7DvXWFMow8evkOdjQ7PCQO07jNjJo75+A85Jwu3Ov3AA==}
     peerDependencies:
@@ -9984,6 +10084,13 @@ packages:
 
   '@tiptap/starter-kit@3.27.1':
     resolution: {integrity: sha512-vfxRsqW8rCc0k4pzo0ilU3wobVi2wqVj88VZI2SlgZlNnUAkrDGDIAph7CTa9k9fshV+O1ivpEgPC5yC046jow==}
+
+  '@tiptap/suggestion@3.27.1':
+    resolution: {integrity: sha512-GNBPRav+lAfXzqmmUAS6ylRAn3G8JfsP6XosjoORxJIQJLx1ktDqwp6tm1Vgz9aGIM2TrBxLS1uBbI1Gb2/1VA==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': 3.27.1
+      '@tiptap/pm': 3.27.1
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -10813,6 +10920,9 @@ packages:
 
   electron-to-chromium@1.5.376:
     resolution: {integrity: sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==}
+
+  emoji-mart@5.6.0:
+    resolution: {integrity: sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -12531,6 +12641,9 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tippy.js@6.3.7:
+    resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
+
   tldts-core@7.4.3:
     resolution: {integrity: sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==}
 
@@ -13541,6 +13654,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@emoji-mart/data@1.2.1': {}
+
+  '@emoji-mart/react@1.1.1(emoji-mart@5.6.0)(react@19.2.7)':
+    dependencies:
+      emoji-mart: 5.6.0
+      react: 19.2.7
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -14655,6 +14775,8 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
     optional: true
+
+  '@popperjs/core@2.11.8': {}
 
   '@preact/signals-core@1.14.3': {}
 
@@ -15916,6 +16038,12 @@ snapshots:
       '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
       '@tiptap/pm': 3.27.1
 
+  '@tiptap/extension-mention@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/suggestion@3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
+      '@tiptap/pm': 3.27.1
+      '@tiptap/suggestion': 3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
+
   '@tiptap/extension-ordered-list@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
     dependencies:
       '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
@@ -16021,6 +16149,12 @@ snapshots:
       '@tiptap/extension-text': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
       '@tiptap/extension-underline': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
       '@tiptap/extensions': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
+      '@tiptap/pm': 3.27.1
+
+  '@tiptap/suggestion@3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
       '@tiptap/pm': 3.27.1
 
   '@tybys/wasm-util@0.10.2':
@@ -16853,6 +16987,8 @@ snapshots:
       zrender: 6.1.0
 
   electron-to-chromium@1.5.376: {}
+
+  emoji-mart@5.6.0: {}
 
   emoji-regex@10.6.0: {}
 
@@ -18973,6 +19109,10 @@ snapshots:
   tinyrainbow@3.1.0: {}
 
   tinyspy@4.0.4: {}
+
+  tippy.js@6.3.7:
+    dependencies:
+      '@popperjs/core': 2.11.8
 
   tldts-core@7.4.3: {}
 


### PR DESCRIPTION
## Problem

`develop` is red again — `pnpm install --frozen-lockfile` fails:

```
specifiers in the lockfile don't match specifiers in package.json:
26 dependencies were added: @tiptap/*, @emoji-mart/*, sonner, tippy.js, @granit/react-timeline, …
```

PR #767 (react-ui-timeline) was merged with red CI — exactly the #765 pattern (fixed in #766). The broken install masked every downstream check, so lint/index/arch failures landed latent on `develop`.

## Fixes (all verified green under develop's deps)

1. **Lockfile** — regenerate `pnpm-lock.yaml` for the 26 deps `react-timeline` + `react-ui-timeline` added. Restores `--frozen-lockfile`.
2. **front-index** — regenerate `.mcp-front-index.json` (was missing the new packages' exports).
3. **lint** — `import-x/order` across the package (`eslint --fix`); removed two orphan `eslint-disable` directives (`react-hooks/exhaustive-deps`, `react-refresh/only-export-components`) — neither plugin is registered in `eslint.config.js`, so they errored as unknown rules (same as the `set-state-in-effect` case in #766).
4. **arch** — `entity-timeline.tsx` uses `react-router-dom` `Link`, so add `@granit/react-ui-timeline` to `UI_ROUTER_BASELINE`.

## Verification

`pnpm install --frozen-lockfile`, `pnpm lint`, arch-tests green. tsc + full test suite running.

> Note: same class of merge-with-red-CI as #765/#766. Worth enforcing branch protection so PRs can't merge with failing checks.