### PR TITLE
chore(react-ui-authentication-local): drop unused axios peer dep

### DIFF
--- a/packages/@granit/react-ui-authentication-local/package.json
+++ b/packages/@granit/react-ui-authentication-local/package.json
@@ -25,7 +25,6 @@
     "@granit/react-validation": "workspace:*",
     "@granit/utils": "workspace:*",
     "@granit/validation": "workspace:*",
-    "axios": "^1.7.0",
     "lucide-react": "^1.21.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -58,7 +57,6 @@
     "@granit/validation": "workspace:*",
     "@storybook/react-vite": "^10.4.6",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "^1.7.0",
     "i18next": "^26.0.0",
     "react-i18next": "^17.0.0",
     "storybook": "^10.4.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4139,9 +4139,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.101.1
         version: 5.101.1(react@19.2.7)
-      axios:
-        specifier: 1.18.1
-        version: 1.18.1
       i18next:
         specifier: ^26.0.0
         version: 26.3.1(typescript@6.0.3)


### PR DESCRIPTION
## What

Removes the `axios` entry from both `peerDependencies` and `devDependencies` of `@granit/react-ui-authentication-local`. It was never imported — the package's error narrowing uses `isAxiosError`/`HttpError` re-exported from `@granit/api-client`.

## Why

Audit finding (CLEANUP, UI tier): a stale HTTP-client dependency declared but unused. `@granit/api-client` is retained (it is used for error helpers).

## Verification

- `tsc --noEmit` ✓
- eslint (package) ✓
- vitest `react-ui-authentication-local` — 114 passed ✓
- lockfile synced (`pnpm install --lockfile-only`)

Part of the `/audit` sweep of `react-ui-*` packages (scope A of 5).