### PR TITLE
feat(react-entities): add multiselect standard form component

### DIFF
--- a/packages/@granit/react-entities/src/__tests__/standard-form-components.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/standard-form-components.test.tsx
@@ -169,6 +169,92 @@ describe('STANDARD_FORM_COMPONENTS', () => {
     expect(container.querySelector('[data-granit-select-misconfigured]')).not.toBeNull();
   });
 
+  // -------------------------------------------------------------------------
+  // multiselect — the default for [Flags] enum fields. The wire value is a
+  // single comma-separated string (STJ JsonStringEnumConverter), e.g.
+  // "Customer, Supplier", NOT a JSON array. "None"/null/"" mean the empty set.
+  // -------------------------------------------------------------------------
+
+  function flagsVariant() {
+    return singleFieldVariant(
+      field('multiselect', {
+        config: {
+          options: [
+            { value: 'Customer', labelKey: 'Enum:PartyRoles.Customer' },
+            { value: 'Supplier', labelKey: 'Enum:PartyRoles.Supplier' },
+            { value: 'Employee', labelKey: null },
+          ],
+        },
+      })
+    );
+  }
+
+  function setSelection(select: HTMLSelectElement, values: readonly string[]) {
+    for (const option of Array.from(select.options)) {
+      option.selected = values.includes(option.value);
+    }
+    fireEvent.change(select);
+  }
+
+  it('multiselect — parses the comma-joined string into selected options', () => {
+    const { container } = harness(flagsVariant(), 'Customer, Supplier');
+    const select = container.querySelector('select') as HTMLSelectElement;
+    expect(select.multiple).toBe(true);
+    const selected = Array.from(select.selectedOptions, (o) => o.value);
+    expect(selected).toEqual(['Customer', 'Supplier']);
+  });
+
+  it('multiselect — selecting options emits the comma-joined string', () => {
+    const { container, onChange } = harness(flagsVariant(), 'Customer');
+    const select = container.querySelector('select') as HTMLSelectElement;
+    setSelection(select, ['Customer', 'Supplier']);
+    expect(onChange).toHaveBeenLastCalledWith({ X: 'Customer, Supplier' });
+  });
+
+  it('multiselect — deselecting an option round-trips the remaining flag', () => {
+    const { container, onChange } = harness(flagsVariant(), 'Customer, Supplier');
+    const select = container.querySelector('select') as HTMLSelectElement;
+    setSelection(select, ['Supplier']);
+    expect(onChange).toHaveBeenLastCalledWith({ X: 'Supplier' });
+  });
+
+  it('multiselect — deselecting everything emits the "None" zero-member token', () => {
+    const { container, onChange } = harness(flagsVariant(), 'Customer');
+    const select = container.querySelector('select') as HTMLSelectElement;
+    setSelection(select, []);
+    expect(onChange).toHaveBeenLastCalledWith({ X: 'None' });
+  });
+
+  it.each([
+    { label: 'None', value: 'None' },
+    { label: 'empty string', value: '' },
+    { label: 'null', value: null },
+  ])('multiselect — treats $label as the empty set', ({ value }) => {
+    const { container } = harness(flagsVariant(), value);
+    const select = container.querySelector('select') as HTMLSelectElement;
+    expect(Array.from(select.selectedOptions)).toHaveLength(0);
+  });
+
+  it('multiselect — surfaces the misconfiguration marker when config.options is missing', () => {
+    const { container } = harness(singleFieldVariant(field('multiselect')), null);
+    expect(container.querySelector('[data-granit-select-misconfigured]')).not.toBeNull();
+    expect(container.querySelector('select')).toBeNull();
+  });
+
+  it('multiselect — exposes disabled when readOnly', () => {
+    const { container } = render(
+      <EntityRendererProvider components={STANDARD_FORM_COMPONENTS}>
+        <EntityForm
+          variant={flagsVariant()}
+          values={{ X: 'Customer' }}
+          onChange={() => undefined}
+          readOnly
+        />
+      </EntityRendererProvider>
+    );
+    expect((container.querySelector('select') as HTMLSelectElement).disabled).toBe(true);
+  });
+
   it('readOnly — text/textarea expose readOnly, boolean/select expose disabled', () => {
     function renderRO(component: string) {
       const { container, unmount } = render(

--- a/packages/@granit/react-entities/src/field-components/standard-form-components.tsx
+++ b/packages/@granit/react-entities/src/field-components/standard-form-components.tsx
@@ -201,6 +201,55 @@ const SelectComponent: EntityFormComponent = ({
   );
 };
 
+/**
+ * Multi-choice counterpart of {@link SelectComponent}, the default for
+ * `[Flags]` enum fields (the .NET side emits `multiselect` from
+ * `FieldBuilder.ChooseDefaultComponent` — ADR-041). It consumes the same
+ * `config.options` shape ({@link SelectComponentOption}); `value` on each
+ * option is the enum member name (e.g. `"Customer"`), symmetric with STJ's
+ * `JsonStringEnumConverter`.
+ *
+ * Wire format: the field value is a single comma-separated string, not a
+ * JSON array — e.g. `"Customer, Supplier"` for `Customer | Supplier`, and
+ * `"None"` (or `null` / `""`) for the empty set. The component parses that
+ * string into the set of selected names and emits the same comma-joined
+ * string on change, so the flags enum binds round-trip.
+ */
+const MultiselectComponent: EntityFormComponent = ({
+  field,
+  value,
+  onChange,
+  readOnly,
+  errorMessage,
+}) => {
+  const options = readOptions(field.config);
+  if (!options) {
+    return (
+      <div data-granit-select-misconfigured="" data-property={field.propertyName}>
+        Multiselect component on {field.propertyName} requires <code>config.options</code> with the
+        documented shape.
+      </div>
+    );
+  }
+  const selected = parseFlagsValue(value);
+  return (
+    <select
+      multiple
+      {...commonProps(field, errorMessage)}
+      value={[...selected]}
+      disabled={readOnly}
+      onChange={(e) => {
+        const names = Array.from(e.target.selectedOptions, (option) => option.value);
+        onChange(joinFlagsValue(names));
+      }}
+    >
+      {options.map((option) => (
+        <SelectOption key={String(option.value)} option={option} />
+      ))}
+    </select>
+  );
+};
+
 function SelectOption({ option }: { readonly option: SelectComponentOption }): ReactNode {
   return <option value={String(option.value)}>{option.labelKey ?? String(option.value)}</option>;
 }
@@ -241,6 +290,32 @@ function stringifySelectValue(value: unknown): string {
 }
 
 /**
+ * Parses a `[Flags]` enum wire value into the set of selected member names.
+ * The value is the comma-separated string produced by STJ's
+ * `JsonStringEnumConverter` (e.g. `"Customer, Supplier"`); whitespace around
+ * names is tolerated. `null`, `undefined`, `""` and the zero-member token
+ * `"None"` all map to the empty set (the zero member is dropped from
+ * `config.options`, so it never round-trips as a selectable name).
+ */
+function parseFlagsValue(value: unknown): ReadonlySet<string> {
+  if (typeof value !== 'string') return new Set();
+  const names = value
+    .split(',')
+    .map((name) => name.trim())
+    .filter((name) => name !== '' && name !== 'None');
+  return new Set(names);
+}
+
+/**
+ * Joins selected member names back into the comma-separated wire string,
+ * matching STJ's `", "` separator. The empty selection emits `"None"` (the
+ * zero-member token) so the non-nullable flags enum still binds.
+ */
+function joinFlagsValue(names: readonly string[]): string {
+  return names.length === 0 ? 'None' : names.join(', ');
+}
+
+/**
  * Standard form-component catalog (ADR-041 minimum set). Pass it to
  * `<EntityRendererProvider components={STANDARD_FORM_COMPONENTS}>` to
  * get working unstyled HTML inputs out of the box. Apps that want
@@ -265,6 +340,7 @@ export const STANDARD_FORM_COMPONENTS: EntityComponentCatalog = Object.freeze({
     time: TimeComponent,
     datetime: DatetimeComponent,
     select: SelectComponent,
+    multiselect: MultiselectComponent,
     lookup: LookupFormComponent,
   }),
 });


### PR DESCRIPTION
## What

Adds `MultiselectComponent` to `STANDARD_FORM_COMPONENTS.form` in [standard-form-components.tsx](packages/@granit/react-entities/src/field-components/standard-form-components.tsx), registered under the `multiselect` key right after `select`.

## Why

The backend (granit-dotnet #2845) now emits `multiselect` as the default component for `[Flags]` enum fields (`FieldBuilder.ChooseDefaultComponent`), with `config.options` of shape `{ value, labelKey }[]` — the same shape `select` consumes. The standard catalog had `select` but no `multiselect`, so these fields fell through to the `MissingComponent` placeholder. ADR-041 lists `multiselect` as a standard catalog name.

## Wire format (verified against granit-dotnet / granit-business)

The `[Flags]` enum is serialized by STJ `JsonStringEnumConverter` as a **single comma-separated string** (e.g. `"Customer, Supplier"`), **not** a JSON array. Each option `value` is the enum member **name** (e.g. `"Customer"`), symmetric with the converter. The zero member (`None = 0`) is dropped from `config.options` by `FieldBuilder.BuildEnumOptions`.

The component:
- parses the incoming string → set of selected names (tolerates whitespace; `null` / `""` / `"None"` → empty set);
- emits the same comma-joined string on change (`", "` separator, matching STJ); an empty selection emits the `"None"` zero-member token so the non-nullable flags enum binds round-trip;
- renders the same `data-granit-select-misconfigured` fallback as `select` when `config.options` is absent;
- honours `readOnly` (`disabled`) and `errorMessage` (`aria-invalid`) like `SelectComponent`.

Reuses `readOptions`, `SelectComponentOption`, `SelectOption` and `commonProps` — no duplication.

## Tests

8 cases added to [standard-form-components.test.tsx](packages/@granit/react-entities/src/__tests__/standard-form-components.test.tsx): parse comma-joined string → selection, select/deselect round-trips, deselect-all → `"None"`, `None`/`""`/`null` → empty set, missing-options misconfigured fallback, and `readOnly` → disabled.

## Checks

- `vitest run` — react-entities 346/346 green (43 files)
- `tsc --noEmit` (react-entities) clean
- `eslint --max-warnings 0` on changed files clean