### PR TITLE
build(deps): pin js-yaml to 4.x so markdownlint-cli2 runs again

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
       "dompurify": ">=3.4.11",
       "esbuild": ">=0.28.1",
       "js-cookie": ">=3.0.7",
-      "js-yaml": ">=4.2.0",
+      "js-yaml": "^4.2.0",
       "markdown-it": ">=14.2.0",
       "msw": "^2.14.6",
       "picomatch": ">=4.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   dompurify: '>=3.4.11'
   esbuild: '>=0.28.1'
   js-cookie: '>=3.0.7'
-  js-yaml: '>=4.2.0'
+  js-yaml: ^4.2.0
   markdown-it: '>=14.2.0'
   msw: ^2.14.6
   picomatch: '>=4.0.4'
@@ -11493,8 +11493,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.1.0:
-    resolution: {integrity: sha512-s8VA5jkR8f22S3NAXmhKPFqGUduqZGlsufabVOgN14iTdw/RXcym7bKkbwjxLK9Yw2lEvvmJjFp119+KPeo8Kg==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -16729,7 +16729,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 5.1.0
+      js-yaml: 4.2.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -17455,7 +17455,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.1.0:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -17668,7 +17668,7 @@ snapshots:
   markdownlint-cli2@0.22.1:
     dependencies:
       globby: 16.2.0
-      js-yaml: 5.1.0
+      js-yaml: 4.2.0
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
       markdown-it: 14.2.0


### PR DESCRIPTION
## Problem

The `.md` lint step (`markdownlint-cli2` in lint-staged / pre-commit) was **broken
repo-wide**: it crashed on every markdown file with

```
SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'
```

Root cause: the pnpm override `"js-yaml": ">=4.2.0"` (introduced by the bulk
"update all to latest" in #710) resolved to **js-yaml 5.1.0**. v5 went ESM-native
and dropped the default export, but `markdownlint-cli2@0.22.1` imports it as
`import yaml from 'js-yaml'`. The override (more specific than markdownlint's own
`js-yaml: 4.1.1` request) forced v5 everywhere, so the tool could not load.

This silently disabled the "all `.md` must pass markdownlint" convention — markdown
commits only got through via `--no-verify`.

## Fix

`"js-yaml": ">=4.2.0"` → `"js-yaml": "^4.2.0"` (i.e. `>=4.2.0 <5`). js-yaml **4.2.0**
exists, satisfies the original `>=4.2.0` floor, and keeps the v4 default export that
markdownlint needs. Nothing in the tree requires v5 (it was only present because of
the override), so constraining to the 4.x line is safe.

## Verification

- `js-yaml` now resolves to **4.2.0** (was 5.1.0).
- `markdownlint-cli2` runs cleanly — lints all 4 repo docs with **0 errors**.
- `eslint` + `tsc` unaffected (smoke-checked).
- Diff is only the override + lockfile.