### PR TITLE
refactor(react-localization): host the canonical resolveLabel helper

### DIFF
--- a/packages/@granit/react-localization/src/index.ts
+++ b/packages/@granit/react-localization/src/index.ts
@@ -30,3 +30,4 @@ export { I18nextProvider, Trans } from 'react-i18next';
 // Custom useTranslation wrapper that auto-applies standard separators for
 // custom namespaces when the app disables them globally. See use-translation.ts.
 export { useTranslation } from './use-translation';
+export { resolveLabel } from './resolve-label';

--- a/packages/@granit/react-localization/src/resolve-label.ts
+++ b/packages/@granit/react-localization/src/resolve-label.ts
@@ -1,0 +1,25 @@
+// Loose i18next TFunction shape — keeps the helper free of `react-i18next`
+// peer typings so non-React callers (and headless code) can use it too.
+type TranslateFn = (key: string) => string;
+
+/**
+ * Resolves a backend display key (e.g. `AuditingEndpoints:Workspace.Item`) to a
+ * human label. With a `t` function, i18next is consulted first; otherwise (or
+ * on a miss) it falls back to the last segment of the key, then to `fallback`.
+ *
+ * Apps configured with `nsSeparator: false; keySeparator: false` resolve
+ * `t(displayKey)` as a literal lookup against the flat bundle — the
+ * last-segment fallback only matters before the backend translations load.
+ *
+ * Shared by the workspace chrome (`@granit/react-ui-shell-admin`) and any host
+ * that wires a manifest-driven `ResolveLabel` (e.g. for `@granit/react-entities`).
+ */
+export function resolveLabel(displayKey: string | null, fallback: string, t?: TranslateFn): string {
+  if (!displayKey) return fallback;
+  if (t) {
+    const translated = t(displayKey);
+    if (translated && translated !== displayKey) return translated;
+  }
+  const lastSegment = displayKey.split(/[.:]/).pop();
+  return lastSegment && lastSegment.length > 0 ? lastSegment : fallback;
+}

--- a/packages/@granit/react-ui-shell-admin/src/workspace-utils.ts
+++ b/packages/@granit/react-ui-shell-admin/src/workspace-utils.ts
@@ -1,3 +1,4 @@
+import { resolveLabel } from '@granit/react-localization';
 import {
   buildWorkspaceUrl,
   resolveFeatureRoute,
@@ -5,29 +6,13 @@ import {
   type WorkspaceItemResponse,
 } from '@granit/workspaces';
 
+// Re-export the shared label resolver (canonical home: @granit/react-localization)
+// so workspace-utils stays the single import surface for shell-admin's helpers.
+export { resolveLabel };
+
 // Loose i18next TFunction shape — keeps the helper free of
 // `react-i18next` peer typings.
 type TranslateFn = (key: string) => string;
-
-// Resolves a backend display key (e.g. `AuditingEndpoints:Workspace.Item`)
-// to its translated label. When a `t` function is provided, i18next is
-// consulted first; otherwise (or when the translation misses) we fall
-// back to the last segment of the key, then to the supplied fallback.
-//
-// The showcase `i18n` instance is configured with
-// `nsSeparator: false; keySeparator: false`, so `t(displayKey)` is a
-// literal lookup against the flat bundle populated by
-// `LocalizationProvider`. The last-segment fallback only matters when
-// the backend translation hasn't loaded yet.
-export function resolveLabel(displayKey: string | null, fallback: string, t?: TranslateFn): string {
-  if (!displayKey) return fallback;
-  if (t) {
-    const translated = t(displayKey);
-    if (translated && translated !== displayKey) return translated;
-  }
-  const lastSegment = displayKey.split(/[.:]/).pop();
-  return lastSegment && lastSegment.length > 0 ? lastSegment : fallback;
-}
 
 // Resolves the navigation URL for one workspace item. Entity items route
 // through `/w/{parentWorkspace}/{entityName}` so the manifest renderer


### PR DESCRIPTION
`resolveLabel` (display-key → translated label, with last-segment fallback) lived in `react-ui-shell-admin/workspace-utils`, but it's a generic i18n helper. The upcoming `@granit/react-ui-entities` (manifest-driven entity UI) needs it too, and depending on `shell-admin` for it would be a layer inversion.

Move it to its natural home, `@granit/react-localization`, and have `shell-admin` **re-export** it from `workspace-utils` so existing consumers are unaffected (zero behavioural change).

Validated: tsc clean (react-localization + shell-admin), arch-tests pass (2840).