### PR TITLE
refactor(react-ui): route toast through the foundation, not sonner directly

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -6181,6 +6181,11 @@
           "name": "useTranslation",
           "kind": "function",
           "signature": "function useTranslation< Ns extends FlatNamespace | readonly [FlatNamespace?, ...FlatNamespace[]] = 'translation', KPrefix extends KeyPrefix<FallbackNs<Ns>> = undefined, >( ns?: Ns, options?: UseTranslationOptions<KPrefix> ): UseTranslationResponse<FallbackNs<Ns>, KPrefix>"
+        },
+        {
+          "name": "resolveLabel",
+          "kind": "function",
+          "signature": "function resolveLabel(displayKey: string | null, fallback: string, t?: TranslateFn): string"
         }
       ]
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -96,6 +96,10 @@ export default tseslint.config(
               name: 'axios',
               message: "Import Axios types from '@granit/api-client' instead. The api-client package owns the HTTP client façade (createApiClient, AxiosInstance re-export, interceptors).",
             },
+            {
+              name: 'sonner',
+              message: "Import `toast` / `Toaster` from '@granit/react-ui' instead. The react-ui foundation owns the sonner wrapper (themed Toaster, semantic icons); domain UI packages must not depend on sonner directly.",
+            },
           ],
         },
       ],
@@ -127,6 +131,18 @@ export default tseslint.config(
       '**/*.test.{ts,tsx}',
     ],
     rules: { 'no-restricted-imports': 'off', 'no-restricted-globals': 'off' },
+  },
+
+  // react-ui owns the sonner wrapper (themed Toaster + re-exported toast), so it
+  // is the only package allowed to import sonner directly. Keep the fetch ban.
+  {
+    files: ['packages/@granit/react-ui/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        { paths: [{ name: 'axios', message: "Import Axios types from '@granit/api-client' instead." }] },
+      ],
+    },
   },
 
   // Test files — relax some rules

--- a/packages/@granit/react-ui-account/package.json
+++ b/packages/@granit/react-ui-account/package.json
@@ -28,8 +28,7 @@
     "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {
@@ -62,7 +61,6 @@
     "react-dom": "^19.0.0",
     "react-i18next": "^17.0.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "storybook": "^10.4.6"
   }
 }

--- a/packages/@granit/react-ui-account/src/delete-account-page.tsx
+++ b/packages/@granit/react-ui-account/src/delete-account-page.tsx
@@ -12,10 +12,10 @@ import {
   DialogTitle,
   Input,
   Label,
+  toast,
 } from '@granit/react-ui';
 import { AlertTriangle } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from './logger';
 

--- a/packages/@granit/react-ui-account/src/profile-page.tsx
+++ b/packages/@granit/react-ui-account/src/profile-page.tsx
@@ -9,9 +9,9 @@ import {
   Input,
   Label,
   Spinner,
+  toast,
 } from '@granit/react-ui';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from './logger';
 

--- a/packages/@granit/react-ui-account/src/security/external-login-buttons.test.tsx
+++ b/packages/@granit/react-ui-account/src/security/external-login-buttons.test.tsx
@@ -1,8 +1,8 @@
 import { HttpError } from '@granit/api-client';
+import { toast } from '@granit/react-ui';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { I18nextProvider } from 'react-i18next';
-import { toast } from 'sonner';
 
 import { testI18n } from '../__tests__/test-utils';
 

--- a/packages/@granit/react-ui-account/src/security/external-login-buttons.tsx
+++ b/packages/@granit/react-ui-account/src/security/external-login-buttons.tsx
@@ -1,9 +1,8 @@
 import { HttpError } from '@granit/api-client';
 import { useChallengeExternalLogin } from '@granit/react-account';
 import { useTranslation } from '@granit/react-localization';
-import { Button } from '@granit/react-ui';
+import { toast, Button } from '@granit/react-ui';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-account/src/security/external-logins-page.tsx
+++ b/packages/@granit/react-ui-account/src/security/external-logins-page.tsx
@@ -8,9 +8,9 @@ import {
   CardHeader,
   CardTitle,
   Spinner,
+  toast,
 } from '@granit/react-ui';
 import { Link2Off } from 'lucide-react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-account/src/security/passkeys-page.tsx
+++ b/packages/@granit/react-ui-account/src/security/passkeys-page.tsx
@@ -23,11 +23,11 @@ import {
   Input,
   Label,
   Spinner,
+  toast,
 } from '@granit/react-ui';
 import { fromBase64Url } from '@granit/react-ui-authentication-local';
 import { Fingerprint, Pencil, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-account/src/security/password-page.tsx
+++ b/packages/@granit/react-ui-account/src/security/password-page.tsx
@@ -1,9 +1,17 @@
 import { useChangePassword } from '@granit/react-account';
 import { useTranslation } from '@granit/react-localization';
-import { Button, Card, CardContent, CardHeader, CardTitle, Input, Label } from '@granit/react-ui';
+import {
+  toast,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+} from '@granit/react-ui';
 import { Eye, EyeOff } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-account/src/security/two-factor-page.tsx
+++ b/packages/@granit/react-ui-account/src/security/two-factor-page.tsx
@@ -21,11 +21,11 @@ import {
   Label,
   Separator,
   Spinner,
+  toast,
 } from '@granit/react-ui';
 import { CheckCircle, Copy, Mail, Shield, XCircle } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import { useEffect, useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-ai-chat/package.json
+++ b/packages/@granit/react-ui-ai-chat/package.json
@@ -30,8 +30,7 @@
     "marked": "^18.0.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {
@@ -67,7 +66,6 @@
     "react-dom": "^19.0.0",
     "react-i18next": "^17.0.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "storybook": "^10.4.6"
   }
 }

--- a/packages/@granit/react-ui-ai-chat/src/__tests__/chat-message-actions.test.tsx
+++ b/packages/@granit/react-ui-ai-chat/src/__tests__/chat-message-actions.test.tsx
@@ -1,5 +1,5 @@
+import { toast } from '@granit/react-ui';
 import { screen, waitFor } from '@testing-library/react';
-import { toast } from 'sonner';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatMessageActions } from '../components/chat-message-actions';

--- a/packages/@granit/react-ui-ai-chat/src/__tests__/chat-settings-page.test.tsx
+++ b/packages/@granit/react-ui-ai-chat/src/__tests__/chat-settings-page.test.tsx
@@ -1,5 +1,5 @@
+import { toast } from '@granit/react-ui';
 import { screen, waitFor } from '@testing-library/react';
-import { toast } from 'sonner';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatSettingsPage } from '../chat-settings-page';

--- a/packages/@granit/react-ui-ai-chat/src/chat-settings-page.tsx
+++ b/packages/@granit/react-ui-ai-chat/src/chat-settings-page.tsx
@@ -15,9 +15,9 @@ import {
   SelectTrigger,
   SelectValue,
   Textarea,
+  toast,
 } from '@granit/react-ui';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from './logger';
 

--- a/packages/@granit/react-ui-ai-chat/src/components/chat-message-actions.tsx
+++ b/packages/@granit/react-ui-ai-chat/src/components/chat-message-actions.tsx
@@ -22,10 +22,10 @@ import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
+  toast,
 } from '@granit/react-ui';
 import { ChevronDown, Code2, Copy, Flag, Hash, RefreshCw, RemoveFormatting } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-ai/package.json
+++ b/packages/@granit/react-ui-ai/package.json
@@ -30,7 +30,6 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "zod": "^4.4.3"
   },
   "publishConfig": {
@@ -65,7 +64,6 @@
     "react-hook-form": "^7.80.0",
     "react-i18next": "^17.0.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "storybook": "^10.4.6",
     "zod": "^4.4.3"
   }

--- a/packages/@granit/react-ui-ai/src/ai-workspace-create-page.tsx
+++ b/packages/@granit/react-ui-ai/src/ai-workspace-create-page.tsx
@@ -1,9 +1,8 @@
 import { useCreateAIWorkspace } from '@granit/react-ai';
 import { useTranslation } from '@granit/react-localization';
-import { Button, Separator } from '@granit/react-ui';
+import { toast, Button, Separator } from '@granit/react-ui';
 import { ArrowLeft } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { WorkspaceForm } from './components/workspace-form';
 import { logger } from './logger';

--- a/packages/@granit/react-ui-ai/src/ai-workspace-edit-page.tsx
+++ b/packages/@granit/react-ui-ai/src/ai-workspace-edit-page.tsx
@@ -2,10 +2,9 @@ import { AI_WORKSPACE_KINDS, AIPermissions } from '@granit/ai';
 import { useAIWorkspace, useUpdateAIWorkspace } from '@granit/react-ai';
 import { usePermissions } from '@granit/react-authorization';
 import { useTranslation } from '@granit/react-localization';
-import { Badge, Button, Separator, Spinner } from '@granit/react-ui';
+import { toast, Badge, Button, Separator, Spinner } from '@granit/react-ui';
 import { AlertCircle, ArrowLeft } from 'lucide-react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { WorkspaceDetail } from './components/workspace-detail';
 import { WorkspaceForm } from './components/workspace-form';

--- a/packages/@granit/react-ui-ai/src/ai-workspace-list-page.tsx
+++ b/packages/@granit/react-ui-ai/src/ai-workspace-list-page.tsx
@@ -2,12 +2,11 @@ import { AI_WORKSPACE_KINDS, AIPermissions } from '@granit/ai';
 import { useAIWorkspaces, useDeleteAIWorkspace } from '@granit/react-ai';
 import { usePermissions } from '@granit/react-authorization';
 import { useTranslation } from '@granit/react-localization';
-import { Badge, Button, Card, CardContent, Spinner } from '@granit/react-ui';
+import { toast, Badge, Button, Card, CardContent, Spinner } from '@granit/react-ui';
 import { ViewSwitcher } from '@granit/react-ui-admin-kit';
 import { Plus } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { createWorkspaceColumns } from './components/workspace-columns';
 import { WorkspaceDeleteDialog } from './components/workspace-delete-dialog';

--- a/packages/@granit/react-ui-authentication-api-keys/package.json
+++ b/packages/@granit/react-ui-authentication-api-keys/package.json
@@ -28,8 +28,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-authentication-api-keys/src/api-key-create-page.tsx
+++ b/packages/@granit/react-ui-authentication-api-keys/src/api-key-create-page.tsx
@@ -16,6 +16,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  toast,
 } from '@granit/react-ui';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { toISODateString } from '@granit/types';
@@ -23,7 +24,6 @@ import { Loader2 } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { ApiKeySecretDialog } from './components/api-key-secret-dialog';
 import { API_KEY_ENVIRONMENTS, API_KEY_TYPES, CACHE_BEHAVIORS } from './constants';

--- a/packages/@granit/react-ui-authentication-local/package.json
+++ b/packages/@granit/react-ui-authentication-local/package.json
@@ -30,8 +30,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-authentication-local/src/confirm-email-page.tsx
+++ b/packages/@granit/react-ui-authentication-local/src/confirm-email-page.tsx
@@ -1,8 +1,7 @@
 import { useConfirmEmail, useResendConfirmation } from '@granit/react-account';
 import { useTranslation } from '@granit/react-localization';
-import { Button } from '@granit/react-ui';
+import { toast, Button } from '@granit/react-ui';
 import { useEffect, useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from './logger';
 import { TokenConfirmationResult, type ConfirmationStatus } from './token-confirmation-result';

--- a/packages/@granit/react-ui-authentication-local/src/external-login-buttons.tsx
+++ b/packages/@granit/react-ui-authentication-local/src/external-login-buttons.tsx
@@ -1,9 +1,8 @@
 import { HttpError } from '@granit/api-client';
 import { useAvailableExternalProviders, useChallengeExternalLogin } from '@granit/react-account';
 import { useTranslation } from '@granit/react-localization';
-import { Button } from '@granit/react-ui';
+import { toast, Button } from '@granit/react-ui';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { ExternalProviderIcon } from './external-provider-icon';
 import { logger } from './logger';

--- a/packages/@granit/react-ui-blob-storage/package.json
+++ b/packages/@granit/react-ui-blob-storage/package.json
@@ -27,8 +27,7 @@
     "@tanstack/react-table": "^8.21.3",
     "lucide-react": "^1.21.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "sonner": "^2.0.7"
+    "react-dom": "^19.0.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-blob-storage/src/blob-list-page.tsx
+++ b/packages/@granit/react-ui-blob-storage/src/blob-list-page.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuTrigger,
   StatusBadge,
   type StatusBadgeIntent,
+  toast,
 } from '@granit/react-ui';
 import {
   FilterPresets,
@@ -22,7 +23,6 @@ import {
 } from '@granit/react-ui-admin-kit';
 import { Download, MoreHorizontal, Trash2 } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
-import { toast } from 'sonner';
 
 import { BlobCleanupOrphansButton } from './components/blob-cleanup-orphans-button';
 import { BlobDeleteDialog } from './components/blob-delete-dialog';

--- a/packages/@granit/react-ui-blob-storage/src/components/blob-cleanup-orphans-button.tsx
+++ b/packages/@granit/react-ui-blob-storage/src/components/blob-cleanup-orphans-button.tsx
@@ -10,10 +10,10 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   Button,
+  toast,
 } from '@granit/react-ui';
 import { Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-catalog/package.json
+++ b/packages/@granit/react-ui-catalog/package.json
@@ -30,8 +30,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-catalog/src/__tests__/lifecycle-actions.test.tsx
+++ b/packages/@granit/react-ui-catalog/src/__tests__/lifecycle-actions.test.tsx
@@ -1,8 +1,8 @@
+import { toast } from '@granit/react-ui';
 import { workflowTranslationsEn } from '@granit/react-workflow';
 import { toEntityId } from '@granit/types';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { toast } from 'sonner';
 import { beforeAll, vi } from 'vitest';
 
 import { LifecycleActions } from '../components/lifecycle-actions';

--- a/packages/@granit/react-ui-catalog/src/catalog-create-page.tsx
+++ b/packages/@granit/react-ui-catalog/src/catalog-create-page.tsx
@@ -17,12 +17,12 @@ import {
   SelectTrigger,
   SelectValue,
   Textarea,
+  toast,
 } from '@granit/react-ui';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { Loader2 } from 'lucide-react';
 import { useForm, type Resolver } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { PRODUCT_TYPES } from './constants';
 import { capitalize } from './lib/capitalize';

--- a/packages/@granit/react-ui-catalog/src/catalog-edit-page.tsx
+++ b/packages/@granit/react-ui-catalog/src/catalog-edit-page.tsx
@@ -15,6 +15,7 @@ import {
   Input,
   Spinner,
   Textarea,
+  toast,
 } from '@granit/react-ui';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { toEntityId } from '@granit/types';
@@ -22,7 +23,6 @@ import { AlertTriangle, Loader2 } from 'lucide-react';
 import { useEffect } from 'react';
 import { useForm, type Resolver } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { capitalize } from './lib/capitalize';
 

--- a/packages/@granit/react-ui-catalog/src/components/external-mappings-manager.tsx
+++ b/packages/@granit/react-ui-catalog/src/components/external-mappings-manager.tsx
@@ -13,11 +13,11 @@ import {
   FormLabel,
   FormMessage,
   Input,
+  toast,
 } from '@granit/react-ui';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { Loader2, Plus, Trash2 } from 'lucide-react';
 import { useForm, type Resolver } from 'react-hook-form';
-import { toast } from 'sonner';
 
 import { capitalize } from '../lib/capitalize';
 

--- a/packages/@granit/react-ui-catalog/src/components/lifecycle-actions.tsx
+++ b/packages/@granit/react-ui-catalog/src/components/lifecycle-actions.tsx
@@ -11,12 +11,12 @@ import {
   Button,
   Input,
   Label,
+  toast,
 } from '@granit/react-ui';
 import { buildLifecycleTransitionPrompt } from '@granit/react-workflow';
 import { WorkflowLifecycleStatus, type WorkflowLifecycleStatusValue } from '@granit/workflow';
 import { Archive, Loader2, Send } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import type { ProductResponse } from '@granit/catalog';
 

--- a/packages/@granit/react-ui-catalog/src/components/metadata-editor.tsx
+++ b/packages/@granit/react-ui-catalog/src/components/metadata-editor.tsx
@@ -1,9 +1,8 @@
 import { useUpdateProductMetadata } from '@granit/react-catalog';
 import { useTranslation } from '@granit/react-localization';
-import { Button, Input } from '@granit/react-ui';
+import { toast, Button, Input } from '@granit/react-ui';
 import { Loader2, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import type { ProductResponse } from '@granit/catalog';
 

--- a/packages/@granit/react-ui-cms-hostnames/package.json
+++ b/packages/@granit/react-ui-cms-hostnames/package.json
@@ -24,8 +24,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-cms-hostnames/src/components/cms-hostname-add-form.tsx
+++ b/packages/@granit/react-ui-cms-hostnames/src/components/cms-hostname-add-form.tsx
@@ -1,10 +1,9 @@
 import { cmsHostnamesConstraints } from '@granit/cms-hostnames';
 import { useAddSiteHostname } from '@granit/react-cms-hostnames';
 import { useTranslation } from '@granit/react-localization';
-import { Button, Checkbox, Input, Label } from '@granit/react-ui';
+import { toast, Button, Checkbox, Input, Label } from '@granit/react-ui';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { Controller, useForm, type Resolver } from 'react-hook-form';
-import { toast } from 'sonner';
 
 // Client-only UX guard for a real FQDN. The CMS contract carries only
 // `required` + `maxLength` on `host` (the .NET endpoint runs the authoritative

--- a/packages/@granit/react-ui-cms-hostnames/src/hostnames-page.tsx
+++ b/packages/@granit/react-ui-cms-hostnames/src/hostnames-page.tsx
@@ -22,10 +22,10 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  toast,
 } from '@granit/react-ui';
 import { ArrowLeft, RefreshCw, Star, Trash2 } from 'lucide-react';
 import { Link, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { CmsHostnameAddForm } from './components/cms-hostname-add-form';
 import { CmsHostnameStatusBadge } from './components/cms-hostname-status-badge';

--- a/packages/@granit/react-ui-cms-menus/package.json
+++ b/packages/@granit/react-ui-cms-menus/package.json
@@ -24,8 +24,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-cms-menus/src/menu-form-page.tsx
+++ b/packages/@granit/react-ui-cms-menus/src/menu-form-page.tsx
@@ -1,13 +1,12 @@
 import { cmsConstraints, type MenuItemRequest } from '@granit/cms';
 import { useMenu, useCreateMenu, useUpdateMenu } from '@granit/react-cms';
 import { useTranslation } from '@granit/react-localization';
-import { Button, Input, Label, Separator, Textarea } from '@granit/react-ui';
+import { toast, Button, Input, Label, Separator, Textarea } from '@granit/react-ui';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { ArrowLeft } from 'lucide-react';
 import { useEffect } from 'react';
 import { useForm, type Resolver } from 'react-hook-form';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 interface MenuFormValues {
   key: string;

--- a/packages/@granit/react-ui-cms-menus/src/menus-list-page.tsx
+++ b/packages/@granit/react-ui-cms-menus/src/menus-list-page.tsx
@@ -18,10 +18,10 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  toast,
 } from '@granit/react-ui';
 import { ArrowLeft, Plus, Pencil, Trash2 } from 'lucide-react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 export function MenusListPage() {
   const { t } = useTranslation();

--- a/packages/@granit/react-ui-cms-pages/package.json
+++ b/packages/@granit/react-ui-cms-pages/package.json
@@ -24,8 +24,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-cms-pages/src/page-form-page.tsx
+++ b/packages/@granit/react-ui-cms-pages/src/page-form-page.tsx
@@ -11,13 +11,13 @@ import {
   SelectTrigger,
   SelectValue,
   Separator,
+  toast,
 } from '@granit/react-ui';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { ArrowLeft, ExternalLink } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { Controller, useForm, type Resolver } from 'react-hook-form';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { buildPageEditorUrl } from './renderer';
 

--- a/packages/@granit/react-ui-cms-pages/src/page-tree-page.tsx
+++ b/packages/@granit/react-ui-cms-pages/src/page-tree-page.tsx
@@ -18,10 +18,10 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  toast,
 } from '@granit/react-ui';
 import { ArrowLeft, Plus, Pencil, Trash2 } from 'lucide-react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 export function PageTreePage() {
   const { t } = useTranslation();

--- a/packages/@granit/react-ui-cms-redirects/package.json
+++ b/packages/@granit/react-ui-cms-redirects/package.json
@@ -23,8 +23,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-cms-redirects/src/components/redirect-form-dialog.tsx
+++ b/packages/@granit/react-ui-cms-redirects/src/components/redirect-form-dialog.tsx
@@ -16,11 +16,11 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  toast,
 } from '@granit/react-ui';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { useEffect, useMemo } from 'react';
 import { Controller, useForm, type Resolver } from 'react-hook-form';
-import { toast } from 'sonner';
 
 import type {
   RedirectMatchType,

--- a/packages/@granit/react-ui-cms-redirects/src/redirects-list-page.tsx
+++ b/packages/@granit/react-ui-cms-redirects/src/redirects-list-page.tsx
@@ -19,11 +19,11 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  toast,
 } from '@granit/react-ui';
 import { ArrowLeft, Pencil, Plus, Trash2, ToggleLeft, ToggleRight } from 'lucide-react';
 import { useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { RedirectFormDialog } from './components/redirect-form-dialog';
 

--- a/packages/@granit/react-ui-cms-releases/package.json
+++ b/packages/@granit/react-ui-cms-releases/package.json
@@ -24,8 +24,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-cms-releases/src/components/release-form-dialog.tsx
+++ b/packages/@granit/react-ui-cms-releases/src/components/release-form-dialog.tsx
@@ -17,12 +17,12 @@ import {
   FormLabel,
   FormMessage,
   Input,
+  toast,
 } from '@granit/react-ui';
 import { TimezonePicker } from '@granit/react-ui-admin-kit';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { useEffect } from 'react';
 import { useForm, type Resolver } from 'react-hook-form';
-import { toast } from 'sonner';
 
 function capitalize(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);

--- a/packages/@granit/react-ui-cms-releases/src/release-detail-page.tsx
+++ b/packages/@granit/react-ui-cms-releases/src/release-detail-page.tsx
@@ -18,6 +18,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  toast,
 } from '@granit/react-ui';
 import { TimezonePicker } from '@granit/react-ui-admin-kit';
 import { createConstraintsResolver } from '@granit/react-validation';
@@ -25,7 +26,6 @@ import { ArrowLeft } from 'lucide-react';
 import { useEffect } from 'react';
 import { useForm, type Resolver } from 'react-hook-form';
 import { Link, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import type { ReleaseActionStatus, ReleaseResponse, ReleaseStatus } from '@granit/cms';
 

--- a/packages/@granit/react-ui-cms-releases/src/releases-list-page.tsx
+++ b/packages/@granit/react-ui-cms-releases/src/releases-list-page.tsx
@@ -10,11 +10,11 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  toast,
 } from '@granit/react-ui';
 import { ArrowLeft, Eye, Plus, Send } from 'lucide-react';
 import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { ReleaseFormDialog } from './components/release-form-dialog';
 

--- a/packages/@granit/react-ui-cms-seo/package.json
+++ b/packages/@granit/react-ui-cms-seo/package.json
@@ -23,8 +23,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {
@@ -49,7 +48,6 @@
     "i18next": "^26.0.0",
     "react-hook-form": "^7.80.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "storybook": "^10.4.6"
   }
 }

--- a/packages/@granit/react-ui-cms-seo/src/seo-dashboard-page.tsx
+++ b/packages/@granit/react-ui-cms-seo/src/seo-dashboard-page.tsx
@@ -24,13 +24,13 @@ import {
   TabsList,
   TabsTrigger,
   Textarea,
+  toast,
 } from '@granit/react-ui';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { Check, X } from 'lucide-react';
 import { useState } from 'react';
 import { useForm, type Resolver } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import type {
   RobotsTxtRule,

--- a/packages/@granit/react-ui-cms-sites/package.json
+++ b/packages/@granit/react-ui-cms-sites/package.json
@@ -23,8 +23,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-cms-sites/src/site-form-page.tsx
+++ b/packages/@granit/react-ui-cms-sites/src/site-form-page.tsx
@@ -1,13 +1,12 @@
 import { cmsConstraints } from '@granit/cms';
 import { useSite, useCreateSite, useUpdateSite } from '@granit/react-cms';
 import { useTranslation } from '@granit/react-localization';
-import { Badge, Button, Input, Label, Separator, Switch } from '@granit/react-ui';
+import { toast, Badge, Button, Input, Label, Separator, Switch } from '@granit/react-ui';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { ArrowLeft } from 'lucide-react';
 import { useEffect } from 'react';
 import { Controller, useForm, type Resolver } from 'react-hook-form';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 interface SiteFormValues {
   slug: string;

--- a/packages/@granit/react-ui-cms-sites/src/sites-list-page.tsx
+++ b/packages/@granit/react-ui-cms-sites/src/sites-list-page.tsx
@@ -18,6 +18,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  toast,
 } from '@granit/react-ui';
 import {
   Plus,
@@ -31,7 +32,6 @@ import {
   Network,
 } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 export function SitesListPage() {
   const { t } = useTranslation();

--- a/packages/@granit/react-ui-customer-balance/package.json
+++ b/packages/@granit/react-ui-customer-balance/package.json
@@ -26,8 +26,7 @@
     "lucide-react": "^1.21.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
-    "sonner": "^2.0.7"
+    "react-hook-form": "^7.80.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-customer-balance/src/components/add-credit-dialog.tsx
+++ b/packages/@granit/react-ui-customer-balance/src/components/add-credit-dialog.tsx
@@ -14,12 +14,12 @@ import {
   SelectTrigger,
   SelectValue,
   Textarea,
+  toast,
 } from '@granit/react-ui';
 import { FormDialog } from '@granit/react-ui-admin-kit';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { toISODateString } from '@granit/types';
 import { useForm, type Resolver } from 'react-hook-form';
-import { toast } from 'sonner';
 
 import type { AdminCreditRequest } from '@granit/customer-balance';
 import type { CurrencyCode } from '@granit/types';

--- a/packages/@granit/react-ui-customer-balance/src/components/apply-debit-dialog.tsx
+++ b/packages/@granit/react-ui-customer-balance/src/components/apply-debit-dialog.tsx
@@ -9,11 +9,11 @@ import {
   FormMessage,
   Input,
   Textarea,
+  toast,
 } from '@granit/react-ui';
 import { FormDialog } from '@granit/react-ui-admin-kit';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { useForm, type Resolver } from 'react-hook-form';
-import { toast } from 'sonner';
 
 import type { AdminDebitRequest } from '@granit/customer-balance';
 import type { CurrencyCode } from '@granit/types';

--- a/packages/@granit/react-ui-dashboards/package.json
+++ b/packages/@granit/react-ui-dashboards/package.json
@@ -26,8 +26,7 @@
     "lucide-react": "^1.21.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-dashboards/src/dashboard-edit-page.tsx
+++ b/packages/@granit/react-ui-dashboards/src/dashboard-edit-page.tsx
@@ -48,11 +48,11 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  toast,
 } from '@granit/react-ui';
 import { ArrowLeft, Plus, RotateCcw, Save, Trash2 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { logger } from './logger';
 

--- a/packages/@granit/react-ui-dashboards/src/dashboard-list-page.tsx
+++ b/packages/@granit/react-ui-dashboards/src/dashboard-list-page.tsx
@@ -13,11 +13,10 @@ import {
   useResyncDashboard,
 } from '@granit/react-dashboards';
 import { useTranslation } from '@granit/react-localization';
-import { Button, Spinner } from '@granit/react-ui';
+import { toast, Button, Spinner } from '@granit/react-ui';
 import { Archive, ArchiveRestore, LayoutDashboard, Pencil, RefreshCw, Send } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { DriftBadge } from './components/dashboard-drift-badge';
 import { DashboardImportFromCatalog } from './components/dashboard-import-from-catalog';

--- a/packages/@granit/react-ui-entities-customization/package.json
+++ b/packages/@granit/react-ui-entities-customization/package.json
@@ -25,8 +25,7 @@
     "@granit/react-workspaces": "workspace:*",
     "lucide-react": "^1.21.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "sonner": "^2.0.7"
+    "react-dom": "^19.0.0"
   },
   "publishConfig": {
     "exports": {
@@ -59,7 +58,6 @@
     "react-dom": "^19.0.0",
     "react-i18next": "^17.0.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "storybook": "^10.4.6"
   }
 }

--- a/packages/@granit/react-ui-entities-customization/src/components/entity-views-tab.tsx
+++ b/packages/@granit/react-ui-entities-customization/src/components/entity-views-tab.tsx
@@ -36,10 +36,10 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  toast,
 } from '@granit/react-ui';
 import { Globe, Pencil, Pin, PinOff, Star, Trash2, Users } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import type {
   EntityViewCreateBodyRequest,

--- a/packages/@granit/react-ui-entities-customization/src/components/workspace-customization-tab.tsx
+++ b/packages/@granit/react-ui-entities-customization/src/components/workspace-customization-tab.tsx
@@ -17,10 +17,10 @@ import {
   SelectTrigger,
   SelectValue,
   Spinner,
+  toast,
 } from '@granit/react-ui';
 import { useWorkspaces } from '@granit/react-workspaces';
 import { useMemo, useState } from 'react';
-import { toast } from 'sonner';
 
 import { useMemoSyncDraft } from '../hooks/use-memo-sync-draft';
 

--- a/packages/@granit/react-ui-entities-customization/src/customization-page.tsx
+++ b/packages/@granit/react-ui-entities-customization/src/customization-page.tsx
@@ -24,9 +24,9 @@ import {
   SheetDescription,
   SheetHeader,
   SheetTitle,
+  toast,
 } from '@granit/react-ui';
 import { useMemo, useState } from 'react';
-import { toast } from 'sonner';
 
 import { EntityCustomizationSection } from './components/entity-customization-section';
 import { EntityViewsTab } from './components/entity-views-tab';

--- a/packages/@granit/react-ui-features/package.json
+++ b/packages/@granit/react-ui-features/package.json
@@ -22,8 +22,7 @@
     "lucide-react": "^1.21.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-features/src/components/set-override-dialog.tsx
+++ b/packages/@granit/react-ui-features/src/components/set-override-dialog.tsx
@@ -17,9 +17,9 @@ import {
   SelectTrigger,
   SelectValue,
   Switch,
+  toast,
 } from '@granit/react-ui';
 import { useCallback, useState } from 'react';
-import { toast } from 'sonner';
 
 import type { FeatureDefinitionResponse, FeatureValueResponse } from '@granit/features';
 

--- a/packages/@granit/react-ui-hostnames/package.json
+++ b/packages/@granit/react-ui-hostnames/package.json
@@ -24,8 +24,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-hostnames/src/components/hostname-add-dialog.tsx
+++ b/packages/@granit/react-ui-hostnames/src/components/hostname-add-dialog.tsx
@@ -17,12 +17,12 @@ import {
   FormLabel,
   FormMessage,
   Input,
+  toast,
 } from '@granit/react-ui';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { CheckCircle2, Loader2, XCircle } from 'lucide-react';
 import { useState } from 'react';
 import { useForm, type Resolver } from 'react-hook-form';
-import { toast } from 'sonner';
 
 // Client-only UX guard for a real FQDN. The contract carries only `maxLength` on
 // `host` (the .NET endpoint runs the authoritative hostname check), so this regex

--- a/packages/@granit/react-ui-hostnames/src/components/hostname-row-actions.tsx
+++ b/packages/@granit/react-ui-hostnames/src/components/hostname-row-actions.tsx
@@ -16,9 +16,9 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
   Button,
+  toast,
 } from '@granit/react-ui';
 import { Loader2, RefreshCw, Star, Trash2 } from 'lucide-react';
-import { toast } from 'sonner';
 
 import type { ManagedHostnameResponse } from '@granit/hostnames';
 

--- a/packages/@granit/react-ui-identity/package.json
+++ b/packages/@granit/react-ui-identity/package.json
@@ -28,8 +28,7 @@
     "lucide-react": "^1.21.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-identity/src/cache/identity-cache-page.tsx
+++ b/packages/@granit/react-ui-identity/src/cache/identity-cache-page.tsx
@@ -15,11 +15,11 @@ import {
   CardTitle,
   Input,
   Spinner,
+  toast,
 } from '@granit/react-ui';
 import { toEntityId } from '@granit/types';
 import { DatabaseZap, RefreshCw, Search, Users } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-identity/src/groups/group-detail-page.tsx
+++ b/packages/@granit/react-ui-identity/src/groups/group-detail-page.tsx
@@ -24,11 +24,11 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  toast,
 } from '@granit/react-ui';
 import { ArrowLeft, Plus, X } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { UserSearchCombobox } from '../components/user-search-combobox';
 

--- a/packages/@granit/react-ui-identity/src/roles/role-detail-page.tsx
+++ b/packages/@granit/react-ui-identity/src/roles/role-detail-page.tsx
@@ -23,11 +23,11 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  toast,
 } from '@granit/react-ui';
 import { ArrowLeft, Plus, X } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { UserSearchCombobox } from '../components/user-search-combobox';
 

--- a/packages/@granit/react-ui-identity/src/users/components/user-create-dialog.tsx
+++ b/packages/@granit/react-ui-identity/src/users/components/user-create-dialog.tsx
@@ -10,9 +10,9 @@ import {
   Input,
   Label,
   Switch,
+  toast,
 } from '@granit/react-ui';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../../logger';
 

--- a/packages/@granit/react-ui-identity/src/users/user-detail-page.tsx
+++ b/packages/@granit/react-ui-identity/src/users/user-detail-page.tsx
@@ -18,13 +18,13 @@ import {
   Label,
   Separator,
   Spinner,
+  toast,
 } from '@granit/react-ui';
 import { DetailAsideLayout, DetailAsideMobileTrigger } from '@granit/react-ui-admin-kit';
 import { toEntityId } from '@granit/types';
 import { AlertTriangle, ArrowLeft, AlertCircle, Pencil, Trash2 } from 'lucide-react';
 import * as React from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-invoicing/package.json
+++ b/packages/@granit/react-ui-invoicing/package.json
@@ -31,7 +31,6 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "zod": "^4.4.3"
   },
   "publishConfig": {
@@ -67,7 +66,6 @@
     "react-hook-form": "^7.80.0",
     "react-i18next": "^17.0.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "storybook": "^10.4.6",
     "zod": "^4.4.3"
   }

--- a/packages/@granit/react-ui-invoicing/src/components/create-invoice-dialog.tsx
+++ b/packages/@granit/react-ui-invoicing/src/components/create-invoice-dialog.tsx
@@ -20,11 +20,11 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  toast,
 } from '@granit/react-ui';
 import { toISODateString } from '@granit/types';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
-import { toast } from 'sonner';
 import { z } from 'zod';
 
 import { logger } from '../logger';

--- a/packages/@granit/react-ui-localization/package.json
+++ b/packages/@granit/react-ui-localization/package.json
@@ -28,8 +28,7 @@
     "@tanstack/react-table": "^8.21.3",
     "lucide-react": "^1.21.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "sonner": "^2.0.7"
+    "react-dom": "^19.0.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-localization/src/components/translation-create-dialog.tsx
+++ b/packages/@granit/react-ui-localization/src/components/translation-create-dialog.tsx
@@ -16,9 +16,9 @@ import {
   SelectTrigger,
   SelectValue,
   Textarea,
+  toast,
 } from '@granit/react-ui';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { useLanguages } from '../languages-context';
 import { logger } from '../logger';

--- a/packages/@granit/react-ui-localization/src/components/translation-delete-dialog.tsx
+++ b/packages/@granit/react-ui-localization/src/components/translation-delete-dialog.tsx
@@ -9,8 +9,8 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  toast,
 } from '@granit/react-ui';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-localization/src/components/translation-edit-dialog.tsx
+++ b/packages/@granit/react-ui-localization/src/components/translation-edit-dialog.tsx
@@ -11,9 +11,9 @@ import {
   Input,
   Label,
   Textarea,
+  toast,
 } from '@granit/react-ui';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-metering/package.json
+++ b/packages/@granit/react-ui-metering/package.json
@@ -29,8 +29,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-metering/src/components/archive-meter-dialog.tsx
+++ b/packages/@granit/react-ui-metering/src/components/archive-meter-dialog.tsx
@@ -8,8 +8,8 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  toast,
 } from '@granit/react-ui';
-import { toast } from 'sonner';
 
 import type { MeterDefinitionResponse } from '@granit/metering';
 

--- a/packages/@granit/react-ui-metering/src/components/record-events-dialog.tsx
+++ b/packages/@granit/react-ui-metering/src/components/record-events-dialog.tsx
@@ -15,13 +15,13 @@ import {
   FormItem,
   FormMessage,
   Input,
+  toast,
 } from '@granit/react-ui';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { toEntityId, toISODateString } from '@granit/types';
 import { Plus, Trash2 } from 'lucide-react';
 import { useMemo } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
-import { toast } from 'sonner';
 
 import type { MeterDefinitionResponse } from '@granit/metering';
 import type { Resolver } from 'react-hook-form';

--- a/packages/@granit/react-ui-metering/src/meter-detail-page.tsx
+++ b/packages/@granit/react-ui-metering/src/meter-detail-page.tsx
@@ -19,13 +19,13 @@ import {
   DialogHeader,
   DialogTitle,
   Skeleton,
+  toast,
 } from '@granit/react-ui';
 import { toEntityId } from '@granit/types';
 import { cn } from '@granit/utils';
 import { ArrowLeft, Archive, Pencil, Send, Upload } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { ArchiveMeterDialog } from './components/archive-meter-dialog';
 import { MeterForm } from './components/meter-form';

--- a/packages/@granit/react-ui-metering/src/meter-list-page.tsx
+++ b/packages/@granit/react-ui-metering/src/meter-list-page.tsx
@@ -14,12 +14,12 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  toast,
 } from '@granit/react-ui';
 import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import { Plus } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { createMeterColumns } from './components/meter-columns';
 import { MeterForm } from './components/meter-form';

--- a/packages/@granit/react-ui-multi-tenancy/package.json
+++ b/packages/@granit/react-ui-multi-tenancy/package.json
@@ -32,7 +32,6 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "zod": "^4.4.3"
   },
   "publishConfig": {
@@ -67,7 +66,6 @@
     "react-hook-form": "^7.80.0",
     "react-i18next": "^17.0.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "storybook": "^10.4.6",
     "zod": "^4.4.3"
   }

--- a/packages/@granit/react-ui-multi-tenancy/src/tenant-create-page.tsx
+++ b/packages/@granit/react-ui-multi-tenancy/src/tenant-create-page.tsx
@@ -1,9 +1,8 @@
 import { useTranslation } from '@granit/react-localization';
 import { TenantAdminProvider, useCreateTenant } from '@granit/react-multi-tenancy';
-import { Button, Separator } from '@granit/react-ui';
+import { toast, Button, Separator } from '@granit/react-ui';
 import { ArrowLeft } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { TenantForm } from './components/tenant-form';
 

--- a/packages/@granit/react-ui-multi-tenancy/src/tenant-edit-page.tsx
+++ b/packages/@granit/react-ui-multi-tenancy/src/tenant-edit-page.tsx
@@ -7,13 +7,12 @@ import {
   useTenantDetail,
   useUpdateTenant,
 } from '@granit/react-multi-tenancy';
-import { Badge, Button, Separator } from '@granit/react-ui';
+import { toast, Badge, Button, Separator } from '@granit/react-ui';
 import { DetailAsideLayout, DetailAsideMobileTrigger } from '@granit/react-ui-admin-kit';
 import { useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, Loader2, Network } from 'lucide-react';
 import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { TenantForm } from './components/tenant-form';
 import { TenantStatusDialog } from './components/tenant-status-dialog';

--- a/packages/@granit/react-ui-multi-tenancy/src/tenant-list-page.tsx
+++ b/packages/@granit/react-ui-multi-tenancy/src/tenant-list-page.tsx
@@ -12,7 +12,7 @@ import {
   useQueryMeta,
   useSmartFilter,
 } from '@granit/react-query-engine';
-import { Button, Spinner } from '@granit/react-ui';
+import { toast, Button, Spinner } from '@granit/react-ui';
 import {
   FilterPresets,
   GroupBySelector,
@@ -27,7 +27,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Plus } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { createTenantColumns } from './components/tenant-columns';
 import { TenantStatusDialog } from './components/tenant-status-dialog';

--- a/packages/@granit/react-ui-notifications/package.json
+++ b/packages/@granit/react-ui-notifications/package.json
@@ -26,7 +26,6 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "zod": "^4.4.3"
   },
   "publishConfig": {

--- a/packages/@granit/react-ui-notifications/src/__tests__/notification-toast-handler.test.tsx
+++ b/packages/@granit/react-ui-notifications/src/__tests__/notification-toast-handler.test.tsx
@@ -1,4 +1,4 @@
-import { toast } from 'sonner';
+import { toast } from '@granit/react-ui';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { NotificationToastHandler } from '../components/notification-toast-handler';

--- a/packages/@granit/react-ui-notifications/src/components/notification-toast-handler.tsx
+++ b/packages/@granit/react-ui-notifications/src/components/notification-toast-handler.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from '@granit/react-localization';
 import { useRealTimeNotifications } from '@granit/react-notifications';
+import { toast } from '@granit/react-ui';
 import { useEffect, useMemo, useRef } from 'react';
-import { toast } from 'sonner';
 
 import { resolveNotificationPresentation } from '../rendering';
 

--- a/packages/@granit/react-ui-openiddict-admin/package.json
+++ b/packages/@granit/react-ui-openiddict-admin/package.json
@@ -27,7 +27,6 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "zod": "^4.4.3"
   },
   "publishConfig": {
@@ -59,7 +58,6 @@
     "react-hook-form": "^7.80.0",
     "react-i18next": "^17.0.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "storybook": "^10.4.6",
     "zod": "^4.4.3"
   }

--- a/packages/@granit/react-ui-openiddict-admin/src/applications/oidc-applications-page.tsx
+++ b/packages/@granit/react-ui-openiddict-admin/src/applications/oidc-applications-page.tsx
@@ -29,12 +29,12 @@ import {
   SelectValue,
   Spinner,
   Textarea,
+  toast,
 } from '@granit/react-ui';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { CheckCircle2, Loader2, Pencil, Plus, Shield, Trash2, XCircle } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { toast } from 'sonner';
 import { z } from 'zod';
 
 import { logger } from '../logger';

--- a/packages/@granit/react-ui-openiddict-admin/src/authorizations/oidc-authorizations-page.tsx
+++ b/packages/@granit/react-ui-openiddict-admin/src/authorizations/oidc-authorizations-page.tsx
@@ -22,12 +22,12 @@ import {
   FormMessage,
   Input,
   Spinner,
+  toast,
 } from '@granit/react-ui';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { KeyRound, Loader2, Plus, ShieldOff } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { toast } from 'sonner';
 import { z } from 'zod';
 
 import { logger } from '../logger';

--- a/packages/@granit/react-ui-openiddict-admin/src/scopes/oidc-scopes-page.tsx
+++ b/packages/@granit/react-ui-openiddict-admin/src/scopes/oidc-scopes-page.tsx
@@ -24,12 +24,12 @@ import {
   Input,
   Spinner,
   Textarea,
+  toast,
 } from '@granit/react-ui';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Layers, Loader2, Pencil, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { toast } from 'sonner';
 import { z } from 'zod';
 
 import { logger } from '../logger';

--- a/packages/@granit/react-ui-parties/package.json
+++ b/packages/@granit/react-ui-parties/package.json
@@ -34,7 +34,6 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "zod": "^4.4.3"
   },
   "publishConfig": {
@@ -73,7 +72,6 @@
     "react-hook-form": "^7.80.0",
     "react-i18next": "^17.0.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "storybook": "^10.4.6",
     "zod": "^4.4.3"
   }

--- a/packages/@granit/react-ui-parties/src/components/add-role-dialog.tsx
+++ b/packages/@granit/react-ui-parties/src/components/add-role-dialog.tsx
@@ -13,9 +13,9 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  toast,
 } from '@granit/react-ui';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { PARTY_ASSIGNABLE_ROLES } from '../constants';
 import { logger } from '../logger';

--- a/packages/@granit/react-ui-parties/src/components/addresses-tab.tsx
+++ b/packages/@granit/react-ui-parties/src/components/addresses-tab.tsx
@@ -1,9 +1,8 @@
 import { useTranslation } from '@granit/react-localization';
 import { useRemovePartyAddressMutation } from '@granit/react-parties';
-import { Badge, Button, Card, CardContent } from '@granit/react-ui';
+import { toast, Badge, Button, Card, CardContent } from '@granit/react-ui';
 import { Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-parties/src/components/create-conflict-dialog.tsx
+++ b/packages/@granit/react-ui-parties/src/components/create-conflict-dialog.tsx
@@ -10,10 +10,10 @@ import {
   DialogHeader,
   DialogTitle,
   Skeleton,
+  toast,
 } from '@granit/react-ui';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-parties/src/components/download-vcard-button.tsx
+++ b/packages/@granit/react-ui-parties/src/components/download-vcard-button.tsx
@@ -1,10 +1,9 @@
 import { downloadPartyVCard } from '@granit/parties';
 import { useTranslation } from '@granit/react-localization';
 import { usePartiesConfig } from '@granit/react-parties';
-import { Button } from '@granit/react-ui';
+import { toast, Button } from '@granit/react-ui';
 import { Download } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-parties/src/components/edit-tax-status-dialog.tsx
+++ b/packages/@granit/react-ui-parties/src/components/edit-tax-status-dialog.tsx
@@ -8,12 +8,12 @@ import {
   FormLabel,
   FormMessage,
   Input,
+  toast,
 } from '@granit/react-ui';
 import { FormDialog } from '@granit/react-ui-admin-kit';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 import { partyTaxStatusSchema, type PartyTaxStatusFormValues } from '../validation';

--- a/packages/@granit/react-ui-parties/src/components/emails-tab.tsx
+++ b/packages/@granit/react-ui-parties/src/components/emails-tab.tsx
@@ -1,9 +1,8 @@
 import { useTranslation } from '@granit/react-localization';
 import { useRemovePartyEmailMutation } from '@granit/react-parties';
-import { Badge, Button } from '@granit/react-ui';
+import { toast, Badge, Button } from '@granit/react-ui';
 import { Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-parties/src/components/external-mappings-tab.tsx
+++ b/packages/@granit/react-ui-parties/src/components/external-mappings-tab.tsx
@@ -11,10 +11,10 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  toast,
 } from '@granit/react-ui';
 import { Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-parties/src/components/lifecycle-actions.tsx
+++ b/packages/@granit/react-ui-parties/src/components/lifecycle-actions.tsx
@@ -14,10 +14,10 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  toast,
 } from '@granit/react-ui';
 import { Archive, PauseCircle, PlayCircle } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-parties/src/components/merge-action.tsx
+++ b/packages/@granit/react-ui-parties/src/components/merge-action.tsx
@@ -7,11 +7,11 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  toast,
 } from '@granit/react-ui';
 import { GitMerge } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { PartyPickerDialog } from './party-picker-dialog';
 

--- a/packages/@granit/react-ui-parties/src/components/merge-from-candidate.tsx
+++ b/packages/@granit/react-ui-parties/src/components/merge-from-candidate.tsx
@@ -11,10 +11,10 @@ import {
   Label,
   RadioGroup,
   RadioGroupItem,
+  toast,
 } from '@granit/react-ui';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import type { PartyDuplicateCandidateResponse, PartyId } from '@granit/parties';
 

--- a/packages/@granit/react-ui-parties/src/components/metadata-tab.tsx
+++ b/packages/@granit/react-ui-parties/src/components/metadata-tab.tsx
@@ -1,9 +1,8 @@
 import { useTranslation } from '@granit/react-localization';
 import { useReplacePartyMetadataMutation } from '@granit/react-parties';
-import { Button, Input } from '@granit/react-ui';
+import { toast, Button, Input } from '@granit/react-ui';
 import { Plus, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 import { metadataLimits } from '../validation';

--- a/packages/@granit/react-ui-parties/src/components/party-add-dialog.tsx
+++ b/packages/@granit/react-ui-parties/src/components/party-add-dialog.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@granit/react-localization';
+import { toast } from '@granit/react-ui';
 import { FormDialog } from '@granit/react-ui-admin-kit';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-parties/src/components/party-identity-form.tsx
+++ b/packages/@granit/react-ui-parties/src/components/party-identity-form.tsx
@@ -10,12 +10,12 @@ import {
   FormMessage,
   Input,
   Textarea,
+  toast,
 } from '@granit/react-ui';
 import { TimezonePicker, UrlInput } from '@granit/react-ui-admin-kit';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 import { partyIdentitySchema, type PartyIdentityFormValues } from '../validation';

--- a/packages/@granit/react-ui-parties/src/components/phones-tab.tsx
+++ b/packages/@granit/react-ui-parties/src/components/phones-tab.tsx
@@ -1,10 +1,9 @@
 import { useTranslation } from '@granit/react-localization';
 import { useRemovePartyPhoneMutation } from '@granit/react-parties';
-import { Badge, Button } from '@granit/react-ui';
+import { toast, Badge, Button } from '@granit/react-ui';
 import { formatPhoneInternational } from '@granit/react-ui-admin-kit';
 import { Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-parties/src/components/roles-tab.tsx
+++ b/packages/@granit/react-ui-parties/src/components/roles-tab.tsx
@@ -1,9 +1,8 @@
 import { useTranslation } from '@granit/react-localization';
 import { useRemovePartyRoleMutation } from '@granit/react-parties';
-import { Badge, Button } from '@granit/react-ui';
+import { toast, Badge, Button } from '@granit/react-ui';
 import { Plus, X } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { PARTY_ASSIGNABLE_ROLES, parsePartyRoleFlags } from '../constants';
 import { logger } from '../logger';

--- a/packages/@granit/react-ui-parties/src/components/tax-status-card.tsx
+++ b/packages/@granit/react-ui-parties/src/components/tax-status-card.tsx
@@ -1,8 +1,7 @@
 import { useTranslation } from '@granit/react-localization';
 import { useClearPartyTaxStatusMutation } from '@granit/react-parties';
-import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from '@granit/react-ui';
+import { toast, Badge, Button, Card, CardContent, CardHeader, CardTitle } from '@granit/react-ui';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-parties/src/party-create-page.tsx
+++ b/packages/@granit/react-ui-parties/src/party-create-page.tsx
@@ -1,11 +1,10 @@
 import { isAxiosError } from '@granit/api-client';
 import { useTranslation } from '@granit/react-localization';
 import { useCreatePartyMutation } from '@granit/react-parties';
-import { Button, Separator } from '@granit/react-ui';
+import { toast, Button, Separator } from '@granit/react-ui';
 import { ArrowLeft } from 'lucide-react';
 import { useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { CreateConflictDialog } from './components/create-conflict-dialog';
 import { PartyCreateForm } from './components/party-create-form';

--- a/packages/@granit/react-ui-payments/package.json
+++ b/packages/@granit/react-ui-payments/package.json
@@ -27,8 +27,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-payments/src/components/attach-method-dialog.tsx
+++ b/packages/@granit/react-ui-payments/src/components/attach-method-dialog.tsx
@@ -9,9 +9,9 @@ import {
   DialogHeader,
   DialogTitle,
   Spinner,
+  toast,
 } from '@granit/react-ui';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import type { PaymentAvailableMethodResponse } from '@granit/payments';
 

--- a/packages/@granit/react-ui-payments/src/components/charge-dialog.tsx
+++ b/packages/@granit/react-ui-payments/src/components/charge-dialog.tsx
@@ -16,11 +16,11 @@ import {
   FormLabel,
   FormMessage,
   Input,
+  toast,
 } from '@granit/react-ui';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { toEntityId } from '@granit/types';
 import { useForm, type Resolver } from 'react-hook-form';
-import { toast } from 'sonner';
 
 import type { CurrencyCode } from '@granit/types';
 

--- a/packages/@granit/react-ui-payments/src/components/detach-method-dialog.tsx
+++ b/packages/@granit/react-ui-payments/src/components/detach-method-dialog.tsx
@@ -9,8 +9,8 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  toast,
 } from '@granit/react-ui';
-import { toast } from 'sonner';
 
 import type { PaymentMethodResponse } from '@granit/payments';
 

--- a/packages/@granit/react-ui-payments/src/components/payment-configuration-section.tsx
+++ b/packages/@granit/react-ui-payments/src/components/payment-configuration-section.tsx
@@ -19,9 +19,9 @@ import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
+  toast,
 } from '@granit/react-ui';
 import { RefreshCw } from 'lucide-react';
-import { toast } from 'sonner';
 
 import { categoryIndex } from '../payment-method-category';
 

--- a/packages/@granit/react-ui-payments/src/components/refund-dialog.tsx
+++ b/packages/@granit/react-ui-payments/src/components/refund-dialog.tsx
@@ -17,11 +17,11 @@ import {
   FormMessage,
   Input,
   Textarea,
+  toast,
 } from '@granit/react-ui';
 import { createConstraintsResolver } from '@granit/react-validation';
 import { toEntityId } from '@granit/types';
 import { useForm, type Resolver } from 'react-hook-form';
-import { toast } from 'sonner';
 
 interface RefundFormValues {
   amount: number;

--- a/packages/@granit/react-ui-privacy/package.json
+++ b/packages/@granit/react-ui-privacy/package.json
@@ -28,7 +28,6 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "zod": "^4.4.3"
   },
   "publishConfig": {
@@ -62,7 +61,6 @@
     "react-hook-form": "^7.80.0",
     "react-i18next": "^17.0.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "storybook": "^10.4.6",
     "zod": "^4.4.3"
   }

--- a/packages/@granit/react-ui-privacy/src/components/deletion-request-table.tsx
+++ b/packages/@granit/react-ui-privacy/src/components/deletion-request-table.tsx
@@ -12,9 +12,9 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  toast,
 } from '@granit/react-ui';
 import { Loader2, XCircle } from 'lucide-react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-privacy/src/legal-documents/components/legal-document-publish-dialog.tsx
+++ b/packages/@granit/react-ui-privacy/src/legal-documents/components/legal-document-publish-dialog.tsx
@@ -9,8 +9,8 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  toast,
 } from '@granit/react-ui';
-import { toast } from 'sonner';
 
 interface LegalDocumentPublishDialogProps {
   readonly documentId: string;

--- a/packages/@granit/react-ui-privacy/src/legal-documents/legal-document-create-page.tsx
+++ b/packages/@granit/react-ui-privacy/src/legal-documents/legal-document-create-page.tsx
@@ -1,9 +1,8 @@
 import { useTranslation } from '@granit/react-localization';
 import { useCreateLegalDocument } from '@granit/react-privacy';
-import { Button, Separator } from '@granit/react-ui';
+import { toast, Button, Separator } from '@granit/react-ui';
 import { ArrowLeft } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { LegalDocumentForm } from './components/legal-document-form';
 

--- a/packages/@granit/react-ui-privacy/src/legal-documents/legal-document-edit-page.tsx
+++ b/packages/@granit/react-ui-privacy/src/legal-documents/legal-document-edit-page.tsx
@@ -1,10 +1,9 @@
 import { useTranslation } from '@granit/react-localization';
 import { useLegalDocument, useUpdateLegalDocument } from '@granit/react-privacy';
-import { Button, Separator } from '@granit/react-ui';
+import { toast, Button, Separator } from '@granit/react-ui';
 import { ArrowLeft, Loader2 } from 'lucide-react';
 import { useEffect } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { LegalDocumentForm } from './components/legal-document-form';
 

--- a/packages/@granit/react-ui-privacy/src/privacy-admin-dsr-page.tsx
+++ b/packages/@granit/react-ui-privacy/src/privacy-admin-dsr-page.tsx
@@ -11,10 +11,10 @@ import {
   Checkbox,
   Input,
   Label,
+  toast,
 } from '@granit/react-ui';
 import { Loader2, Send } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 export function PrivacyAdminDsrPage() {
   const { t } = useTranslation();

--- a/packages/@granit/react-ui-privacy/src/privacy-deletion-page.tsx
+++ b/packages/@granit/react-ui-privacy/src/privacy-deletion-page.tsx
@@ -18,10 +18,10 @@ import {
   Checkbox,
   Label,
   Textarea,
+  toast,
 } from '@granit/react-ui';
 import { AlertTriangle, Info, Loader2, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { DeletionRequestTable } from './components/deletion-request-table';
 import { logger } from './logger';

--- a/packages/@granit/react-ui-privacy/src/privacy-opt-out-page.tsx
+++ b/packages/@granit/react-ui-privacy/src/privacy-opt-out-page.tsx
@@ -17,9 +17,9 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
+  toast,
 } from '@granit/react-ui';
 import { Loader2, ShieldOff } from 'lucide-react';
-import { toast } from 'sonner';
 
 export function PrivacyOptOutPage() {
   const { t } = useTranslation();

--- a/packages/@granit/react-ui-reference-data/package.json
+++ b/packages/@granit/react-ui-reference-data/package.json
@@ -33,8 +33,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-reference-data/src/components/reference-data-list-page-shell.tsx
+++ b/packages/@granit/react-ui-reference-data/src/components/reference-data-list-page-shell.tsx
@@ -6,7 +6,7 @@ import {
   useQueryMeta,
   useSmartFilter,
 } from '@granit/react-query-engine';
-import { Button, Card, CardContent, Skeleton, Spinner } from '@granit/react-ui';
+import { toast, Button, Card, CardContent, Skeleton, Spinner } from '@granit/react-ui';
 import {
   FilterPresets,
   GroupBySelector,
@@ -24,7 +24,6 @@ import { ImportDialog } from '@granit/react-ui-data-exchange';
 import { Plus } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-settings/package.json
+++ b/packages/@granit/react-ui-settings/package.json
@@ -19,8 +19,7 @@
     "@granit/react-ui": "workspace:*",
     "@granit/settings": "workspace:*",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "sonner": "^2.0.7"
+    "react-dom": "^19.0.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-settings/src/__tests__/app-settings-panel.test.tsx
+++ b/packages/@granit/react-ui-settings/src/__tests__/app-settings-panel.test.tsx
@@ -1,6 +1,6 @@
 import { mockAppSettings } from '@granit/react-settings/testing';
+import { toast } from '@granit/react-ui';
 import { screen, waitFor } from '@testing-library/react';
-import { toast } from 'sonner';
 
 import { AppSettingsPanel } from '../components/app-settings-panel';
 

--- a/packages/@granit/react-ui-settings/src/components/app-settings-panel.tsx
+++ b/packages/@granit/react-ui-settings/src/components/app-settings-panel.tsx
@@ -16,9 +16,9 @@ import {
   SelectValue,
   Skeleton,
   Switch,
+  toast,
 } from '@granit/react-ui';
 import * as React from 'react';
-import { toast } from 'sonner';
 
 import type {
   AdminAppSettingResponse,

--- a/packages/@granit/react-ui-subscriptions/package.json
+++ b/packages/@granit/react-ui-subscriptions/package.json
@@ -27,8 +27,7 @@
     "lucide-react": "^1.21.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7"
+    "react-router-dom": "^7.18.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-subscriptions/src/plans/components/archive-plan-dialog.tsx
+++ b/packages/@granit/react-ui-subscriptions/src/plans/components/archive-plan-dialog.tsx
@@ -9,9 +9,9 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  toast,
 } from '@granit/react-ui';
 import { toEntityId } from '@granit/types';
-import { toast } from 'sonner';
 
 import type { PlanId } from '@granit/subscriptions';
 

--- a/packages/@granit/react-ui-subscriptions/src/plans/components/create-price-dialog.tsx
+++ b/packages/@granit/react-ui-subscriptions/src/plans/components/create-price-dialog.tsx
@@ -9,10 +9,10 @@ import {
   DialogTitle,
   Input,
   Label,
+  toast,
 } from '@granit/react-ui';
 import { toEntityId } from '@granit/types';
 import { useState, type FormEvent } from 'react';
-import { toast } from 'sonner';
 
 import type { BillingInterval, PlanId } from '@granit/subscriptions';
 import type { CurrencyCode } from '@granit/types';

--- a/packages/@granit/react-ui-subscriptions/src/plans/components/edit-plan-dialog.tsx
+++ b/packages/@granit/react-ui-subscriptions/src/plans/components/edit-plan-dialog.tsx
@@ -10,10 +10,10 @@ import {
   Input,
   Label,
   Textarea,
+  toast,
 } from '@granit/react-ui';
 import { toEntityId } from '@granit/types';
 import { useState, type FormEvent } from 'react';
-import { toast } from 'sonner';
 
 import type { PlanId } from '@granit/subscriptions';
 

--- a/packages/@granit/react-ui-subscriptions/src/plans/components/publish-plan-dialog.tsx
+++ b/packages/@granit/react-ui-subscriptions/src/plans/components/publish-plan-dialog.tsx
@@ -9,9 +9,9 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  toast,
 } from '@granit/react-ui';
 import { toEntityId } from '@granit/types';
-import { toast } from 'sonner';
 
 import type { PlanId } from '@granit/subscriptions';
 

--- a/packages/@granit/react-ui-subscriptions/src/plans/plan-list-page.tsx
+++ b/packages/@granit/react-ui-subscriptions/src/plans/plan-list-page.tsx
@@ -14,6 +14,7 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  toast,
 } from '@granit/react-ui';
 import {
   FilterPresets,
@@ -27,7 +28,6 @@ import { useSmartFilterSync } from '@granit/react-ui-admin-kit';
 import { Plus } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-subscriptions/src/seats/components/assign-seat-dialog.tsx
+++ b/packages/@granit/react-ui-subscriptions/src/seats/components/assign-seat-dialog.tsx
@@ -9,10 +9,10 @@ import {
   DialogTitle,
   Input,
   Label,
+  toast,
 } from '@granit/react-ui';
 import { toEntityId } from '@granit/types';
 import { useState, type FormEvent } from 'react';
-import { toast } from 'sonner';
 
 import type { SubscriptionId } from '@granit/subscriptions';
 import type { UserId } from '@granit/types';

--- a/packages/@granit/react-ui-subscriptions/src/seats/components/revoke-seat-dialog.tsx
+++ b/packages/@granit/react-ui-subscriptions/src/seats/components/revoke-seat-dialog.tsx
@@ -9,9 +9,9 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  toast,
 } from '@granit/react-ui';
 import { toEntityId } from '@granit/types';
-import { toast } from 'sonner';
 
 import type { SeatResponse, SubscriptionId } from '@granit/subscriptions';
 

--- a/packages/@granit/react-ui-subscriptions/src/subscriptions/components/bulk-migrate-dialog.tsx
+++ b/packages/@granit/react-ui-subscriptions/src/subscriptions/components/bulk-migrate-dialog.tsx
@@ -9,10 +9,10 @@ import {
   DialogTitle,
   Input,
   Label,
+  toast,
 } from '@granit/react-ui';
 import { toEntityId } from '@granit/types';
 import { useState, type FormEvent } from 'react';
-import { toast } from 'sonner';
 
 import type { PlanId, PlanPriceId } from '@granit/subscriptions';
 

--- a/packages/@granit/react-ui-subscriptions/src/subscriptions/components/cancel-subscription-dialog.tsx
+++ b/packages/@granit/react-ui-subscriptions/src/subscriptions/components/cancel-subscription-dialog.tsx
@@ -16,10 +16,10 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  toast,
 } from '@granit/react-ui';
 import { toEntityId } from '@granit/types';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import type { SubscriptionId } from '@granit/subscriptions';
 

--- a/packages/@granit/react-ui-subscriptions/src/subscriptions/components/change-plan-dialog.tsx
+++ b/packages/@granit/react-ui-subscriptions/src/subscriptions/components/change-plan-dialog.tsx
@@ -13,10 +13,10 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  toast,
 } from '@granit/react-ui';
 import { toEntityId } from '@granit/types';
 import { useState, type FormEvent } from 'react';
-import { toast } from 'sonner';
 
 import type { PlanId, SubscriptionId } from '@granit/subscriptions';
 

--- a/packages/@granit/react-ui-subscriptions/src/subscriptions/components/create-subscription-dialog.tsx
+++ b/packages/@granit/react-ui-subscriptions/src/subscriptions/components/create-subscription-dialog.tsx
@@ -14,10 +14,10 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  toast,
 } from '@granit/react-ui';
 import { toEntityId, toISODateString } from '@granit/types';
 import { useState, type FormEvent } from 'react';
-import { toast } from 'sonner';
 
 import type { PlanId } from '@granit/subscriptions';
 import type { CurrencyCode } from '@granit/types';

--- a/packages/@granit/react-ui-subscriptions/src/subscriptions/components/migrate-price-dialog.tsx
+++ b/packages/@granit/react-ui-subscriptions/src/subscriptions/components/migrate-price-dialog.tsx
@@ -15,10 +15,10 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  toast,
 } from '@granit/react-ui';
 import { toEntityId } from '@granit/types';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { formatCurrency } from '../../format-currency';
 

--- a/packages/@granit/react-ui-templating/package.json
+++ b/packages/@granit/react-ui-templating/package.json
@@ -45,7 +45,6 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "zod": "^4.4.3"
   },
   "publishConfig": {
@@ -96,7 +95,6 @@
     "react-hook-form": "^7.80.0",
     "react-i18next": "^17.0.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "storybook": "^10.4.6",
     "zod": "^4.4.3"
   }

--- a/packages/@granit/react-ui-templating/src/components/template-categories-dialog.tsx
+++ b/packages/@granit/react-ui-templating/src/components/template-categories-dialog.tsx
@@ -9,10 +9,10 @@ import {
   DialogTitle,
   Input,
   Skeleton,
+  toast,
 } from '@granit/react-ui';
 import { Pencil, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-templating/src/components/template-history.tsx
+++ b/packages/@granit/react-ui-templating/src/components/template-history.tsx
@@ -16,11 +16,11 @@ import {
   Button,
   Checkbox,
   Skeleton,
+  toast,
 } from '@granit/react-ui';
 import { getRevision } from '@granit/templating';
 import { GitCompareArrows, RotateCcw } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-templating/src/components/template-lifecycle-actions.tsx
+++ b/packages/@granit/react-ui-templating/src/components/template-lifecycle-actions.tsx
@@ -10,10 +10,10 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   Button,
+  toast,
 } from '@granit/react-ui';
 import { Trash2, Upload, Undo2 } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from '../logger';
 

--- a/packages/@granit/react-ui-templating/src/template-create-page.tsx
+++ b/packages/@granit/react-ui-templating/src/template-create-page.tsx
@@ -1,9 +1,8 @@
 import { useTranslation } from '@granit/react-localization';
 import { TemplatingProvider, useTemplateMutations } from '@granit/react-templating';
-import { Button, Separator } from '@granit/react-ui';
+import { toast, Button, Separator } from '@granit/react-ui';
 import { ArrowLeft } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { TemplateForm } from './components/template-form';
 import { TEMPLATING_CONFIG } from './constants';

--- a/packages/@granit/react-ui-templating/src/template-edit-page.tsx
+++ b/packages/@granit/react-ui-templating/src/template-edit-page.tsx
@@ -8,11 +8,11 @@ import {
   TabsContent,
   TabsList,
   TabsTrigger,
+  toast,
 } from '@granit/react-ui';
 import { ArrowLeft } from 'lucide-react';
 import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { TemplateForm } from './components/template-form';
 import { TemplateHistory } from './components/template-history';

--- a/packages/@granit/react-ui-timeline/package.json
+++ b/packages/@granit/react-ui-timeline/package.json
@@ -33,7 +33,6 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "tippy.js": "^6.3.7"
   },
   "publishConfig": {
@@ -69,7 +68,6 @@
     "react-dom": "^19.0.0",
     "react-i18next": "^17.0.0",
     "react-router-dom": "^7.18.0",
-    "sonner": "^2.0.7",
     "storybook": "^10.4.6",
     "tippy.js": "^6.3.7"
   }

--- a/packages/@granit/react-ui-timeline/src/entity-timeline.tsx
+++ b/packages/@granit/react-ui-timeline/src/entity-timeline.tsx
@@ -19,6 +19,7 @@ import {
   DialogHeader,
   DialogTitle,
   Spinner,
+  toast,
 } from '@granit/react-ui';
 import {
   TimelineEntryNotEditableReason,
@@ -29,8 +30,6 @@ import { cn } from '@granit/utils';
 import { AlertCircle, AlertTriangle, Bell, BellOff, MessageSquare, Plus } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { toast } from 'sonner';
-
 
 import { TimelineComposer } from './timeline-composer';
 import { TimelineStream } from './timeline-stream';
@@ -43,7 +42,6 @@ import type {
   TimelineEntryId,
   TimelineEntryNotEditableReasonValue,
 } from '@granit/timeline';
-
 
 // Single-pass tokenizer for the timeline body. Branch 1 is the canonical
 // mention payload (`@[Name](user:guid)`) emitted by `<TimelineComposer>`

--- a/packages/@granit/react-ui/src/sonner.tsx
+++ b/packages/@granit/react-ui/src/sonner.tsx
@@ -50,4 +50,11 @@ const Toaster = ({ theme = 'system', ...props }: Readonly<ToasterProps>) => {
   );
 };
 
+// Re-export the imperative `toast` API so domain UI packages trigger toasts
+// through the foundation barrel instead of depending on `sonner` directly
+// (keeps the shadcn stack confined to the UI tier — see eslint no-restricted-imports).
+export { toast } from 'sonner';
+
+export type { ExternalToast } from 'sonner';
+
 export { Toaster };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3557,9 +3557,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -3699,9 +3696,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -3783,9 +3777,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -3886,9 +3877,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -4090,9 +4078,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/account':
         specifier: workspace:*
@@ -4304,9 +4289,6 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -4383,9 +4365,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -4462,9 +4441,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -4520,9 +4496,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -4575,9 +4548,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -4639,9 +4609,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -4694,9 +4661,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -4786,9 +4750,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -4810,9 +4771,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -4865,9 +4823,6 @@ importers:
       react-hook-form:
         specifier: ^7.80.0
         version: 7.80.0(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -4923,9 +4878,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/analytics':
         specifier: workspace:*
@@ -5178,9 +5130,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -5232,9 +5181,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -5281,9 +5227,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -5330,9 +5273,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -5460,9 +5400,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -5481,9 +5418,6 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -5560,9 +5494,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -5681,9 +5612,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -5705,9 +5633,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -5808,9 +5733,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -5898,9 +5820,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -5925,9 +5844,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -6086,9 +6002,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -6097,10 +6010,6 @@ importers:
         version: 4.4.3
 
   packages/@granit/react-ui-reference-data:
-    dependencies:
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -6267,9 +6176,6 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -6368,9 +6274,6 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -6658,9 +6561,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -6739,9 +6639,6 @@ importers:
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
## What

- Re-export the imperative `toast` API (+ `ExternalToast` type) from `@granit/react-ui` next to the themed `Toaster`.
- Sweep **121** domain call-sites from `import { toast } from 'sonner'` → `@granit/react-ui` (merged into existing barrel imports).
- Drop the now-unused `sonner` dependency from **34** `react-ui-*` packages (+ lockfile).
- Add an eslint `no-restricted-imports` guard banning direct `sonner` imports outside `@granit/react-ui` (mirrors the existing `axios` → `api-client` rule).

## Why

Audit finding (IMPROVEMENT, shadcn confinement / checklist 7e): 121 files depended on `sonner` directly, bypassing the foundation seam. Now toasts flow through the UI-tier foundation only, and the lint rule prevents regression. Behaviour is unchanged — the re-exported `toast` is the same sonner function.

## Verification

- `pnpm tsc` (all packages) ✓
- eslint changed files + new rule, `--max-warnings 0` ✓
- vitest — 2388 passed across 34 changed packages + foundation ✓ (transitive `vi.mock('sonner')` interception still works through the re-export)

Part of the `/audit` `react-ui-*` sweep (scope B of 5).