### PR TITLE
fix(deps): break api-client/testing workspace dependency cycle

### DIFF
--- a/packages/@granit/api-client/package.json
+++ b/packages/@granit/api-client/package.json
@@ -5,8 +5,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./test-utils": "./src/test-utils.ts"
+    ".": "./src/index.ts"
   },
   "files": [
     "dist"
@@ -15,19 +14,14 @@
     "build": "tsup"
   },
   "devDependencies": {
-    "@granit/logger": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/logger": "workspace:*"
   },
   "peerDependencies": {
     "@granit/logger": "workspace:*",
-    "@granit/testing": "workspace:*",
     "axios": "^1.6.0"
   },
   "peerDependenciesMeta": {
     "@granit/logger": {
-      "optional": true
-    },
-    "@granit/testing": {
       "optional": true
     }
   },
@@ -36,10 +30,6 @@
       ".": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
-      },
-      "./test-utils": {
-        "types": "./dist/test-utils.d.ts",
-        "import": "./dist/test-utils.js"
       }
     },
     "registry": "https://npm.pkg.github.com"

--- a/packages/@granit/api-client/src/test-utils.ts
+++ b/packages/@granit/api-client/src/test-utils.ts
@@ -1,5 +1,0 @@
-// ---------------------------------------------------------------------------
-// Backward-compatible re-exports from @granit/testing
-// ---------------------------------------------------------------------------
-
-export { axiosResponse, createMockClient } from '@granit/testing';

--- a/packages/@granit/logger/package.json
+++ b/packages/@granit/logger/package.json
@@ -13,9 +13,6 @@
   "scripts": {
     "build": "tsup"
   },
-  "devDependencies": {
-    "@granit/testing": "workspace:*"
-  },
   "publishConfig": {
     "exports": {
       ".": {

--- a/packages/@granit/notifications/src/__tests__/notification-api.test.ts
+++ b/packages/@granit/notifications/src/__tests__/notification-api.test.ts
@@ -1,4 +1,4 @@
-import { axiosResponse, createMockClient } from '@granit/api-client/test-utils';
+import { axiosResponse, createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
 import {

--- a/packages/@granit/presence/src/__tests__/presence-api.test.ts
+++ b/packages/@granit/presence/src/__tests__/presence-api.test.ts
@@ -1,4 +1,4 @@
-import { axiosResponse, createMockClient } from '@granit/api-client/test-utils';
+import { axiosResponse, createMockClient } from '@granit/testing';
 import { toEntityId, toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 

--- a/packages/@granit/presence/src/__tests__/presence-rooms-api.test.ts
+++ b/packages/@granit/presence/src/__tests__/presence-rooms-api.test.ts
@@ -1,4 +1,4 @@
-import { axiosResponse, createMockClient } from '@granit/api-client/test-utils';
+import { axiosResponse, createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
 import { getResourceRoom, joinResourceRoom, leaveResourceRoom } from '../api/presence-rooms-api';

--- a/packages/@granit/templating/src/__tests__/api.test.ts
+++ b/packages/@granit/templating/src/__tests__/api.test.ts
@@ -1,4 +1,4 @@
-import { axiosResponse, createMockClient } from '@granit/api-client/test-utils';
+import { axiosResponse, createMockClient } from '@granit/testing';
 import { toEntityId, toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 

--- a/packages/@granit/workflow/src/__tests__/api.test.ts
+++ b/packages/@granit/workflow/src/__tests__/api.test.ts
@@ -1,4 +1,4 @@
-import { axiosResponse, createMockClient } from '@granit/api-client/test-utils';
+import { axiosResponse, createMockClient } from '@granit/testing';
 import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -31,7 +31,12 @@ describe('workflow api', () => {
     expect(client.get).toHaveBeenCalledWith('/api/v1/workflow/Document/doc-1/history', {
       params: {},
     });
-    expect(result).toEqual({ items: historyItems, totalCount: 1, hasMore: false, nextCursor: null });
+    expect(result).toEqual({
+      items: historyItems,
+      totalCount: 1,
+      hasMore: false,
+      nextCursor: null,
+    });
   });
 
   it('should call GET with query param for listTransitions', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,9 +315,6 @@ importers:
       '@granit/logger':
         specifier: workspace:*
         version: link:../logger
-      '@granit/testing':
-        specifier: workspace:*
-        version: link:../testing
 
   packages/@granit/arch-tests:
     devDependencies:
@@ -857,11 +854,7 @@ importers:
         specifier: workspace:*
         version: link:../types
 
-  packages/@granit/logger:
-    devDependencies:
-      '@granit/testing':
-        specifier: workspace:*
-        version: link:../testing
+  packages/@granit/logger: {}
 
   packages/@granit/logger-otlp:
     devDependencies:


### PR DESCRIPTION
## Problem

pnpm emitted `WARN There are cyclic workspace dependencies` for `@granit/api-client` and `@granit/testing`. There were actually **two** cycles — the second only surfaced once the first was broken.

## Root cause

**Cycle 1 — `api-client ↔ testing`**
- `api-client → testing`: a backward-compat re-export shim (`src/test-utils.ts`, exposed via the `./test-utils` subpath) re-exporting `axiosResponse`/`createMockClient` from `@granit/testing`.
- `testing → api-client`: a **type-only** import of the Axios type façade — the natural, intended direction (the mock depends on the client it mocks).

**Cycle 2 — `api-client → logger → testing → api-client`**
- Kept alive by a **dead** `@granit/testing` devDependency in `@granit/logger` that no source file imports.

## Fix

- Delete the `test-utils` shim, its `./test-utils` export, and the `@granit/testing` dev/peer dep from `@granit/api-client`.
- Point the 5 consumer tests (`presence` ×2, `notifications`, `templating`, `workflow`) at `@granit/testing` directly — all already declare it as a devDependency.
- Drop the unused `@granit/testing` devDependency from `@granit/logger`.

Dependencies now flow one way (`testing → api-client`, type-only); pnpm reports no cycle.

## Verification (in a worktree off `origin/develop`, warm store)

- `pnpm install` — **no cyclic-dependency warning**
- `tsc --noEmit` — clean on all 7 touched packages
- ESLint — clean on the 5 modified test files
- Tests — **294/294 passing** (api-client, testing, logger + 4 consumers)
- arch-tests — 3118 passing; 1 **pre-existing** failure unrelated to this diff (`react-ui-ai-prompts/prompt-catalogue-page.stories.tsx` undeclared imports)