### PR TITLE
fix(react-ui-entities): import toast from @granit/react-ui, not sonner (#776 fallout)

### DIFF
--- a/packages/@granit/react-ui-entities/src/entity-kanban-view.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-kanban-view.tsx
@@ -4,7 +4,7 @@ import { useEntityActionDispatcher, type EntityActionHandlers } from '@granit/re
 import { useDateFormatter, useTranslation } from '@granit/react-localization';
 import { resolveLabel } from '@granit/react-localization';
 import { useQueryConfig } from '@granit/react-query-engine';
-import { Button } from '@granit/react-ui';
+import { Button, toast } from '@granit/react-ui';
 import { cn } from '@granit/utils';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -18,7 +18,6 @@ import {
   Trash2,
 } from 'lucide-react';
 import { useCallback, useMemo, useState, type DragEvent } from 'react';
-import { toast } from 'sonner';
 
 import { logger } from './logger';
 

--- a/packages/@granit/react-ui-entities/src/workspace-entity-form-page.tsx
+++ b/packages/@granit/react-ui-entities/src/workspace-entity-form-page.tsx
@@ -7,11 +7,10 @@ import {
 } from '@granit/react-entities';
 import { useTranslation } from '@granit/react-localization';
 import { resolveLabel } from '@granit/react-localization';
-import { Button, Skeleton } from '@granit/react-ui';
+import { Button, Skeleton, toast } from '@granit/react-ui';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { CollectionSectionCard } from './collection-section-card';
 import { EntityPageLayout } from './entity-page-layout';

--- a/packages/@granit/react-ui-entities/src/workspace-entity-page.tsx
+++ b/packages/@granit/react-ui-entities/src/workspace-entity-page.tsx
@@ -31,6 +31,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   Checkbox,
+  toast,
 } from '@granit/react-ui';
 import {
   FilterPresets,
@@ -45,7 +46,6 @@ import { useSidePeek } from '@granit/react-workspaces';
 import { ChevronRight, Pencil, Plus } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
 import { recapParentRefs } from './bulk-recap';
 import { useEntityActionScope } from './entity-action-scope';


### PR DESCRIPTION
## Problem

`develop` lint is red after #776:

```
'sonner' import is restricted. Import `toast` / `Toaster` from '@granit/react-ui' instead.
  lint: packages/@granit/react-ui-entities/src/entity-kanban-view.tsx:21
```

#776 ("route toast through the foundation, not sonner directly") added a `no-restricted-imports` rule banning direct `sonner` imports in domain UI packages. react-ui-entities imported `toast` from `sonner` in 3 files (entity-kanban-view, workspace-entity-form-page, workspace-entity-page) — a cross-PR interaction (react-ui-entities and #776 merged around the same time).

## Fix

Import `toast` from `@granit/react-ui` (which re-exports it from its themed sonner wrapper).

## Verification

lint ✅, tsc ✅ (toast resolves from react-ui), react-ui-entities tests ✅. Branched from latest develop (874d3064).