### PR TITLE
fix(react-documents): retry: 0 on finalize and append-version mutations

### DIFF
--- a/packages/@granit/react-documents/src/hooks/use-document-mutations.ts
+++ b/packages/@granit/react-documents/src/hooks/use-document-mutations.ts
@@ -111,6 +111,10 @@ export function useFinalizeUpload(): UseMutationResult<
   return useMutation({
     mutationFn: (request: FinalizeUploadRequest) =>
       finalizeUpload(config.client, config.basePath, request),
+    // blobId is single-use: once the blob is Rejected it cannot be re-confirmed.
+    // Retrying with the same blobId escalates a 422 validation error into a
+    // confusing 400 BlobNotValidException. Never retry this mutation.
+    retry: 0,
     onSuccess: (data) => {
       logger.debug('Document upload finalized', { id: data.id });
       invalidateAllFolders(queryClient, config);
@@ -243,6 +247,8 @@ export function useAppendDocumentVersion(): UseMutationResult<
   return useMutation({
     mutationFn: ({ id, request }: DocumentIdMutationArgs<AppendVersionRequest>) =>
       appendDocumentVersion(config.client, config.basePath, id, request),
+    // Same blobId single-use constraint as useFinalizeUpload — never retry.
+    retry: 0,
     onSuccess: (_data, { id }) => {
       logger.debug('Document version appended', { id });
       invalidateDocumentVersions(queryClient, config, id);


### PR DESCRIPTION
## Summary

As a Développeur, when a document upload's finalize step fails due to blob validation, I expect a single clear error rather than the failure escalating to a different (more confusing) HTTP status on retry.

**Root cause:** The global mutation retry config (`mutationMaxAttempts=2`) retried `useFinalizeUpload` and `useAppendDocumentVersion` with the same `blobId` after a validation failure. Since a `blobId` is single-use (once the blob is `Rejected` it cannot be re-confirmed), the retry triggered `BlobNotValidException` on the backend — returning HTTP 400 instead of the expected 422.

**Fix:** Set `retry: 0` on `useFinalizeUpload` and `useAppendDocumentVersion`. These mutations are non-idempotent by nature: every retry uses the same single-use `blobId`, so retrying after any failure is always wrong.

## Related

Found while diagnosing `POST /documents/finalize 400` errors.
Companion fixes:
- `granit-dotnet`: `MagicBytesValidator` now accepts ZIP-based Office container formats (root cause fix)
- `granit-business`: `ConfirmAndAdjustReservationAsync` maps `BlobNotValidException` → `InvalidOperationException` (defense-in-depth)

## Test plan

- [ ] Upload a file where finalize fails → single error shown, no second request fired (check network tab)
- [ ] Upload a valid file → still succeeds (regression)
- [ ] Append a version where finalize fails → single error, no retry
- [ ] Append a valid version → still succeeds (regression)