### PR TITLE
fix(ai): sync workspace contract with backend — name→key, displayName

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2815,7 +2815,7 @@
         {
           "name": "useAIWorkspace",
           "kind": "function",
-          "signature": "function useAIWorkspace( name: string, options?:"
+          "signature": "function useAIWorkspace( key: string, options?:"
         },
         {
           "name": "useCreateAIWorkspace",
@@ -10956,6 +10956,187 @@
           "name": "createSubscriptionColumns",
           "kind": "function",
           "signature": "function createSubscriptionColumns("
+        }
+      ]
+    },
+    {
+      "name": "@granit/react-ui-workflow",
+      "description": "Granit admin workflow UI — the status bar, transition dialog, history table and the self-contained EntityWorkflow card that pair with the headless @granit/react-workflow. App-agnostic: EntityWorkflow takes the API config as a prop and the package ships its own Workflow.* translations.",
+      "exports": [
+        {
+          "name": "EntityWorkflow",
+          "kind": "function",
+          "signature": "function EntityWorkflow("
+        },
+        {
+          "name": "EntityWorkflowProps",
+          "kind": "interface",
+          "signature": "interface EntityWorkflowProps",
+          "members": [
+            {
+              "name": "config",
+              "kind": "property",
+              "signature": "config: WorkflowConfig"
+            },
+            {
+              "name": "entityType",
+              "kind": "property",
+              "signature": "entityType: string"
+            },
+            {
+              "name": "entityId",
+              "kind": "property",
+              "signature": "entityId: string"
+            },
+            {
+              "name": "currentState",
+              "kind": "property",
+              "signature": "currentState: string"
+            },
+            {
+              "name": "states",
+              "kind": "property",
+              "signature": "states: readonly string[]"
+            },
+            {
+              "name": "onStateChange",
+              "kind": "method",
+              "signature": "onStateChange?: (newState: string) => void"
+            },
+            {
+              "name": "className",
+              "kind": "property",
+              "signature": "className?: string"
+            }
+          ]
+        },
+        {
+          "name": "TransitionCommentDialog",
+          "kind": "function",
+          "signature": "function TransitionCommentDialog("
+        },
+        {
+          "name": "TransitionCommentDialogProps",
+          "kind": "interface",
+          "signature": "interface TransitionCommentDialogProps",
+          "members": [
+            {
+              "name": "open",
+              "kind": "property",
+              "signature": "open: boolean"
+            },
+            {
+              "name": "transitionName",
+              "kind": "property",
+              "signature": "transitionName: string"
+            },
+            {
+              "name": "requiresApproval",
+              "kind": "property",
+              "signature": "requiresApproval: boolean"
+            },
+            {
+              "name": "onConfirm",
+              "kind": "method",
+              "signature": "onConfirm: (comment?: string) => void"
+            },
+            {
+              "name": "onCancel",
+              "kind": "method",
+              "signature": "onCancel: () => void"
+            }
+          ]
+        },
+        {
+          "name": "WorkflowHistory",
+          "kind": "function",
+          "signature": "function WorkflowHistory("
+        },
+        {
+          "name": "WorkflowHistoryProps",
+          "kind": "interface",
+          "signature": "interface WorkflowHistoryProps",
+          "members": [
+            {
+              "name": "history",
+              "kind": "property",
+              "signature": "history: readonly TransitionHistory[]"
+            },
+            {
+              "name": "loading",
+              "kind": "property",
+              "signature": "loading?: boolean"
+            },
+            {
+              "name": "emptyMessage",
+              "kind": "property",
+              "signature": "emptyMessage?: string"
+            },
+            {
+              "name": "className",
+              "kind": "property",
+              "signature": "className?: string"
+            }
+          ]
+        },
+        {
+          "name": "WorkflowStatusBar",
+          "kind": "function",
+          "signature": "function WorkflowStatusBar("
+        },
+        {
+          "name": "WorkflowStatusBarProps",
+          "kind": "interface",
+          "signature": "interface WorkflowStatusBarProps",
+          "members": [
+            {
+              "name": "currentState",
+              "kind": "property",
+              "signature": "currentState: string"
+            },
+            {
+              "name": "states",
+              "kind": "property",
+              "signature": "states: readonly string[]"
+            },
+            {
+              "name": "transitions",
+              "kind": "property",
+              "signature": "transitions: readonly WorkflowTransition[]"
+            },
+            {
+              "name": "onTransition",
+              "kind": "method",
+              "signature": "onTransition?: (targetState: string, comment?: string) => void"
+            },
+            {
+              "name": "isLoading",
+              "kind": "property",
+              "signature": "isLoading?: boolean"
+            },
+            {
+              "name": "className",
+              "kind": "property",
+              "signature": "className?: string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "@granit/react-ui-workspaces",
+      "description": "Granit admin workspaces UI — the workspace landing page that pairs with the headless @granit/react-workspaces. App-agnostic: it takes the route workspace name and an icon-render slot as props, and ships its own Workspace.* translations.",
+      "exports": [
+        {
+          "name": "WorkspacePage",
+          "kind": "function",
+          "signature": "function WorkspacePage("
+        },
+        {
+          "name": "WorkspacePageProps",
+          "kind": "interface",
+          "signature": "interface WorkspacePageProps",
+          "members": []
         }
       ]
     },

--- a/contracts/openapi/ai.json
+++ b/contracts/openapi/ai.json
@@ -80,6 +80,16 @@
               }
             }
           },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
           "409": {
             "description": "Conflict",
             "content": {
@@ -143,7 +153,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -212,7 +222,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -240,8 +250,28 @@
               }
             }
           },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -262,16 +292,6 @@
           },
           "403": {
             "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -301,7 +321,7 @@
           {
             "name": "name",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Unique registered name.",
             "required": true,
             "schema": {
               "type": "string"
@@ -727,7 +747,7 @@
           {
             "name": "workspaceName",
             "in": "path",
-            "description": "Workspace identifier \u2014 isolates configuration and routing per AI workspace.",
+            "description": "Workspace identifier — isolates configuration and routing per AI workspace.",
             "required": true,
             "schema": {
               "type": "string"
@@ -751,6 +771,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AIChatResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
                 }
               }
             }
@@ -822,13 +852,13 @@
       "post": {
         "tags": ["AI - Inference"],
         "summary": "Streams a chat completion response via Server-Sent Events.",
-        "description": "Opens an SSE stream that emits incremental content chunks as they arrive from the provider. The stream ends with a [DONE] sentinel. If the provider returns an error after streaming has started, an SSE 'error' event is emitted before closing. Returns 404 if the workspace does not exist, 422 if the model is not found, or 502/503 if the provider is unavailable.",
+        "description": "Opens an SSE stream that emits incremental 'delta' content frames as they arrive from the provider, then a 'usage' frame with the token counts; end-of-stream is the stream closing. A provider failure before any content is returned as an HTTP problem; a failure after streaming has started is emitted as an 'error' frame. Returns 404 if the workspace does not exist, or 502/503 if the provider is unavailable.",
         "operationId": "AIChatStream",
         "parameters": [
           {
             "name": "workspaceName",
             "in": "path",
-            "description": "Workspace identifier \u2014 isolates configuration and routing per AI workspace.",
+            "description": "Workspace identifier — isolates configuration and routing per AI workspace.",
             "required": true,
             "schema": {
               "type": "string"
@@ -851,7 +881,17 @@
             "content": {
               "text/event-stream": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/AIChatStreamEvent"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
                 }
               }
             }
@@ -939,7 +979,7 @@
           {
             "name": "workspaceName",
             "in": "path",
-            "description": "Workspace identifier \u2014 isolates configuration and routing per AI workspace.",
+            "description": "Workspace identifier — isolates configuration and routing per AI workspace.",
             "required": true,
             "schema": {
               "type": "string"
@@ -963,6 +1003,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AIEmbeddingResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
                 }
               }
             }
@@ -1053,7 +1103,8 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/AIChatMessageRequest"
-            }
+            },
+            "x-granit-validator": "Validation:MaxChatMessages"
           }
         }
       },
@@ -1083,6 +1134,29 @@
           "duration": {
             "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$",
             "type": "string"
+          }
+        }
+      },
+      "AIChatStreamEvent": {
+        "required": ["type"],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "content": {
+            "type": ["null", "string"]
+          },
+          "inputTokens": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "outputTokens": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "error": {
+            "type": ["null", "string"]
           }
         }
       },
@@ -1131,10 +1205,12 @@
         "type": "object",
         "properties": {
           "inputs": {
+            "maxLength": 32000,
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "x-granit-validator": "Validation:MaxEmbeddingInputs"
           }
         }
       },
@@ -1286,6 +1362,10 @@
           "costCurrency": {
             "type": ["null", "string"]
           },
+          "conversationId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
           "timestamp": {
             "type": "string",
             "format": "date-time"
@@ -1294,17 +1374,25 @@
             "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$",
             "type": ["null", "string"]
           },
-          "conversationId": {
-            "type": ["null", "string"],
-            "format": "uuid"
+          "promptVersion": {
+            "type": ["null", "string"]
+          },
+          "promptTemplateName": {
+            "type": ["null", "string"]
+          },
+          "promptTemplateVersion": {
+            "type": ["null", "integer"],
+            "format": "int32"
           }
         }
       },
       "AIWorkspaceCreateRequest": {
-        "required": ["name", "provider", "model"],
+        "required": ["key", "provider", "model"],
         "type": "object",
         "properties": {
-          "name": {
+          "key": {
+            "maxLength": 128,
+            "pattern": "^[a-z0-9][a-z0-9-]*$",
             "type": "string"
           },
           "provider": {
@@ -1312,6 +1400,9 @@
           },
           "model": {
             "type": "string"
+          },
+          "displayName": {
+            "type": ["null", "string"]
           },
           "systemPrompt": {
             "type": ["null", "string"]
@@ -1324,9 +1415,6 @@
           "maxOutputTokens": {
             "type": ["null", "integer"],
             "format": "int32"
-          },
-          "workspaceModelName": {
-            "type": ["null", "string"]
           }
         }
       },
@@ -1351,20 +1439,20 @@
       },
       "AIWorkspaceResponse": {
         "required": [
-          "name",
+          "key",
           "provider",
           "model",
+          "displayName",
           "systemPrompt",
           "temperature",
           "maxOutputTokens",
           "kind",
           "activated",
-          "capabilities",
-          "workspaceModelName"
+          "capabilities"
         ],
         "type": "object",
         "properties": {
-          "name": {
+          "key": {
             "type": "string"
           },
           "provider": {
@@ -1372,6 +1460,9 @@
           },
           "model": {
             "type": "string"
+          },
+          "displayName": {
+            "type": ["null", "string"]
           },
           "systemPrompt": {
             "type": ["null", "string"]
@@ -1400,9 +1491,6 @@
                 "$ref": "#/components/schemas/AIModelCapabilities"
               }
             ]
-          },
-          "workspaceModelName": {
-            "type": ["null", "string"]
           }
         }
       },
@@ -1415,6 +1503,9 @@
           },
           "model": {
             "type": "string"
+          },
+          "displayName": {
+            "type": ["null", "string"]
           },
           "systemPrompt": {
             "type": ["null", "string"]
@@ -1431,9 +1522,6 @@
           "activated": {
             "type": "boolean",
             "default": false
-          },
-          "workspaceModelName": {
-            "type": ["null", "string"]
           }
         }
       },
@@ -1726,6 +1814,10 @@
                 "costCurrency": {
                   "type": ["null", "string"]
                 },
+                "conversationId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
                 "timestamp": {
                   "type": "string",
                   "format": "date-time"
@@ -1733,6 +1825,16 @@
                 "duration": {
                   "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$",
                   "type": ["null", "string"]
+                },
+                "promptVersion": {
+                  "type": ["null", "string"]
+                },
+                "promptTemplateName": {
+                  "type": ["null", "string"]
+                },
+                "promptTemplateVersion": {
+                  "type": ["null", "integer"],
+                  "format": "int32"
                 }
               }
             }

--- a/packages/@granit/ai/src/__tests__/ai-workspaces-api.test.ts
+++ b/packages/@granit/ai/src/__tests__/ai-workspaces-api.test.ts
@@ -57,7 +57,7 @@ describe('ai-workspaces-api', () => {
   describe('createAIWorkspace', () => {
     it('should POST {basePath}/workspaces', async () => {
       const client = createMockClient();
-      const request = { name: 'test', provider: 'OpenAI', model: 'gpt-4o' };
+      const request = { key: 'test', provider: 'OpenAI', model: 'gpt-4o' };
       const response = { ...request, kind: 'Dynamic', activated: true };
       vi.mocked(client.post).mockResolvedValue({ data: response });
 

--- a/packages/@granit/ai/src/api/ai-workspaces-api.ts
+++ b/packages/@granit/ai/src/api/ai-workspaces-api.ts
@@ -25,17 +25,17 @@ export async function listAIWorkspaces(
 }
 
 /**
- * Get a single AI workspace by name.
+ * Get a single AI workspace by key.
  *
- * `GET {basePath}/workspaces/{name}`
+ * `GET {basePath}/workspaces/{key}`
  */
 export async function getAIWorkspace(
   client: AxiosInstance,
   basePath: string,
-  name: string
+  key: string
 ): Promise<AIWorkspaceResponse> {
   const response = await client.get<AIWorkspaceResponse>(
-    `${basePath}/workspaces/${encodeURIComponent(name)}`
+    `${basePath}/workspaces/${encodeURIComponent(key)}`
   );
   return response.data;
 }
@@ -57,16 +57,16 @@ export async function createAIWorkspace(
 /**
  * Update an existing dynamic AI workspace.
  *
- * `PUT {basePath}/workspaces/{name}`
+ * `PUT {basePath}/workspaces/{key}`
  */
 export async function updateAIWorkspace(
   client: AxiosInstance,
   basePath: string,
-  name: string,
+  key: string,
   request: AIWorkspaceUpdateRequest
 ): Promise<AIWorkspaceResponse> {
   const response = await client.put<AIWorkspaceResponse>(
-    `${basePath}/workspaces/${encodeURIComponent(name)}`,
+    `${basePath}/workspaces/${encodeURIComponent(key)}`,
     request
   );
   return response.data;
@@ -75,12 +75,12 @@ export async function updateAIWorkspace(
 /**
  * Delete a dynamic AI workspace.
  *
- * `DELETE {basePath}/workspaces/{name}`
+ * `DELETE {basePath}/workspaces/{key}`
  */
 export async function deleteAIWorkspace(
   client: AxiosInstance,
   basePath: string,
-  name: string
+  key: string
 ): Promise<void> {
-  await client.delete(`${basePath}/workspaces/${encodeURIComponent(name)}`);
+  await client.delete(`${basePath}/workspaces/${encodeURIComponent(key)}`);
 }

--- a/packages/@granit/ai/src/types/index.ts
+++ b/packages/@granit/ai/src/types/index.ts
@@ -29,12 +29,12 @@ export const AI_STREAM_DONE_MARKER = '[DONE]';
 
 /** Server-enforced limits for workspace fields. */
 export const AI_WORKSPACE_LIMITS = {
-  /** `name` maximum length. Pattern: `^[a-z0-9][a-z0-9-]*$`. */
-  NAME_MAX_LENGTH: 128,
-  /** Slug pattern for workspace names (lowercase alphanumeric + hyphens, no leading hyphen). */
-  NAME_PATTERN: /^[a-z0-9][a-z0-9-]*$/,
-  /** `workspaceModelName` maximum length (display label). */
-  MODEL_NAME_MAX_LENGTH: 64,
+  /** `key` maximum length. Pattern: `^[a-z0-9][a-z0-9-]*$`. */
+  KEY_MAX_LENGTH: 128,
+  /** Slug pattern for workspace keys (lowercase alphanumeric + hyphens, no leading hyphen). */
+  KEY_PATTERN: /^[a-z0-9][a-z0-9-]*$/,
+  /** `displayName` maximum length (display label). */
+  DISPLAY_NAME_MAX_LENGTH: 64,
 } as const;
 
 // -- Workspace ---------------------------------------------------------------
@@ -44,17 +44,18 @@ export type AIWorkspaceKind = 'System' | 'Dynamic';
 
 /** Workspace configuration returned by the API. Mirrors `AIWorkspaceResponse`. */
 export interface AIWorkspaceResponse {
-  readonly name: string;
+  /** Machine key identifying this workspace (slug). */
+  readonly key: string;
   readonly provider: string;
   readonly model: string;
+  /** Short human-readable label (e.g. "GPT-4o"); null if unset (fall back to model). */
+  readonly displayName: string | null;
   readonly systemPrompt: string | null;
   readonly temperature: number | null;
   readonly maxOutputTokens: number | null;
   readonly kind: AIWorkspaceKind;
   readonly activated: boolean;
   readonly capabilities: AIModelCapabilities | null;
-  /** Human-readable model label (e.g. "GPT-4o"); null if not set. */
-  readonly workspaceModelName: string | null;
 }
 
 /** List response wrapper. Mirrors `AIWorkspaceListResponse`. */
@@ -65,25 +66,26 @@ export interface AIWorkspaceListResponse {
 
 /** Create workspace request. Mirrors `AIWorkspaceCreateRequest`. */
 export interface AIWorkspaceCreateRequest {
-  readonly name: string;
+  /** Machine key identifying this workspace (slug, `^[a-z0-9][a-z0-9-]*$`). */
+  readonly key: string;
   readonly provider: string;
   readonly model: string;
+  readonly displayName?: string | null;
   readonly systemPrompt?: string | null;
   readonly temperature?: number | null;
   readonly maxOutputTokens?: number | null;
-  readonly workspaceModelName?: string | null;
 }
 
 /** Update workspace request. Mirrors `AIWorkspaceUpdateRequest`. */
 export interface AIWorkspaceUpdateRequest {
   readonly provider: string;
   readonly model: string;
+  /** Pass null to clear the label. */
+  readonly displayName?: string | null;
   readonly systemPrompt?: string | null;
   readonly temperature?: number | null;
   readonly maxOutputTokens?: number | null;
   readonly activated: boolean;
-  /** Pass null to clear the label. */
-  readonly workspaceModelName?: string | null;
 }
 
 // -- Chat completion ---------------------------------------------------------
@@ -221,7 +223,7 @@ export interface AIUsageRecord {
   readonly outputTokens: number;
   readonly estimatedCost: number | null;
   readonly costCurrency: string | null;
+  readonly conversationId: ConversationId | null;
   readonly timestamp: ISODateString;
   readonly duration: string | null;
-  readonly conversationId: ConversationId | null;
 }

--- a/packages/@granit/react-ai/src/__tests__/ai-hooks.test.tsx
+++ b/packages/@granit/react-ai/src/__tests__/ai-hooks.test.tsx
@@ -98,13 +98,13 @@ describe('useCreateAIWorkspace', () => {
     });
 
     await act(async () => {
-      result.current.create({ name: 'test', provider: 'OpenAI', model: 'gpt-4o' });
+      result.current.create({ key: 'test', provider: 'OpenAI', model: 'gpt-4o' });
     });
 
     await waitFor(() => expect(result.current.isPending).toBe(false));
 
     expect(client.post).toHaveBeenCalledWith('/api/v1/ai/workspaces', {
-      name: 'test',
+      key: 'test',
       provider: 'OpenAI',
       model: 'gpt-4o',
     });
@@ -119,7 +119,7 @@ describe('useCreateAIWorkspace', () => {
     });
 
     await act(async () => {
-      result.current.create({ name: 'dup', provider: 'OpenAI', model: 'gpt-4o' });
+      result.current.create({ key: 'dup', provider: 'OpenAI', model: 'gpt-4o' });
     });
 
     await waitFor(() => expect(result.current.error).not.toBeNull());
@@ -131,7 +131,7 @@ describe('useCreateAIWorkspace', () => {
 describe('useUpdateAIWorkspace', () => {
   it('should PUT to update a workspace', async () => {
     const client = createMockClient();
-    vi.mocked(client.put).mockResolvedValue(axiosResponse({ name: 'ws' }));
+    vi.mocked(client.put).mockResolvedValue(axiosResponse({ key: 'ws' }));
 
     const { result } = renderHook(() => useUpdateAIWorkspace(), {
       wrapper: createWrapper(client, '/api/v1/ai'),

--- a/packages/@granit/react-ai/src/hooks/use-ai-workspace.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-workspace.ts
@@ -9,7 +9,7 @@ import type { AIWorkspaceResponse } from '@granit/ai';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 /**
- * Fetch a single AI workspace by name.
+ * Fetch a single AI workspace by key.
  *
  * @example
  * ```tsx
@@ -18,14 +18,14 @@ import type { UseQueryResult } from '@tanstack/react-query';
  * ```
  */
 export function useAIWorkspace(
-  name: string,
+  key: string,
   options?: { enabled?: boolean }
 ): UseQueryResult<AIWorkspaceResponse> {
   const config = useAIConfig();
 
   return useQuery({
-    queryKey: aiKeys.workspace(config.queryKeyPrefix, name),
-    queryFn: () => getAIWorkspace(config.client, config.basePath, name),
+    queryKey: aiKeys.workspace(config.queryKeyPrefix, key),
+    queryFn: () => getAIWorkspace(config.client, config.basePath, key),
     enabled: options?.enabled ?? true,
   });
 }

--- a/packages/@granit/react-ai/src/hooks/use-ai-workspaces.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-workspaces.ts
@@ -14,7 +14,7 @@ import type { UseQueryResult } from '@tanstack/react-query';
  * @example
  * ```tsx
  * const { data } = useAIWorkspaces();
- * data?.workspaces.map(ws => <div key={ws.name}>{ws.name}</div>);
+ * data?.workspaces.map(ws => <div key={ws.key}>{ws.key}</div>);
  * ```
  */
 export function useAIWorkspaces(options?: {

--- a/packages/@granit/react-ai/src/hooks/use-delete-ai-workspace.ts
+++ b/packages/@granit/react-ai/src/hooks/use-delete-ai-workspace.ts
@@ -7,8 +7,8 @@ import { useAIConfig } from '../providers/ai-provider';
 import { aiKeys } from './query-keys';
 
 export interface UseDeleteAIWorkspaceReturn {
-  readonly remove: (name: string) => void;
-  readonly removeAsync: (name: string) => Promise<void>;
+  readonly remove: (key: string) => void;
+  readonly removeAsync: (key: string) => Promise<void>;
   readonly isPending: boolean;
   readonly error: Error | null;
 }
@@ -29,7 +29,7 @@ export function useDeleteAIWorkspace(): UseDeleteAIWorkspaceReturn {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: (name: string) => deleteAIWorkspace(config.client, config.basePath, name),
+    mutationFn: (key: string) => deleteAIWorkspace(config.client, config.basePath, key),
     onSuccess: () => {
       queryClient
         .invalidateQueries({ queryKey: aiKeys.workspaces(config.queryKeyPrefix) })
@@ -38,15 +38,15 @@ export function useDeleteAIWorkspace(): UseDeleteAIWorkspaceReturn {
   });
 
   const remove = useCallback(
-    (name: string) => {
-      mutation.mutate(name);
+    (key: string) => {
+      mutation.mutate(key);
     },
     [mutation]
   );
 
   const removeAsync = useCallback(
-    async (name: string) => {
-      await mutation.mutateAsync(name);
+    async (key: string) => {
+      await mutation.mutateAsync(key);
     },
     [mutation]
   );

--- a/packages/@granit/react-ai/src/testing/data.ts
+++ b/packages/@granit/react-ai/src/testing/data.ts
@@ -119,7 +119,7 @@ export const mockProviderModels: Record<string, AIProviderModelResponse[]> = {
 
 export const mockWorkspaces: AIWorkspaceResponse[] = [
   {
-    name: 'default',
+    key: 'default',
     provider: 'OpenAI',
     model: 'gpt-4o',
     systemPrompt: 'You are a helpful assistant for the Granit Showcase platform.',
@@ -128,10 +128,10 @@ export const mockWorkspaces: AIWorkspaceResponse[] = [
     kind: 'System',
     activated: true,
     capabilities: gpt4oCaps,
-    workspaceModelName: 'GPT-4o',
+    displayName: 'GPT-4o',
   },
   {
-    name: 'code-review',
+    key: 'code-review',
     provider: 'OpenAI',
     model: 'gpt-4o-mini',
     systemPrompt: 'You are a senior code reviewer. Be concise and actionable.',
@@ -140,10 +140,10 @@ export const mockWorkspaces: AIWorkspaceResponse[] = [
     kind: 'Dynamic',
     activated: true,
     capabilities: basicChatCaps,
-    workspaceModelName: null,
+    displayName: null,
   },
   {
-    name: 'translation',
+    key: 'translation',
     provider: 'AzureOpenAI',
     model: 'gpt-4o',
     systemPrompt: 'You are a professional translator. Translate accurately preserving tone.',
@@ -152,10 +152,10 @@ export const mockWorkspaces: AIWorkspaceResponse[] = [
     kind: 'Dynamic',
     activated: true,
     capabilities: gpt4oCaps,
-    workspaceModelName: null,
+    displayName: null,
   },
   {
-    name: 'summarizer',
+    key: 'summarizer',
     provider: 'Ollama',
     model: 'llama3.1',
     systemPrompt: null,
@@ -164,7 +164,7 @@ export const mockWorkspaces: AIWorkspaceResponse[] = [
     kind: 'Dynamic',
     activated: false,
     capabilities: ollamaCaps,
-    workspaceModelName: null,
+    displayName: null,
   },
 ];
 

--- a/packages/@granit/react-ai/src/testing/handlers.ts
+++ b/packages/@granit/react-ai/src/testing/handlers.ts
@@ -19,7 +19,7 @@ import type { Mutable } from '@granit/testing';
 export const aiWorkspaceQueryMetadata: QueryMetadata = {
   columns: [
     {
-      name: 'name',
+      name: 'key',
       label: 'Name',
       type: 'String',
       order: 0,
@@ -83,14 +83,14 @@ export const aiWorkspaceQueryMetadata: QueryMetadata = {
     },
   ],
   filterableFields: [
-    { name: 'name', type: 'String', operators: STRING_OPERATORS },
+    { name: 'key', type: 'String', operators: STRING_OPERATORS },
     { name: 'provider', type: 'String', operators: ENUM_OPERATORS },
     { name: 'model', type: 'String', operators: ENUM_OPERATORS },
     { name: 'kind', type: 'String', operators: ENUM_OPERATORS },
     { name: 'activated', type: 'Boolean', operators: BOOLEAN_OPERATORS },
   ],
   sortableFields: [
-    { name: 'name' },
+    { name: 'key' },
     { name: 'provider' },
     { name: 'model' },
     { name: 'kind' },
@@ -133,7 +133,7 @@ function addUsageRecord(
     ),
     tenantId: toEntityId<'Tenant'>('tenant-1'),
     userId: toEntityId<'User'>('user-1'),
-    workspaceName: ws.name,
+    workspaceName: ws.key,
     provider: ws.provider,
     model: ws.model,
     inputTokens,
@@ -332,8 +332,8 @@ export function createAIHandlers(baseUrl = '/api/v1/ai') {
     }),
 
     // GET single
-    http.get(`${baseUrl}/workspaces/:name`, ({ params }) => {
-      const ws = workspaces.find((w) => w.name === params.name);
+    http.get(`${baseUrl}/workspaces/:key`, ({ params }) => {
+      const ws = workspaces.find((w) => w.key === params.key);
       if (!ws) return new HttpResponse(null, { status: 404 });
       return HttpResponse.json(ws);
     }),
@@ -342,12 +342,12 @@ export function createAIHandlers(baseUrl = '/api/v1/ai') {
     http.post(`${baseUrl}/workspaces`, async ({ request }) => {
       const body = (await request.json()) as AIWorkspaceCreateRequest;
 
-      if (workspaces.some((w) => w.name === body.name)) {
+      if (workspaces.some((w) => w.key === body.key)) {
         return HttpResponse.json(
           {
             title: 'Conflict',
             status: 409,
-            detail: `A workspace named '${body.name}' already exists.`,
+            detail: `A workspace named '${body.key}' already exists.`,
           },
           { status: 409 }
         );
@@ -356,7 +356,7 @@ export function createAIHandlers(baseUrl = '/api/v1/ai') {
       const model = mockProviderModels[body.provider]?.find((m) => m.id === body.model);
 
       const created: AIWorkspaceResponse = {
-        name: body.name,
+        key: body.key,
         provider: body.provider,
         model: body.model,
         systemPrompt: body.systemPrompt ?? null,
@@ -365,7 +365,7 @@ export function createAIHandlers(baseUrl = '/api/v1/ai') {
         kind: 'Dynamic',
         activated: true,
         capabilities: model?.capabilities ?? null,
-        workspaceModelName: body.workspaceModelName ?? null,
+        displayName: body.displayName ?? null,
       };
 
       workspaces = [...workspaces, created];
@@ -373,9 +373,9 @@ export function createAIHandlers(baseUrl = '/api/v1/ai') {
     }),
 
     // PUT update
-    http.put(`${baseUrl}/workspaces/:name`, async ({ params, request }) => {
-      const name = params.name as string;
-      const index = workspaces.findIndex((w) => w.name === name);
+    http.put(`${baseUrl}/workspaces/:key`, async ({ params, request }) => {
+      const key = params.key as string;
+      const index = workspaces.findIndex((w) => w.key === key);
 
       if (index === -1) return new HttpResponse(null, { status: 404 });
 
@@ -386,7 +386,7 @@ export function createAIHandlers(baseUrl = '/api/v1/ai') {
           {
             title: 'Unprocessable Entity',
             status: 422,
-            detail: `System workspace '${name}' cannot be modified.`,
+            detail: `System workspace '${key}' cannot be modified.`,
           },
           { status: 422 }
         );
@@ -403,14 +403,14 @@ export function createAIHandlers(baseUrl = '/api/v1/ai') {
         activated: body.activated,
       };
 
-      workspaces = workspaces.map((w) => (w.name === name ? updated : w));
+      workspaces = workspaces.map((w) => (w.key === key ? updated : w));
       return HttpResponse.json(updated);
     }),
 
     // DELETE
-    http.delete(`${baseUrl}/workspaces/:name`, ({ params }) => {
-      const name = params.name as string;
-      const ws = workspaces.find((w) => w.name === name);
+    http.delete(`${baseUrl}/workspaces/:key`, ({ params }) => {
+      const key = params.key as string;
+      const ws = workspaces.find((w) => w.key === key);
 
       if (!ws) return new HttpResponse(null, { status: 404 });
 
@@ -419,13 +419,13 @@ export function createAIHandlers(baseUrl = '/api/v1/ai') {
           {
             title: 'Unprocessable Entity',
             status: 422,
-            detail: `System workspace '${name}' cannot be deleted.`,
+            detail: `System workspace '${key}' cannot be deleted.`,
           },
           { status: 422 }
         );
       }
 
-      workspaces = workspaces.filter((w) => w.name !== name);
+      workspaces = workspaces.filter((w) => w.key !== key);
       return new HttpResponse(null, { status: 204 });
     }),
 
@@ -434,7 +434,7 @@ export function createAIHandlers(baseUrl = '/api/v1/ai') {
     // SSE streaming endpoint (must be registered before the non-streaming route)
     http.post(`${baseUrl}/chat/:workspaceName/stream`, async ({ params, request }) => {
       const wsName = params.workspaceName as string;
-      const ws = workspaces.find((w) => w.name === wsName);
+      const ws = workspaces.find((w) => w.key === wsName);
 
       if (!ws) {
         return HttpResponse.json(
@@ -472,7 +472,7 @@ export function createAIHandlers(baseUrl = '/api/v1/ai') {
 
     http.post(`${baseUrl}/chat/:workspaceName`, async ({ params, request }) => {
       const wsName = params.workspaceName as string;
-      const ws = workspaces.find((w) => w.name === wsName);
+      const ws = workspaces.find((w) => w.key === wsName);
 
       if (!ws) {
         return HttpResponse.json(
@@ -506,7 +506,7 @@ export function createAIHandlers(baseUrl = '/api/v1/ai') {
 
     http.post(`${baseUrl}/embeddings/:workspaceName`, async ({ params, request }) => {
       const wsName = params.workspaceName as string;
-      const ws = workspaces.find((w) => w.name === wsName);
+      const ws = workspaces.find((w) => w.key === wsName);
 
       if (!ws) {
         return HttpResponse.json(

--- a/packages/@granit/react-ui-ai-chat/src/__tests__/chat-page.test.tsx
+++ b/packages/@granit/react-ui-ai-chat/src/__tests__/chat-page.test.tsx
@@ -95,8 +95,8 @@ vi.mock('@granit/react-ai', () => ({
   useAIWorkspaces: () => ({
     data: {
       workspaces: [
-        { name: 'Auto', workspaceModelName: null, model: null },
-        { name: 'support', workspaceModelName: 'GPT-4o', model: 'gpt-4o' },
+        { key: 'Auto', displayName: null, model: null },
+        { key: 'support', displayName: 'GPT-4o', model: 'gpt-4o' },
       ],
     },
   }),

--- a/packages/@granit/react-ui-ai-chat/src/__tests__/model-catalog.test.tsx
+++ b/packages/@granit/react-ui-ai-chat/src/__tests__/model-catalog.test.tsx
@@ -73,7 +73,7 @@ describe('buildWorkspaceOptions', () => {
   });
 
   it('uses the model id only for the icon, never as the picker label', () => {
-    // workspaceModelName set → label is the friendly display name; the raw model
+    // displayName set → label is the friendly display name; the raw model
     // id drives the brand but never leaks into the label.
     const [option] = buildWorkspaceOptions(
       ['general-chat'],

--- a/packages/@granit/react-ui-ai-chat/src/chat-page.tsx
+++ b/packages/@granit/react-ui-ai-chat/src/chat-page.tsx
@@ -203,16 +203,16 @@ function ChatSurface({ selectedId, initialWorkspaceKey }: Readonly<ChatSurfacePr
   );
 
   // From the admin workspace list, map each workspace key to its display label
-  // (workspaceModelName, "GPT-4o") and, separately, to the raw model id it runs
+  // (displayName, "GPT-4o") and, separately, to the raw model id it runs
   // ("deepseek-r1:7b"). The label drives the picker text; the model id drives the
   // brand icon — so a seeded workspace with no display label still shows the right
-  // provider glyph while keeping the workspace name as its label.
+  // provider glyph while keeping the workspace key as its label.
   const { modelNameByKey, modelByKey } = useMemo(() => {
     const labels: Record<string, string | null> = {};
     const models: Record<string, string | null> = {};
     for (const ws of aiWorkspaces.data?.workspaces ?? []) {
-      labels[ws.name] = ws.workspaceModelName;
-      models[ws.name] = ws.model;
+      labels[ws.key] = ws.displayName;
+      models[ws.key] = ws.model;
     }
     return { modelNameByKey: labels, modelByKey: models };
   }, [aiWorkspaces.data]);

--- a/packages/@granit/react-ui-ai-chat/src/model-catalog.tsx
+++ b/packages/@granit/react-ui-ai-chat/src/model-catalog.tsx
@@ -219,7 +219,7 @@ function capabilityGlyph(capability: Capability, t: TranslateFn): ReactNode {
  * mark under the "Available" group, so the list never breaks on unknown values.
  *
  * @param modelNameByKey - Optional map of workspace key → its display label
- *   (`AIWorkspaceResponse.workspaceModelName`, e.g. `GPT-4o`). Drives the picker
+ *   (`AIWorkspaceResponse.displayName`, e.g. `GPT-4o`). Drives the picker
  *   label and, when set, is also a brand-matching hint. Null/absent → the label
  *   falls back to the workspace name (never the raw model id).
  * @param modelByKey - Optional map of workspace key → the raw model id it runs

--- a/packages/@granit/react-ui-ai/src/__tests__/ai-workspace-create-page.test.tsx
+++ b/packages/@granit/react-ui-ai/src/__tests__/ai-workspace-create-page.test.tsx
@@ -14,7 +14,7 @@ const formMock = vi.hoisted(() => ({
     key: 'my-workspace',
     provider: 'OpenAI',
     model: 'gpt-4o',
-    workspaceModelName: 'GPT-4o',
+    displayName: 'GPT-4o',
     systemPrompt: 'be helpful',
     temperature: '0.7',
     maxOutputTokens: '4096',
@@ -55,14 +55,14 @@ vi.mock('../components/workspace-form', () => ({
 describe('AIWorkspaceCreatePage', () => {
   beforeEach(() => {
     createMock.mockReset();
-    createMock.mockResolvedValue({ name: 'my-workspace' });
+    createMock.mockResolvedValue({ key: 'my-workspace' });
     navigateMock.mockReset();
     toastMock.success.mockReset();
     formMock.submitValues = {
       key: 'my-workspace',
       provider: 'OpenAI',
       model: 'gpt-4o',
-      workspaceModelName: 'GPT-4o',
+      displayName: 'GPT-4o',
       systemPrompt: 'be helpful',
       temperature: '0.7',
       maxOutputTokens: '4096',
@@ -81,10 +81,10 @@ describe('AIWorkspaceCreatePage', () => {
 
     await waitFor(() =>
       expect(createMock).toHaveBeenCalledWith({
-        name: 'my-workspace',
+        key: 'my-workspace',
         provider: 'OpenAI',
         model: 'gpt-4o',
-        workspaceModelName: 'GPT-4o',
+        displayName: 'GPT-4o',
         systemPrompt: 'be helpful',
         temperature: 0.7,
         maxOutputTokens: 4096,
@@ -99,7 +99,7 @@ describe('AIWorkspaceCreatePage', () => {
       key: 'bare',
       provider: 'OpenAI',
       model: 'gpt-4o',
-      workspaceModelName: '',
+      displayName: '',
       systemPrompt: '',
       temperature: '',
       maxOutputTokens: '',
@@ -109,10 +109,10 @@ describe('AIWorkspaceCreatePage', () => {
 
     await waitFor(() =>
       expect(createMock).toHaveBeenCalledWith({
-        name: 'bare',
+        key: 'bare',
         provider: 'OpenAI',
         model: 'gpt-4o',
-        workspaceModelName: null,
+        displayName: null,
         systemPrompt: null,
         temperature: null,
         maxOutputTokens: null,

--- a/packages/@granit/react-ui-ai/src/__tests__/ai-workspace-edit-page.test.tsx
+++ b/packages/@granit/react-ui-ai/src/__tests__/ai-workspace-edit-page.test.tsx
@@ -8,7 +8,7 @@ import type { EditWorkspaceFormValues } from '../validation';
 import type { AIWorkspaceResponse } from '@granit/ai';
 
 const baseWorkspace: AIWorkspaceResponse = {
-  name: 'test-workspace',
+  key: 'test-workspace',
   provider: 'OpenAI',
   model: 'gpt-4o',
   systemPrompt: 'sys',
@@ -17,7 +17,7 @@ const baseWorkspace: AIWorkspaceResponse = {
   kind: 'Dynamic',
   activated: true,
   capabilities: null,
-  workspaceModelName: null,
+  displayName: null,
 };
 
 const state = vi.hoisted(() => ({
@@ -34,7 +34,7 @@ const formMock = vi.hoisted(() => ({
   submitValues: {
     provider: 'OpenAI',
     model: 'gpt-4o',
-    workspaceModelName: '',
+    displayName: '',
     systemPrompt: '',
     temperature: '',
     maxOutputTokens: '',
@@ -109,7 +109,7 @@ describe('AIWorkspaceEditPage', () => {
     formMock.submitValues = {
       provider: 'OpenAI',
       model: 'gpt-4o',
-      workspaceModelName: '',
+      displayName: '',
       systemPrompt: '',
       temperature: '',
       maxOutputTokens: '',
@@ -165,7 +165,7 @@ describe('AIWorkspaceEditPage', () => {
     formMock.submitValues = {
       provider: 'OpenAI',
       model: 'gpt-4o',
-      workspaceModelName: 'GPT-4o',
+      displayName: 'GPT-4o',
       systemPrompt: 'sys',
       temperature: '0.5',
       maxOutputTokens: '2048',
@@ -178,7 +178,7 @@ describe('AIWorkspaceEditPage', () => {
       expect(state.updateAsync).toHaveBeenCalledWith('test-workspace', {
         provider: 'OpenAI',
         model: 'gpt-4o',
-        workspaceModelName: 'GPT-4o',
+        displayName: 'GPT-4o',
         systemPrompt: 'sys',
         temperature: 0.5,
         maxOutputTokens: 2048,
@@ -196,7 +196,7 @@ describe('AIWorkspaceEditPage', () => {
       expect(state.updateAsync).toHaveBeenCalledWith('test-workspace', {
         provider: 'OpenAI',
         model: 'gpt-4o',
-        workspaceModelName: null,
+        displayName: null,
         systemPrompt: null,
         temperature: null,
         maxOutputTokens: null,

--- a/packages/@granit/react-ui-ai/src/__tests__/ai-workspace-list-page.test.tsx
+++ b/packages/@granit/react-ui-ai/src/__tests__/ai-workspace-list-page.test.tsx
@@ -92,14 +92,14 @@ describe('AIWorkspaceListPage', () => {
   it('renders the table rows for each workspace', () => {
     dataMock.data = { workspaces: mockWorkspaces };
     renderWithProviders(<AIWorkspaceListPage />);
-    expect(screen.getByText(mockWorkspaces[0]!.name)).toBeInTheDocument();
+    expect(screen.getByText(mockWorkspaces[0]!.key)).toBeInTheDocument();
   });
 
   it('navigates to the detail page when a table row is clicked', async () => {
     dataMock.data = { workspaces: mockWorkspaces };
     const { user } = renderWithProviders(<AIWorkspaceListPage />);
-    await user.click(screen.getByText(mockWorkspaces[0]!.name));
-    expect(navigateMock).toHaveBeenCalledWith(`/ai/workspaces/${mockWorkspaces[0]!.name}`);
+    await user.click(screen.getByText(mockWorkspaces[0]!.key));
+    expect(navigateMock).toHaveBeenCalledWith(`/ai/workspaces/${mockWorkspaces[0]!.key}`);
   });
 
   it('switches to the grid view and renders workspace cards', async () => {
@@ -121,7 +121,7 @@ describe('AIWorkspaceListPage', () => {
     // System card exposes a View button (read-only) and a System badge.
     expect(screen.getByText('System')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'View' }));
-    expect(navigateMock).toHaveBeenCalledWith(`/ai/workspaces/${systemWs.name}`);
+    expect(navigateMock).toHaveBeenCalledWith(`/ai/workspaces/${systemWs.key}`);
   });
 
   it('opens the delete dialog from a grid card Delete button', async () => {
@@ -142,13 +142,13 @@ describe('AIWorkspaceListPage', () => {
     dataMock.data = { workspaces: [dynamicWs] };
     const { user } = renderWithProviders(<AIWorkspaceListPage />);
 
-    await user.click(screen.getByRole('button', { name: `Actions for ${dynamicWs.name}` }));
+    await user.click(screen.getByRole('button', { name: `Actions for ${dynamicWs.key}` }));
     await user.click(screen.getByText('Delete'));
 
     const confirmButtons = screen.getAllByRole('button', { name: 'Delete' });
     await user.click(confirmButtons[confirmButtons.length - 1]!);
 
-    await waitFor(() => expect(dataMock.removeAsync).toHaveBeenCalledWith(dynamicWs.name));
+    await waitFor(() => expect(dataMock.removeAsync).toHaveBeenCalledWith(dynamicWs.key));
     await waitFor(() =>
       expect(toastMock.success).toHaveBeenCalledWith('Workspace deleted successfully')
     );
@@ -160,7 +160,7 @@ describe('AIWorkspaceListPage', () => {
     dataMock.removeAsync.mockRejectedValue(new Error('boom'));
     const { user } = renderWithProviders(<AIWorkspaceListPage />);
 
-    await user.click(screen.getByRole('button', { name: `Actions for ${dynamicWs.name}` }));
+    await user.click(screen.getByRole('button', { name: `Actions for ${dynamicWs.key}` }));
     await user.click(screen.getByText('Delete'));
     const confirmButtons = screen.getAllByRole('button', { name: 'Delete' });
     await user.click(confirmButtons[confirmButtons.length - 1]!);

--- a/packages/@granit/react-ui-ai/src/__tests__/workspace-columns.test.tsx
+++ b/packages/@granit/react-ui-ai/src/__tests__/workspace-columns.test.tsx
@@ -53,12 +53,12 @@ describe('createWorkspaceColumns', () => {
 
   it('exposes the expected column ids', () => {
     const ids = makeColumns().map((c) => c.id);
-    expect(ids).toEqual(['name', 'provider', 'model', 'kind', 'activated', 'actions']);
+    expect(ids).toEqual(['key', 'provider', 'model', 'kind', 'activated', 'actions']);
   });
 
   it('renders the name cell with the workspace name', () => {
-    renderCell(makeColumns(), 'name', dynamicWs);
-    expect(screen.getByText(dynamicWs.name)).toBeInTheDocument();
+    renderCell(makeColumns(), 'key', dynamicWs);
+    expect(screen.getByText(dynamicWs.key)).toBeInTheDocument();
   });
 
   it('renders the model cell with the model id', () => {
@@ -91,11 +91,11 @@ describe('createWorkspaceColumns', () => {
     const onDelete = vi.fn();
     const { user } = renderCell(makeColumns({ onEdit, onDelete }), 'actions', dynamicWs);
 
-    await user.click(screen.getByRole('button', { name: `Actions for ${dynamicWs.name}` }));
+    await user.click(screen.getByRole('button', { name: `Actions for ${dynamicWs.key}` }));
     await user.click(screen.getByText('Edit'));
     expect(onEdit).toHaveBeenCalledWith(dynamicWs);
 
-    await user.click(screen.getByRole('button', { name: `Actions for ${dynamicWs.name}` }));
+    await user.click(screen.getByRole('button', { name: `Actions for ${dynamicWs.key}` }));
     await user.click(screen.getByText('Delete'));
     expect(onDelete).toHaveBeenCalledWith(dynamicWs);
   });
@@ -104,7 +104,7 @@ describe('createWorkspaceColumns', () => {
     const onView = vi.fn();
     const { user } = renderCell(makeColumns({ onView }), 'actions', systemWs);
 
-    await user.click(screen.getByRole('button', { name: `Actions for ${systemWs.name}` }));
+    await user.click(screen.getByRole('button', { name: `Actions for ${systemWs.key}` }));
     expect(screen.queryByText('Edit')).not.toBeInTheDocument();
     expect(screen.queryByText('Delete')).not.toBeInTheDocument();
     await user.click(screen.getByText('View'));
@@ -115,7 +115,7 @@ describe('createWorkspaceColumns', () => {
     const onView = vi.fn();
     const { user } = renderCell(makeColumns({ onView, canManage: false }), 'actions', dynamicWs);
 
-    await user.click(screen.getByRole('button', { name: `Actions for ${dynamicWs.name}` }));
+    await user.click(screen.getByRole('button', { name: `Actions for ${dynamicWs.key}` }));
     expect(screen.queryByText('Delete')).not.toBeInTheDocument();
     await user.click(screen.getByText('View'));
     expect(onView).toHaveBeenCalledWith(dynamicWs);
@@ -123,7 +123,7 @@ describe('createWorkspaceColumns', () => {
 
   it('renders header strings via the translate fn', () => {
     const columns = makeColumns();
-    render(<>{getCol(columns, 'name').header as string}</>);
+    render(<>{getCol(columns, 'key').header as string}</>);
     expect(screen.getByText('Unique key')).toBeInTheDocument();
   });
 });

--- a/packages/@granit/react-ui-ai/src/__tests__/workspace-detail.test.tsx
+++ b/packages/@granit/react-ui-ai/src/__tests__/workspace-detail.test.tsx
@@ -29,13 +29,13 @@ describe('WorkspaceDetail', () => {
   it('shows the display name when present', () => {
     const ws = mockWorkspaces[0]!;
     renderWithProviders(<WorkspaceDetail workspace={ws} />);
-    expect(screen.getByText(ws.workspaceModelName!)).toBeInTheDocument();
+    expect(screen.getByText(ws.displayName!)).toBeInTheDocument();
   });
 
   it('falls back to a dash for missing optional values', () => {
     const ws: AIWorkspaceResponse = {
       ...mockWorkspaces[0]!,
-      workspaceModelName: null,
+      displayName: null,
       systemPrompt: null,
       temperature: null,
       maxOutputTokens: null,

--- a/packages/@granit/react-ui-ai/src/__tests__/workspace-form.test.tsx
+++ b/packages/@granit/react-ui-ai/src/__tests__/workspace-form.test.tsx
@@ -12,9 +12,9 @@ const providerState = vi.hoisted(() => ({ selected: undefined as string | undefi
 
 vi.mock('@granit/ai', () => ({
   AI_WORKSPACE_LIMITS: {
-    NAME_MAX_LENGTH: 128,
-    NAME_PATTERN: /^[a-z0-9][a-z0-9-]*$/,
-    MODEL_NAME_MAX_LENGTH: 64,
+    KEY_MAX_LENGTH: 128,
+    KEY_PATTERN: /^[a-z0-9][a-z0-9-]*$/,
+    DISPLAY_NAME_MAX_LENGTH: 64,
   },
 }));
 
@@ -105,7 +105,7 @@ describe('WorkspaceForm (edit)', () => {
   const defaultValues: EditWorkspaceFormValues = {
     provider: 'OpenAI',
     model: 'gpt-4o',
-    workspaceModelName: 'GPT-4o',
+    displayName: 'GPT-4o',
     systemPrompt: 'be helpful',
     temperature: 0.7,
     maxOutputTokens: 4096,

--- a/packages/@granit/react-ui-ai/src/__tests__/workspace-table.test.tsx
+++ b/packages/@granit/react-ui-ai/src/__tests__/workspace-table.test.tsx
@@ -9,7 +9,7 @@ import type { AIWorkspaceResponse } from '@granit/ai';
 import type { ColumnDef } from '@tanstack/react-table';
 
 const columns: ColumnDef<AIWorkspaceResponse, unknown>[] = [
-  { id: 'name', accessorKey: 'name', header: 'Name', cell: ({ row }) => row.original.name },
+  { id: 'key', accessorKey: 'key', header: 'Key', cell: ({ row }) => row.original.key },
   {
     id: 'provider',
     accessorKey: 'provider',
@@ -21,9 +21,9 @@ const columns: ColumnDef<AIWorkspaceResponse, unknown>[] = [
 describe('WorkspaceTable', () => {
   it('renders a header row and a body row per workspace', () => {
     renderWithProviders(<WorkspaceTable data={mockWorkspaces} columns={columns} />);
-    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Key')).toBeInTheDocument();
     for (const ws of mockWorkspaces) {
-      expect(screen.getByText(ws.name)).toBeInTheDocument();
+      expect(screen.getByText(ws.key)).toBeInTheDocument();
     }
   });
 
@@ -32,7 +32,7 @@ describe('WorkspaceTable', () => {
     const { user } = renderWithProviders(
       <WorkspaceTable data={mockWorkspaces} columns={columns} onRowClick={onRowClick} />
     );
-    await user.click(screen.getByText(mockWorkspaces[0]!.name));
+    await user.click(screen.getByText(mockWorkspaces[0]!.key));
     expect(onRowClick).toHaveBeenCalledWith(mockWorkspaces[0]);
   });
 

--- a/packages/@granit/react-ui-ai/src/__tests__/workspace-test-panel.test.tsx
+++ b/packages/@granit/react-ui-ai/src/__tests__/workspace-test-panel.test.tsx
@@ -53,7 +53,7 @@ const baseCaps: AIModelCapabilities = {
 
 function makeWorkspace(caps: Partial<AIModelCapabilities>): AIWorkspaceResponse {
   return {
-    name: 'test-ws',
+    key: 'test-ws',
     provider: 'OpenAI',
     model: 'gpt-4o',
     systemPrompt: null,
@@ -62,7 +62,7 @@ function makeWorkspace(caps: Partial<AIModelCapabilities>): AIWorkspaceResponse 
     kind: 'Dynamic',
     activated: true,
     capabilities: { ...baseCaps, ...caps },
-    workspaceModelName: null,
+    displayName: null,
   };
 }
 

--- a/packages/@granit/react-ui-ai/src/ai-workspace-create-page.tsx
+++ b/packages/@granit/react-ui-ai/src/ai-workspace-create-page.tsx
@@ -17,16 +17,16 @@ export function AIWorkspaceCreatePage() {
   const handleSubmit = async (data: CreateWorkspaceFormValues) => {
     try {
       const result = await createAsync({
-        name: data.key,
+        key: data.key,
         provider: data.provider,
         model: data.model,
-        workspaceModelName: data.workspaceModelName || null,
+        displayName: data.displayName || null,
         systemPrompt: data.systemPrompt || null,
         temperature: data.temperature ? Number(data.temperature) : null,
         maxOutputTokens: data.maxOutputTokens ? Number(data.maxOutputTokens) : null,
       });
       toast.success(t('AI.Workspaces.CreateSuccess'));
-      navigate(`/ai/workspaces/${result.name}`);
+      navigate(`/ai/workspaces/${result.key}`);
     } catch (err) {
       // API errors are surfaced by the global MutationCache.onError toast.
       logger.error('[AIWorkspaceCreatePage] Failed to create workspace', err);

--- a/packages/@granit/react-ui-ai/src/ai-workspace-edit-page.tsx
+++ b/packages/@granit/react-ui-ai/src/ai-workspace-edit-page.tsx
@@ -28,7 +28,7 @@ export function AIWorkspaceEditPage() {
       await updateAsync(name, {
         provider: data.provider,
         model: data.model,
-        workspaceModelName: data.workspaceModelName || null,
+        displayName: data.displayName || null,
         systemPrompt: data.systemPrompt || null,
         temperature: data.temperature ? Number(data.temperature) : null,
         maxOutputTokens: data.maxOutputTokens ? Number(data.maxOutputTokens) : null,
@@ -72,7 +72,7 @@ export function AIWorkspaceEditPage() {
   const defaultValues: EditWorkspaceFormValues = {
     provider: workspace.provider,
     model: workspace.model,
-    workspaceModelName: workspace.workspaceModelName ?? '',
+    displayName: workspace.displayName ?? '',
     systemPrompt: workspace.systemPrompt ?? '',
     temperature: workspace.temperature ?? ('' as const),
     maxOutputTokens: workspace.maxOutputTokens ?? ('' as const),
@@ -90,7 +90,7 @@ export function AIWorkspaceEditPage() {
         </Button>
         <Separator orientation="vertical" className="h-6" />
         <div>
-          <h2 className="text-2xl font-semibold text-foreground font-mono">{workspace.name}</h2>
+          <h2 className="text-2xl font-semibold text-foreground font-mono">{workspace.key}</h2>
           <p className="text-sm text-muted-foreground">
             {workspace.provider} / {workspace.model}
           </p>

--- a/packages/@granit/react-ui-ai/src/ai-workspace-list-page.tsx
+++ b/packages/@granit/react-ui-ai/src/ai-workspace-list-page.tsx
@@ -32,8 +32,8 @@ export function AIWorkspaceListPage() {
     () =>
       createWorkspaceColumns({
         t,
-        onView: (ws) => navigate(`/ai/workspaces/${ws.name}`),
-        onEdit: (ws) => navigate(`/ai/workspaces/${ws.name}`),
+        onView: (ws) => navigate(`/ai/workspaces/${ws.key}`),
+        onEdit: (ws) => navigate(`/ai/workspaces/${ws.key}`),
         onDelete: (ws) => setDeleteTarget(ws),
         canManage,
       }),
@@ -43,7 +43,7 @@ export function AIWorkspaceListPage() {
   const handleDelete = async () => {
     if (!deleteTarget) return;
     try {
-      await removeAsync(deleteTarget.name);
+      await removeAsync(deleteTarget.key);
       toast.success(t('AI.Workspaces.DeleteSuccess'));
       setDeleteTarget(null);
     } catch (err) {
@@ -84,20 +84,20 @@ export function AIWorkspaceListPage() {
         <WorkspaceTable
           data={workspaces}
           columns={columns}
-          onRowClick={(ws) => navigate(`/ai/workspaces/${ws.name}`)}
+          onRowClick={(ws) => navigate(`/ai/workspaces/${ws.key}`)}
         />
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {workspaces.map((ws) => (
             <Card
-              key={ws.name}
+              key={ws.key}
               className="cursor-pointer transition-colors hover:border-primary/50"
-              onClick={() => navigate(`/ai/workspaces/${ws.name}`)}
+              onClick={() => navigate(`/ai/workspaces/${ws.key}`)}
             >
               <CardContent className="pt-6">
                 <div className="flex items-start justify-between">
                   <div className="space-y-1">
-                    <p className="font-mono text-sm font-medium">{ws.name}</p>
+                    <p className="font-mono text-sm font-medium">{ws.key}</p>
                     <p className="text-xs text-muted-foreground">
                       {ws.provider} / {ws.model}
                     </p>
@@ -123,7 +123,7 @@ export function AIWorkspaceListPage() {
                       size="sm"
                       onClick={(e) => {
                         e.stopPropagation();
-                        navigate(`/ai/workspaces/${ws.name}`);
+                        navigate(`/ai/workspaces/${ws.key}`);
                       }}
                     >
                       {ws.kind === AI_WORKSPACE_KINDS.SYSTEM || !canManage

--- a/packages/@granit/react-ui-ai/src/components/workspace-columns.tsx
+++ b/packages/@granit/react-ui-ai/src/components/workspace-columns.tsx
@@ -32,10 +32,10 @@ export function createWorkspaceColumns({
 }: WorkspaceColumnOptions): ColumnDef<AIWorkspaceResponse, unknown>[] {
   return [
     {
-      id: 'name',
-      accessorKey: 'name',
+      id: 'key',
+      accessorKey: 'key',
       header: t('AI.Workspaces.Form.Key'),
-      cell: ({ row }) => <span className="font-mono text-sm font-medium">{row.original.name}</span>,
+      cell: ({ row }) => <span className="font-mono text-sm font-medium">{row.original.key}</span>,
     },
     {
       id: 'provider',
@@ -85,7 +85,7 @@ export function createWorkspaceColumns({
                 variant="ghost"
                 size="icon"
                 className="h-8 w-8"
-                aria-label={`Actions for ${ws.name}`}
+                aria-label={`Actions for ${ws.key}`}
               >
                 <MoreHorizontal className="h-4 w-4" />
               </Button>

--- a/packages/@granit/react-ui-ai/src/components/workspace-delete-dialog.tsx
+++ b/packages/@granit/react-ui-ai/src/components/workspace-delete-dialog.tsx
@@ -39,8 +39,8 @@ export function WorkspaceDeleteDialog({
           <AlertDialogTitle>{t('AI.Workspaces.DeleteDialog.Title')}</AlertDialogTitle>
           <AlertDialogDescription>
             {isSystem
-              ? t('AI.Workspaces.DeleteDialog.SystemWarning', { name: workspace?.name })
-              : t('AI.Workspaces.DeleteDialog.Description', { name: workspace?.name })}
+              ? t('AI.Workspaces.DeleteDialog.SystemWarning', { name: workspace?.key })
+              : t('AI.Workspaces.DeleteDialog.Description', { name: workspace?.key })}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/packages/@granit/react-ui-ai/src/components/workspace-detail.stories.tsx
+++ b/packages/@granit/react-ui-ai/src/components/workspace-detail.stories.tsx
@@ -4,7 +4,7 @@ import type { AIWorkspaceResponse } from '@granit/ai';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const workspace: AIWorkspaceResponse = {
-  name: 'default-chat',
+  key: 'default-chat',
   provider: 'OpenAI',
   model: 'gpt-4o',
   systemPrompt: 'You are a helpful assistant for the Granit platform.',

--- a/packages/@granit/react-ui-ai/src/components/workspace-detail.tsx
+++ b/packages/@granit/react-ui-ai/src/components/workspace-detail.tsx
@@ -29,8 +29,8 @@ export function WorkspaceDetail({ workspace }: WorkspaceDetailProps) {
             <Field label={t('AI.Workspaces.Form.ProviderName')} value={workspace.provider} />
             <Field label={t('AI.Workspaces.Form.Model')} value={workspace.model} mono />
           </div>
-          {workspace.workspaceModelName && (
-            <Field label={t('AI.Workspaces.Form.ModelName')} value={workspace.workspaceModelName} />
+          {workspace.displayName && (
+            <Field label={t('AI.Workspaces.Form.ModelName')} value={workspace.displayName} />
           )}
           <WorkspaceCapabilities capabilities={workspace.capabilities} />
         </CardContent>

--- a/packages/@granit/react-ui-ai/src/components/workspace-form.tsx
+++ b/packages/@granit/react-ui-ai/src/components/workspace-form.tsx
@@ -49,7 +49,7 @@ function slugifyKey(value: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+/, '')
-    .slice(0, AI_WORKSPACE_LIMITS.NAME_MAX_LENGTH);
+    .slice(0, AI_WORKSPACE_LIMITS.KEY_MAX_LENGTH);
 }
 
 interface WorkspaceFormBaseProps {
@@ -90,7 +90,7 @@ export function WorkspaceForm(props: Readonly<WorkspaceFormProps>) {
     defaultValues: {
       provider: '',
       model: '',
-      workspaceModelName: '',
+      displayName: '',
       systemPrompt: '',
       temperature: '',
       maxOutputTokens: '',
@@ -130,7 +130,7 @@ export function WorkspaceForm(props: Readonly<WorkspaceFormProps>) {
             <CardContent className="space-y-4">
               <FormField
                 control={form.control}
-                name="workspaceModelName"
+                name="displayName"
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>{t('AI.Workspaces.Form.ModelName')}</FormLabel>
@@ -249,7 +249,7 @@ export function WorkspaceForm(props: Readonly<WorkspaceFormProps>) {
             {!isCreate && (
               <FormField
                 control={form.control}
-                name="workspaceModelName"
+                name="displayName"
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>{t('AI.Workspaces.Form.ModelName')}</FormLabel>

--- a/packages/@granit/react-ui-ai/src/components/workspace-test-panel.tsx
+++ b/packages/@granit/react-ui-ai/src/components/workspace-test-panel.tsx
@@ -51,10 +51,10 @@ export function WorkspaceTestPanel({ workspace }: WorkspaceTestPanelProps) {
             </TabsTrigger>
           </TabsList>
           <TabsContent value="chat" className="mt-4">
-            <ChatTestTab workspaceName={workspace.name} />
+            <ChatTestTab workspaceName={workspace.key} />
           </TabsContent>
           <TabsContent value="embeddings" className="mt-4">
-            <EmbeddingsTestTab workspaceName={workspace.name} />
+            <EmbeddingsTestTab workspaceName={workspace.key} />
           </TabsContent>
         </Tabs>
       </CardContent>

--- a/packages/@granit/react-ui-ai/src/validation.ts
+++ b/packages/@granit/react-ui-ai/src/validation.ts
@@ -7,14 +7,13 @@ type TranslateFn = ReturnType<typeof useTranslation>['t'];
 
 export function createWorkspaceSchema(t: TranslateFn) {
   return z.object({
-    // UI vocabulary: the workspace's identifier slug is surfaced as "key"
-    // (matching the `workspaceKey` reference used on conversations/messages).
-    // Mapped back to the API's `name` field at the create-page boundary.
+    // The workspace's machine key (slug) — the API's `key` field, and the same
+    // value ai-chat references as `workspaceKey` on conversations/messages.
     key: z
       .string()
       .min(1, t('Validation.Required', { field: t('AI.Workspaces.Form.Key') }))
-      .max(AI_WORKSPACE_LIMITS.NAME_MAX_LENGTH)
-      .regex(AI_WORKSPACE_LIMITS.NAME_PATTERN, t('AI.Workspaces.Validation.NameFormat')),
+      .max(AI_WORKSPACE_LIMITS.KEY_MAX_LENGTH)
+      .regex(AI_WORKSPACE_LIMITS.KEY_PATTERN, t('AI.Workspaces.Validation.NameFormat')),
     provider: z
       .string()
       .min(1, t('Validation.Required', { field: t('AI.Workspaces.Form.ProviderName') }))
@@ -23,9 +22,9 @@ export function createWorkspaceSchema(t: TranslateFn) {
       .string()
       .min(1, t('Validation.Required', { field: t('AI.Workspaces.Form.Model') }))
       .max(128),
-    workspaceModelName: z
+    displayName: z
       .string()
-      .max(AI_WORKSPACE_LIMITS.MODEL_NAME_MAX_LENGTH)
+      .max(AI_WORKSPACE_LIMITS.DISPLAY_NAME_MAX_LENGTH)
       .optional()
       .or(z.literal('')),
     systemPrompt: z.string().max(32000).optional().or(z.literal('')),
@@ -44,9 +43,9 @@ export function editWorkspaceSchema(t: TranslateFn) {
       .string()
       .min(1, t('Validation.Required', { field: t('AI.Workspaces.Form.Model') }))
       .max(128),
-    workspaceModelName: z
+    displayName: z
       .string()
-      .max(AI_WORKSPACE_LIMITS.MODEL_NAME_MAX_LENGTH)
+      .max(AI_WORKSPACE_LIMITS.DISPLAY_NAME_MAX_LENGTH)
       .optional()
       .or(z.literal('')),
     systemPrompt: z.string().max(32000).optional().or(z.literal('')),


### PR DESCRIPTION
## What

The `Granit.AI` backend renamed the AI-workspace **identifier** from `Name` → **`Key`** (`AIWorkspaceEntity`, `AIWorkspaceCreateRequest/Response`, domain `AIWorkspace`) and the human-readable label `workspaceModelName` → **`displayName`**. The front contract had drifted — it still sent `{ name }` to a backend expecting `{ key }` (latent create bug), and `contracts/openapi/ai.json` was a stale snapshot.

This syncs the whole front AI surface to the shipped backend.

- **Re-vendor** `contracts/openapi/ai.json` from granit-dotnet's generated spec (`Granit.OpenApi.Generator`). Brings the `key` constraints (`maxLength 128` + slug `pattern`) into the spec and reorders `displayName` / `AIUsageRecord` fields.
- **@granit/ai**: `AIWorkspace{Response,CreateRequest,UpdateRequest}` `name`→`key` (+ field order to match spec), `workspaceModelName`→`displayName`; `AI_WORKSPACE_LIMITS` `NAME_*`→`KEY_*`, `MODEL_NAME_MAX_LENGTH`→`DISPLAY_NAME_MAX_LENGTH`; workspace api fns param `name`→`key`.
- **@granit/react-ai**: workspace hooks param `name`→`key`; testing fixtures + MSW handlers + QE field id aligned to `key`.
- **@granit/react-ui-ai**: drop the stale `{ name: data.key }` create-page remap (`key` is direct now); columns / detail / list / forms / tests `name`→`key`; corrected the validation comment.
- **@granit/react-ui-ai-chat**: workspace label/model maps keyed by `ws.key`, label from `ws.displayName`.

## Why

The form's `key` vocabulary was correct all along — the create-page `name: data.key` remap was the bug, mapping the right value back onto the wrong (stale) field. The chat/embedding/usage `workspaceName` echoes are unchanged (still `workspaceName` in the spec).

## Verification

- `pnpm tsc` (all packages) ✓
- eslint (ai / react-ai / react-ui-ai / react-ui-ai-chat) `--max-warnings 0` ✓
- vitest — **964 passed** across the 4 AI packages + `@granit/contract-tests` (the DTO-vs-spec oracle) ✓
- Rebased onto latest `develop` (#785).

Follow-up to the `/audit` discussion: `ai` was one of the modules flagged for keeping zod, and the root cause turned out to be this stale `name`/`key` contract drift.