### PR TITLE
feat(react-ui-dashboards): read-mode DashboardViewPage + entity-form label fallback

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -8784,6 +8784,11 @@
           "signature": "function DashboardEditPage()"
         },
         {
+          "name": "DashboardViewPage",
+          "kind": "function",
+          "signature": "function DashboardViewPage()"
+        },
+        {
           "name": "DashboardPage",
           "kind": "function",
           "signature": "function DashboardPage()"

--- a/packages/@granit/react-entities/src/__tests__/entity-form.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-form.test.tsx
@@ -196,6 +196,39 @@ describe('EntityForm', () => {
     expect(container.textContent).toContain('[Field.Number.Label]');
   });
 
+  it('falls back to a humanized property name when a field has no labelKey', () => {
+    const variant = manifest(
+      section('identity', 0, [
+        field('Kind', 0, { labelKey: null }),
+        field('TaxId', 1, { labelKey: null }),
+      ])
+    );
+    const { container } = render(
+      withProvider(<EntityForm variant={variant} values={{}} onChange={() => undefined} />)
+    );
+    const labels = Array.from(
+      container.querySelectorAll('[data-granit-field-label]'),
+      (el) => el.textContent
+    );
+    expect(labels).toContain('Kind');
+    expect(labels).toContain('Tax Id');
+  });
+
+  it('passes the humanized property name as the resolver fallback for null labelKey', () => {
+    const variant = manifest(section('identity', 0, [field('TaxId', 0, { labelKey: null })]));
+    const resolve = vi.fn((key: string, fallback?: string) => fallback ?? `[${key}]`);
+    const { container } = render(
+      withProvider(
+        <EntityForm variant={variant} values={{}} onChange={() => undefined} />,
+        catalog,
+        resolve
+      )
+    );
+    expect(resolve).toHaveBeenCalledWith('TaxId', 'Tax Id');
+    const label = container.querySelector('[data-property="TaxId"] [data-granit-field-label]');
+    expect(label?.textContent).toBe('Tax Id');
+  });
+
   it('renders the error message when one is provided for a field', () => {
     const variant = manifest(section('main', 0, [field('Email', 0)]));
     const { container } = render(

--- a/packages/@granit/react-entities/src/components/entity-form.tsx
+++ b/packages/@granit/react-entities/src/components/entity-form.tsx
@@ -151,11 +151,18 @@ function EntityFormField({
   const componentId = field.lookup ? 'lookup' : field.component;
   const Component = components.form[componentId];
 
+  // Always render a label: fields whose entity definition never called
+  // `.Label(...)` arrive with `labelKey: null`, and without a fallback they'd
+  // render no label at all. Route the humanized property name through
+  // `resolveLabel` so apps can still localize by property name and the i18n
+  // bridge's `defaultValue` path keeps working.
+  const labelText = field.labelKey
+    ? resolveLabel(field.labelKey)
+    : resolveLabel(field.propertyName, humanizePropertyName(field.propertyName));
+
   return (
     <div data-granit-form-field="" data-property={field.propertyName} data-component={componentId}>
-      {field.labelKey ? (
-        <label data-granit-field-label="">{resolveLabel(field.labelKey)}</label>
-      ) : null}
+      <label data-granit-field-label="">{labelText}</label>
       {Component ? (
         <Component
           field={field}
@@ -178,4 +185,13 @@ function EntityFormField({
       ) : null}
     </div>
   );
+}
+
+/**
+ * Turns a PascalCase property name into spaced words for use as a fallback
+ * label when the manifest carries no `labelKey` (`"TaxId"` → `"Tax Id"`,
+ * `"DefaultCurrency"` → `"Default Currency"`, `"Kind"` → `"Kind"`).
+ */
+function humanizePropertyName(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2');
 }

--- a/packages/@granit/react-ui-dashboards/src/__tests__/dashboard-view-page.test.tsx
+++ b/packages/@granit/react-ui-dashboards/src/__tests__/dashboard-view-page.test.tsx
@@ -1,0 +1,59 @@
+import { screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { DashboardViewPage } from '../dashboard-view-page';
+
+import { renderDashboards } from './test-utils';
+
+const detail = {
+  id: '8c6b1e10-0000-4000-8000-000000000001',
+  name: 'Invoicing overview',
+  category: 'Finance',
+  status: 'Published',
+  layoutColumns: 12,
+  layoutRowHeight: 80,
+  widgets: [],
+};
+
+const useDashboardDetail = vi.fn();
+
+vi.mock('@granit/react-dashboards', () => ({
+  useDashboardDetail: (id: string) => useDashboardDetail(id),
+  RenderedDashboard: ({ dashboardId }: { readonly dashboardId: string }) => (
+    <div data-slot="rendered-dashboard" data-dashboard-id={dashboardId} />
+  ),
+}));
+
+describe('DashboardViewPage', () => {
+  it('renders the dashboard chrome and the rendered surface once detail loads', () => {
+    useDashboardDetail.mockReturnValue({ data: detail, isLoading: false });
+    renderDashboards(<DashboardViewPage />);
+
+    expect(document.querySelector('[data-slot="dashboard-view-page"]')).toBeInTheDocument();
+    expect(screen.getByText('Invoicing overview')).toBeInTheDocument();
+    expect(document.querySelector('[data-slot="rendered-dashboard"]')).toBeInTheDocument();
+  });
+
+  it('shows the status badge for the persisted dashboard', () => {
+    useDashboardDetail.mockReturnValue({ data: detail, isLoading: false });
+    renderDashboards(<DashboardViewPage />);
+
+    const badge = document.querySelector('[data-slot="dashboard-status-badge"]');
+    expect(badge?.textContent).toBe('Published');
+  });
+
+  it('exposes an Edit affordance back to the composer', () => {
+    useDashboardDetail.mockReturnValue({ data: detail, isLoading: false });
+    renderDashboards(<DashboardViewPage />);
+
+    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+  });
+
+  it('renders a not-found empty state when the dashboard is missing', () => {
+    useDashboardDetail.mockReturnValue({ data: undefined, isLoading: false });
+    renderDashboards(<DashboardViewPage />);
+
+    expect(screen.getByText('Dashboard not found.')).toBeInTheDocument();
+    expect(document.querySelector('[data-slot="rendered-dashboard"]')).not.toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-ui-dashboards/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-ui-dashboards/src/__tests__/test-utils.tsx
@@ -40,6 +40,7 @@ void testI18n.use(initReactI18next).init({
         'Common.Resync': 'Re-sync',
         'Common.Save': 'Save',
         'Common.Saving': 'Saving…',
+        'Common.View': 'View',
       },
     },
   },

--- a/packages/@granit/react-ui-dashboards/src/dashboard-list-page.tsx
+++ b/packages/@granit/react-ui-dashboards/src/dashboard-list-page.tsx
@@ -15,7 +15,15 @@ import {
 import { useTranslation } from '@granit/react-localization';
 import { toast, Button, Spinner } from '@granit/react-ui';
 import { EmptyState } from '@granit/react-ui-kit';
-import { Archive, ArchiveRestore, LayoutDashboard, Pencil, RefreshCw, Send } from 'lucide-react';
+import {
+  Archive,
+  ArchiveRestore,
+  Eye,
+  LayoutDashboard,
+  Pencil,
+  RefreshCw,
+  Send,
+} from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -204,6 +212,16 @@ export function DashboardListPage() {
                       {t('Common.Archive', { defaultValue: 'Archive' })}
                     </Button>
                   )}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() =>
+                      navigate(`/dashboards/manage/${encodeURIComponent(dashboard.id)}`)
+                    }
+                  >
+                    <Eye className="mr-2 h-4 w-4" />
+                    {t('Common.View', { defaultValue: 'View' })}
+                  </Button>
                   <Button
                     variant="outline"
                     size="sm"

--- a/packages/@granit/react-ui-dashboards/src/dashboard-view-page.tsx
+++ b/packages/@granit/react-ui-dashboards/src/dashboard-view-page.tsx
@@ -1,0 +1,91 @@
+import { RenderedDashboard, useDashboardDetail } from '@granit/react-dashboards';
+import { useTranslation } from '@granit/react-localization';
+import { Button, Spinner } from '@granit/react-ui';
+import { EmptyState } from '@granit/react-ui-kit';
+import { ArrowLeft, LayoutDashboard, Pencil } from 'lucide-react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { StatusBadge } from './components/dashboard-status-badge';
+
+/**
+ * Read-mode page for a single persisted dashboard. The list page
+ * ({@link DashboardListPage}) links here to *visualize* a dashboard, while
+ * `/dashboards/manage/:id/edit` ({@link DashboardEditPage}) opens the composer.
+ *
+ * - **Load** — `useDashboardDetail(id)` supplies the chrome (name, status,
+ *   category) and the grid geometry (`layoutColumns` / `layoutRowHeight`).
+ * - **Render** — `<RenderedDashboard>` issues the single
+ *   `POST /dashboards/{id}/render` round-trip and dispatches each widget
+ *   snapshot through the registries composed at the app root. Grid columns
+ *   and row height are piped from the detail so the rendered layout matches
+ *   the one persisted by the editor.
+ */
+export function DashboardViewPage() {
+  const { id = '' } = useParams<{ id: string }>();
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const dashboardId = decodeURIComponent(id);
+  const { data: detail, isLoading } = useDashboardDetail(dashboardId);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <div data-slot="dashboard-view-page" className="space-y-4">
+        <Button variant="ghost" size="sm" onClick={() => navigate('/dashboards/manage')}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          {t('Common.Back', { defaultValue: 'Back' })}
+        </Button>
+        <EmptyState
+          icon={LayoutDashboard}
+          message={t('Dashboards.View.NotFound', { defaultValue: 'Dashboard not found.' })}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-slot="dashboard-view-page"
+      data-dashboard-id={detail.id}
+      data-dashboard-status={detail.status}
+      className="space-y-4"
+    >
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="sm" onClick={() => navigate('/dashboards/manage')}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            {t('Common.Back', { defaultValue: 'Back' })}
+          </Button>
+          <div>
+            <h2 className="text-2xl font-semibold text-foreground">{detail.name}</h2>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              <StatusBadge status={detail.status} /> · {detail.category}
+            </p>
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => navigate(`/dashboards/manage/${encodeURIComponent(dashboardId)}/edit`)}
+        >
+          <Pencil className="mr-2 h-4 w-4" />
+          {t('Common.Edit', { defaultValue: 'Edit' })}
+        </Button>
+      </div>
+
+      <RenderedDashboard
+        dashboardId={dashboardId}
+        columns={detail.layoutColumns}
+        rowHeight={detail.layoutRowHeight}
+      />
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-dashboards/src/index.ts
+++ b/packages/@granit/react-ui-dashboards/src/index.ts
@@ -6,6 +6,7 @@
 
 export { DashboardListPage } from './dashboard-list-page';
 export { DashboardEditPage } from './dashboard-edit-page';
+export { DashboardViewPage } from './dashboard-view-page';
 export { DashboardPage } from './dashboard-page';
 
 // Public components

--- a/packages/@granit/react-ui-dashboards/src/locales/en.ts
+++ b/packages/@granit/react-ui-dashboards/src/locales/en.ts
@@ -52,6 +52,7 @@ export const dashboardsTranslationsEn = {
   'Dashboards.List.Toast.ResyncSuccess':
     'Re-synced “{{name}}” to v{{version}} · {{widgetsAdded}} added, {{widgetsRemoved}} removed, {{overridesCarriedOver}} overrides preserved',
   'Dashboards.List.WidgetsSuffix': 'widgets',
+  'Dashboards.View.NotFound': 'Dashboard not found.',
 } as const;
 
 export type DashboardsTranslations = typeof dashboardsTranslationsEn;

--- a/packages/@granit/react-ui-dashboards/src/locales/fr.ts
+++ b/packages/@granit/react-ui-dashboards/src/locales/fr.ts
@@ -50,4 +50,5 @@ export const dashboardsTranslationsFr = {
   'Dashboards.List.Toast.ResyncSuccess':
     '« {{name}} » re-synchronisé en v{{version}} · {{widgetsAdded}} ajouté(s), {{widgetsRemoved}} retiré(s), {{overridesCarriedOver}} surcharge(s) préservée(s)',
   'Dashboards.List.WidgetsSuffix': 'widgets',
+  'Dashboards.View.NotFound': 'Tableau de bord introuvable.',
 } as const;


### PR DESCRIPTION
## Summary

Two scoped changes split across two commits.

### `feat(react-ui-dashboards)` — read-mode DashboardViewPage
- New `DashboardViewPage` rendering a persisted dashboard via `useDashboardDetail` + `RenderedDashboard`, with a not-found empty state and an Edit affordance back to the composer.
- Wires a **View** action on `DashboardListPage` linking to `/dashboards/manage/:id`.
- Adds `Common.View` and `Dashboards.View.NotFound` translations (en/fr).

### `fix(react-entities)` — humanize property name as label fallback
- Fields whose entity definition never called `.Label(...)` arrive with `labelKey: null` and previously rendered **no label at all**.
- Routes the humanized property name through `resolveLabel` (`"TaxId"` → `"Tax Id"`) so apps can still localize by property name and the i18n bridge's `defaultValue` path keeps working.

## Test plan
- [x] `DashboardViewPage` tests: chrome + rendered surface, status badge, Edit affordance, not-found empty state.
- [x] `EntityForm` tests: humanized fallback for null `labelKey`, resolver receives humanized fallback.
- [x] Pre-commit hooks pass (gitleaks, prettier, eslint --max-warnings 0, tsc, front-index regen).