### PR TITLE
fix(react-ui-entities): resolve code-quality warnings + lockfile sync

### DIFF
--- a/packages/@granit/react-ui-entities/src/entity-detail-content.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-detail-content.tsx
@@ -7,7 +7,7 @@ import {
 } from '@granit/react-entities';
 import { useDateFormatter, useTranslation } from '@granit/react-localization';
 import { resolveLabel } from '@granit/react-localization';
-import { Skeleton, Spinner } from '@granit/react-ui';
+import { Skeleton } from '@granit/react-ui';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -248,20 +248,16 @@ export function EntityDetailContent({
         )}
       </header>
 
-      {isEntityLoading ? (
-        <Spinner />
-      ) : (
-        <EntityDetail
-          variant={detailVariant}
-          values={values}
-          formVariants={manifest.forms ?? undefined}
-          propertyComponents={propertyComponents}
-          entityName={manifest.identity?.name ?? entityName}
-          entityId={entityId}
-          relations={manifest.relations ?? undefined}
-          onRelationClick={handleRelationClick}
-        />
-      )}
+      <EntityDetail
+        variant={detailVariant}
+        values={values}
+        formVariants={manifest.forms ?? undefined}
+        propertyComponents={propertyComponents}
+        entityName={manifest.identity?.name ?? entityName}
+        entityId={entityId}
+        relations={manifest.relations ?? undefined}
+        onRelationClick={handleRelationClick}
+      />
 
       {sortedCollectionSections.map((section) => (
         <CollectionSectionCard

--- a/packages/@granit/testing/src/setup.ts
+++ b/packages/@granit/testing/src/setup.ts
@@ -44,6 +44,9 @@ if (typeof globalThis.window !== 'undefined') {
     root = null;
     rootMargin = '';
     thresholds = [];
+    constructor(_callback?: unknown, options?: { rootMargin?: string }) {
+      this.rootMargin = options?.rootMargin ?? '';
+    }
     observe() {}
     unobserve() {}
     disconnect() {}


### PR DESCRIPTION
## What

Fixes two `github-code-quality` warnings on the entity-rendering UI (originally flagged on the now-merged #773), plus an unrelated develop install breakage that blocks CI.

### 1. Useless conditional — `entity-detail-content.tsx`
The bot was right that `isEntityLoading` was always `false` here: the early return at the top of the component already renders a skeleton while loading. There is no `entityQuery` to swap in (the bot's suggested fix doesn't fit this code), so the correct fix is to **remove the dead ternary** and render `<EntityDetail>` directly. Dropped the now-unused `Spinner` import.

### 2. Superfluous constructor arguments — `entity-gallery-view.tsx`
Production `new IntersectionObserver(callback, options)` is correct per the DOM spec. The analyzer resolved `IntersectionObserver` to the **test stub** (`IntersectionObserverStub` in `@granit/testing`), which had no constructor (→ zero-arg). Fix belongs in the stub, not production code: gave it the real `(callback, options?)` signature (reflecting `rootMargin`). Production code untouched.

### 3. Lockfile sync (separate commit)
`origin/develop` is currently **not installable** with `--frozen-lockfile`: `@granit/react-ui-entities`'s deps were added to `package.json` (via #773) without a lockfile sync. Regenerated `pnpm-lock.yaml` so this branch — and develop after merge — installs cleanly in CI.

## Verification
- ESLint clean (also auto-fixed pre-existing `import-x/order` errors in the two entity files)
- `tsc --noEmit` clean (`@granit/testing`, `@granit/react-ui-entities`)
- 74 tests pass (`entity-gallery`, `entity-detail`)