### PR TITLE
fix(react-ui-workflow): rename i18n exports to avoid headless collision

### DIFF
--- a/packages/@granit/react-ui-workflow/src/__tests__/entity-workflow.test.tsx
+++ b/packages/@granit/react-ui-workflow/src/__tests__/entity-workflow.test.tsx
@@ -4,7 +4,7 @@ import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { EntityWorkflow } from '../entity-workflow';
-import { workflowTranslationsEn } from '../locales';
+import { workflowAdminTranslationsEn } from '../locales';
 
 import type { ReactElement, ReactNode } from 'react';
 
@@ -70,7 +70,7 @@ void testI18n.use(initReactI18next).init({
   defaultNS: 'translation',
   nsSeparator: false,
   keySeparator: false,
-  resources: { en: { translation: { ...workflowTranslationsEn } } },
+  resources: { en: { translation: { ...workflowAdminTranslationsEn } } },
   interpolation: { escapeValue: false },
 });
 

--- a/packages/@granit/react-ui-workflow/src/index.ts
+++ b/packages/@granit/react-ui-workflow/src/index.ts
@@ -2,4 +2,4 @@ export { EntityWorkflow, type EntityWorkflowProps } from './entity-workflow';
 export { TransitionCommentDialog, type TransitionCommentDialogProps } from './transition-comment-dialog';
 export { WorkflowHistory, type WorkflowHistoryProps } from './workflow-history';
 export { WorkflowStatusBar, type WorkflowStatusBarProps } from './workflow-status-bar';
-export { workflowTranslationsEn, workflowTranslationsFr } from './locales';
+export { workflowAdminTranslationsEn, workflowAdminTranslationsFr } from './locales';

--- a/packages/@granit/react-ui-workflow/src/locales/en.ts
+++ b/packages/@granit/react-ui-workflow/src/locales/en.ts
@@ -3,7 +3,7 @@
  * keys in the `translation` namespace (the host registers them with separators
  * disabled, so the dotted keys are looked up verbatim).
  */
-export const workflowTranslationsEn = {
+export const workflowAdminTranslationsEn = {
   'Components.Workflow.Actions': 'Workflow actions',
   'Components.Workflow.RequestApproval': 'Request approval',
   'Workflow.ApprovalDialogDescription':

--- a/packages/@granit/react-ui-workflow/src/locales/fr.ts
+++ b/packages/@granit/react-ui-workflow/src/locales/fr.ts
@@ -1,7 +1,7 @@
 /**
- * French strings for the workflow UI. See {@link workflowTranslationsEn}.
+ * French strings for the workflow UI. See {@link workflowAdminTranslationsEn}.
  */
-export const workflowTranslationsFr = {
+export const workflowAdminTranslationsFr = {
   'Components.Workflow.Actions': 'Actions du workflow',
   'Components.Workflow.RequestApproval': "Demander l'approbation",
   'Workflow.ApprovalDialogDescription':

--- a/packages/@granit/react-ui-workflow/src/locales/index.ts
+++ b/packages/@granit/react-ui-workflow/src/locales/index.ts
@@ -1,2 +1,2 @@
-export { workflowTranslationsEn } from './en';
-export { workflowTranslationsFr } from './fr';
+export { workflowAdminTranslationsEn } from './en';
+export { workflowAdminTranslationsFr } from './fr';

--- a/packages/@granit/react-ui-workflow/src/stories-i18n.ts
+++ b/packages/@granit/react-ui-workflow/src/stories-i18n.ts
@@ -1,7 +1,7 @@
 import i18next from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
-import { workflowTranslationsEn } from './locales';
+import { workflowAdminTranslationsEn } from './locales';
 
 // Shared i18next instance for Storybook stories. Mirrors the runtime flat-key
 // setup (separators disabled) and bundles the package's own Workflow.* keys.
@@ -13,6 +13,6 @@ await storyI18n.use(initReactI18next).init({
   defaultNS: 'translation',
   nsSeparator: false,
   keySeparator: false,
-  resources: { en: { translation: { ...workflowTranslationsEn } } },
+  resources: { en: { translation: { ...workflowAdminTranslationsEn } } },
   interpolation: { escapeValue: false },
 });


### PR DESCRIPTION
Headless `@granit/react-workflow` already exports `workflowTranslationsEn/Fr`. The new `@granit/react-ui-workflow` (#784) reused the same names, so a host registering both bundles hits a duplicate-identifier error. Renamed the UI bundle to **`workflowAdminTranslationsEn/Fr`** — the convention for UI packages colliding with their headless counterpart (timelineAdmin / taxonomyAdmin / aiChatAdmin / …). Package tsc + eslint + 8 unit tests + arch-tests (3031) green. The showcase adoption MR imports the renamed symbol.