### PR TITLE
feat(react-ui-workflow): extract the workflow UI components

### DIFF
--- a/packages/@granit/react-ui-workflow/README.md
+++ b/packages/@granit/react-ui-workflow/README.md
@@ -1,0 +1,39 @@
+# @granit/react-ui-workflow
+
+Workflow UI for Granit admin apps — pairs with the headless
+[`@granit/react-workflow`](../react-workflow) (the transition/history hooks and
+`WorkflowProvider`).
+
+The headless package owns the _data_ (`useTransitions`, `useExecuteTransition`,
+`useWorkflowHistory`); this package owns the _UI_.
+
+## Components
+
+- **`WorkflowStatusBar`** — the state chips + available-transition buttons.
+- **`TransitionCommentDialog`** — optional-comment dialog shown before a
+  transition (handles the approval-required variant).
+- **`WorkflowHistory`** — the transition audit-trail table.
+- **`EntityWorkflow`** — a self-contained card combining the three above; it
+  mounts `WorkflowProvider` internally, so a consumer only supplies the API
+  `config` plus the entity coordinates.
+
+`EntityWorkflow` is app-agnostic: it takes the workflow API `config`
+(`{ client, basePath }`) as a prop — the host passes its own `workflowConfig` —
+so the package never reaches into app config. The `Workflow.*` /
+`Components.Workflow.*` strings ship in `workflowTranslationsEn` /
+`workflowTranslationsFr`; register them in your i18n instance.
+
+## Usage
+
+```tsx
+import { EntityWorkflow } from '@granit/react-ui-workflow';
+import { workflowConfig } from '@/app/shared/app-config';
+
+<EntityWorkflow
+  config={workflowConfig}
+  entityType="Invoice"
+  entityId={invoice.id}
+  currentState={invoice.status}
+  states={INVOICE_WORKFLOW_STATES}
+/>;
+```

--- a/packages/@granit/react-ui-workflow/package.json
+++ b/packages/@granit/react-ui-workflow/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@granit/react-ui-workflow",
+  "description": "Granit admin workflow UI — the status bar, transition dialog, history table and the self-contained EntityWorkflow card that pair with the headless @granit/react-workflow. App-agnostic: EntityWorkflow takes the API config as a prop and the package ships its own Workflow.* translations.",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/react-workflow": "workspace:*",
+    "@granit/utils": "workspace:*",
+    "@granit/workflow": "workspace:*",
+    "lucide-react": "^1.21.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-localization": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/react-workflow": "workspace:*",
+    "@granit/utils": "workspace:*",
+    "@granit/workflow": "workspace:*",
+    "@storybook/react-vite": "^10.4.6",
+    "@tanstack/react-query": "^5.0.0",
+    "i18next": "^26.0.0",
+    "lucide-react": "^1.21.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-i18next": "^17.0.0",
+    "storybook": "^10.4.6"
+  }
+}

--- a/packages/@granit/react-ui-workflow/src/__tests__/entity-workflow.test.tsx
+++ b/packages/@granit/react-ui-workflow/src/__tests__/entity-workflow.test.tsx
@@ -1,0 +1,227 @@
+import { render, screen } from '@testing-library/react';
+import i18next from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { EntityWorkflow } from '../entity-workflow';
+import { workflowTranslationsEn } from '../locales';
+
+import type { ReactElement, ReactNode } from 'react';
+
+// Mock @granit/react-workflow — drive the data hooks directly.
+const { mockUseTransitions, mockUseExecuteTransition, mockUseWorkflowHistory } = vi.hoisted(() => ({
+  mockUseTransitions: vi.fn(),
+  mockUseExecuteTransition: vi.fn(),
+  mockUseWorkflowHistory: vi.fn(),
+}));
+
+vi.mock('@granit/react-workflow', () => ({
+  WorkflowProvider: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  useTransitions: mockUseTransitions,
+  useExecuteTransition: mockUseExecuteTransition,
+  useWorkflowHistory: mockUseWorkflowHistory,
+}));
+
+vi.mock('../workflow-status-bar', () => ({
+  WorkflowStatusBar: ({
+    currentState,
+    states,
+  }: {
+    currentState: string;
+    states: readonly string[];
+  }) => (
+    <div data-testid="workflow-status-bar" data-current-state={currentState}>
+      {states.map((s) => (
+        <span key={s} data-state={s}>
+          {s}
+        </span>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('../workflow-history', () => ({
+  WorkflowHistory: ({
+    history,
+    loading,
+    emptyMessage,
+  }: {
+    history: Array<{ previousState: string; newState: string }>;
+    loading?: boolean;
+    emptyMessage?: string;
+  }) => (
+    <div data-testid="workflow-history">
+      {loading && <span>Loading…</span>}
+      {!loading && history.length === 0 && <span>{emptyMessage}</span>}
+      {history.map((entry, i) => (
+        <div key={i} data-testid="workflow-history-entry">
+          {entry.previousState} → {entry.newState}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+const testI18n = i18next.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  ns: ['translation'],
+  defaultNS: 'translation',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: { ...workflowTranslationsEn } } },
+  interpolation: { escapeValue: false },
+});
+
+function renderWithProviders(ui: ReactElement) {
+  return render(<I18nextProvider i18n={testI18n}>{ui}</I18nextProvider>);
+}
+
+const defaultTransitionsResult = {
+  data: { currentState: 'Active', availableTransitions: [] },
+  isLoading: false,
+  isError: false,
+  error: null,
+  refetch: vi.fn(),
+};
+
+const defaultExecuteResult = {
+  transition: vi.fn().mockResolvedValue(null),
+  isPending: false,
+  data: null,
+  error: null,
+};
+
+const defaultHistoryResult = {
+  data: { items: [], totalCount: 0, hasMore: false, nextCursor: null },
+  isLoading: false,
+  isError: false,
+  error: null,
+  refetch: vi.fn(),
+};
+
+const states = ['PendingValidation', 'Active', 'Suspended', 'Archived'];
+
+function renderEntityWorkflow() {
+  return renderWithProviders(
+    <EntityWorkflow
+      config={{}}
+      entityType="User"
+      entityId="u-1"
+      currentState="Active"
+      states={states}
+    />
+  );
+}
+
+describe('EntityWorkflow', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('displays the Workflow title', () => {
+    mockUseTransitions.mockReturnValue(defaultTransitionsResult);
+    mockUseExecuteTransition.mockReturnValue(defaultExecuteResult);
+    mockUseWorkflowHistory.mockReturnValue(defaultHistoryResult);
+    renderEntityWorkflow();
+    expect(screen.getByText('Workflow')).toBeInTheDocument();
+  });
+
+  it('displays the spinner during initial loading', () => {
+    mockUseTransitions.mockReturnValue({
+      ...defaultTransitionsResult,
+      data: undefined,
+      isLoading: true,
+    });
+    mockUseExecuteTransition.mockReturnValue(defaultExecuteResult);
+    mockUseWorkflowHistory.mockReturnValue(defaultHistoryResult);
+    renderEntityWorkflow();
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('displays the error state when loading fails', () => {
+    mockUseTransitions.mockReturnValue({
+      ...defaultTransitionsResult,
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('Network error'),
+    });
+    mockUseExecuteTransition.mockReturnValue(defaultExecuteResult);
+    mockUseWorkflowHistory.mockReturnValue(defaultHistoryResult);
+    renderEntityWorkflow();
+    expect(screen.getByText('Failed to load workflow')).toBeInTheDocument();
+  });
+
+  it('displays the status bar with the correct current state', () => {
+    mockUseTransitions.mockReturnValue({
+      ...defaultTransitionsResult,
+      data: {
+        currentState: 'Active',
+        availableTransitions: [
+          { targetState: 'Suspended', name: 'Suspend', allowed: true, requiresApproval: false },
+        ],
+      },
+    });
+    mockUseExecuteTransition.mockReturnValue(defaultExecuteResult);
+    mockUseWorkflowHistory.mockReturnValue(defaultHistoryResult);
+    renderEntityWorkflow();
+    expect(screen.getByTestId('workflow-status-bar')).toHaveAttribute('data-current-state', 'Active');
+  });
+
+  it('displays the empty message when there is no history', () => {
+    mockUseTransitions.mockReturnValue(defaultTransitionsResult);
+    mockUseExecuteTransition.mockReturnValue(defaultExecuteResult);
+    mockUseWorkflowHistory.mockReturnValue(defaultHistoryResult);
+    renderEntityWorkflow();
+    expect(screen.getByText('No transitions recorded yet.')).toBeInTheDocument();
+  });
+
+  it('displays the history entries', () => {
+    mockUseTransitions.mockReturnValue(defaultTransitionsResult);
+    mockUseExecuteTransition.mockReturnValue(defaultExecuteResult);
+    mockUseWorkflowHistory.mockReturnValue({
+      ...defaultHistoryResult,
+      data: {
+        items: [
+          {
+            previousState: 'PendingValidation',
+            newState: 'Active',
+            transitionedAt: '2025-12-15T09:35:00Z',
+            transitionedBy: 'System Admin',
+            comment: null,
+          },
+        ],
+        totalCount: 1,
+        hasMore: false,
+        nextCursor: null,
+      },
+    });
+    mockUseExecuteTransition.mockReturnValue(defaultExecuteResult);
+    renderEntityWorkflow();
+    expect(screen.getByText('PendingValidation → Active')).toBeInTheDocument();
+  });
+
+  it('passes entityType and entityId to the data hooks', () => {
+    mockUseTransitions.mockReturnValue(defaultTransitionsResult);
+    mockUseExecuteTransition.mockReturnValue(defaultExecuteResult);
+    mockUseWorkflowHistory.mockReturnValue(defaultHistoryResult);
+    renderEntityWorkflow();
+    expect(mockUseTransitions).toHaveBeenCalledWith(
+      expect.objectContaining({ currentState: 'Active' })
+    );
+    expect(mockUseExecuteTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+    expect(mockUseWorkflowHistory).toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: 'User', entityId: 'u-1' })
+    );
+  });
+
+  it('sets the data-slot attribute', () => {
+    mockUseTransitions.mockReturnValue(defaultTransitionsResult);
+    mockUseExecuteTransition.mockReturnValue(defaultExecuteResult);
+    mockUseWorkflowHistory.mockReturnValue(defaultHistoryResult);
+    renderEntityWorkflow();
+    expect(document.querySelector('[data-slot="entity-workflow"]')).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-workflow/src/entity-workflow.stories.tsx
+++ b/packages/@granit/react-ui-workflow/src/entity-workflow.stories.tsx
@@ -1,0 +1,61 @@
+import { createApiClient } from '@granit/api-client';
+import { createWorkflowHandlers } from '@granit/react-workflow/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { I18nextProvider } from 'react-i18next';
+
+import { EntityWorkflow } from './entity-workflow';
+import { storyI18n } from './stories-i18n';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const client = createApiClient({ baseURL: '' });
+const config = { client, basePath: '/api/v1/workflow' };
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const meta: Meta<typeof EntityWorkflow> = {
+  title: 'Workflow/EntityWorkflow',
+  component: EntityWorkflow,
+  tags: ['autodocs', '!test'],
+  args: { config },
+  parameters: {
+    layout: 'padded',
+    msw: { handlers: createWorkflowHandlers() },
+  },
+  argTypes: {
+    entityType: { control: 'text' },
+    entityId: { control: 'text' },
+    states: { control: 'object' },
+  },
+  decorators: [
+    (Story) => (
+      <I18nextProvider i18n={storyI18n}>
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      </I18nextProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    entityType: 'User',
+    entityId: 'user-001',
+    currentState: 'Active',
+    states: ['PendingValidation', 'Active', 'Suspended', 'Archived'],
+  },
+};
+
+export const FewStates: Story = {
+  args: {
+    entityType: 'User',
+    entityId: 'user-001',
+    currentState: 'Draft',
+    states: ['Draft', 'Active', 'Closed'],
+  },
+};

--- a/packages/@granit/react-ui-workflow/src/entity-workflow.tsx
+++ b/packages/@granit/react-ui-workflow/src/entity-workflow.tsx
@@ -1,0 +1,220 @@
+
+import { useTranslation } from '@granit/react-localization';
+import { Card, CardContent, CardHeader, CardTitle, Spinner, toast } from '@granit/react-ui';
+import {
+  WorkflowProvider,
+  useExecuteTransition,
+  useTransitions,
+  useWorkflowHistory,
+} from '@granit/react-workflow';
+import { cn } from '@granit/utils';
+import { AlertCircle, GitBranch } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+
+import { TransitionCommentDialog } from './transition-comment-dialog';
+import { WorkflowHistory } from './workflow-history';
+import { WorkflowStatusBar } from './workflow-status-bar';
+
+import type { WorkflowConfig } from '@granit/react-workflow';
+import type { WorkflowTransition, WorkflowTransitionResult } from '@granit/workflow';
+
+export interface EntityWorkflowProps {
+  /**
+   * Workflow API config (`{ client, basePath }`) injected by the host — the
+   * showcase passes its `workflowConfig`. Kept a prop so the package stays
+   * agnostic of how the app builds its API client.
+   */
+  config: WorkflowConfig;
+  entityType: string;
+  entityId: string;
+  currentState: string;
+  /** Ordered list of all possible workflow states for display */
+  states: readonly string[];
+  onStateChange?: (newState: string) => void;
+  className?: string;
+}
+
+type EntityWorkflowInnerProps = Omit<EntityWorkflowProps, 'config'>;
+
+function EntityWorkflowInner({
+  entityType,
+  entityId,
+  currentState,
+  states,
+  onStateChange,
+  className,
+}: Readonly<EntityWorkflowInnerProps>) {
+  const { t } = useTranslation();
+
+  const {
+    data: transitionsData,
+    isLoading: statusLoading,
+    isError: statusError,
+  } = useTransitions({ currentState });
+
+  const transitions = useMemo(() => transitionsData?.availableTransitions ?? [], [transitionsData]);
+
+  const { data: historyData, isLoading: historyLoading } = useWorkflowHistory({
+    entityType,
+    entityId,
+  });
+
+  const history = historyData?.items ?? [];
+
+  const [pendingTransition, setPendingTransition] = useState<WorkflowTransition | null>(null);
+
+  const handleOutcome = useCallback(
+    (result: WorkflowTransitionResult) => {
+      switch (result.outcome) {
+        case 'Completed':
+          toast.success(t('Workflow.OutcomeCompleted'));
+          break;
+        case 'ApprovalRequested':
+          toast.info(t('Workflow.OutcomeApprovalRequested'));
+          break;
+        case 'Denied':
+          toast.error(t('Workflow.OutcomeDenied'));
+          break;
+        case 'InvalidTransition':
+          toast.error(t('Workflow.OutcomeInvalidTransition'));
+          break;
+      }
+      if (result.outcome === 'Completed' && result.resultingState) {
+        onStateChange?.(result.resultingState);
+      }
+    },
+    [t, onStateChange]
+  );
+
+  const { transition, isPending: transitioning } = useExecuteTransition({
+    onSuccess: handleOutcome,
+  });
+
+  const handleTransition = useCallback(
+    (targetState: string) => {
+      const dto = transitions.find((tr) => tr.targetState === targetState);
+      if (dto) {
+        setPendingTransition(dto);
+      }
+    },
+    [transitions]
+  );
+
+  const handleConfirmTransition = useCallback(
+    (comment?: string) => {
+      if (!pendingTransition) return;
+      transition(currentState, pendingTransition.targetState, comment);
+      setPendingTransition(null);
+    },
+    [pendingTransition, transition, currentState]
+  );
+
+  if (statusLoading && transitions.length === 0) {
+    return (
+      <Card className={className} data-slot="entity-workflow">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <GitBranch className="h-5 w-5" />
+            {t('Workflow.Title')}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex justify-center py-8">
+          <Spinner size="md" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (statusError && transitions.length === 0) {
+    return (
+      <Card className={className} data-slot="entity-workflow">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <GitBranch className="h-5 w-5" />
+            {t('Workflow.Title')}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col items-center gap-2 py-8 text-center">
+            <AlertCircle className="h-8 w-8 text-muted" />
+            <p className="text-sm font-medium text-foreground">{t('Workflow.ErrorTitle')}</p>
+            <p className="text-sm text-muted-foreground">{t('Workflow.ErrorMessage')}</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={cn(className)} data-slot="entity-workflow">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <GitBranch className="h-5 w-5" />
+          {t('Workflow.Title')}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <WorkflowStatusBar
+          currentState={currentState}
+          states={states}
+          transitions={transitions}
+          onTransition={handleTransition}
+          isLoading={transitioning}
+          className={cn(
+            'flex flex-wrap items-center gap-3',
+            '[&_[data-testid=workflow-states]]:flex [&_[data-testid=workflow-states]]:flex-wrap [&_[data-testid=workflow-states]]:items-center [&_[data-testid=workflow-states]]:gap-1',
+            '[&_span[data-state]]:inline-flex [&_span[data-state]]:items-center [&_span[data-state]]:rounded-full [&_span[data-state]]:px-3 [&_span[data-state]]:py-1 [&_span[data-state]]:text-xs [&_span[data-state]]:font-medium',
+            '[&_[data-current=true]]:bg-primary [&_[data-current=true]]:text-primary-foreground',
+            '[&_[data-past=true]]:bg-success-500/15 [&_[data-past=true]]:text-success-600 dark:[&_[data-past=true]]:text-success-500',
+            '[&_[data-current=false][data-past=false]]:bg-secondary [&_[data-current=false][data-past=false]]:text-muted-foreground',
+            '[&_fieldset]:flex [&_fieldset]:gap-2 [&_fieldset]:border-0 [&_fieldset]:p-0 [&_fieldset]:m-0',
+            '[&_fieldset_button]:inline-flex [&_fieldset_button]:items-center [&_fieldset_button]:rounded-md [&_fieldset_button]:px-3 [&_fieldset_button]:py-1.5 [&_fieldset_button]:text-xs [&_fieldset_button]:font-medium [&_fieldset_button]:cursor-pointer [&_fieldset_button]:transition-colors',
+            '[&_fieldset_button]:bg-primary [&_fieldset_button]:text-primary-foreground [&_fieldset_button]:hover:bg-primary/90',
+            '[&_fieldset_button:disabled]:opacity-50 [&_fieldset_button:disabled]:cursor-not-allowed',
+            '[&_fieldset_button[data-requires-approval=true]]:bg-warning-500/15 [&_fieldset_button[data-requires-approval=true]]:text-warning-600 dark:[&_fieldset_button[data-requires-approval=true]]:text-warning-500 [&_fieldset_button[data-requires-approval=true]]:border [&_fieldset_button[data-requires-approval=true]]:border-warning-500/40'
+          )}
+        />
+
+        <div>
+          <h4 className="mb-3 text-sm font-medium text-foreground">{t('Workflow.HistoryTitle')}</h4>
+          <WorkflowHistory
+            history={history}
+            loading={historyLoading}
+            emptyMessage={t('Workflow.HistoryEmpty')}
+            className={cn(
+              'space-y-2',
+              '[&_[data-testid=workflow-history-loading]]:flex [&_[data-testid=workflow-history-loading]]:justify-center [&_[data-testid=workflow-history-loading]]:py-4 [&_[data-testid=workflow-history-loading]]:text-sm [&_[data-testid=workflow-history-loading]]:text-muted-foreground',
+              '[&_[data-testid=workflow-history-empty]]:py-4 [&_[data-testid=workflow-history-empty]]:text-center [&_[data-testid=workflow-history-empty]]:text-sm [&_[data-testid=workflow-history-empty]]:text-muted-foreground',
+              '[&_[data-testid=workflow-history]]:list-none [&_[data-testid=workflow-history]]:space-y-2 [&_[data-testid=workflow-history]]:p-0',
+              '[&_[data-testid=workflow-history-entry]]:flex [&_[data-testid=workflow-history-entry]]:flex-wrap [&_[data-testid=workflow-history-entry]]:items-center [&_[data-testid=workflow-history-entry]]:gap-2 [&_[data-testid=workflow-history-entry]]:rounded-md [&_[data-testid=workflow-history-entry]]:border [&_[data-testid=workflow-history-entry]]:border-border [&_[data-testid=workflow-history-entry]]:p-3 [&_[data-testid=workflow-history-entry]]:text-sm',
+              '[&_[data-testid=workflow-history-states]]:font-medium [&_[data-testid=workflow-history-states]]:text-foreground',
+              '[&_[data-testid=workflow-history-author]]:text-muted-foreground',
+              '[&_[data-testid=workflow-history-date]]:text-xs [&_[data-testid=workflow-history-date]]:text-muted-foreground',
+              '[&_[data-testid=workflow-history-comment]]:w-full [&_[data-testid=workflow-history-comment]]:italic [&_[data-testid=workflow-history-comment]]:text-muted-foreground'
+            )}
+          />
+        </div>
+        <TransitionCommentDialog
+          open={pendingTransition !== null}
+          transitionName={pendingTransition?.name ?? ''}
+          requiresApproval={pendingTransition?.requiresApproval ?? false}
+          onConfirm={handleConfirmTransition}
+          onCancel={() => setPendingTransition(null)}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Self-contained entity workflow component.
+ * Wraps WorkflowProvider internally so consumers only need to provide the API
+ * `config` plus entityType, entityId, currentState, and the ordered states.
+ */
+export function EntityWorkflow({ config, ...props }: Readonly<EntityWorkflowProps>) {
+  return (
+    <WorkflowProvider config={config}>
+      <EntityWorkflowInner {...props} />
+    </WorkflowProvider>
+  );
+}

--- a/packages/@granit/react-ui-workflow/src/index.ts
+++ b/packages/@granit/react-ui-workflow/src/index.ts
@@ -1,0 +1,5 @@
+export { EntityWorkflow, type EntityWorkflowProps } from './entity-workflow';
+export { TransitionCommentDialog, type TransitionCommentDialogProps } from './transition-comment-dialog';
+export { WorkflowHistory, type WorkflowHistoryProps } from './workflow-history';
+export { WorkflowStatusBar, type WorkflowStatusBarProps } from './workflow-status-bar';
+export { workflowTranslationsEn, workflowTranslationsFr } from './locales';

--- a/packages/@granit/react-ui-workflow/src/locales/en.ts
+++ b/packages/@granit/react-ui-workflow/src/locales/en.ts
@@ -1,0 +1,27 @@
+/**
+ * English strings for the workflow UI. Flat `Workflow.*` / `Components.Workflow.*`
+ * keys in the `translation` namespace (the host registers them with separators
+ * disabled, so the dotted keys are looked up verbatim).
+ */
+export const workflowTranslationsEn = {
+  'Components.Workflow.Actions': 'Workflow actions',
+  'Components.Workflow.RequestApproval': 'Request approval',
+  'Workflow.ApprovalDialogDescription':
+    'This transition requires approval. Add a comment for the reviewer.',
+  'Workflow.ApprovalDialogTitle': 'Request approval',
+  'Workflow.Cancel': 'Cancel',
+  'Workflow.CommentPlaceholder': 'Comment (optional)...',
+  'Workflow.Confirm': 'Confirm',
+  'Workflow.ErrorMessage': 'Could not load workflow status.',
+  'Workflow.ErrorTitle': 'Failed to load workflow',
+  'Workflow.HistoryEmpty': 'No transitions recorded yet.',
+  'Workflow.HistoryTitle': 'Transition History',
+  'Workflow.OutcomeApprovalRequested': 'Approval request sent.',
+  'Workflow.OutcomeCompleted': 'Transition completed successfully.',
+  'Workflow.OutcomeDenied': 'Insufficient permission for this transition.',
+  'Workflow.OutcomeInvalidTransition': 'This transition is not possible in the current state.',
+  'Workflow.RequestApproval': 'Request approval',
+  'Workflow.Title': 'Workflow',
+  'Workflow.TransitionDialogDescription': 'You can add an optional comment before confirming.',
+  'Workflow.TransitionDialogTitle': 'Confirm transition: {{name}}',
+} as const;

--- a/packages/@granit/react-ui-workflow/src/locales/fr.ts
+++ b/packages/@granit/react-ui-workflow/src/locales/fr.ts
@@ -1,0 +1,26 @@
+/**
+ * French strings for the workflow UI. See {@link workflowTranslationsEn}.
+ */
+export const workflowTranslationsFr = {
+  'Components.Workflow.Actions': 'Actions du workflow',
+  'Components.Workflow.RequestApproval': "Demander l'approbation",
+  'Workflow.ApprovalDialogDescription':
+    'Cette transition nécessite une approbation. Ajoutez un commentaire pour le validateur.',
+  'Workflow.ApprovalDialogTitle': "Demander l'approbation",
+  'Workflow.Cancel': 'Annuler',
+  'Workflow.CommentPlaceholder': 'Commentaire (optionnel)...',
+  'Workflow.Confirm': 'Confirmer',
+  'Workflow.ErrorMessage': 'Impossible de charger le statut du workflow.',
+  'Workflow.ErrorTitle': 'Échec du chargement du workflow',
+  'Workflow.HistoryEmpty': 'Aucune transition enregistrée.',
+  'Workflow.HistoryTitle': 'Historique des transitions',
+  'Workflow.OutcomeApprovalRequested': "Demande d'approbation envoyée.",
+  'Workflow.OutcomeCompleted': 'Transition effectuée avec succès.',
+  'Workflow.OutcomeDenied': 'Permission insuffisante pour cette transition.',
+  'Workflow.OutcomeInvalidTransition': "Cette transition n'est pas possible dans l'état actuel.",
+  'Workflow.RequestApproval': "Demander l'approbation",
+  'Workflow.Title': 'Workflow',
+  'Workflow.TransitionDialogDescription':
+    'Vous pouvez ajouter un commentaire optionnel avant de confirmer.',
+  'Workflow.TransitionDialogTitle': 'Confirmer la transition : {{name}}',
+} as const;

--- a/packages/@granit/react-ui-workflow/src/locales/index.ts
+++ b/packages/@granit/react-ui-workflow/src/locales/index.ts
@@ -1,0 +1,2 @@
+export { workflowTranslationsEn } from './en';
+export { workflowTranslationsFr } from './fr';

--- a/packages/@granit/react-ui-workflow/src/stories-i18n.ts
+++ b/packages/@granit/react-ui-workflow/src/stories-i18n.ts
@@ -1,0 +1,18 @@
+import i18next from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import { workflowTranslationsEn } from './locales';
+
+// Shared i18next instance for Storybook stories. Mirrors the runtime flat-key
+// setup (separators disabled) and bundles the package's own Workflow.* keys.
+export const storyI18n = i18next.createInstance();
+await storyI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  ns: ['translation'],
+  defaultNS: 'translation',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: { ...workflowTranslationsEn } } },
+  interpolation: { escapeValue: false },
+});

--- a/packages/@granit/react-ui-workflow/src/transition-comment-dialog.stories.tsx
+++ b/packages/@granit/react-ui-workflow/src/transition-comment-dialog.stories.tsx
@@ -1,0 +1,43 @@
+import { I18nextProvider } from 'react-i18next';
+import { fn } from 'storybook/test';
+
+import { storyI18n } from './stories-i18n';
+import { TransitionCommentDialog } from './transition-comment-dialog';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof TransitionCommentDialog> = {
+  title: 'Workflow/TransitionCommentDialog',
+  component: TransitionCommentDialog,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  args: {
+    open: true,
+    transitionName: 'Publish',
+    requiresApproval: false,
+    onConfirm: fn(),
+    onCancel: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <I18nextProvider i18n={storyI18n}>
+        <Story />
+      </I18nextProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { open: true, transitionName: 'Publish', requiresApproval: false },
+};
+
+export const RequiresApproval: Story = {
+  args: { open: true, transitionName: 'Submit for Review', requiresApproval: true },
+};
+
+export const Closed: Story = {
+  args: { open: false, transitionName: 'Publish', requiresApproval: false },
+};

--- a/packages/@granit/react-ui-workflow/src/transition-comment-dialog.tsx
+++ b/packages/@granit/react-ui-workflow/src/transition-comment-dialog.tsx
@@ -1,0 +1,81 @@
+
+import { useTranslation } from '@granit/react-localization';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Textarea,
+} from '@granit/react-ui';
+import { useState } from 'react';
+
+export interface TransitionCommentDialogProps {
+  open: boolean;
+  transitionName: string;
+  requiresApproval: boolean;
+  onConfirm: (comment?: string) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Dialog shown before executing a workflow transition.
+ * Allows the user to attach an optional comment (max 2000 chars).
+ * When approval is required, the dialog title reflects the approval request.
+ */
+export function TransitionCommentDialog({
+  open,
+  transitionName,
+  requiresApproval,
+  onConfirm,
+  onCancel,
+}: Readonly<TransitionCommentDialogProps>) {
+  const { t } = useTranslation();
+  const [comment, setComment] = useState('');
+
+  const handleConfirm = () => {
+    onConfirm(comment.trim() || undefined);
+    setComment('');
+  };
+
+  const handleCancel = () => {
+    onCancel();
+    setComment('');
+  };
+
+  const title = requiresApproval
+    ? t('Workflow.ApprovalDialogTitle')
+    : t('Workflow.TransitionDialogTitle', { name: transitionName });
+
+  const description = requiresApproval
+    ? t('Workflow.ApprovalDialogDescription')
+    : t('Workflow.TransitionDialogDescription');
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleCancel()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <Textarea
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          placeholder={t('Workflow.CommentPlaceholder')}
+          maxLength={2000}
+          rows={3}
+        />
+        <DialogFooter>
+          <Button variant="outline" onClick={handleCancel}>
+            {t('Workflow.Cancel')}
+          </Button>
+          <Button onClick={handleConfirm}>
+            {requiresApproval ? t('Workflow.RequestApproval') : t('Workflow.Confirm')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/@granit/react-ui-workflow/src/workflow-history.stories.tsx
+++ b/packages/@granit/react-ui-workflow/src/workflow-history.stories.tsx
@@ -1,0 +1,53 @@
+import { mockWorkflowHistory } from '@granit/react-workflow/testing';
+
+import { WorkflowHistory } from './workflow-history';
+
+import type { TransitionHistory } from '@granit/workflow';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof WorkflowHistory> = {
+  title: 'Workflow/WorkflowHistory',
+  component: WorkflowHistory,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { history: mockWorkflowHistory },
+};
+
+export const MultipleEntries: Story = {
+  args: {
+    history: [
+      ...mockWorkflowHistory,
+      {
+        previousState: 'Active',
+        newState: 'Suspended',
+        transitionedAt: '2026-01-10T14:20:00Z',
+        transitionedBy: 'Jane Doe',
+        comment: 'Temporary suspension pending review.',
+      } satisfies TransitionHistory,
+      {
+        previousState: 'Suspended',
+        newState: 'Active',
+        transitionedAt: '2026-01-15T08:00:00Z',
+        transitionedBy: 'John Smith',
+      } satisfies TransitionHistory,
+    ],
+  },
+};
+
+export const Empty: Story = {
+  args: { history: [], emptyMessage: 'No transitions yet.' },
+};
+
+export const CustomEmptyMessage: Story = {
+  args: { history: [], emptyMessage: 'This workflow has no history entries.' },
+};
+
+export const Loading: Story = {
+  args: { history: [], loading: true },
+};

--- a/packages/@granit/react-ui-workflow/src/workflow-history.tsx
+++ b/packages/@granit/react-ui-workflow/src/workflow-history.tsx
@@ -1,0 +1,62 @@
+import { Spinner, Table, TableBody, TableCell, TableRow } from '@granit/react-ui';
+
+import type { TransitionHistory } from '@granit/workflow';
+
+export interface WorkflowHistoryProps {
+  history: readonly TransitionHistory[];
+  loading?: boolean;
+  emptyMessage?: string;
+  className?: string;
+}
+
+/**
+ * Displays the workflow transition history (audit trail).
+ *
+ * Renders each transition as a table row showing: previous state -> new state,
+ * author, date, and optional comment.
+ */
+export function WorkflowHistory({
+  history,
+  loading = false,
+  emptyMessage = 'No transitions yet.',
+  className,
+}: Readonly<WorkflowHistoryProps>) {
+  if (loading) {
+    return (
+      <div className={className} data-testid="workflow-history-loading" aria-busy="true">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (history.length === 0) {
+    return (
+      <div className={className} data-testid="workflow-history-empty">
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  return (
+    <Table className={className} data-testid="workflow-history">
+      <TableBody>
+        {history.map((entry, index) => (
+          <TableRow key={`${entry.transitionedAt}-${index}`} data-testid="workflow-history-entry">
+            <TableCell data-testid="workflow-history-states">
+              {entry.previousState} → {entry.newState}
+            </TableCell>
+            <TableCell data-testid="workflow-history-author">{entry.transitionedBy}</TableCell>
+            <TableCell>
+              <time dateTime={entry.transitionedAt} data-testid="workflow-history-date">
+                {entry.transitionedAt}
+              </time>
+            </TableCell>
+            {entry.comment && (
+              <TableCell data-testid="workflow-history-comment">{entry.comment}</TableCell>
+            )}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/packages/@granit/react-ui-workflow/src/workflow-status-bar.stories.tsx
+++ b/packages/@granit/react-ui-workflow/src/workflow-status-bar.stories.tsx
@@ -1,0 +1,78 @@
+import { I18nextProvider } from 'react-i18next';
+import { fn } from 'storybook/test';
+
+import { storyI18n } from './stories-i18n';
+import { WorkflowStatusBar } from './workflow-status-bar';
+
+import type { WorkflowTransition } from '@granit/workflow';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const USER_STATES = ['PendingValidation', 'Active', 'Suspended', 'Archived'] as const;
+
+const allowedTransitions: WorkflowTransition[] = [
+  { targetState: 'Suspended', name: 'Suspend', allowed: true, requiresApproval: false },
+  { targetState: 'Archived', name: 'Archive', allowed: false, requiresApproval: true },
+];
+
+const meta: Meta<typeof WorkflowStatusBar> = {
+  title: 'Workflow/WorkflowStatusBar',
+  component: WorkflowStatusBar,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+  argTypes: {
+    currentState: { control: 'select', options: USER_STATES },
+    isLoading: { control: 'boolean' },
+  },
+  args: { onTransition: fn() },
+  decorators: [
+    (Story) => (
+      <I18nextProvider i18n={storyI18n}>
+        <Story />
+      </I18nextProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { currentState: 'Active', states: USER_STATES, transitions: allowedTransitions },
+};
+
+export const FirstState: Story = {
+  args: {
+    currentState: 'PendingValidation',
+    states: USER_STATES,
+    transitions: [{ targetState: 'Active', name: 'Activate', allowed: true, requiresApproval: false }],
+  },
+};
+
+export const LastState: Story = {
+  args: { currentState: 'Archived', states: USER_STATES, transitions: [] },
+};
+
+export const Loading: Story = {
+  args: {
+    currentState: 'Active',
+    states: USER_STATES,
+    transitions: allowedTransitions,
+    isLoading: true,
+  },
+};
+
+export const RequiresApproval: Story = {
+  args: {
+    currentState: 'Suspended',
+    states: USER_STATES,
+    transitions: [{ targetState: 'Active', name: 'Reactivate', allowed: false, requiresApproval: true }],
+  },
+};
+
+export const SimpleThreeState: Story = {
+  args: {
+    currentState: 'Draft',
+    states: ['Draft', 'Published', 'Archived'],
+    transitions: [{ targetState: 'Published', name: 'Publish', allowed: true, requiresApproval: false }],
+  },
+};

--- a/packages/@granit/react-ui-workflow/src/workflow-status-bar.tsx
+++ b/packages/@granit/react-ui-workflow/src/workflow-status-bar.tsx
@@ -1,0 +1,89 @@
+import { useTranslation } from '@granit/react-localization';
+import { Badge, Button } from '@granit/react-ui';
+
+import type { WorkflowTransition } from '@granit/workflow';
+
+export interface WorkflowStatusBarProps {
+  currentState: string;
+  states: readonly string[];
+  transitions: readonly WorkflowTransition[];
+  onTransition?: (targetState: string, comment?: string) => void;
+  isLoading?: boolean;
+  className?: string;
+}
+
+/**
+ * Workflow status bar (Odoo-style).
+ *
+ * Renders the workflow states as badge chips with action buttons for
+ * available transitions.
+ */
+export function WorkflowStatusBar({
+  currentState,
+  states,
+  transitions,
+  onTransition,
+  isLoading = false,
+  className,
+}: Readonly<WorkflowStatusBarProps>) {
+  const { t } = useTranslation();
+  const currentIndex = states.indexOf(currentState);
+
+  return (
+    <div
+      className={className}
+      data-slot="workflow-status-bar"
+      data-testid="workflow-status-bar"
+      data-current-state={currentState}
+    >
+      <div data-testid="workflow-states">
+        {states.map((state, index) => {
+          const isCurrent = state === currentState;
+          const isPast = index < currentIndex;
+          let variant: 'default' | 'secondary' | 'outline' = 'outline';
+          if (isCurrent) variant = 'default';
+          else if (isPast) variant = 'secondary';
+
+          return (
+            <Badge
+              key={state}
+              variant={variant}
+              data-state={state}
+              data-current={isCurrent}
+              data-past={isPast}
+              data-testid={`workflow-state-${state}`}
+              aria-current={isCurrent ? 'step' : undefined}
+            >
+              {state}
+            </Badge>
+          );
+        })}
+      </div>
+
+      {transitions.length > 0 && (
+        <fieldset data-testid="workflow-actions" aria-label={t('Components.Workflow.Actions')}>
+          {transitions.map((transition) => {
+            const label =
+              transition.requiresApproval && !transition.allowed
+                ? t('Components.Workflow.RequestApproval')
+                : transition.name;
+
+            return (
+              <Button
+                key={transition.targetState}
+                size="sm"
+                disabled={isLoading}
+                data-target={transition.targetState}
+                data-requires-approval={transition.requiresApproval}
+                data-testid={`workflow-action-${transition.targetState}`}
+                onClick={() => onTransition?.(transition.targetState)}
+              >
+                {label}
+              </Button>
+            );
+          })}
+        </fieldset>
+      )}
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-workflow/tsconfig.json
+++ b/packages/@granit/react-ui-workflow/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": [
+    "src/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.stories.ts",
+    "src/**/*.stories.tsx"
+  ]
+}

--- a/packages/@granit/react-ui-workflow/tsup.config.ts
+++ b/packages/@granit/react-ui-workflow/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6808,6 +6808,51 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
 
+  packages/@granit/react-ui-workflow:
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-localization':
+        specifier: workspace:*
+        version: link:../react-localization
+      '@granit/react-ui':
+        specifier: workspace:*
+        version: link:../react-ui
+      '@granit/react-workflow':
+        specifier: workspace:*
+        version: link:../react-workflow
+      '@granit/utils':
+        specifier: workspace:*
+        version: link:../utils
+      '@granit/workflow':
+        specifier: workspace:*
+        version: link:../workflow
+      '@storybook/react-vite':
+        specifier: ^10.4.6
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(yaml@2.9.0))
+      '@tanstack/react-query':
+        specifier: 5.101.1
+        version: 5.101.1(react@19.2.7)
+      i18next:
+        specifier: ^26.0.0
+        version: 26.3.1(typescript@6.0.3)
+      lucide-react:
+        specifier: ^1.21.0
+        version: 1.21.0(react@19.2.7)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+      react-i18next:
+        specifier: ^17.0.0
+        version: 17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+      storybook:
+        specifier: ^10.4.6
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
   packages/@granit/react-validation:
     dependencies:
       '@granit/validation':


### PR DESCRIPTION
## What

New **`@granit/react-ui-workflow`** package — the UI counterpart of the headless `@granit/react-workflow`. It holds the workflow chrome moved out of the showcase host:

- **`WorkflowStatusBar`** — state chips + available-transition buttons
- **`TransitionCommentDialog`** — optional-comment dialog (handles the approval-required variant)
- **`WorkflowHistory`** — transition audit-trail table
- **`EntityWorkflow`** — self-contained card combining the three; mounts `WorkflowProvider` internally

## Why

Domain-UI backfill: a second admin app rendering entity workflows would consume these, not rebuild them. The showcase keeps a one-line wrapper that injects its `workflowConfig`.

## Decoupling (app-agnostic)

- **`EntityWorkflow` takes the workflow API `config` (`{ client, basePath }`) as a prop** instead of importing `@/app/shared/app-config`, so the package never reaches into app wiring.
- `cn` from `@granit/utils`; `toast` from `@granit/react-ui` (no direct `sonner` dep — satisfies the `no-restricted-imports` foundation rule).
- ships its own flat `Workflow.*` / `Components.Workflow.*` bundle (`workflowTranslationsEn/Fr`).

## Tests

- 4 Storybook stories (StatusBar / Dialog / History / EntityWorkflow, the last mock-backed via `@granit/react-workflow/testing`).
- EntityWorkflow unit test: 8 passing (hooks mocked — title / loading / error / status-bar / empty / history / hook args / data-slot).
- Full arch-tests suite green (3017); package `tsc` + `eslint --max-warnings 0` clean.

## Follow-up (separate MR)

Showcase adoption (consume the package, delete `src/components/workflow/`, register the i18n bundle, inject `workflowConfig` in the invoice-detail route wrapper) lands as a GitLab MR once this merges to `develop`.