### PR TITLE
story(react-ui-shell-admin): colocate WorkspaceIcon story

### DIFF
--- a/packages/@granit/react-ui-shell-admin/package.json
+++ b/packages/@granit/react-ui-shell-admin/package.json
@@ -45,6 +45,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@storybook/react-vite": "^10.4.6",
     "@granit/localization": "workspace:*",
     "@granit/react-account": "workspace:*",
     "@granit/react-authorization": "workspace:*",

--- a/packages/@granit/react-ui-shell-admin/src/workspace-icon.stories.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/workspace-icon.stories.tsx
@@ -1,0 +1,41 @@
+import { WorkspaceIcon } from './workspace-icon';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  title: 'Shell Admin/WorkspaceIcon',
+  component: WorkspaceIcon,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof WorkspaceIcon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { name: 'shield-user', className: 'size-5' },
+};
+
+export const UsersRound: Story = {
+  args: { name: 'users-round', className: 'size-5' },
+};
+
+export const MonitorSmartphone: Story = {
+  args: { name: 'monitor-smartphone', className: 'size-5' },
+};
+
+export const NullNameFallback: Story = {
+  name: 'Null Name (Fallback Square)',
+  args: { name: null, className: 'size-5' },
+};
+
+export const UnknownNameFallback: Story = {
+  name: 'Unknown Name (Fallback Square)',
+  args: { name: 'not-a-real-icon-name-xyz', className: 'size-5' },
+};
+
+export const LargeSize: Story = {
+  args: { name: 'shield-user', className: 'size-10 text-primary' },
+};


### PR DESCRIPTION
Moves the  Storybook story from the showcase into `@granit/react-ui-shell-admin` (next to the component). It was stranded in the showcase after the shell extraction. Adds `@storybook/react-vite` as the package's first story dev dep. Validated: arch-tests 3003, story tsc clean.