### PR TITLE
fix: headless /testing fixtures + react-ui dts/bundle hygiene

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -10669,9 +10669,9 @@
           ]
         },
         {
-          "name": "TimelineStreamEntryResponse",
+          "name": "TimelineEntry",
           "kind": "function",
-          "signature": "function TimelineStreamEntryResponse("
+          "signature": "function TimelineEntry("
         },
         {
           "name": "TimelineEntryProps",

--- a/packages/@granit/react-entities-customization/package.json
+++ b/packages/@granit/react-entities-customization/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
   },
   "files": [
     "dist"
@@ -19,13 +20,23 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
+    "msw": "^2.12.0",
     "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "import": "./dist/testing/index.js"
       }
     },
     "registry": "https://npm.pkg.github.com"

--- a/packages/@granit/react-entities-customization/src/testing/data.ts
+++ b/packages/@granit/react-entities-customization/src/testing/data.ts
@@ -1,0 +1,42 @@
+import type {
+  EntityCustomizationResponse,
+  LayoutDelta,
+  WorkspaceCustomizationResponse,
+} from '@granit/entities-customization';
+import type { SchemaField } from '../layout/apply-deltas';
+import type { ISODateString } from '@granit/types';
+import type { Mutable } from '@granit/testing';
+
+/**
+ * Schema fields for the `Quote` form layout, before any deltas apply.
+ * Mirrors the shape the editors/`applyDeltas` tests inline.
+ */
+export const mockSchemaFields: Mutable<SchemaField>[] = [
+  { name: 'name', label: 'Name', defaultGroup: 'general' },
+  { name: 'amount', label: 'Amount', defaultGroup: 'pricing' },
+  { name: 'currency', label: 'Currency', defaultGroup: 'pricing' },
+  { name: 'internalNotes', label: 'Internal notes' },
+];
+
+/** A representative delta of each kind in the closed catalog (`reorder`/`regroup`/`hide`). */
+export const mockLayoutDeltas: Mutable<LayoutDelta>[] = [
+  { $type: 'reorder', fieldName: 'currency', beforeFieldName: 'amount', afterFieldName: null },
+  { $type: 'regroup', fieldName: 'amount', groupKey: 'finance' },
+  { $type: 'hide', fieldName: 'internalNotes' },
+];
+
+/** Mock response for `GET|PUT /entities/Quote/customization/FormDefault`. */
+export const mockEntityCustomization: Mutable<EntityCustomizationResponse> = {
+  id: 'cust-1',
+  entityName: 'Quote',
+  layoutKind: 'FormDefault',
+  deltas: [{ $type: 'hide', fieldName: 'internalNotes' }],
+};
+
+/** Mock response for `GET|PUT /workspaces/sales/customization`. */
+export const mockWorkspaceCustomization: Mutable<WorkspaceCustomizationResponse> = {
+  workspaceName: 'sales',
+  deltas: [{ $type: 'hide', fieldName: 'tile-pipeline' }],
+  updatedAt: '2026-02-27T08:00:00Z' as ISODateString,
+  updatedByUserId: 'user-001',
+};

--- a/packages/@granit/react-entities-customization/src/testing/handlers.ts
+++ b/packages/@granit/react-entities-customization/src/testing/handlers.ts
@@ -1,0 +1,85 @@
+import { noContent, notFound } from '@granit/testing/msw';
+import { http, HttpResponse } from 'msw';
+
+import { DEFAULT_API_BASE } from '../constants';
+
+import { mockEntityCustomization, mockWorkspaceCustomization } from './data';
+
+import type {
+  EntityCustomizationRequest,
+  EntityCustomizationResponse,
+  WorkspaceCustomizationRequest,
+  WorkspaceCustomizationResponse,
+} from '@granit/entities-customization';
+
+/**
+ * Create stateful MSW handlers for the entity-customization endpoints.
+ *
+ * Covers `GET|PUT|DELETE {apiBase}/entities/{name}/customization/{layoutKind}`.
+ * PUT echoes the submitted deltas; DELETE resets to the base layout (empty deltas).
+ *
+ * @param apiBase - API root without trailing slash (default: `/api/v1`)
+ */
+export function createEntityCustomizationHandlers(apiBase = DEFAULT_API_BASE) {
+  let current: EntityCustomizationResponse = { ...mockEntityCustomization };
+  const url = `${apiBase}/entities/:entityName/customization/:layoutKind`;
+
+  return [
+    http.get(url, ({ params }) =>
+      HttpResponse.json<EntityCustomizationResponse>({
+        ...current,
+        entityName: String(params.entityName),
+        layoutKind: current.layoutKind,
+      })
+    ),
+
+    http.put(url, async ({ request, params }) => {
+      const body = (await request.json()) as EntityCustomizationRequest;
+      current = {
+        ...current,
+        entityName: String(params.entityName),
+        deltas: body.deltas,
+      };
+      return HttpResponse.json<EntityCustomizationResponse>(current);
+    }),
+
+    http.delete(url, () => {
+      current = { ...current, deltas: [] };
+      return noContent();
+    }),
+  ];
+}
+
+/**
+ * Create stateful MSW handlers for the workspace-customization endpoints.
+ *
+ * Covers `GET|PUT {apiBase}/workspaces/{name}/customization`.
+ * PUT echoes the submitted deltas and stamps `updatedAt`/`updatedByUserId`.
+ *
+ * @param apiBase - API root without trailing slash (default: `/api/v1`)
+ */
+export function createWorkspaceCustomizationHandlers(apiBase = DEFAULT_API_BASE) {
+  let current: WorkspaceCustomizationResponse = { ...mockWorkspaceCustomization };
+  const url = `${apiBase}/workspaces/:workspaceName/customization`;
+
+  return [
+    http.get(url, ({ params }) => {
+      const workspaceName = String(params.workspaceName);
+      if (workspaceName.length === 0) return notFound();
+      return HttpResponse.json<WorkspaceCustomizationResponse>({
+        ...current,
+        workspaceName,
+      });
+    }),
+
+    http.put(url, async ({ request, params }) => {
+      const body = (await request.json()) as WorkspaceCustomizationRequest;
+      current = {
+        ...current,
+        workspaceName: String(params.workspaceName),
+        deltas: body.deltas,
+      };
+      return HttpResponse.json<WorkspaceCustomizationResponse>(current);
+    }),
+  ];
+}

--- a/packages/@granit/react-entities-customization/src/testing/index.ts
+++ b/packages/@granit/react-entities-customization/src/testing/index.ts
@@ -1,0 +1,14 @@
+// ---------------------------------------------------------------------------
+// @granit/react-entities-customization/testing — Mock data & MSW handlers
+// ---------------------------------------------------------------------------
+
+export {
+  mockEntityCustomization,
+  mockLayoutDeltas,
+  mockSchemaFields,
+  mockWorkspaceCustomization,
+} from './data';
+export {
+  createEntityCustomizationHandlers,
+  createWorkspaceCustomizationHandlers,
+} from './handlers';

--- a/packages/@granit/react-entities-views/package.json
+++ b/packages/@granit/react-entities-views/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
   },
   "files": [
     "dist"
@@ -18,14 +19,24 @@
     "@granit/entities-views": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
+    "msw": "^2.12.0",
     "react": "^19.0.0",
     "react-i18next": "^17.0.0"
+  },
+  "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "import": "./dist/testing/index.js"
       }
     },
     "registry": "https://npm.pkg.github.com"

--- a/packages/@granit/react-entities-views/src/__tests__/use-entity-view-crud.test.tsx
+++ b/packages/@granit/react-entities-views/src/__tests__/use-entity-view-crud.test.tsx
@@ -6,6 +6,12 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
+import {
+  mockPersonalView,
+  sampleCreateRequest,
+  sampleUpdateRequest,
+} from '@granit/react-entities-views/testing';
+
 import { defaultEntityViewQueryKey } from '../hooks/use-default-entity-view';
 import { entityViewQueryKey } from '../hooks/use-entity-view';
 import {
@@ -20,24 +26,12 @@ import type { ReactNode } from 'react';
 
 const ENTITY = 'Granit.Parties.Party';
 const ENCODED = encodeURIComponent(ENTITY);
-const VIEW_ID = '8c6b1e10-0000-4000-8000-000000000001';
+const VIEW_ID = mockPersonalView.id;
 
 const VIEW: EntityViewResponse = {
-  id: VIEW_ID,
-  entityName: ENTITY,
-  basedOn: 'default',
-  kind: 'list',
-  name: 'My open parties',
-  description: null,
-  icon: null,
-  state: { filters: [] },
-  visibility: 'Personal',
+  ...mockPersonalView,
   ownerId: '00000000-0000-0000-0000-000000000010',
-  sharedWith: null,
-  isPinned: false,
-  isDefault: false,
   isPersonalDefault: false,
-  sortOrder: 0,
 };
 
 let lastBody: unknown = null;
@@ -96,14 +90,7 @@ describe('useCreateEntityView', () => {
     const { result } = renderHook(() => useCreateEntityView(ENTITY), { wrapper });
     let returned: EntityViewResponse | undefined;
     await act(async () => {
-      returned = await result.current.mutateAsync({
-        basedOn: 'default',
-        kind: 'list',
-        name: 'My open parties',
-        description: null,
-        icon: null,
-        state: { filters: [] },
-      });
+      returned = await result.current.mutateAsync(sampleCreateRequest);
     });
     expect(returned).toEqual(VIEW);
     expect(lastBody).toMatchObject({ name: 'My open parties', kind: 'list' });
@@ -135,15 +122,7 @@ describe('useUpdateEntityView', () => {
     const { wrapper, queryClient } = makeWrapper();
     const { result } = renderHook(() => useUpdateEntityView(ENTITY), { wrapper });
     await act(async () => {
-      await result.current.mutateAsync({
-        id: VIEW_ID,
-        request: {
-          name: 'Renamed',
-          description: null,
-          icon: null,
-          state: { filters: [] },
-        },
-      });
+      await result.current.mutateAsync({ id: VIEW_ID, request: sampleUpdateRequest });
     });
     expect(lastBody).toMatchObject({ name: 'Renamed' });
     expect(queryClient.getQueryData(entityViewQueryKey(ENTITY, VIEW_ID))).toEqual({

--- a/packages/@granit/react-entities-views/src/__tests__/use-entity-view-flags.test.tsx
+++ b/packages/@granit/react-entities-views/src/__tests__/use-entity-view-flags.test.tsx
@@ -6,6 +6,8 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
+import { mockPersonalView, sampleShareRequest } from '@granit/react-entities-views/testing';
+
 import { defaultEntityViewQueryKey } from '../hooks/use-default-entity-view';
 import { entityViewQueryKey } from '../hooks/use-entity-view';
 import {
@@ -21,25 +23,14 @@ import type { ReactNode } from 'react';
 
 const ENTITY = 'Granit.Parties.Party';
 const ENCODED = encodeURIComponent(ENTITY);
-const VIEW_ID = '8c6b1e10-0000-4000-8000-000000000001';
+const VIEW_ID = mockPersonalView.id;
 const VIEW_PATH = `http://localhost/api/v1/entities/${ENCODED}/views/${encodeURIComponent(VIEW_ID)}`;
 
 const VIEW: EntityViewResponse = {
-  id: VIEW_ID,
-  entityName: ENTITY,
-  basedOn: 'default',
-  kind: 'list',
-  name: 'My open parties',
-  description: null,
-  icon: null,
+  ...mockPersonalView,
   state: {},
-  visibility: 'Personal',
   ownerId: '00000000-0000-0000-0000-000000000010',
-  sharedWith: null,
-  isPinned: false,
-  isDefault: false,
   isPersonalDefault: false,
-  sortOrder: 0,
 };
 
 const lastBodyByEndpoint = new Map<string, unknown>();
@@ -155,10 +146,7 @@ describe('useShareEntityView', () => {
     const { result } = renderHook(() => useShareEntityView(ENTITY), { wrapper });
 
     await act(async () => {
-      await result.current.mutateAsync({
-        id: VIEW_ID,
-        request: { roles: ['admin'], users: [] },
-      });
+      await result.current.mutateAsync({ id: VIEW_ID, request: sampleShareRequest });
     });
 
     expect(lastBodyByEndpoint.get('share')).toEqual({ roles: ['admin'], users: [] });

--- a/packages/@granit/react-entities-views/src/__tests__/use-entity-views.test.tsx
+++ b/packages/@granit/react-entities-views/src/__tests__/use-entity-views.test.tsx
@@ -6,44 +6,19 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
+import { mockPersonalView, mockTenantView } from '@granit/react-entities-views/testing';
+
 import { defaultEntityViewQueryKey, useDefaultEntityView } from '../hooks/use-default-entity-view';
 import { entityViewQueryKey, useEntityView } from '../hooks/use-entity-view';
 import { entityViewsQueryKey, useEntityViews } from '../hooks/use-entity-views';
 
-import type { EntityViewResponse } from '@granit/entities-views';
 import type { ReactNode } from 'react';
 
 const ENTITY = 'Granit.Parties.Party';
 const ENCODED = encodeURIComponent(ENTITY);
 
-const VIEW_A: EntityViewResponse = {
-  id: '8c6b1e10-0000-4000-8000-000000000001',
-  entityName: ENTITY,
-  basedOn: 'default',
-  kind: 'list',
-  name: 'My open parties',
-  description: null,
-  icon: null,
-  state: { filters: [] },
-  visibility: 'Personal',
-  ownerId: '00000000-0000-0000-0000-000000000001',
-  sharedWith: null,
-  isPinned: false,
-  isDefault: false,
-  isPersonalDefault: true,
-  sortOrder: 0,
-};
-
-const VIEW_B: EntityViewResponse = {
-  ...VIEW_A,
-  id: '8c6b1e10-0000-4000-8000-000000000002',
-  name: 'Tenant overdue',
-  visibility: 'Tenant',
-  ownerId: null,
-  isPersonalDefault: false,
-  isDefault: true,
-  sortOrder: 10,
-};
+const VIEW_A = mockPersonalView;
+const VIEW_B = mockTenantView;
 
 function freshHandlers() {
   return [

--- a/packages/@granit/react-entities-views/src/testing/data.ts
+++ b/packages/@granit/react-entities-views/src/testing/data.ts
@@ -1,0 +1,101 @@
+import type {
+  EntityViewCreateBodyRequest,
+  EntityViewResponse,
+  EntityViewShareBodyRequest,
+  EntityViewUpdateBodyRequest,
+} from '@granit/entities-views';
+import type { Mutable } from '@granit/testing';
+
+/** Wire identifier of the entity every fixture below targets. */
+export const SAMPLE_ENTITY_NAME = 'Granit.Parties.Party';
+
+/**
+ * A Personal saved view starred as the caller's personal default — the
+ * shape the list / single / default endpoints return for an owner.
+ */
+export const mockPersonalView: Mutable<EntityViewResponse> = {
+  id: '8c6b1e10-0000-4000-8000-000000000001',
+  entityName: SAMPLE_ENTITY_NAME,
+  basedOn: 'default',
+  kind: 'list',
+  name: 'My open parties',
+  description: null,
+  icon: null,
+  state: { filters: [] },
+  visibility: 'Personal',
+  ownerId: '00000000-0000-0000-0000-000000000001',
+  sharedWith: null,
+  isPinned: false,
+  isDefault: false,
+  isPersonalDefault: true,
+  sortOrder: 0,
+};
+
+/** A Tenant view promoted to the tenant default (owner-less). */
+export const mockTenantView: Mutable<EntityViewResponse> = {
+  id: '8c6b1e10-0000-4000-8000-000000000002',
+  entityName: SAMPLE_ENTITY_NAME,
+  basedOn: 'default',
+  kind: 'list',
+  name: 'Tenant overdue',
+  description: null,
+  icon: null,
+  state: { filters: [] },
+  visibility: 'Tenant',
+  ownerId: null,
+  sharedWith: null,
+  isPinned: false,
+  isDefault: true,
+  isPersonalDefault: false,
+  sortOrder: 10,
+};
+
+/** A Shared view targeted at a role — exercises the `sharedWith` audience shape. */
+export const mockSharedView: Mutable<EntityViewResponse> = {
+  id: '8c6b1e10-0000-4000-8000-000000000003',
+  entityName: SAMPLE_ENTITY_NAME,
+  basedOn: 'default',
+  kind: 'list',
+  name: 'Team backlog',
+  description: 'Shared with the operations team',
+  icon: 'users',
+  state: { filters: [], sort: '-createdAt' },
+  visibility: 'Shared',
+  ownerId: '00000000-0000-0000-0000-000000000001',
+  sharedWith: { roles: ['admin'], users: [] },
+  isPinned: true,
+  isDefault: false,
+  isPersonalDefault: false,
+  sortOrder: 20,
+};
+
+/** The full accessible list for {@link SAMPLE_ENTITY_NAME}, sorted by `sortOrder`. */
+export const mockEntityViews: Mutable<EntityViewResponse>[] = [
+  mockPersonalView,
+  mockTenantView,
+  mockSharedView,
+];
+
+/** Sample create body — mirrors `useCreateEntityView().mutateAsync(...)` input. */
+export const sampleCreateRequest: EntityViewCreateBodyRequest = {
+  basedOn: 'default',
+  kind: 'list',
+  name: 'My open parties',
+  description: null,
+  icon: null,
+  state: { filters: [] },
+};
+
+/** Sample update body — mirrors `useUpdateEntityView().mutateAsync(...)` input. */
+export const sampleUpdateRequest: EntityViewUpdateBodyRequest = {
+  name: 'Renamed',
+  description: null,
+  icon: null,
+  state: { filters: [] },
+};
+
+/** Sample share body — promotes a Personal view to Shared with the `admin` role. */
+export const sampleShareRequest: EntityViewShareBodyRequest = {
+  roles: ['admin'],
+  users: [],
+};

--- a/packages/@granit/react-entities-views/src/testing/handlers.ts
+++ b/packages/@granit/react-entities-views/src/testing/handlers.ts
@@ -1,0 +1,148 @@
+import { noContent, notFound } from '@granit/testing/msw';
+import { http, HttpResponse } from 'msw';
+
+import { mockEntityViews, SAMPLE_ENTITY_NAME } from './data';
+
+import type {
+  EntityViewCreateBodyRequest,
+  EntityViewResponse,
+  EntityViewShareBodyRequest,
+  EntityViewToggleFlagRequest,
+  EntityViewUpdateBodyRequest,
+} from '@granit/entities-views';
+
+/** Default `entities` base path — matches the `ENTITIES_BASE_PATH` the hooks use. */
+export const DEFAULT_BASE_PATH = '/api/v1/entities';
+
+interface CreateEntityViewHandlersOptions {
+  /** API base path (default: `/api/v1/entities`). */
+  readonly baseUrl?: string;
+  /** Entity wire identifier to scope the handlers to (default: `Granit.Parties.Party`). */
+  readonly entityName?: string;
+  /** Seed views (default: {@link mockEntityViews}). */
+  readonly views?: readonly EntityViewResponse[];
+}
+
+/**
+ * Create stateful MSW handlers for the EntityView CRUD + flag endpoints.
+ *
+ * Backs the list / single / default reads and the create / update / delete /
+ * pin / star / set-default / share mutations against an in-memory store seeded
+ * from {@link mockEntityViews}. Mirrors
+ * `Granit.Entities.Views.Endpoints.EntityViewsEndpoints`.
+ */
+export function createEntityViewHandlers(options: CreateEntityViewHandlersOptions = {}) {
+  const baseUrl = options.baseUrl ?? DEFAULT_BASE_PATH;
+  const entityName = options.entityName ?? SAMPLE_ENTITY_NAME;
+  const store: EntityViewResponse[] = [...(options.views ?? mockEntityViews)];
+
+  const viewsRoot = `${baseUrl}/${encodeURIComponent(entityName)}/views`;
+  const find = (id: unknown): EntityViewResponse | undefined =>
+    store.find((view) => view.id === id);
+  const sorted = (): EntityViewResponse[] =>
+    [...store].sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name));
+
+  return [
+    // GET /views — accessible list, sorted by sortOrder then name
+    http.get(viewsRoot, () => HttpResponse.json(sorted())),
+
+    // GET /views/_default — resolved default, or 204 when none
+    http.get(`${viewsRoot}/_default`, () => {
+      const fallback =
+        store.find((view) => view.isPersonalDefault) ?? store.find((view) => view.isDefault);
+      return fallback ? HttpResponse.json(fallback) : noContent();
+    }),
+
+    // POST /views — create a Personal view owned by the caller (201)
+    http.post(viewsRoot, async ({ request }) => {
+      const body = (await request.json()) as EntityViewCreateBodyRequest;
+      const created: EntityViewResponse = {
+        id: `view-${store.length + 1}`,
+        entityName,
+        basedOn: body.basedOn,
+        kind: body.kind,
+        name: body.name,
+        description: body.description,
+        icon: body.icon,
+        state: body.state,
+        visibility: 'Personal',
+        ownerId: '00000000-0000-0000-0000-000000000001',
+        sharedWith: null,
+        isPinned: false,
+        isDefault: false,
+        isPersonalDefault: false,
+        sortOrder: store.length,
+      };
+      store.push(created);
+      return HttpResponse.json(created, { status: 201 });
+    }),
+
+    // PUT /views/:id — update editable fields
+    http.put(`${viewsRoot}/:id`, async ({ params, request }) => {
+      const view = find(params.id);
+      if (!view) return notFound();
+      const body = (await request.json()) as EntityViewUpdateBodyRequest;
+      const updated: EntityViewResponse = {
+        ...view,
+        name: body.name,
+        description: body.description,
+        icon: body.icon,
+        state: body.state,
+      };
+      store.splice(store.indexOf(view), 1, updated);
+      return HttpResponse.json(updated);
+    }),
+
+    // DELETE /views/:id — remove a view (204)
+    http.delete(`${viewsRoot}/:id`, ({ params }) => {
+      const view = find(params.id);
+      if (!view) return notFound();
+      store.splice(store.indexOf(view), 1);
+      return noContent();
+    }),
+
+    // POST /views/:id/pin — toggle pinned-as-tab
+    http.post(`${viewsRoot}/:id/pin`, async ({ params, request }) => {
+      const view = find(params.id);
+      if (!view) return notFound();
+      const { value } = (await request.json()) as EntityViewToggleFlagRequest;
+      const updated: EntityViewResponse = { ...view, isPinned: value };
+      store.splice(store.indexOf(view), 1, updated);
+      return HttpResponse.json(updated);
+    }),
+
+    // POST /views/:id/set-default — toggle tenant default
+    http.post(`${viewsRoot}/:id/set-default`, async ({ params, request }) => {
+      const view = find(params.id);
+      if (!view) return notFound();
+      const { value } = (await request.json()) as EntityViewToggleFlagRequest;
+      const updated: EntityViewResponse = { ...view, isDefault: value };
+      store.splice(store.indexOf(view), 1, updated);
+      return HttpResponse.json(updated);
+    }),
+
+    // POST /views/:id/star — toggle personal default
+    http.post(`${viewsRoot}/:id/star`, async ({ params, request }) => {
+      const view = find(params.id);
+      if (!view) return notFound();
+      const { value } = (await request.json()) as EntityViewToggleFlagRequest;
+      const updated: EntityViewResponse = { ...view, isPersonalDefault: value };
+      store.splice(store.indexOf(view), 1, updated);
+      return HttpResponse.json(updated);
+    }),
+
+    // POST /views/:id/share — promote to Shared / update audience
+    http.post(`${viewsRoot}/:id/share`, async ({ params, request }) => {
+      const view = find(params.id);
+      if (!view) return notFound();
+      const body = (await request.json()) as EntityViewShareBodyRequest;
+      const updated: EntityViewResponse = {
+        ...view,
+        visibility: 'Shared',
+        sharedWith: { roles: body.roles, users: body.users },
+      };
+      store.splice(store.indexOf(view), 1, updated);
+      return HttpResponse.json(updated);
+    }),
+  ];
+}

--- a/packages/@granit/react-entities-views/src/testing/index.ts
+++ b/packages/@granit/react-entities-views/src/testing/index.ts
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------------------
+// @granit/react-entities-views/testing — Mock data & MSW handlers
+// ---------------------------------------------------------------------------
+
+export {
+  mockEntityViews,
+  mockPersonalView,
+  mockSharedView,
+  mockTenantView,
+  sampleCreateRequest,
+  sampleShareRequest,
+  sampleUpdateRequest,
+  SAMPLE_ENTITY_NAME,
+} from './data';
+export { createEntityViewHandlers, DEFAULT_BASE_PATH } from './handlers';

--- a/packages/@granit/react-entities/package.json
+++ b/packages/@granit/react-entities/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
   },
   "files": [
     "dist"
@@ -24,15 +25,25 @@
     "@granit/react-query-engine": "workspace:*",
     "@granit/utils": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
+    "msw": "^2.12.0",
     "react": "^19.0.0",
     "react-hook-form": "^7.80.0",
     "react-i18next": "^17.0.0"
+  },
+  "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "import": "./dist/testing/index.js"
       }
     },
     "registry": "https://npm.pkg.github.com"

--- a/packages/@granit/react-entities/src/testing/data.ts
+++ b/packages/@granit/react-entities/src/testing/data.ts
@@ -1,0 +1,228 @@
+import type {
+  BulkActionResponse,
+  CalendarItemResponse,
+  EntityDiscoveryResponse,
+  EntityManifestResponse,
+  RelationAggregatesResponse,
+} from '@granit/entities';
+import type { Mutable } from '@granit/testing';
+
+/**
+ * Wire identifier reused across the fixtures so handlers, query keys and
+ * assertions all line up on the same entity name. Mirrors the canonical
+ * `Granit.Parties.Party` used in the hook tests.
+ */
+export const SAMPLE_ENTITY_NAME = 'Granit.Parties.Party';
+
+/** Stable id of the sample source row used by relation-aggregate / detail fixtures. */
+export const SAMPLE_ENTITY_ID = '8c6b1e10-0000-4000-8000-000000000001';
+
+/**
+ * Discovery tree returned by `GET /api/v1/entities`. One module group with a
+ * single readable entity — enough to drive the discovery hook and the nav
+ * tree without dragging in every registered module.
+ */
+export const mockEntityDiscovery: EntityDiscoveryResponse = {
+  schemaVersion: 1,
+  modules: [
+    {
+      module: 'Parties',
+      items: [
+        {
+          name: SAMPLE_ENTITY_NAME,
+          displayKey: 'Granit.Parties.Party.DisplayName',
+          icon: 'users',
+          permissionGroup: 'Parties.Parties',
+          links: {
+            manifest: `/api/v1/entities/${SAMPLE_ENTITY_NAME}`,
+            list: '/api/v1/parties',
+          },
+        },
+        {
+          name: 'Granit.Parties.Contact',
+          displayKey: 'Granit.Parties.Contact.DisplayName',
+          icon: 'user',
+          permissionGroup: 'Parties.Contacts',
+          links: {
+            manifest: '/api/v1/entities/Granit.Parties.Contact',
+            list: null,
+          },
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * Full per-entity manifest returned by `GET /api/v1/entities/{name}` with no
+ * `?facets=` filter — every facet populated. Slim variants (facet-filtered)
+ * come back with the omitted facets as `null`; build those from this base.
+ */
+export const mockEntityManifest: EntityManifestResponse = {
+  schemaVersion: 1,
+  identity: {
+    name: SAMPLE_ENTITY_NAME,
+    entityClrType: 'Granit.Parties.Domain.Party',
+    displayKey: 'Granit.Parties.Party.DisplayName',
+    icon: 'users',
+    permissionGroup: 'Parties.Parties',
+    displayProperty: 'Number',
+    subtitleProperty: 'Kind',
+  },
+  permissions: {
+    canRead: true,
+    canCreate: true,
+    canUpdate: true,
+    canDelete: false,
+    canManage: false,
+    canExecute: false,
+  },
+  forms: [
+    {
+      name: 'default',
+      customizable: true,
+      sections: [
+        {
+          key: 'identity',
+          labelKey: 'Granit.Parties.Party.Section.Identity',
+          order: 0,
+          collapsedByDefault: false,
+          fields: [
+            {
+              propertyName: 'Number',
+              clrTypeName: 'String',
+              component: 'text',
+              config: null,
+              labelKey: 'Granit.Parties.Party.Number',
+              helpKey: null,
+              order: 0,
+              readOnly: false,
+              visibleIf: null,
+              lookup: null,
+              provenance: null,
+            },
+            {
+              propertyName: 'Kind',
+              clrTypeName: 'String',
+              component: 'select',
+              config: null,
+              labelKey: 'Granit.Parties.Party.Kind',
+              helpKey: null,
+              order: 1,
+              readOnly: false,
+              visibleIf: null,
+              lookup: null,
+              provenance: null,
+            },
+          ],
+          ownedCollection: null,
+        },
+      ],
+      hiddenByOverride: null,
+    },
+  ],
+  details: [
+    {
+      name: 'default',
+      sections: [
+        {
+          key: 'identity',
+          labelKey: 'Granit.Parties.Party.Section.Identity',
+          order: 0,
+          inheritsFromFormVariant: 'default',
+          fields: null,
+        },
+      ],
+      sidePanels: [
+        { kind: 'Audit', order: 0 },
+        { kind: 'Timeline', order: 1 },
+      ],
+    },
+  ],
+  collections: {
+    query: { name: 'Granit.Parties.PartyQuery', clrTypeName: 'PartyQueryDefinition' },
+    export: null,
+    metrics: [],
+    dashboards: [],
+    defaultViewId: null,
+    listLayouts: [],
+    headerActions: [],
+    selectionActions: [],
+  },
+  relations: [
+    {
+      name: 'Invoices',
+      cardinality: 'Many',
+      display: 'SmartButton',
+      targetEntityName: 'Granit.Invoicing.Invoice',
+      displayKey: 'Granit.Parties.Party.Relation.Invoices',
+      icon: 'file-text',
+      order: 0,
+      queryDefinitionName: null,
+      aggregates: [
+        { kind: 'Count', propertyName: null, labelKey: null, format: null },
+        { kind: 'Sum', propertyName: 'Total', labelKey: null, format: 'currency' },
+      ],
+      contributorAssemblyName: null,
+    },
+  ],
+  actions: [
+    {
+      name: 'Approve',
+      kind: 'WorkflowTransition',
+      displayKey: 'Granit.Parties.Party.Action.Approve',
+      icon: 'check',
+      order: 0,
+      urlTemplate: null,
+      httpMethod: null,
+      confirmationKey: 'Granit.Parties.Party.Action.Approve.Confirm',
+      workflowTransitionName: 'Approve',
+      contributorAssemblyName: null,
+    },
+  ],
+  activities: null,
+};
+
+/**
+ * Calendar items returned by `GET /api/v1/entities/{name}/calendar`. Covers
+ * both a ranged event (start + end + colour) and a point-in-time marker
+ * (`end: null`, `color: null`).
+ */
+export const mockCalendarItems: Mutable<CalendarItemResponse>[] = [
+  {
+    id: SAMPLE_ENTITY_ID,
+    start: '2026-05-04T09:00:00Z',
+    end: '2026-05-04T10:30:00Z',
+    title: 'INV-001',
+    color: 'Blue',
+  },
+  {
+    id: '8c6b1e10-0000-4000-8000-000000000002',
+    start: '2026-05-12T00:00:00Z',
+    end: null,
+    title: 'INV-002',
+    color: null,
+  },
+];
+
+/**
+ * Relation-aggregate response for `POST /api/v1/entities/{name}/{id}/relations/aggregates`.
+ * `Invoices` exercises a fully-populated numeric set; `Payments` exercises the
+ * empty-set case where `Sum/Avg/Min/Max` collapse to `null` (ADR-038).
+ */
+export const mockRelationAggregates: RelationAggregatesResponse = {
+  aggregates: {
+    Invoices: { count: 12, sum: 4500, avg: 375, min: 100, max: 1200, currency: 'EUR' },
+    Payments: { count: 8, sum: null, avg: null, min: null, max: null, currency: null },
+  },
+};
+
+/**
+ * Bulk-action recap for `POST /api/v1/entities/{name}/bulk/{action}` — two
+ * rows processed, one captured per-id failure (partial-success path the retry
+ * UX drives off).
+ */
+export const mockBulkActionResponse: BulkActionResponse = {
+  affected: 2,
+  failures: [{ id: 'q-3', reason: 'Workflow transition not allowed in state Draft.' }],
+};

--- a/packages/@granit/react-entities/src/testing/handlers.ts
+++ b/packages/@granit/react-entities/src/testing/handlers.ts
@@ -1,0 +1,64 @@
+import { notFound } from '@granit/testing/msw';
+import { http, HttpResponse } from 'msw';
+
+import {
+  mockBulkActionResponse,
+  mockCalendarItems,
+  mockEntityDiscovery,
+  mockEntityManifest,
+  mockRelationAggregates,
+} from './data';
+
+import type { CalendarItemResponse } from '@granit/entities';
+
+/** Default base path the entities endpoints mount under (mirrors the hooks). */
+export const ENTITIES_BASE_PATH = '/api/v1/entities';
+
+/** Strong ETag the manifest handler emits — drives the 304 / If-None-Match path. */
+export const SAMPLE_MANIFEST_ETAG = '"f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"';
+
+/**
+ * Create stateful MSW handlers for the `@granit/entities` HTTP surface:
+ * discovery, per-entity manifest (ETag-aware), calendar range, relation
+ * aggregates and bulk actions. Pass an absolute `baseUrl` (including the
+ * origin) when the test server expects fully-qualified URLs.
+ *
+ * @param baseUrl - API base path (default: `/api/v1/entities`)
+ */
+export function createEntitiesHandlers(baseUrl = ENTITIES_BASE_PATH) {
+  return [
+    // GET /entities — discovery tree
+    http.get(baseUrl, () => HttpResponse.json(mockEntityDiscovery)),
+
+    // GET /entities/:name/calendar — events overlapping the [from, to] window,
+    // narrowed by optional filter[…] / search params.
+    http.get(`${baseUrl}/:name/calendar`, ({ request }) => {
+      const url = new URL(request.url);
+      const search = url.searchParams.get('search');
+      let items: CalendarItemResponse[] = [...mockCalendarItems];
+      if (search) {
+        items = items.filter((item) => item.title.toLowerCase().includes(search.toLowerCase()));
+      }
+      return HttpResponse.json(items);
+    }),
+
+    // POST /entities/:name/:id/relations/aggregates — batched aggregate values
+    http.post(`${baseUrl}/:name/:id/relations/aggregates`, () =>
+      HttpResponse.json(mockRelationAggregates)
+    ),
+
+    // POST /entities/:name/bulk/:action — fan-out action, partial-failure recap
+    http.post(`${baseUrl}/:name/bulk/:action`, () => HttpResponse.json(mockBulkActionResponse)),
+
+    // GET /entities/:name — per-entity manifest with ETag / 304 support
+    http.get(`${baseUrl}/:name`, ({ request, params }) => {
+      if (typeof params.name !== 'string' || params.name.length === 0) {
+        return notFound();
+      }
+      if (request.headers.get('if-none-match') === SAMPLE_MANIFEST_ETAG) {
+        return new HttpResponse(null, { status: 304, headers: { ETag: SAMPLE_MANIFEST_ETAG } });
+      }
+      return HttpResponse.json(mockEntityManifest, { headers: { ETag: SAMPLE_MANIFEST_ETAG } });
+    }),
+  ];
+}

--- a/packages/@granit/react-entities/src/testing/index.ts
+++ b/packages/@granit/react-entities/src/testing/index.ts
@@ -1,0 +1,18 @@
+// ---------------------------------------------------------------------------
+// @granit/react-entities/testing — Mock data & MSW handlers
+// ---------------------------------------------------------------------------
+
+export {
+  SAMPLE_ENTITY_ID,
+  SAMPLE_ENTITY_NAME,
+  mockBulkActionResponse,
+  mockCalendarItems,
+  mockEntityDiscovery,
+  mockEntityManifest,
+  mockRelationAggregates,
+} from './data';
+export {
+  ENTITIES_BASE_PATH,
+  SAMPLE_MANIFEST_ETAG,
+  createEntitiesHandlers,
+} from './handlers';

--- a/packages/@granit/react-notifications-mobile-push/package.json
+++ b/packages/@granit/react-notifications-mobile-push/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
   },
   "files": [
     "dist"
@@ -21,7 +22,13 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
+    "msw": "^2.12.0",
     "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@capacitor/push-notifications": "^8.1.1",
@@ -37,6 +44,10 @@
       ".": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "import": "./dist/testing/index.js"
       }
     },
     "registry": "https://npm.pkg.github.com"

--- a/packages/@granit/react-notifications-mobile-push/src/__tests__/use-device-tokens.test.tsx
+++ b/packages/@granit/react-notifications-mobile-push/src/__tests__/use-device-tokens.test.tsx
@@ -1,7 +1,7 @@
 import { listDeviceTokens } from '@granit/notifications-mobile-push';
+import { mockMobilePushTokens } from '@granit/react-notifications-mobile-push/testing';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
-import { toISODateString } from '@granit/types';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -9,7 +9,6 @@ import { describe, expect, it, vi } from 'vitest';
 import { deviceTokenKeys, useDeviceTokens } from '../hooks/use-device-tokens';
 import { MobilePushProvider } from '../providers/mobile-push-provider';
 
-import type { MobilePushTokenResponse } from '@granit/notifications-mobile-push';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -17,18 +16,7 @@ vi.mock('@granit/notifications-mobile-push', () => ({
   listDeviceTokens: vi.fn(),
 }));
 
-const mockTokens: readonly MobilePushTokenResponse[] = [
-  {
-    deviceToken: 'token-abc-123',
-    platform: 'android',
-    createdAt: toISODateString('2026-03-17T10:00:00Z'),
-  },
-  {
-    deviceToken: 'token-def-456',
-    platform: 'ios',
-    createdAt: toISODateString('2026-03-17T09:00:00Z'),
-  },
-];
+const mockTokens = mockMobilePushTokens;
 
 function createWrapper(client: AxiosInstance, basePath?: string) {
   return function Wrapper({ children }: { children: ReactNode }) {

--- a/packages/@granit/react-notifications-mobile-push/src/testing/data.ts
+++ b/packages/@granit/react-notifications-mobile-push/src/testing/data.ts
@@ -1,0 +1,33 @@
+import { toISODateString } from '@granit/types';
+
+import type { DeviceTokenDto, MobilePushTokenResponse } from '@granit/notifications-mobile-push';
+
+/**
+ * Registered device tokens returned by
+ * `GET {basePath}/notifications/mobile-push/tokens`.
+ *
+ * Mirrors the bare `MobilePushTokenResponse[]` the .NET endpoint produces — one
+ * token per platform so the device-token list exercises both `android` and `ios`.
+ */
+export const mockMobilePushTokens: MobilePushTokenResponse[] = [
+  {
+    deviceToken: 'token-abc-123',
+    platform: 'android',
+    createdAt: toISODateString('2026-03-17T10:00:00Z'),
+  },
+  {
+    deviceToken: 'token-def-456',
+    platform: 'ios',
+    createdAt: toISODateString('2026-03-17T09:00:00Z'),
+  },
+];
+
+/**
+ * Sample registration payload for
+ * `POST {basePath}/notifications/mobile-push/tokens`.
+ */
+export const mockDeviceTokenRegistration: DeviceTokenDto = {
+  token: 'token-ghi-789',
+  platform: 'android',
+  deviceId: 'device-001',
+};

--- a/packages/@granit/react-notifications-mobile-push/src/testing/handlers.ts
+++ b/packages/@granit/react-notifications-mobile-push/src/testing/handlers.ts
@@ -1,0 +1,53 @@
+import { noContent } from '@granit/testing/msw';
+import { toISODateString } from '@granit/types';
+import { http, HttpResponse } from 'msw';
+
+import { DEFAULT_BASE_PATH } from '../constants';
+
+import { mockMobilePushTokens } from './data';
+
+import type { DeviceTokenDto, MobilePushTokenResponse } from '@granit/notifications-mobile-push';
+
+/**
+ * Create stateful MSW handlers for the mobile-push device-token endpoints.
+ *
+ * Handlers mutate an in-memory token list — register / unregister are reflected
+ * in subsequent GET calls. The endpoint path mirrors
+ * `buildApiUrl(basePath, 'notifications', 'mobile-push', 'tokens')`, so the
+ * tokens resource lives at `{baseUrl}/notifications/mobile-push/tokens`.
+ *
+ * @param baseUrl - API base path (default: `/api/v1/notifications`)
+ */
+export function createMobilePushHandlers(baseUrl = DEFAULT_BASE_PATH) {
+  const tokensUrl = `${baseUrl}/notifications/mobile-push/tokens`;
+  let tokens: MobilePushTokenResponse[] = [...mockMobilePushTokens];
+
+  return [
+    // GET registered device tokens for the current user
+    http.get(tokensUrl, () => HttpResponse.json(tokens)),
+
+    // POST register a device token — 204 No Content
+    http.post(tokensUrl, async ({ request }) => {
+      const body = (await request.json()) as DeviceTokenDto;
+      const alreadyRegistered = tokens.some((t) => t.deviceToken === body.token);
+      if (!alreadyRegistered) {
+        tokens = [
+          ...tokens,
+          {
+            deviceToken: body.token,
+            platform: body.platform,
+            createdAt: toISODateString('2026-03-17T12:00:00Z'),
+          },
+        ];
+      }
+      return noContent();
+    }),
+
+    // DELETE unregister a device token — 204 No Content
+    http.delete(`${tokensUrl}/:token`, ({ params }) => {
+      const token = decodeURIComponent(params.token as string);
+      tokens = tokens.filter((t) => t.deviceToken !== token);
+      return noContent();
+    }),
+  ];
+}

--- a/packages/@granit/react-notifications-mobile-push/src/testing/index.ts
+++ b/packages/@granit/react-notifications-mobile-push/src/testing/index.ts
@@ -1,0 +1,6 @@
+// ---------------------------------------------------------------------------
+// @granit/react-notifications-mobile-push/testing — Mock data & MSW handlers
+// ---------------------------------------------------------------------------
+
+export { mockDeviceTokenRegistration, mockMobilePushTokens } from './data';
+export { createMobilePushHandlers } from './handlers';

--- a/packages/@granit/react-ui-dashboards/src/dashboard-page.tsx
+++ b/packages/@granit/react-ui-dashboards/src/dashboard-page.tsx
@@ -1,5 +1,4 @@
 import { Dashboard, DashboardViewSwitcher, RenderedDashboard } from '@granit/react-dashboards';
-import { SAMPLE_FINANCE_DASHBOARD_ID } from '@granit/react-dashboards/testing';
 import { useTranslation } from '@granit/react-localization';
 import { Button } from '@granit/react-ui';
 import { Pencil } from 'lucide-react';
@@ -44,6 +43,11 @@ const DEMO_VIEWS: readonly DashboardView[] = [
   { name: 'overview', widgets: [], displayNameLocalizationKey: 'Dashboards.Demo.Views.Overview' },
   { name: 'details', widgets: [], displayNameLocalizationKey: 'Dashboards.Demo.Views.Details' },
 ];
+
+// Mirrors the MSW seed `SAMPLE_FINANCE_DASHBOARD_ID` in
+// `@granit/react-dashboards/testing`. Inlined here so this shipped demo page
+// does not import the test-only `/testing` barrel into the bundle.
+const SAMPLE_FINANCE_DASHBOARD_ID = '8c6b1e10-0000-4000-8000-000000000001';
 
 export function DashboardPage() {
   const { t } = useTranslation();

--- a/packages/@granit/react-ui-timeline/src/entity-timeline.tsx
+++ b/packages/@granit/react-ui-timeline/src/entity-timeline.tsx
@@ -185,7 +185,7 @@ export interface EntityTimelineProps {
   /** Number of entries per page. Default: 20 */
   pageSize?: number;
   /**
-   * Forwarded to each `<TimelineStreamEntryResponse>`'s reaction bar. Hosts compute it
+   * Forwarded to each `<TimelineEntry>`'s reaction bar. Hosts compute it
    * via `usePermissions().hasPermission('Timeline.Reactions.React')` at the call
    * site so this component stays QueryClient-free for stories / tests
    * that don't need the auth stack mounted. Default: `false`.

--- a/packages/@granit/react-ui-timeline/src/index.ts
+++ b/packages/@granit/react-ui-timeline/src/index.ts
@@ -1,6 +1,6 @@
 export { EntityTimeline, type EntityTimelineProps } from './entity-timeline';
 export { TimelineStream, type TimelineStreamProps } from './timeline-stream';
-export { TimelineStreamEntryResponse, type TimelineEntryProps } from './timeline-entry';
+export { TimelineEntry, type TimelineEntryProps } from './timeline-entry';
 export { TimelineComposer, type TimelineComposerProps } from './timeline-composer';
 export { ReactionStrip, type ReactionStripProps } from './reaction-strip';
 export { MentionEditor, type MentionEditorProps } from './mention-editor';

--- a/packages/@granit/react-ui-timeline/src/timeline-entry.stories.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-entry.stories.tsx
@@ -6,9 +6,7 @@ import { toEntityId, toISODateString } from '@granit/types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fn } from 'storybook/test';
 
-
-
-import { TimelineStreamEntryResponse as TimelineEntryComponent } from './timeline-entry';
+import { TimelineEntry as TimelineEntryComponent } from './timeline-entry';
 
 import type { ReactionEmoji, TimelineStreamEntryResponse } from '@granit/timeline';
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -17,7 +15,10 @@ const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
 });
 
-const storyTimelineConfig = { client: createApiClient({ baseURL: '' }), basePath: '/api/v1/timeline' };
+const storyTimelineConfig = {
+  client: createApiClient({ baseURL: '' }),
+  basePath: '/api/v1/timeline',
+};
 
 const commentEntry: TimelineStreamEntryResponse = {
   id: toEntityId<'TimelineStreamEntryResponse'>('tl-1'),

--- a/packages/@granit/react-ui-timeline/src/timeline-entry.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-entry.tsx
@@ -94,7 +94,7 @@ function getAvatarTintClass(authorId: string | null | undefined): string {
   return AVATAR_PALETTE[Math.abs(hash) % AVATAR_PALETTE.length]!;
 }
 
-export function TimelineStreamEntryResponse({
+export function TimelineEntry({
   entry,
   entityType,
   entityId,
@@ -230,7 +230,7 @@ export function TimelineStreamEntryResponse({
 
 // Sub-component that owns the `useToggleReaction` hook (and thus the
 // `useMutation` → `useQueryClient` chain). Mounting it conditionally
-// keeps the parent `<TimelineStreamEntryResponse>` mountable without a
+// keeps the parent `<TimelineEntry>` mountable without a
 // `<QueryClientProvider>` for any non-reacting scenario (read-only
 // users, unit tests, stories without auth wiring).
 interface InteractiveReactionBarProps {

--- a/packages/@granit/react-ui-timeline/src/timeline-stream.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-stream.tsx
@@ -3,7 +3,7 @@ import { Button, Spinner } from '@granit/react-ui';
 import { cn } from '@granit/utils';
 import { useCallback, useMemo } from 'react';
 
-import { TimelineStreamEntryResponse } from './timeline-entry.js';
+import { TimelineEntry } from './timeline-entry.js';
 
 import type { TimelineEntryProps } from './timeline-entry.js';
 import type {
@@ -15,13 +15,13 @@ import type {
 export interface TimelineStreamProps {
   entries: readonly TimelineEntryType[];
   /**
-   * Stream's entity context — threaded into each `<TimelineStreamEntryResponse>` so
+   * Stream's entity context — threaded into each `<TimelineEntry>` so
    * reactions (`useToggleReaction`) can scope their cache patches by
    * stream.
    */
   entityType?: string;
   entityId?: string;
-  /** Forwarded to each `<TimelineStreamEntryResponse>` — gates the reaction bar's interactive mode. */
+  /** Forwarded to each `<TimelineEntry>` — gates the reaction bar's interactive mode. */
   canReact?: boolean;
   loading?: boolean;
   loadingMore?: boolean;
@@ -155,7 +155,7 @@ export function TimelineStream({
         return renderEntry ? (
           <div key={entry.id}>{renderEntry(entryProps)}</div>
         ) : (
-          <TimelineStreamEntryResponse key={entry.id} {...entryProps} />
+          <TimelineEntry key={entry.id} {...entryProps} />
         );
       })}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2262,6 +2262,9 @@ importers:
       '@tanstack/react-query':
         specifier: 5.101.1
         version: 5.101.1(react@19.2.7)
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@26.0.0)(typescript@6.0.3)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -2311,6 +2314,9 @@ importers:
       '@tanstack/react-query':
         specifier: 5.101.1
         version: 5.101.1(react@19.2.7)
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@26.0.0)(typescript@6.0.3)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -2339,6 +2345,9 @@ importers:
       '@tanstack/react-query':
         specifier: 5.101.1
         version: 5.101.1(react@19.2.7)
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@26.0.0)(typescript@6.0.3)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -2755,6 +2764,9 @@ importers:
       '@tanstack/react-query':
         specifier: 5.101.1
         version: 5.101.1(react@19.2.7)
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@26.0.0)(typescript@6.0.3)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -6334,6 +6346,9 @@ importers:
       '@granit/workspaces':
         specifier: workspace:*
         version: link:../workspaces
+      '@storybook/react-vite':
+        specifier: ^10.4.6
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(yaml@2.9.0))
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -140,6 +140,90 @@ export default defineConfig({
         __dirname,
         'packages/@granit/react-workflow/src/testing/index.ts'
       ),
+      '@granit/react-activities/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-activities/src/testing/index.ts'
+      ),
+      '@granit/react-ai-prompts/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-ai-prompts/src/testing/index.ts'
+      ),
+      '@granit/react-analytics/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-analytics/src/testing/index.ts'
+      ),
+      '@granit/react-bank-accounts/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-bank-accounts/src/testing/index.ts'
+      ),
+      '@granit/react-bff/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-bff/src/testing/index.ts'
+      ),
+      '@granit/react-catalog/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-catalog/src/testing/index.ts'
+      ),
+      '@granit/react-cms-hostnames/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-cms-hostnames/src/testing/index.ts'
+      ),
+      '@granit/react-cms-redirects/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-cms-redirects/src/testing/index.ts'
+      ),
+      '@granit/react-cms-seo/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-cms-seo/src/testing/index.ts'
+      ),
+      '@granit/react-cms/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-cms/src/testing/index.ts'
+      ),
+      '@granit/react-cookies/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-cookies/src/testing/index.ts'
+      ),
+      '@granit/react-dashboards/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-dashboards/src/testing/index.ts'
+      ),
+      '@granit/react-payments-sepa-direct-debit/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-payments-sepa-direct-debit/src/testing/index.ts'
+      ),
+      '@granit/react-payments-sepa-transfer/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-payments-sepa-transfer/src/testing/index.ts'
+      ),
+      '@granit/react-reference-data/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-reference-data/src/testing/index.ts'
+      ),
+      '@granit/react-taxonomy/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-taxonomy/src/testing/index.ts'
+      ),
+      '@granit/react-workspaces/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-workspaces/src/testing/index.ts'
+      ),
+      '@granit/react-entities/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-entities/src/testing/index.ts'
+      ),
+      '@granit/react-entities-views/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-entities-views/src/testing/index.ts'
+      ),
+      '@granit/react-entities-customization/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-entities-customization/src/testing/index.ts'
+      ),
+      '@granit/react-notifications-mobile-push/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-notifications-mobile-push/src/testing/index.ts'
+      ),
       '@granit/auditing': path.resolve(__dirname, 'packages/@granit/auditing/src/index.ts'),
       '@granit/account': path.resolve(__dirname, 'packages/@granit/account/src/index.ts'),
       '@granit/ai': path.resolve(__dirname, 'packages/@granit/ai/src/index.ts'),


### PR DESCRIPTION
## Context

Follow-up to a framework audit of the headless `@granit/react-*` tier. The tier-wide structural checks (layer separation, shadcn confinement, HTTP-client conformity, logging) came back clean; this PR fixes the actionable findings plus a published-build break surfaced in CI.

## Changes

### Shared `/testing` fixtures (checklist 5e — GAP)
Four API-backed headless packages shipped hooks + tests but no shared fixtures barrel, forcing inline DTO duplication. Added `src/testing/` (typed `mock*` fixtures + MSW handlers + barrel + `./testing` export), mirroring the canonical `@granit/react-auditing/testing` pattern:

- `@granit/react-entities`
- `@granit/react-entities-views` (tests rebased onto fixtures)
- `@granit/react-entities-customization`
- `@granit/react-notifications-mobile-push` (test rebased)

Registered their vitest aliases plus the 17 pre-existing barrels that lacked one (config consistency — resolution already worked via `exports`, so non-breaking).

### `react-ui-dashboards` — drop `/testing` import from shipped code (CLEANUP)
`DashboardPage` (a demo page) imported `SAMPLE_FINANCE_DASHBOARD_ID` from `@granit/react-dashboards/testing`, pulling the test-only barrel into bundled code. Inlined the seed id locally.

### `react-ui-timeline` — fix tsup dts build (BUILD break)
The entry component was named `TimelineStreamEntryResponse`, colliding with the imported DTO type of the same name. `tsc` tolerated the type/value overlap but `rollup-plugin-dts` could not, failing the published dts build. Renamed the component to `TimelineEntry` (def, barrel export, `timeline-stream` usage, story alias, docs).

## Verification

- `react-ui-timeline build` (tsup + dts) ✅
- `tsc --noEmit` on all touched packages ✅
- `lint` (6 packages) ✅
- Tests: 368/368 across timeline, dashboards, the 4 new barrels and a cms consumer ✅
- `pnpm install --frozen-lockfile` ✅

## Blast radius

New public exports only (`TimelineEntry`, four `./testing` subpaths). No existing consumed API renamed — showcase only imports `EntityTimeline` + translations from `react-ui-timeline`.