### PR TITLE
fix(shell-admin): restore resolveLabel in react-localization test mocks (#770 fallout)

### DIFF
--- a/packages/@granit/react-ui-shell-admin/src/__tests__/command-palette.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/command-palette.test.tsx
@@ -15,7 +15,12 @@ import {
 import type { WorkspaceTreeResponse } from '@granit/workspaces';
 import type * as ReactRouter from 'react-router-dom';
 
-vi.mock('@granit/react-localization', () => ({ useTranslation: () => ({ t: makeT() }) }));
+// resolveLabel is a real (pure) export of @granit/react-localization (#770);
+// keep it via importOriginal and override only useTranslation for the test.
+vi.mock('@granit/react-localization', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@granit/react-localization')>()),
+  useTranslation: () => ({ t: makeT() }),
+}));
 
 vi.mock('./workspace-icon', () => ({
   WorkspaceIcon: ({ name }: { name: string | null }) => <span data-slot="icon">{name ?? ''}</span>,

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/host-home-page.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/host-home-page.test.tsx
@@ -6,7 +6,12 @@ import { makeT, makeTree, makeWorkspace, renderShell } from './test-utils';
 import type { WorkspaceTreeResponse } from '@granit/workspaces';
 import type * as ReactRouter from 'react-router-dom';
 
-vi.mock('@granit/react-localization', () => ({ useTranslation: () => ({ t: makeT() }) }));
+// resolveLabel is a real (pure) export of @granit/react-localization (#770);
+// keep it via importOriginal and override only useTranslation for the test.
+vi.mock('@granit/react-localization', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@granit/react-localization')>()),
+  useTranslation: () => ({ t: makeT() }),
+}));
 
 vi.mock('./workspace-icon', () => ({
   WorkspaceIcon: ({ name }: { name: string | null }) => <span data-slot="icon">{name ?? ''}</span>,

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/workspace-content-nav.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/workspace-content-nav.test.tsx
@@ -12,7 +12,12 @@ import {
 
 import type { WorkspaceTreeResponse } from '@granit/workspaces';
 
-vi.mock('@granit/react-localization', () => ({ useTranslation: () => ({ t: makeT() }) }));
+// resolveLabel is a real (pure) export of @granit/react-localization (#770);
+// keep it via importOriginal and override only useTranslation for the test.
+vi.mock('@granit/react-localization', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@granit/react-localization')>()),
+  useTranslation: () => ({ t: makeT() }),
+}));
 
 vi.mock('./workspace-icon', () => ({
   WorkspaceIcon: ({ name }: { name: string | null }) => <span data-slot="icon">{name ?? ''}</span>,

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/workspace-switcher-menu.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/workspace-switcher-menu.test.tsx
@@ -6,7 +6,12 @@ import { makeT, makeTree, makeWorkspace, renderShell } from './test-utils';
 import type { WorkspaceTreeResponse } from '@granit/workspaces';
 import type * as ReactRouter from 'react-router-dom';
 
-vi.mock('@granit/react-localization', () => ({ useTranslation: () => ({ t: makeT() }) }));
+// resolveLabel is a real (pure) export of @granit/react-localization (#770);
+// keep it via importOriginal and override only useTranslation for the test.
+vi.mock('@granit/react-localization', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@granit/react-localization')>()),
+  useTranslation: () => ({ t: makeT() }),
+}));
 
 vi.mock('./workspace-icon', () => ({
   WorkspaceIcon: ({ name }: { name: string | null }) => <span data-slot="icon">{name ?? ''}</span>,


### PR DESCRIPTION
## Problem

`develop` is red on test shards (1, 2, 4) after #770:

```
TypeError: resolveLabel is not a function
  ❯ packages/@granit/react-ui-shell-admin/src/command-palette.tsx:85
[vitest] No "resolveLabel" export is defined on the "@granit/react-localization" mock.
```

#770 ("host the canonical resolveLabel helper") moved `resolveLabel` to be a real, pure export of `@granit/react-localization`; shell-admin's `workspace-utils.ts` now re-exports it from there. Four shell-admin test files mock `@granit/react-localization` with **only** `useTranslation`, so the re-exported `resolveLabel` resolved to `undefined` once #770 landed.

Failing suites: `CommandPalette`, `WorkspaceContentNav`, `HostHomePage`, `WorkspaceSwitcherMenu`.

## Fix

Switch those four mocks to `importOriginal`, keeping the real (pure) `resolveLabel` and overriding only `useTranslation` — which is the tests' actual intent and is robust to future react-localization changes:

```ts
vi.mock('@granit/react-localization', async (importOriginal) => ({
  ...(await importOriginal<typeof import('@granit/react-localization')>()),
  useTranslation: () => ({ t: makeT() }),
}));
```

## Verification

All 15 shell-admin test files green (91 tests); full `pnpm test run` + lint + tsc running. Branched from latest `develop` (d54f416a).