### PR TITLE
fix(shell-admin): use Record type in importOriginal mock (lint follow-up to #771)

### DIFF
--- a/packages/@granit/react-ui-shell-admin/src/__tests__/command-palette.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/command-palette.test.tsx
@@ -18,7 +18,7 @@ import type * as ReactRouter from 'react-router-dom';
 // resolveLabel is a real (pure) export of @granit/react-localization (#770);
 // keep it via importOriginal and override only useTranslation for the test.
 vi.mock('@granit/react-localization', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@granit/react-localization')>()),
+  ...(await importOriginal<Record<string, unknown>>()),
   useTranslation: () => ({ t: makeT() }),
 }));
 

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/host-home-page.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/host-home-page.test.tsx
@@ -9,7 +9,7 @@ import type * as ReactRouter from 'react-router-dom';
 // resolveLabel is a real (pure) export of @granit/react-localization (#770);
 // keep it via importOriginal and override only useTranslation for the test.
 vi.mock('@granit/react-localization', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@granit/react-localization')>()),
+  ...(await importOriginal<Record<string, unknown>>()),
   useTranslation: () => ({ t: makeT() }),
 }));
 

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/workspace-content-nav.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/workspace-content-nav.test.tsx
@@ -15,7 +15,7 @@ import type { WorkspaceTreeResponse } from '@granit/workspaces';
 // resolveLabel is a real (pure) export of @granit/react-localization (#770);
 // keep it via importOriginal and override only useTranslation for the test.
 vi.mock('@granit/react-localization', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@granit/react-localization')>()),
+  ...(await importOriginal<Record<string, unknown>>()),
   useTranslation: () => ({ t: makeT() }),
 }));
 

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/workspace-switcher-menu.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/workspace-switcher-menu.test.tsx
@@ -9,7 +9,7 @@ import type * as ReactRouter from 'react-router-dom';
 // resolveLabel is a real (pure) export of @granit/react-localization (#770);
 // keep it via importOriginal and override only useTranslation for the test.
 vi.mock('@granit/react-localization', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@granit/react-localization')>()),
+  ...(await importOriginal<Record<string, unknown>>()),
   useTranslation: () => ({ t: makeT() }),
 }));
 


### PR DESCRIPTION
## Problem

#771 (resolveLabel mock fix) merged with a forbidden inline `import()` type annotation, turning develop **lint** red:

```
21:35  error  `import()` type annotations are forbidden  @typescript-eslint/consistent-type-imports
```

In four shell-admin test mocks: `importOriginal<typeof import('@granit/react-localization')>()`.

## Fix

Use `importOriginal<Record<string, unknown>>()` — the generic only types the spread; `importOriginal` returns the real module at runtime, so the resolveLabel behaviour from #771 is unchanged.

## Verification

lint (the 4 files) ✅, `tsc` (shell-admin) ✅, all 15 shell-admin test files / 91 tests ✅. Branched from latest `develop`.