### PR TITLE
test(react-ui): Storybook stories for documents + ai-prompts pages (audit G-1)

### DIFF
--- a/packages/@granit/react-ui-ai-prompts/src/prompt-catalogue-page.stories.tsx
+++ b/packages/@granit/react-ui-ai-prompts/src/prompt-catalogue-page.stories.tsx
@@ -1,0 +1,53 @@
+import { createApiClient } from '@granit/api-client';
+import { AIPromptsProvider } from '@granit/react-ai-prompts';
+import { createAIPromptsHandlers } from '@granit/react-ai-prompts/testing';
+import { GranitClientProvider } from '@granit/react-api-client';
+import { AuthorizationProvider } from '@granit/react-authorization';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { I18nextProvider } from 'react-i18next';
+import { MemoryRouter } from 'react-router-dom';
+
+import { PromptCataloguePage } from './prompt-catalogue-page';
+import { storyI18n } from './stories-i18n';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const client = createApiClient({ baseURL: '' });
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const meta: Meta<typeof PromptCataloguePage> = {
+  title: 'AI Prompts/PromptCataloguePage',
+  component: PromptCataloguePage,
+  tags: ['autodocs', '!test'],
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers: createAIPromptsHandlers() },
+  },
+  decorators: [
+    (Story) => (
+      <I18nextProvider i18n={storyI18n}>
+        <QueryClientProvider client={queryClient}>
+          <GranitClientProvider client={client}>
+            <AuthorizationProvider config={{}}>
+              <AIPromptsProvider config={{}}>
+                <MemoryRouter>
+                  <div className="p-6">
+                    <Story />
+                  </div>
+                </MemoryRouter>
+              </AIPromptsProvider>
+            </AuthorizationProvider>
+          </GranitClientProvider>
+        </QueryClientProvider>
+      </I18nextProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The catalogue listing system and own prompts, backed by the mock prompt handlers. */
+export const Default: Story = {};

--- a/packages/@granit/react-ui-ai-prompts/src/stories-i18n.ts
+++ b/packages/@granit/react-ui-ai-prompts/src/stories-i18n.ts
@@ -1,0 +1,22 @@
+import i18next from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import { aiPromptsAdminTranslationsEn } from './locales';
+
+// Shared i18next instance for Storybook stories. Mirrors the runtime flat-key
+// setup (separators disabled) and bundles the package's own AiPrompts.* admin
+// strings. The page references no Common.* keys (the host-owned Common.* block
+// stays empty), so only the package bundle is registered here.
+const Common = {} as const;
+
+export const storyI18n = i18next.createInstance();
+await storyI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  ns: ['translation'],
+  defaultNS: 'translation',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: { ...aiPromptsAdminTranslationsEn, ...Common } } },
+  interpolation: { escapeValue: false },
+});

--- a/packages/@granit/react-ui-documents/src/document-detail-page.stories.tsx
+++ b/packages/@granit/react-ui-documents/src/document-detail-page.stories.tsx
@@ -1,0 +1,55 @@
+import { createApiClient } from '@granit/api-client';
+import { AuthorizationProvider } from '@granit/react-authorization';
+import { DocumentsProvider } from '@granit/react-documents';
+import { createDocumentsHandlers, DOC_NDA_ID } from '@granit/react-documents/testing';
+import { TaxonomyProvider } from '@granit/react-taxonomy';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { I18nextProvider } from 'react-i18next';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { DocumentDetailPage } from './document-detail-page';
+import { storyI18n } from './stories-i18n';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const client = createApiClient({ baseURL: '' });
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const meta: Meta<typeof DocumentDetailPage> = {
+  title: 'Documents/DocumentDetailPage',
+  component: DocumentDetailPage,
+  tags: ['autodocs', '!test'],
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers: createDocumentsHandlers() },
+  },
+  decorators: [
+    (Story) => (
+      <I18nextProvider i18n={storyI18n}>
+        <QueryClientProvider client={queryClient}>
+          <AuthorizationProvider config={{ client }}>
+            <DocumentsProvider config={{ client }}>
+              <TaxonomyProvider config={{ client }}>
+                <MemoryRouter initialEntries={[`/documents/${DOC_NDA_ID}`]}>
+                  <div className="p-6">
+                    <Routes>
+                      <Route path="/documents/:id" element={<Story />} />
+                    </Routes>
+                  </div>
+                </MemoryRouter>
+              </TaxonomyProvider>
+            </DocumentsProvider>
+          </AuthorizationProvider>
+        </QueryClientProvider>
+      </I18nextProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Per-document detail view — header actions, tag/category strips, document summary, version timeline and shares dialog — for the NDA fixture, backed by the mock documents/versions/shares endpoints. */
+export const Default: Story = {};

--- a/packages/@granit/react-ui-documents/src/document-properties-page.stories.tsx
+++ b/packages/@granit/react-ui-documents/src/document-properties-page.stories.tsx
@@ -1,0 +1,49 @@
+import { createApiClient } from '@granit/api-client';
+import { DocumentsProvider } from '@granit/react-documents';
+import { createDocumentsHandlers, DOC_NDA_ID } from '@granit/react-documents/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { I18nextProvider } from 'react-i18next';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { DocumentPropertiesPage } from './document-properties-page';
+import { storyI18n } from './stories-i18n';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const client = createApiClient({ baseURL: '' });
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const meta: Meta<typeof DocumentPropertiesPage> = {
+  title: 'Documents/DocumentPropertiesPage',
+  component: DocumentPropertiesPage,
+  tags: ['autodocs', '!test'],
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers: createDocumentsHandlers() },
+  },
+  decorators: [
+    (Story) => (
+      <I18nextProvider i18n={storyI18n}>
+        <QueryClientProvider client={queryClient}>
+          <DocumentsProvider config={{ client }}>
+            <MemoryRouter initialEntries={[`/documents/${DOC_NDA_ID}/metadata`]}>
+              <div className="p-6">
+                <Routes>
+                  <Route path="/documents/:id/metadata" element={<Story />} />
+                </Routes>
+              </div>
+            </MemoryRouter>
+          </DocumentsProvider>
+        </QueryClientProvider>
+      </I18nextProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Extracted metadata for the NDA fixture document, served by the mock `/documents/{id}/metadata` endpoint. */
+export const Default: Story = {};

--- a/packages/@granit/react-ui-documents/src/document-public-links-page.stories.tsx
+++ b/packages/@granit/react-ui-documents/src/document-public-links-page.stories.tsx
@@ -1,0 +1,52 @@
+import { createApiClient } from '@granit/api-client';
+import { AuthorizationProvider } from '@granit/react-authorization';
+import { DocumentsProvider } from '@granit/react-documents';
+import { createDocumentsHandlers, DOC_NDA_ID } from '@granit/react-documents/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { I18nextProvider } from 'react-i18next';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { DocumentPublicLinksPage } from './document-public-links-page';
+import { storyI18n } from './stories-i18n';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const client = createApiClient({ baseURL: '' });
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const meta: Meta<typeof DocumentPublicLinksPage> = {
+  title: 'Documents/DocumentPublicLinksPage',
+  component: DocumentPublicLinksPage,
+  tags: ['autodocs', '!test'],
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers: createDocumentsHandlers() },
+  },
+  decorators: [
+    (Story) => (
+      <I18nextProvider i18n={storyI18n}>
+        <QueryClientProvider client={queryClient}>
+          <AuthorizationProvider config={{ client }}>
+            <DocumentsProvider config={{ client }}>
+              <MemoryRouter initialEntries={[`/documents/${DOC_NDA_ID}/public-links`]}>
+                <div className="p-6">
+                  <Routes>
+                    <Route path="/documents/:id/public-links" element={<Story />} />
+                  </Routes>
+                </div>
+              </MemoryRouter>
+            </DocumentsProvider>
+          </AuthorizationProvider>
+        </QueryClientProvider>
+      </I18nextProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Public-link management (create / revoke) for the NDA fixture document, backed by the mock `/documents/{id}/public-links` endpoints. */
+export const Default: Story = {};

--- a/packages/@granit/react-ui-documents/src/document-renditions-page.stories.tsx
+++ b/packages/@granit/react-ui-documents/src/document-renditions-page.stories.tsx
@@ -1,0 +1,49 @@
+import { createApiClient } from '@granit/api-client';
+import { DocumentsProvider } from '@granit/react-documents';
+import { createDocumentsHandlers, DOC_NDA_ID } from '@granit/react-documents/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { I18nextProvider } from 'react-i18next';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { DocumentRenditionsPage } from './document-renditions-page';
+import { storyI18n } from './stories-i18n';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const client = createApiClient({ baseURL: '' });
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const meta: Meta<typeof DocumentRenditionsPage> = {
+  title: 'Documents/DocumentRenditionsPage',
+  component: DocumentRenditionsPage,
+  tags: ['autodocs', '!test'],
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers: createDocumentsHandlers() },
+  },
+  decorators: [
+    (Story) => (
+      <I18nextProvider i18n={storyI18n}>
+        <QueryClientProvider client={queryClient}>
+          <DocumentsProvider config={{ client }}>
+            <MemoryRouter initialEntries={[`/documents/${DOC_NDA_ID}/renditions`]}>
+              <div className="p-6">
+                <Routes>
+                  <Route path="/documents/:id/renditions" element={<Story />} />
+                </Routes>
+              </div>
+            </MemoryRouter>
+          </DocumentsProvider>
+        </QueryClientProvider>
+      </I18nextProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Generated-format variants for the NDA fixture document, served by the mock `/documents/{id}/renditions` endpoint (empty list by default). */
+export const Default: Story = {};

--- a/packages/@granit/react-ui-documents/src/document-resolution-page.stories.tsx
+++ b/packages/@granit/react-ui-documents/src/document-resolution-page.stories.tsx
@@ -1,0 +1,47 @@
+import { createApiClient } from '@granit/api-client';
+import { DocumentsProvider } from '@granit/react-documents';
+import { createDocumentsHandlers } from '@granit/react-documents/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { I18nextProvider } from 'react-i18next';
+import { MemoryRouter } from 'react-router-dom';
+
+import { DocumentResolutionPage } from './document-resolution-page';
+import { storyI18n } from './stories-i18n';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const client = createApiClient({ baseURL: '' });
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const meta: Meta<typeof DocumentResolutionPage> = {
+  title: 'Documents/DocumentResolutionPage',
+  component: DocumentResolutionPage,
+  tags: ['autodocs', '!test'],
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers: createDocumentsHandlers() },
+  },
+  decorators: [
+    (Story) => (
+      <I18nextProvider i18n={storyI18n}>
+        <QueryClientProvider client={queryClient}>
+          <DocumentsProvider config={{ client }}>
+            <MemoryRouter initialEntries={['/documents/resolution']}>
+              <div className="p-6">
+                <Story />
+              </div>
+            </MemoryRouter>
+          </DocumentsProvider>
+        </QueryClientProvider>
+      </I18nextProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Batch document-ID → presigned-URL resolver wired to the mock `/resolution/resolve` endpoint. */
+export const Default: Story = {};

--- a/packages/@granit/react-ui-documents/src/documents-explorer-page.stories.tsx
+++ b/packages/@granit/react-ui-documents/src/documents-explorer-page.stories.tsx
@@ -1,0 +1,50 @@
+import { createApiClient } from '@granit/api-client';
+import { AuthorizationProvider } from '@granit/react-authorization';
+import { DocumentsProvider } from '@granit/react-documents';
+import { createDocumentsHandlers } from '@granit/react-documents/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { I18nextProvider } from 'react-i18next';
+import { MemoryRouter } from 'react-router-dom';
+
+import { DocumentsExplorerPage } from './documents-explorer-page';
+import { storyI18n } from './stories-i18n';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const client = createApiClient({ baseURL: '' });
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const meta: Meta<typeof DocumentsExplorerPage> = {
+  title: 'Documents/DocumentsExplorerPage',
+  component: DocumentsExplorerPage,
+  tags: ['autodocs', '!test'],
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers: createDocumentsHandlers() },
+  },
+  decorators: [
+    (Story) => (
+      <I18nextProvider i18n={storyI18n}>
+        <QueryClientProvider client={queryClient}>
+          <AuthorizationProvider config={{ client }}>
+            <DocumentsProvider config={{ client }}>
+              <MemoryRouter initialEntries={['/documents']}>
+                <div className="p-6">
+                  <Story />
+                </div>
+              </MemoryRouter>
+            </DocumentsProvider>
+          </AuthorizationProvider>
+        </QueryClientProvider>
+      </I18nextProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Full documents explorer — folder tree, list/grid, upload, inspector and quota badge — backed by the mock folders/documents/quota endpoints. */
+export const Default: Story = {};

--- a/packages/@granit/react-ui-documents/src/storage-quota-page.stories.tsx
+++ b/packages/@granit/react-ui-documents/src/storage-quota-page.stories.tsx
@@ -1,0 +1,47 @@
+import { createApiClient } from '@granit/api-client';
+import { DocumentsProvider } from '@granit/react-documents';
+import { createDocumentsHandlers } from '@granit/react-documents/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { I18nextProvider } from 'react-i18next';
+import { MemoryRouter } from 'react-router-dom';
+
+import { StorageQuotaPage } from './storage-quota-page';
+import { storyI18n } from './stories-i18n';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const client = createApiClient({ baseURL: '' });
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const meta: Meta<typeof StorageQuotaPage> = {
+  title: 'Documents/StorageQuotaPage',
+  component: StorageQuotaPage,
+  tags: ['autodocs', '!test'],
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers: createDocumentsHandlers() },
+  },
+  decorators: [
+    (Story) => (
+      <I18nextProvider i18n={storyI18n}>
+        <QueryClientProvider client={queryClient}>
+          <DocumentsProvider config={{ client }}>
+            <MemoryRouter initialEntries={['/documents/storage']}>
+              <div className="p-6">
+                <Story />
+              </div>
+            </MemoryRouter>
+          </DocumentsProvider>
+        </QueryClientProvider>
+      </I18nextProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Tenant-wide storage usage panel backed by the mock `/quota` endpoint. */
+export const Default: Story = {};

--- a/packages/@granit/react-ui-documents/src/stories-i18n.ts
+++ b/packages/@granit/react-ui-documents/src/stories-i18n.ts
@@ -1,0 +1,27 @@
+import i18next from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import { documentsAdminTranslationsEn } from './locales';
+
+// Shared i18next instance for Storybook stories. Mirrors the runtime flat-key
+// setup (separators disabled) and bundles this package's flat `documents:*` map
+// alongside the host-owned Common.* keys these components reference.
+//
+// The page components only ever call `t('documents:…')` (resolved verbatim from
+// the admin bundle below) and `t('taxonomy:…', '<fallback>')` (no taxonomy
+// bundle is registered, so those resolve to their inline fallback string).
+// None of the eight pages reference a `Common.*` key, so the block stays empty —
+// it is kept to mirror the api-keys template and document that fact.
+const Common = {} as const;
+
+export const storyI18n = i18next.createInstance();
+await storyI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  ns: ['translation'],
+  defaultNS: 'translation',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: { ...documentsAdminTranslationsEn, ...Common } } },
+  interpolation: { escapeValue: false },
+});

--- a/packages/@granit/react-ui-documents/src/trash-bin-page.stories.tsx
+++ b/packages/@granit/react-ui-documents/src/trash-bin-page.stories.tsx
@@ -1,0 +1,50 @@
+import { createApiClient } from '@granit/api-client';
+import { AuthorizationProvider } from '@granit/react-authorization';
+import { DocumentsProvider } from '@granit/react-documents';
+import { createDocumentsHandlers } from '@granit/react-documents/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { I18nextProvider } from 'react-i18next';
+import { MemoryRouter } from 'react-router-dom';
+
+import { storyI18n } from './stories-i18n';
+import { TrashBinPage } from './trash-bin-page';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const client = createApiClient({ baseURL: '' });
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const meta: Meta<typeof TrashBinPage> = {
+  title: 'Documents/TrashBinPage',
+  component: TrashBinPage,
+  tags: ['autodocs', '!test'],
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers: createDocumentsHandlers() },
+  },
+  decorators: [
+    (Story) => (
+      <I18nextProvider i18n={storyI18n}>
+        <QueryClientProvider client={queryClient}>
+          <AuthorizationProvider config={{ client }}>
+            <DocumentsProvider config={{ client }}>
+              <MemoryRouter initialEntries={['/documents/trash']}>
+                <div className="p-6">
+                  <Story />
+                </div>
+              </MemoryRouter>
+            </DocumentsProvider>
+          </AuthorizationProvider>
+        </QueryClientProvider>
+      </I18nextProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Trashed-documents list (restore / permanent-delete) backed by the mock `/documents/trash` endpoint. */
+export const Default: Story = {};


### PR DESCRIPTION
## Why

Closes the flagship Storybook-coverage gaps from the `react-ui` audit (finding G-1):
the two packages with non-trivial pages and **zero** stories.

| Package | Before | After |
| --- | --- | --- |
| `@granit/react-ui-documents` | 0 stories / 8 pages | **8 stories** |
| `@granit/react-ui-ai-prompts` | 0 stories / 1 page | **1 story** |

## What

- **documents** — one story per page (detail, properties, public-links, renditions,
  resolution, explorer, storage-quota, trash-bin) + a `stories-i18n` instance. Each
  composes the module providers (Documents / Authorization / Taxonomy) with a story
  Axios client and MSW handlers via `createDocumentsHandlers()`; the four `useParams`
  pages drive a fixture id (`DOC_NDA_ID`) through a matching `MemoryRouter` route.
- **ai-prompts** — `prompt-catalogue-page` story + `stories-i18n`, MSW via
  `createAIPromptsHandlers()`.

All follow the established `api-key-list-page.stories.tsx` template and carry
`tags: ['autodocs','!test']` (docs-only, excluded from the vitest storybook runner —
the tier convention for data-driven page stories).

## Verification

`pnpm tsc` (all packages) + `pnpm lint` (both packages) green. No runtime/export
changes (no dep, lockfile, or front-index churn). Stories are validated by tsc+lint,
matching how the tier gates `!test` page stories.

## Not in scope

`react-ui-authentication-federated` (0/2) is a thin presentational auth aggregator —
left for a later pass per the audit's auth-package exemption.