### PR TITLE
feat(react-ui-workspaces): extract the workspace landing page

### DIFF
--- a/packages/@granit/react-ui-workspaces/README.md
+++ b/packages/@granit/react-ui-workspaces/README.md
@@ -1,0 +1,41 @@
+# @granit/react-ui-workspaces
+
+Workspace UI for Granit admin apps — the workspace landing page that pairs with
+the headless [`@granit/react-workspaces`](../react-workspaces) (the workspace
+tree hooks and route helpers).
+
+The headless package owns the _data_ (`useWorkspaces`, landing routes); this
+package owns the _pages_.
+
+## Components
+
+- **`WorkspacePage`** — the "you are here" landing reached from the launcher or
+  the workspace switcher. It looks the workspace up in the tree and shows its
+  icon, title and a short subtitle.
+
+The page is app-agnostic:
+
+- pass the route's `workspaceName` (the host reads it from `useParams`), so the
+  page stays router-free;
+- pass a `renderIcon` slot — the showcase injects shell-admin's `WorkspaceIcon`,
+  so the package carries no icon-rendering dependency;
+- the `Workspace.*` strings ship in `workspacesTranslationsEn` /
+  `workspacesTranslationsFr`; register them in your i18n instance.
+
+## Usage
+
+```tsx
+import { WorkspaceIcon } from '@granit/react-ui-shell-admin';
+import { WorkspacePage } from '@granit/react-ui-workspaces';
+import { useParams } from 'react-router-dom';
+
+function WorkspacePageRoute() {
+  const { workspace } = useParams<{ workspace: string }>();
+  return (
+    <WorkspacePage
+      workspaceName={workspace}
+      renderIcon={(name, className) => <WorkspaceIcon name={name} className={className} />}
+    />
+  );
+}
+```

--- a/packages/@granit/react-ui-workspaces/package.json
+++ b/packages/@granit/react-ui-workspaces/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@granit/react-ui-workspaces",
+  "description": "Granit admin workspaces UI — the workspace landing page that pairs with the headless @granit/react-workspaces. App-agnostic: it takes the route workspace name and an icon-render slot as props, and ships its own Workspace.* translations.",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/react-workspaces": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/react-workspaces": "workspace:*",
+    "@storybook/react-vite": "^10.4.6",
+    "@tanstack/react-query": "^5.0.0",
+    "i18next": "^26.0.0",
+    "lucide-react": "^1.21.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-i18next": "^17.0.0",
+    "storybook": "^10.4.6"
+  }
+}

--- a/packages/@granit/react-ui-workspaces/src/__tests__/workspace-page.test.tsx
+++ b/packages/@granit/react-ui-workspaces/src/__tests__/workspace-page.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import i18next from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it, vi } from 'vitest';
+
+import { workspacesTranslationsEn } from '../locales';
+import { WorkspacePage } from '../workspace-page';
+
+const mockUseWorkspaces = vi.fn();
+vi.mock('@granit/react-workspaces', () => ({
+  useWorkspaces: () => mockUseWorkspaces() as unknown,
+}));
+
+const testI18n = i18next.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  ns: ['translation'],
+  defaultNS: 'translation',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: { ...workspacesTranslationsEn } } },
+  interpolation: { escapeValue: false },
+});
+
+const renderIcon = (name: string | null) => <span data-testid="icon">{name}</span>;
+
+function renderPage(workspaceName: string | undefined) {
+  return render(
+    <I18nextProvider i18n={testI18n}>
+      <WorkspacePage workspaceName={workspaceName} renderIcon={renderIcon} />
+    </I18nextProvider>
+  );
+}
+
+describe('WorkspacePage', () => {
+  it('renders skeletons while the workspace tree loads', () => {
+    mockUseWorkspaces.mockReturnValue({ data: undefined, isLoading: true });
+    const { container } = renderPage('Showcase.CRM');
+    expect(container.querySelector('.rounded-2xl')).not.toBeNull();
+    expect(screen.queryByTestId('icon')).toBeNull();
+  });
+
+  it('renders the not-found state for an unknown workspace', () => {
+    mockUseWorkspaces.mockReturnValue({ data: { workspaces: [] }, isLoading: false });
+    renderPage('Nope');
+    expect(screen.getByText('Workspace not found')).toBeInTheDocument();
+  });
+
+  it('renders the title (resolved from displayKey) and the injected icon when found', () => {
+    mockUseWorkspaces.mockReturnValue({
+      data: {
+        workspaces: [
+          {
+            name: 'Showcase.CRM',
+            displayKey: 'Showcase:Workspace.CRM',
+            icon: 'contact',
+            isShell: false,
+          },
+        ],
+      },
+      isLoading: false,
+    });
+    renderPage('Showcase.CRM');
+    // resolveLabel falls back to the key's last segment with no translation.
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('CRM');
+    expect(screen.getByTestId('icon')).toHaveTextContent('contact');
+  });
+});

--- a/packages/@granit/react-ui-workspaces/src/index.ts
+++ b/packages/@granit/react-ui-workspaces/src/index.ts
@@ -1,0 +1,2 @@
+export { WorkspacePage, type WorkspacePageProps } from './workspace-page';
+export { workspacesTranslationsEn, workspacesTranslationsFr } from './locales';

--- a/packages/@granit/react-ui-workspaces/src/locales/en.ts
+++ b/packages/@granit/react-ui-workspaces/src/locales/en.ts
@@ -1,0 +1,12 @@
+/**
+ * English strings for the workspaces UI. Flat `Workspace.*` keys in the
+ * `translation` namespace (the host registers them with separators disabled, so
+ * the dotted keys are looked up verbatim).
+ */
+export const workspacesTranslationsEn = {
+  'Workspace.App.Subtitle': 'Pick an item from the sidebar to get started.',
+  'Workspace.NotFound.Body': 'No workspace named ',
+  'Workspace.NotFound.BodySuffix': ' is registered for the current user.',
+  'Workspace.NotFound.Title': 'Workspace not found',
+  'Workspace.Shell.Subtitle': 'Framework shell — populated by module contributions.',
+} as const;

--- a/packages/@granit/react-ui-workspaces/src/locales/fr.ts
+++ b/packages/@granit/react-ui-workspaces/src/locales/fr.ts
@@ -1,0 +1,10 @@
+/**
+ * French strings for the workspaces UI. See {@link workspacesTranslationsEn}.
+ */
+export const workspacesTranslationsFr = {
+  'Workspace.App.Subtitle': 'Choisissez un élément dans la barre latérale pour commencer.',
+  'Workspace.NotFound.Body': 'Aucun espace de travail nommé ',
+  'Workspace.NotFound.BodySuffix': " n'est enregistré pour l'utilisateur actuel.",
+  'Workspace.NotFound.Title': 'Espace de travail introuvable',
+  'Workspace.Shell.Subtitle': 'Coquille du framework — alimentée par les contributions des modules.',
+} as const;

--- a/packages/@granit/react-ui-workspaces/src/locales/index.ts
+++ b/packages/@granit/react-ui-workspaces/src/locales/index.ts
@@ -1,0 +1,2 @@
+export { workspacesTranslationsEn } from './en';
+export { workspacesTranslationsFr } from './fr';

--- a/packages/@granit/react-ui-workspaces/src/stories-i18n.ts
+++ b/packages/@granit/react-ui-workspaces/src/stories-i18n.ts
@@ -1,0 +1,18 @@
+import i18next from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import { workspacesTranslationsEn } from './locales';
+
+// Shared i18next instance for Storybook stories. Mirrors the runtime flat-key
+// setup (separators disabled) and bundles the package's own Workspace.* keys.
+export const storyI18n = i18next.createInstance();
+await storyI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  ns: ['translation'],
+  defaultNS: 'translation',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: { ...workspacesTranslationsEn } } },
+  interpolation: { escapeValue: false },
+});

--- a/packages/@granit/react-ui-workspaces/src/workspace-page.stories.tsx
+++ b/packages/@granit/react-ui-workspaces/src/workspace-page.stories.tsx
@@ -1,0 +1,55 @@
+import { createApiClient } from '@granit/api-client';
+import { GranitClientProvider } from '@granit/react-api-client';
+import { createWorkspacesHandlers } from '@granit/react-workspaces/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DynamicIcon, type IconName } from 'lucide-react/dynamic';
+import { I18nextProvider } from 'react-i18next';
+
+import { storyI18n } from './stories-i18n';
+import { WorkspacePage } from './workspace-page';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const client = createApiClient({ baseURL: '' });
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+// Mirrors the host's injected WorkspaceIcon (lucide dynamic icon by backend name).
+const renderIcon = (name: string | null, className?: string) =>
+  name ? <DynamicIcon name={name as IconName} className={className} /> : null;
+
+const meta: Meta<typeof WorkspacePage> = {
+  title: 'Workspaces/WorkspacePage',
+  component: WorkspacePage,
+  tags: ['autodocs', '!test'],
+  args: { renderIcon },
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers: createWorkspacesHandlers() },
+  },
+  decorators: [
+    (Story) => (
+      <I18nextProvider i18n={storyI18n}>
+        <QueryClientProvider client={queryClient}>
+          <GranitClientProvider client={client}>
+            <Story />
+          </GranitClientProvider>
+        </QueryClientProvider>
+      </I18nextProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The landing screen for an existing workspace (mock `Showcase.CRM`). */
+export const Default: Story = {
+  args: { workspaceName: 'Showcase.CRM' },
+};
+
+/** The "not found" state when the route names a workspace the user can't see. */
+export const NotFound: Story = {
+  args: { workspaceName: 'Does.Not.Exist' },
+};

--- a/packages/@granit/react-ui-workspaces/src/workspace-page.tsx
+++ b/packages/@granit/react-ui-workspaces/src/workspace-page.tsx
@@ -1,0 +1,88 @@
+
+import { resolveLabel, useTranslation } from '@granit/react-localization';
+import { Skeleton } from '@granit/react-ui';
+import { useWorkspaces } from '@granit/react-workspaces';
+
+import type { ReactNode } from 'react';
+
+export interface WorkspacePageProps {
+  /**
+   * Workspace name from the route (`/w/:workspace`). App-agnostic: the host
+   * wrapper reads it from the router (`useParams`) and passes it in, so this
+   * page stays router-free and renders standalone in stories/tests.
+   */
+  readonly workspaceName: string | undefined;
+  /**
+   * Renders a workspace's icon from its backend icon name (a kebab-case lucide
+   * name). Injected by the host — the showcase passes shell-admin's
+   * `WorkspaceIcon` — so the package carries no icon-rendering dependency.
+   */
+  readonly renderIcon: (name: string | null, className?: string) => ReactNode;
+}
+
+/**
+ * Workspace landing — a clean welcome screen reached by clicking a tile on the
+ * launcher or a row in the switcher. The workspace's actual items (entities,
+ * links, sub-workspaces) are surfaced in the sidebar nav, not on this page;
+ * this is just a "you are here" landing while the user picks where to go from
+ * the sidebar.
+ */
+export function WorkspacePage({ workspaceName, renderIcon }: WorkspacePageProps) {
+  const { t } = useTranslation();
+  const { data, isLoading } = useWorkspaces();
+
+  if (isLoading) {
+    return (
+      <div
+        data-content-width="full"
+        className="mx-auto flex max-w-3xl flex-col items-center gap-4 p-12"
+      >
+        <Skeleton className="size-20 rounded-2xl" />
+        <Skeleton className="h-8 w-48" />
+      </div>
+    );
+  }
+
+  const workspace = data?.workspaces.find((w) => w.name === workspaceName);
+
+  if (!workspace) {
+    return (
+      <div
+        data-slot="workspace-page"
+        data-content-width="full"
+        className="mx-auto max-w-3xl space-y-2 p-6"
+      >
+        <h2 className="text-2xl font-semibold">
+          {t('Workspace.NotFound.Title', 'Workspace not found')}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {t('Workspace.NotFound.Body', 'No workspace named ')}
+          <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">{workspaceName}</code>
+          {t('Workspace.NotFound.BodySuffix', ' is registered for the current user.')}
+        </p>
+      </div>
+    );
+  }
+
+  const title = resolveLabel(workspace.displayKey, workspace.name);
+
+  return (
+    <div
+      data-slot="workspace-page"
+      data-content-width="full"
+      className="mx-auto flex max-w-3xl flex-col items-center gap-6 p-12 text-center"
+    >
+      <span className="flex size-20 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-sm">
+        {renderIcon(workspace.icon, 'size-10')}
+      </span>
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">{title}</h1>
+        <p className="text-sm text-muted-foreground">
+          {workspace.isShell
+            ? t('Workspace.Shell.Subtitle', 'Framework shell — populated by module contributions.')
+            : t('Workspace.App.Subtitle', 'Pick an item from the sidebar to get started.')}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-workspaces/tsconfig.json
+++ b/packages/@granit/react-ui-workspaces/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": [
+    "src/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.stories.ts",
+    "src/**/*.stories.tsx"
+  ]
+}

--- a/packages/@granit/react-ui-workspaces/tsup.config.ts
+++ b/packages/@granit/react-ui-workspaces/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6808,6 +6808,48 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
 
+  packages/@granit/react-ui-workspaces:
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-localization':
+        specifier: workspace:*
+        version: link:../react-localization
+      '@granit/react-ui':
+        specifier: workspace:*
+        version: link:../react-ui
+      '@granit/react-workspaces':
+        specifier: workspace:*
+        version: link:../react-workspaces
+      '@storybook/react-vite':
+        specifier: ^10.4.6
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(yaml@2.9.0))
+      '@tanstack/react-query':
+        specifier: 5.101.1
+        version: 5.101.1(react@19.2.7)
+      i18next:
+        specifier: ^26.0.0
+        version: 26.3.1(typescript@6.0.3)
+      lucide-react:
+        specifier: ^1.21.0
+        version: 1.21.0(react@19.2.7)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+      react-i18next:
+        specifier: ^17.0.0
+        version: 17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+      storybook:
+        specifier: ^10.4.6
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
   packages/@granit/react-validation:
     dependencies:
       '@granit/validation':


### PR DESCRIPTION
## What

New **`@granit/react-ui-workspaces`** package — the UI counterpart of the headless `@granit/react-workspaces`. It holds **`WorkspacePage`**, the "you are here" landing reached from the launcher or the workspace switcher (moved out of the showcase host).

## Why

Part of the domain-UI backfill: a second admin app would consume this landing, not rebuild it. The showcase becomes a thin consumer (a route wrapper that injects the icon).

## Decoupling (app-agnostic)

- **router-free** — takes the route `workspaceName` as a prop (the host reads `useParams`), so the page renders standalone in stories/tests and needs no `react-router` dep.
- **icon slot** — takes a `renderIcon` prop; the host injects shell-admin's `WorkspaceIcon`, so the package carries no icon-rendering dependency (and shell-admin keeps `WorkspaceIcon`, which its own chrome uses).
- title via `resolveLabel` from `@granit/react-localization`.
- ships its own flat `Workspace.*` bundle (`workspacesTranslationsEn/Fr`).

## Tests

- Storybook story: mock-backed `Default` + `NotFound`.
- Unit test: loading / not-found / found branches (3 passing).
- Full arch-tests suite green (3017); package `tsc` + `eslint --max-warnings 0` clean.

## Follow-up (separate MR)

Showcase adoption (consume the package, delete the local `workspace-page.tsx`, register the i18n bundle, add the route wrapper) lands as a GitLab MR once this merges to `develop`.