### PR TITLE
fix: unbreak develop CI (react-ui-entities latent failures)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -8908,6 +8908,156 @@
       ]
     },
     {
+      "name": "@granit/react-ui-entities",
+      "description": "Granit manifest-driven entity-rendering UI — generic list/detail/form views plus calendar, kanban and gallery layouts, entity action overlays and collection sections. The UI counterpart to the headless @granit/react-entities. App-agnostic: image rendering, the active workspace and label resolution are injected.",
+      "exports": [
+        {
+          "name": "WorkspaceEntityPage",
+          "kind": "function",
+          "signature": "function WorkspaceEntityPage("
+        },
+        {
+          "name": "EntityCalendarView",
+          "kind": "function",
+          "signature": "function EntityCalendarView("
+        },
+        {
+          "name": "EntityCalendarViewProps",
+          "kind": "interface",
+          "signature": "interface EntityCalendarViewProps",
+          "members": []
+        },
+        {
+          "name": "CalendarViewMode",
+          "kind": "type",
+          "signature": "type CalendarViewMode = 'day' | 'week' | 'month' | 'year'"
+        },
+        {
+          "name": "EntityKanbanView",
+          "kind": "function",
+          "signature": "function EntityKanbanView("
+        },
+        {
+          "name": "EntityKanbanViewProps",
+          "kind": "interface",
+          "signature": "interface EntityKanbanViewProps",
+          "members": []
+        },
+        {
+          "name": "EntityGalleryView",
+          "kind": "function",
+          "signature": "function EntityGalleryView("
+        },
+        {
+          "name": "EntityGalleryViewProps",
+          "kind": "interface",
+          "signature": "interface EntityGalleryViewProps",
+          "members": []
+        },
+        {
+          "name": "GalleryRenderImage",
+          "kind": "type",
+          "signature": "type GalleryRenderImage = ( blobId: string | null, row: Readonly<Record<string, unknown>> ) => ReactNode"
+        },
+        {
+          "name": "EntityViewSwitcher",
+          "kind": "function",
+          "signature": "function EntityViewSwitcher("
+        },
+        {
+          "name": "EntityViewSwitcherProps",
+          "kind": "interface",
+          "signature": "interface EntityViewSwitcherProps",
+          "members": []
+        },
+        {
+          "name": "EntityDetailContent",
+          "kind": "function",
+          "signature": "function EntityDetailContent("
+        },
+        {
+          "name": "EntityDetailContentProps",
+          "kind": "interface",
+          "signature": "interface EntityDetailContentProps",
+          "members": []
+        },
+        {
+          "name": "CollectionSectionCard",
+          "kind": "function",
+          "signature": "function CollectionSectionCard("
+        },
+        {
+          "name": "ActionDrawer",
+          "kind": "function",
+          "signature": "function ActionDrawer()"
+        },
+        {
+          "name": "ActionModal",
+          "kind": "function",
+          "signature": "function ActionModal()"
+        },
+        {
+          "name": "EntityActionButton",
+          "kind": "function",
+          "signature": "function EntityActionButton("
+        },
+        {
+          "name": "EntityActionButtonProps",
+          "kind": "interface",
+          "signature": "interface EntityActionButtonProps",
+          "members": []
+        },
+        {
+          "name": "EntityActionScopeProvider",
+          "kind": "function",
+          "signature": "function EntityActionScopeProvider("
+        },
+        {
+          "name": "useEntityActionScope",
+          "kind": "function",
+          "signature": "function useEntityActionScope(): EntityActionScopeValue"
+        },
+        {
+          "name": "EntityPageLayout",
+          "kind": "function",
+          "signature": "function EntityPageLayout("
+        },
+        {
+          "name": "EntityPageLayoutProps",
+          "kind": "interface",
+          "signature": "interface EntityPageLayoutProps",
+          "members": []
+        },
+        {
+          "name": "EntityPageLayoutWidth",
+          "kind": "type",
+          "signature": "type EntityPageLayoutWidth = keyof typeof PADDING_CLASSES"
+        },
+        {
+          "name": "SidePeekDrawer",
+          "kind": "function",
+          "signature": "function SidePeekDrawer("
+        },
+        {
+          "name": "SidePeekDrawerProps",
+          "kind": "interface",
+          "signature": "interface SidePeekDrawerProps",
+          "members": []
+        },
+        {
+          "name": "recapParentRefs",
+          "kind": "function",
+          "signature": "function recapParentRefs(recap: EntitySelectionBarRecap): readonly ParentRef[]"
+        },
+        {
+          "name": "ParentRef",
+          "kind": "interface",
+          "signature": "interface ParentRef",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/react-ui-entities-customization",
       "description": "Granit admin UI for entity layout customization (Layer 1 admin overrides) — the entity / workspace form-layout editor with a field-resolution inspector, plus the saved-views manager (create / edit / pin / set defaults / delete). Composes @granit/react-entities-customization, @granit/react-entities-views and @granit/react-workspaces (headless) with the foundation UI packages.",
       "exports": [

--- a/packages/@granit/react-ui-entities/src/__tests__/bulk-recap.test.ts
+++ b/packages/@granit/react-ui-entities/src/__tests__/bulk-recap.test.ts
@@ -1,7 +1,8 @@
-import type { EntitySelectionBarRecap } from '@granit/react-entities';
 import { describe, expect, it } from 'vitest';
 
 import { recapParentRefs } from '../bulk-recap';
+
+import type { EntitySelectionBarRecap } from '@granit/react-entities';
 
 const baseRecap: Omit<EntitySelectionBarRecap, 'parents'> = {
   succeeded: ['p-1', 'p-2'],

--- a/packages/@granit/react-ui-entities/src/action-drawer.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/action-drawer.stories.tsx
@@ -1,7 +1,7 @@
+import { createApiClient } from '@granit/api-client';
 import { GranitClientProvider } from '@granit/react-api-client';
 import { EntityActionDrawerHost, useEntityActionDrawer } from '@granit/react-entities';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createApiClient } from '@granit/api-client';
 import { http, HttpResponse } from 'msw';
 
 import { ActionDrawer } from './action-drawer';

--- a/packages/@granit/react-ui-entities/src/action-modal.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/action-modal.stories.tsx
@@ -1,14 +1,13 @@
-import * as React from 'react';
-
-import type { EntityActionManifest } from '@granit/entities';
+import { createApiClient } from '@granit/api-client';
 import { GranitClientProvider } from '@granit/react-api-client';
 import { EntityActionModalHost, useEntityActionModal } from '@granit/react-entities';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createApiClient } from '@granit/api-client';
+import * as React from 'react';
 
 import { ActionModal } from './action-modal';
 import { EntityActionScopeProvider } from './entity-action-scope';
 
+import type { EntityActionManifest } from '@granit/entities';
 import type { EntityActionOverlayState } from '@granit/react-entities';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 

--- a/packages/@granit/react-ui-entities/src/action-modal.tsx
+++ b/packages/@granit/react-ui-entities/src/action-modal.tsx
@@ -1,6 +1,3 @@
-import { useState } from 'react';
-
-import type { EntityFormManifest } from '@granit/entities';
 import { useGranitClient } from '@granit/react-api-client';
 import {
   EntityForm,
@@ -20,8 +17,11 @@ import {
   DialogTitle,
 } from '@granit/react-ui';
 import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 
 import { useEntityActionScope } from './entity-action-scope';
+
+import type { EntityFormManifest } from '@granit/entities';
 
 // ---------------------------------------------------------------------------
 // Modal host UI — paired with `<EntityActionModalHost>`. Body branches on

--- a/packages/@granit/react-ui-entities/src/bulk-recap.ts
+++ b/packages/@granit/react-ui-entities/src/bulk-recap.ts
@@ -1,4 +1,5 @@
 import { parseRelationAggregateParentMarker } from '@granit/react-entities';
+
 import type { EntitySelectionBarRecap } from '@granit/react-entities';
 
 export interface ParentRef {

--- a/packages/@granit/react-ui-entities/src/collection-section-card.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/collection-section-card.stories.tsx
@@ -1,8 +1,7 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
-
 import { CollectionSectionCard } from './collection-section-card';
 
 import type { EntityCollectionSectionManifest } from './manifest-extensions';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 // Invoice line-items section: amount columns formatted via the `money`
 // component (minor units → currency) with a `Sum` footer over `total`.

--- a/packages/@granit/react-ui-entities/src/collection-section-card.tsx
+++ b/packages/@granit/react-ui-entities/src/collection-section-card.tsx
@@ -1,6 +1,5 @@
-import type { ReactNode } from 'react';
-
 import { useDateFormatter, useTranslation } from '@granit/react-localization';
+import { resolveLabel } from '@granit/react-localization';
 import {
   Card,
   CardContent,
@@ -14,12 +13,12 @@ import {
   TableHeader,
   TableRow,
 } from '@granit/react-ui';
-import { resolveLabel } from '@granit/react-localization';
 
 import type {
   CollectionColumnManifest,
   EntityCollectionSectionManifest,
 } from './manifest-extensions';
+import type { ReactNode } from 'react';
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
 

--- a/packages/@granit/react-ui-entities/src/entity-action-button.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-action-button.stories.tsx
@@ -1,15 +1,15 @@
-import { fn } from 'storybook/test';
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import { createApiClient } from '@granit/api-client';
 import { GranitClientProvider } from '@granit/react-api-client';
 import { EntityActionDrawerHost, EntityActionModalHost } from '@granit/react-entities';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { createApiClient } from '@granit/api-client';
 import { http, HttpResponse } from 'msw';
-
-import type { EntityActionManifest } from '@granit/entities';
-import { EntityActionScopeProvider } from './entity-action-scope';
+import { fn } from 'storybook/test';
 
 import { EntityActionButton } from './entity-action-button';
+import { EntityActionScopeProvider } from './entity-action-scope';
+
+import type { EntityActionManifest } from '@granit/entities';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const mockApiClient = createApiClient({ baseURL: '' });
 const queryClient = new QueryClient({

--- a/packages/@granit/react-ui-entities/src/entity-action-button.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-action-button.tsx
@@ -1,13 +1,13 @@
-import { useState } from 'react';
-
-import type { EntityActionManifest } from '@granit/entities';
 import { useEntityActionDispatcher, type EntityActionHandlers } from '@granit/react-entities';
 import { useTranslation } from '@granit/react-localization';
-import { Button } from '@granit/react-ui';
 import { resolveLabel } from '@granit/react-localization';
+import { Button } from '@granit/react-ui';
 import { Download, ExternalLink, PanelRightOpen, Play, SquarePen, Trash2 } from 'lucide-react';
+import { useState } from 'react';
 
 import { logger } from './logger';
+
+import type { EntityActionManifest } from '@granit/entities';
 
 // Showcase-styled wrapper around the framework's entity action
 // dispatcher. Renders a shadcn `<Button>` whose visual is derived from

--- a/packages/@granit/react-ui-entities/src/entity-action-scope.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-action-scope.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, useMemo, useState, type ReactNode } from 'react';
 
 // Host-side scope captured by `<WorkspaceEntityPage>` whenever a list

--- a/packages/@granit/react-ui-entities/src/entity-calendar-view.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-calendar-view.stories.tsx
@@ -1,15 +1,14 @@
-import { fn } from 'storybook/test';
-
+import { createApiClient } from '@granit/api-client';
 import { GranitClientProvider } from '@granit/react-api-client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import type { Meta, StoryObj } from '@storybook/react-vite';
-import { createApiClient } from '@granit/api-client';
 import { http, HttpResponse } from 'msw';
+import { fn } from 'storybook/test';
 
 import { EntityCalendarView } from './entity-calendar-view';
 
-import type { CalendarItemResponse, EntityCalendarLayoutManifest } from '@granit/entities';
 import type { ExtendedEntityManifest } from './manifest-extensions';
+import type { CalendarItemResponse, EntityCalendarLayoutManifest } from '@granit/entities';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const mockApiClient = createApiClient({ baseURL: '' });
 

--- a/packages/@granit/react-ui-entities/src/entity-calendar-view.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-calendar-view.tsx
@@ -1,10 +1,3 @@
-import { useCallback, useMemo, useState } from 'react';
-
-import type {
-  CalendarItemResponse,
-  EntityActionManifest,
-  EntityCalendarLayoutManifest,
-} from '@granit/entities';
 import {
   EntityActionButton,
   resolveAction,
@@ -14,6 +7,7 @@ import {
 } from '@granit/react-entities';
 import { useTimezone, useTranslation } from '@granit/react-localization';
 import { Button, Switch } from '@granit/react-ui';
+import { cn } from '@granit/utils';
 import {
   addDays,
   addMonths,
@@ -31,10 +25,14 @@ import {
   startOfYear,
 } from 'date-fns';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-
-import { cn } from '@granit/utils';
+import { useCallback, useMemo, useState } from 'react';
 
 import type { ExtendedEntityManifest } from './manifest-extensions';
+import type {
+  CalendarItemResponse,
+  EntityActionManifest,
+  EntityCalendarLayoutManifest,
+} from '@granit/entities';
 
 export type CalendarViewMode = 'day' | 'week' | 'month' | 'year';
 

--- a/packages/@granit/react-ui-entities/src/entity-detail-content.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-detail-content.stories.tsx
@@ -1,17 +1,18 @@
+import { createApiClient } from '@granit/api-client';
 import { GranitClientProvider } from '@granit/react-api-client';
 import { EntityRendererProvider } from '@granit/react-entities';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { delay, http, HttpResponse } from 'msw';
+import { MemoryRouter } from 'react-router-dom';
+
+import { EntityDetailContent } from './entity-detail-content';
+
 import type {
   EntityDiscoveryResponse,
   EntityFormFieldManifest,
   EntityManifestResponse,
 } from '@granit/entities';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { createApiClient } from '@granit/api-client';
-import { delay, http, HttpResponse } from 'msw';
-import { MemoryRouter } from 'react-router-dom';
-
-import { EntityDetailContent } from './entity-detail-content';
 
 const ENTITY_NAME = 'Granit.Parties.Party';
 const ENTITY_ID = 'party-1';

--- a/packages/@granit/react-ui-entities/src/entity-detail-content.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-detail-content.tsx
@@ -1,6 +1,3 @@
-import { useMemo } from 'react';
-
-import type { EntityRelationManifest } from '@granit/entities';
 import { useGranitClient } from '@granit/react-api-client';
 import {
   EntityDetail,
@@ -9,14 +6,17 @@ import {
   type EntityActionHandlers,
 } from '@granit/react-entities';
 import { useDateFormatter, useTranslation } from '@granit/react-localization';
-import { Skeleton, Spinner } from '@granit/react-ui';
 import { resolveLabel } from '@granit/react-localization';
+import { Skeleton, Spinner } from '@granit/react-ui';
 import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { CollectionSectionCard } from './collection-section-card';
 import { EntityActionButton } from './entity-action-button';
 import { asExtended } from './manifest-extensions';
+
+import type { EntityRelationManifest } from '@granit/entities';
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
 

--- a/packages/@granit/react-ui-entities/src/entity-gallery-view.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-gallery-view.stories.tsx
@@ -1,16 +1,15 @@
-import { fn } from 'storybook/test';
-
+import { createApiClient } from '@granit/api-client';
 import { GranitClientProvider } from '@granit/react-api-client';
 import { QueryEndpointStateProvider, QueryProvider } from '@granit/react-query-engine';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import type { Meta, StoryObj } from '@storybook/react-vite';
-import { createApiClient } from '@granit/api-client';
 import { http, HttpResponse } from 'msw';
+import { fn } from 'storybook/test';
 
 import { EntityGalleryView } from './entity-gallery-view';
 
-import type { EntityGalleryLayoutManifest } from '@granit/entities';
 import type { ExtendedEntityManifest } from './manifest-extensions';
+import type { EntityGalleryLayoutManifest } from '@granit/entities';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const BASE_PATH = '/api/v1/entities/Granit.Catalog.Product';
 

--- a/packages/@granit/react-ui-entities/src/entity-gallery-view.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-gallery-view.tsx
@@ -1,13 +1,12 @@
-import type { ReactNode } from 'react';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-
-import type { EntityGalleryLayoutManifest, EntityManifestResponse } from '@granit/entities';
 import { getPage, type PagedResult, type QueryRequest } from '@granit/query-engine';
 import { EntityGallery, type EntityActionHandlers } from '@granit/react-entities';
 import { useQueryConfig, useQueryEndpointState } from '@granit/react-query-engine';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import type { ExtendedEntityManifest } from './manifest-extensions';
+import type { EntityGalleryLayoutManifest, EntityManifestResponse } from '@granit/entities';
+import type { ReactNode } from 'react';
 
 /**
  * Image slot — the host injects the image layer (e.g. `<BlobImage>` from

--- a/packages/@granit/react-ui-entities/src/entity-kanban-view.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-kanban-view.stories.tsx
@@ -1,15 +1,14 @@
-import { fn } from 'storybook/test';
-
+import { createApiClient } from '@granit/api-client';
 import { GranitClientProvider } from '@granit/react-api-client';
 import { QueryProvider } from '@granit/react-query-engine';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import type { Meta, StoryObj } from '@storybook/react-vite';
-import { createApiClient } from '@granit/api-client';
+import { fn } from 'storybook/test';
 
 import { EntityKanbanView } from './entity-kanban-view';
 
-import type { EntityFormFieldManifest, EntityKanbanLayoutManifest } from '@granit/entities';
 import type { ExtendedEntityManifest } from './manifest-extensions';
+import type { EntityFormFieldManifest, EntityKanbanLayoutManifest } from '@granit/entities';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const mockApiClient = createApiClient({ baseURL: '' });
 

--- a/packages/@granit/react-ui-entities/src/entity-kanban-view.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-kanban-view.tsx
@@ -1,21 +1,11 @@
-import { useCallback, useMemo, useState, type DragEvent } from 'react';
-
-import type {
-  EntityActionManifest,
-  EntityFormFieldManifest,
-  EntityKanbanCardActionManifest,
-  EntityKanbanColumnManifest,
-  EntityKanbanLayoutManifest,
-  KanbanColor,
-  KanbanColumnState,
-} from '@granit/entities';
 import { buildQueryKey } from '@granit/query-engine';
 import { useGranitClient } from '@granit/react-api-client';
 import { useEntityActionDispatcher, type EntityActionHandlers } from '@granit/react-entities';
 import { useDateFormatter, useTranslation } from '@granit/react-localization';
+import { resolveLabel } from '@granit/react-localization';
 import { useQueryConfig } from '@granit/react-query-engine';
 import { Button } from '@granit/react-ui';
-import { resolveLabel } from '@granit/react-localization';
+import { cn } from '@granit/utils';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   ChevronDown,
@@ -27,12 +17,21 @@ import {
   SquarePen,
   Trash2,
 } from 'lucide-react';
+import { useCallback, useMemo, useState, type DragEvent } from 'react';
 import { toast } from 'sonner';
 
 import { logger } from './logger';
-import { cn } from '@granit/utils';
 
 import type { ExtendedEntityManifest } from './manifest-extensions';
+import type {
+  EntityActionManifest,
+  EntityFormFieldManifest,
+  EntityKanbanCardActionManifest,
+  EntityKanbanColumnManifest,
+  EntityKanbanLayoutManifest,
+  KanbanColor,
+  KanbanColumnState,
+} from '@granit/entities';
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
 

--- a/packages/@granit/react-ui-entities/src/entity-page-layout.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-page-layout.stories.tsx
@@ -1,9 +1,10 @@
 import { Button } from '@granit/react-ui';
 import { ArrowLeft, Plus } from 'lucide-react';
 
+import { EntityPageLayout } from './entity-page-layout';
+
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { EntityPageLayout } from './entity-page-layout';
 
 const meta = {
   title: 'Shared Components/Layout/EntityPageLayout',

--- a/packages/@granit/react-ui-entities/src/entity-page-layout.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-page-layout.tsx
@@ -1,6 +1,7 @@
+import { cn } from '@granit/utils';
+
 import type { ReactNode } from 'react';
 
-import { cn } from '@granit/utils';
 
 // `<EntityPageLayout>` doesn't set max-width itself — Layout's outer
 // content wrapper detects `[data-content-width=…]` via `:has()` and

--- a/packages/@granit/react-ui-entities/src/entity-view-switcher.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-view-switcher.stories.tsx
@@ -1,9 +1,10 @@
 import { fn } from 'storybook/test';
 
+import { EntityViewSwitcher } from './entity-view-switcher';
+
 import type { EntityListLayoutManifest } from '@granit/entities';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { EntityViewSwitcher } from './entity-view-switcher';
 
 const layout = (
   kind: EntityListLayoutManifest['kind'],

--- a/packages/@granit/react-ui-entities/src/entity-view-switcher.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-view-switcher.tsx
@@ -1,9 +1,8 @@
-import type { EntityListLayoutKind, EntityListLayoutManifest } from '@granit/entities';
 import { useTranslation } from '@granit/react-localization';
+import { cn } from '@granit/utils';
 import { Calendar, Images, KanbanSquare, List } from 'lucide-react';
 
-import { cn } from '@granit/utils';
-
+import type { EntityListLayoutKind, EntityListLayoutManifest } from '@granit/entities';
 import type { LucideIcon } from 'lucide-react';
 
 const KIND_ICONS: Readonly<Record<EntityListLayoutKind, LucideIcon>> = {

--- a/packages/@granit/react-ui-entities/src/side-peek-drawer.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/side-peek-drawer.stories.tsx
@@ -1,12 +1,13 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import type { Meta, StoryObj } from '@storybook/react-vite';
 import { createApiClient } from '@granit/api-client';
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { delay, http } from 'msw';
 import { MemoryRouter } from 'react-router-dom';
 
-import { GranitClientProvider } from '@granit/react-api-client';
 
 import { SidePeekDrawer } from './side-peek-drawer';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const mockApiClient = createApiClient({ baseURL: '' });
 

--- a/packages/@granit/react-ui-entities/src/side-peek-drawer.tsx
+++ b/packages/@granit/react-ui-entities/src/side-peek-drawer.tsx
@@ -1,12 +1,12 @@
-import { useCallback } from 'react';
-
-import type { EntityRelationManifest } from '@granit/entities';
 import { useTranslation } from '@granit/react-localization';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@granit/react-ui';
 import { useSidePeek } from '@granit/react-workspaces';
+import { useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { EntityDetailContent } from './entity-detail-content';
+
+import type { EntityRelationManifest } from '@granit/entities';
 
 // Notion-style side peek drawer — globally mounted in `<Layout />` so any
 // list page can pop a row's detail without leaving the list. Driven by

--- a/packages/@granit/react-ui-entities/src/workspace-entity-detail-page.tsx
+++ b/packages/@granit/react-ui-entities/src/workspace-entity-detail-page.tsx
@@ -1,4 +1,3 @@
-import type { EntityRelationManifest } from '@granit/entities';
 import { useTranslation } from '@granit/react-localization';
 import { Button } from '@granit/react-ui';
 import { ArrowLeft } from 'lucide-react';
@@ -6,6 +5,8 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { EntityDetailContent } from './entity-detail-content';
 import { EntityPageLayout } from './entity-page-layout';
+
+import type { EntityRelationManifest } from '@granit/entities';
 
 // Workspace-scoped entity detail route (`/w/:workspace/:entity/:id`).
 // Wraps `<EntityDetailContent />` with the unified `<EntityPageLayout />`

--- a/packages/@granit/react-ui-entities/src/workspace-entity-form-page.tsx
+++ b/packages/@granit/react-ui-entities/src/workspace-entity-form-page.tsx
@@ -6,8 +6,8 @@ import {
   useEntityMetadata,
 } from '@granit/react-entities';
 import { useTranslation } from '@granit/react-localization';
-import { Button, Skeleton } from '@granit/react-ui';
 import { resolveLabel } from '@granit/react-localization';
+import { Button, Skeleton } from '@granit/react-ui';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';

--- a/packages/@granit/react-ui-entities/src/workspace-entity-page.tsx
+++ b/packages/@granit/react-ui-entities/src/workspace-entity-page.tsx
@@ -1,12 +1,3 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
-
-import type {
-  EntityListLayoutKind,
-  EntityListLayoutManifest,
-  EntityManifestResponse,
-  EntitySelectionActionManifest,
-} from '@granit/entities';
-import type { ColumnDefinition, QueryMetadata } from '@granit/query-engine';
 import {
   EntityListPageHeader,
   EntitySelectionBar,
@@ -19,6 +10,7 @@ import {
   type EntitySelectionBarRecap,
 } from '@granit/react-entities';
 import { useDateFormatter, useTranslation } from '@granit/react-localization';
+import { resolveLabel } from '@granit/react-localization';
 import {
   QueryEndpointStateProvider,
   QueryProvider,
@@ -49,14 +41,13 @@ import {
 } from '@granit/react-ui-admin-kit';
 import { useOperatorLabels } from '@granit/react-ui-admin-kit';
 import { useSmartFilterSync } from '@granit/react-ui-admin-kit';
-import { resolveLabel } from '@granit/react-localization';
 import { useSidePeek } from '@granit/react-workspaces';
 import { ChevronRight, Pencil, Plus } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import { recapParentRefs } from './bulk-recap';
-
 import { useEntityActionScope } from './entity-action-scope';
 import { EntityCalendarView } from './entity-calendar-view';
 import { EntityGalleryView, type GalleryRenderImage } from './entity-gallery-view';
@@ -66,6 +57,13 @@ import { EntityViewSwitcher } from './entity-view-switcher';
 import { asExtended } from './manifest-extensions';
 
 import type { ExtendedEntityManifest } from './manifest-extensions';
+import type {
+  EntityListLayoutKind,
+  EntityListLayoutManifest,
+  EntityManifestResponse,
+  EntitySelectionActionManifest,
+} from '@granit/entities';
+import type { ColumnDefinition, QueryMetadata } from '@granit/query-engine';
 import type { ColumnDef } from '@tanstack/react-table';
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5110,6 +5110,87 @@ importers:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
+  packages/@granit/react-ui-entities:
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/entities':
+        specifier: workspace:*
+        version: link:../entities
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-entities':
+        specifier: workspace:*
+        version: link:../react-entities
+      '@granit/react-localization':
+        specifier: workspace:*
+        version: link:../react-localization
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
+      '@granit/react-ui':
+        specifier: workspace:*
+        version: link:../react-ui
+      '@granit/react-ui-admin-kit':
+        specifier: workspace:*
+        version: link:../react-ui-admin-kit
+      '@granit/react-workspaces':
+        specifier: workspace:*
+        version: link:../react-workspaces
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
+      '@granit/utils':
+        specifier: workspace:*
+        version: link:../utils
+      '@storybook/react-vite':
+        specifier: ^10.4.6
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(yaml@2.9.0))
+      '@tanstack/react-query':
+        specifier: 5.101.1
+        version: 5.101.1(react@19.2.7)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      date-fns:
+        specifier: ^4.0.0
+        version: 4.4.0
+      i18next:
+        specifier: ^26.0.0
+        version: 26.3.1(typescript@6.0.3)
+      lucide-react:
+        specifier: ^1.21.0
+        version: 1.21.0(react@19.2.7)
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@26.0.0)(typescript@6.0.3)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+      react-i18next:
+        specifier: ^17.0.0
+        version: 17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+      react-router-dom:
+        specifier: ^7.18.0
+        version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook:
+        specifier: ^10.4.6
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
   packages/@granit/react-ui-entities-customization:
     devDependencies:
       '@granit/api-client':


### PR DESCRIPTION
## Problem

`develop` is red — `pnpm install --frozen-lockfile` fails:

```
ERR_PNPM_OUTDATED_LOCKFILE  … pnpm-lock.yaml is not up to date with
packages/@granit/react-ui-entities/package.json
```

`react-ui-entities` (+ `react-entities`/`entities`) was merged with red CI — the same bypassed-CI pattern as #765/#767. The broken install masked downstream checks, so lint/index failures landed latent on develop.

## Fixes (verified green)

1. **Lockfile** — regenerate `pnpm-lock.yaml` for the packages' deps (`@tanstack/react-table`, `date-fns`, `sonner`, `react-router-dom`, …). Restores `--frozen-lockfile`.
2. **front-index** — regenerate `.mcp-front-index.json` (missing package exports).
3. **lint** — `import-x/order` across `react-ui-entities` (`eslint --fix`); removed an orphan file-level `eslint-disable react-refresh/only-export-components` (no react-refresh plugin registered in `eslint.config.js`).

arch-tests already green (no new direct web-router import). `pnpm install --frozen-lockfile`, `pnpm lint`, arch-tests verified; tsc + full test suite running.

---

⚠️ **This is the 4th merge-with-red-CI break of develop today** (#765, #767, #770, and now react-ui-entities). Strongly recommend enabling branch protection requiring green CI before merge — otherwise develop will keep breaking.