### PR TITLE
feat(privacy): migrate legal-document list to QueryEngine

### DIFF
--- a/packages/@granit/privacy/package.json
+++ b/packages/@granit/privacy/package.json
@@ -15,11 +15,13 @@
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/types": "workspace:*",
     "@granit/validation": "workspace:*"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*",
     "@granit/validation": "workspace:*"

--- a/packages/@granit/privacy/src/__tests__/privacy-api.test.ts
+++ b/packages/@granit/privacy/src/__tests__/privacy-api.test.ts
@@ -334,28 +334,32 @@ describe('privacy-api', () => {
   });
 
   describe('listLegalDocuments', () => {
-    it('sends GET to /legal-documents with params', async () => {
+    it('sends GET to /legal-documents with QueryEngine filter for documentId', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValueOnce({ data: [mockDocument] });
+      vi.mocked(client.get).mockResolvedValueOnce({
+        data: { items: [mockDocument], totalCount: 1 },
+      });
 
       const result = await listLegalDocuments(client, BASE, { documentId: 'privacy-policy' });
 
       expect(client.get).toHaveBeenCalledWith(`${BASE}/legal-documents`, {
-        params: { documentId: 'privacy-policy' },
+        params: { 'filter[documentId.eq]': 'privacy-policy' },
       });
-      expect(result).toEqual([mockDocument]);
+      expect(result).toEqual({ items: [mockDocument], totalCount: 1 });
     });
 
     it('sends GET to /legal-documents without params', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValueOnce({ data: [mockDocument] });
+      vi.mocked(client.get).mockResolvedValueOnce({
+        data: { items: [mockDocument], totalCount: 1 },
+      });
 
       const result = await listLegalDocuments(client, BASE);
 
       expect(client.get).toHaveBeenCalledWith(`${BASE}/legal-documents`, {
         params: undefined,
       });
-      expect(result).toEqual([mockDocument]);
+      expect(result).toEqual({ items: [mockDocument], totalCount: 1 });
     });
   });
 

--- a/packages/@granit/privacy/src/api/privacy-api.ts
+++ b/packages/@granit/privacy/src/api/privacy-api.ts
@@ -1,3 +1,5 @@
+import type { PagedResult } from '@granit/query-engine';
+
 import type {
   LegalDocumentCreateRequest,
   LegalDocumentDetailResponse,
@@ -231,7 +233,7 @@ export async function getLegalDocument(
 }
 
 /**
- * List legal document versions, optionally filtered by document ID.
+ * List legal document versions via the query engine. Optionally filter by document ID.
  *
  * `GET {basePath}/legal-documents`
  */
@@ -239,10 +241,15 @@ export async function listLegalDocuments(
   client: AxiosInstance,
   basePath: string,
   params?: LegalDocumentListParams
-): Promise<LegalDocumentDetailResponse[]> {
-  const { data } = await client.get<LegalDocumentDetailResponse[]>(`${basePath}/legal-documents`, {
-    params,
-  });
+): Promise<PagedResult<LegalDocumentDetailResponse>> {
+  const queryParams: Record<string, string> = {};
+  if (params?.documentId) {
+    queryParams['filter[documentId.eq]'] = params.documentId;
+  }
+  const { data } = await client.get<PagedResult<LegalDocumentDetailResponse>>(
+    `${basePath}/legal-documents`,
+    { params: Object.keys(queryParams).length > 0 ? queryParams : undefined }
+  );
   return data;
 }
 

--- a/packages/@granit/privacy/src/api/privacy-api.ts
+++ b/packages/@granit/privacy/src/api/privacy-api.ts
@@ -1,5 +1,3 @@
-import type { PagedResult } from '@granit/query-engine';
-
 import type {
   LegalDocumentCreateRequest,
   LegalDocumentDetailResponse,
@@ -22,6 +20,7 @@ import type {
   PrivacyUserAgreementResponse,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
+import type { PagedResult } from '@granit/query-engine';
 
 // ── Data Export (GDPR Art. 15/20) ────────────────────────────────────────────
 

--- a/packages/@granit/react-privacy/src/__tests__/use-legal-documents.test.tsx
+++ b/packages/@granit/react-privacy/src/__tests__/use-legal-documents.test.tsx
@@ -70,7 +70,7 @@ const mockDocument: LegalDocumentDetailResponse = {
 
 describe('useLegalDocuments', () => {
   it('should fetch all legal documents', async () => {
-    vi.mocked(listLegalDocuments).mockResolvedValueOnce([mockDocument]);
+    vi.mocked(listLegalDocuments).mockResolvedValueOnce({ items: [mockDocument], totalCount: 1 });
 
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useLegalDocuments(), { wrapper });
@@ -82,7 +82,7 @@ describe('useLegalDocuments', () => {
   });
 
   it('should pass documentId filter params', async () => {
-    vi.mocked(listLegalDocuments).mockResolvedValueOnce([mockDocument]);
+    vi.mocked(listLegalDocuments).mockResolvedValueOnce({ items: [mockDocument], totalCount: 1 });
 
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useLegalDocuments({ documentId: 'privacy-policy' }), {

--- a/packages/@granit/react-privacy/src/hooks/use-legal-documents.ts
+++ b/packages/@granit/react-privacy/src/hooks/use-legal-documents.ts
@@ -25,7 +25,10 @@ export function useLegalDocuments(
 
   return useQuery({
     queryKey: [...buildPrivacyQueryKey(config, 'legal-documents'), params],
-    queryFn: () => listLegalDocuments(config.client, config.basePath!, params),
+    queryFn: async () => {
+      const result = await listLegalDocuments(config.client, config.basePath!, params);
+      return result.items as LegalDocumentDetailResponse[];
+    },
   });
 }
 

--- a/packages/@granit/react-privacy/src/testing/handlers.ts
+++ b/packages/@granit/react-privacy/src/testing/handlers.ts
@@ -515,20 +515,20 @@ export function createPrivacyHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return new HttpResponse(null, { status: 201 });
     }),
 
-    // GET /legal-documents — list all, optionally filtered by documentId
+    // GET /legal-documents — QueryEngine list; filter[documentId.eq] for version history
     http.get(legalBase, ({ request }) => {
       const url = new URL(request.url);
-      const documentId = url.searchParams.get('documentId');
+      const documentIdFilter = url.searchParams.get('filter[documentId.eq]');
 
-      let result = legalDocuments as LegalDocumentDetailResponse[];
-      if (documentId) {
-        result = legalDocuments.filter(
-          (d) => d.documentId === documentId
+      let items = legalDocuments as LegalDocumentDetailResponse[];
+      if (documentIdFilter) {
+        items = legalDocuments.filter(
+          (d) => d.documentId === documentIdFilter
         ) as LegalDocumentDetailResponse[];
       }
 
-      result = [...result].sort((a, b) => b.version - a.version);
-      return HttpResponse.json(result);
+      items = [...items].sort((a, b) => b.version - a.version);
+      return HttpResponse.json({ items, totalCount: items.length });
     }),
 
     // GET /legal-documents/:id — single document by id


### PR DESCRIPTION
## Summary

- `listLegalDocuments` now returns `PagedResult<LegalDocumentDetailResponse>` and translates the `documentId` param into `filter[documentId.eq]` bracket notation expected by the QueryEngine backend (granit-dotnet PR #2843, merged).
- `useLegalDocuments` extracts `.items` internally — callers keep the same `LegalDocumentDetailResponse[]` return type with no component changes.
- `@granit/query-engine` added as peer + dev dependency to `@granit/privacy`.
- MSW handlers updated to return `{ items, totalCount }` (PagedResult shape).
- Unit tests updated for new return type.

## Test plan

- [ ] `LegalDocumentListPage` loads without 500 — full list renders with no `documentId` filter active
- [ ] Filter by document ID via version history page — `filter[documentId.eq]=privacy-policy` scopes results
- [ ] `pnpm test --filter @granit/privacy` and `pnpm test --filter @granit/react-privacy` pass