### PR TITLE
fix(dashboard-editor): widget min-size, cell fill, labels & drag icon

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4684,22 +4684,7 @@
         {
           "name": "resizeWidget",
           "kind": "function",
-          "signature": "function resizeWidget( definition: DashboardDefinition, slug: string, size: WidgetSize ): DashboardDefinition"
-        },
-        {
-          "name": "addWidget",
-          "kind": "function",
-          "signature": "function addWidget<TDefinition extends"
-        },
-        {
-          "name": "composeCatalogs",
-          "kind": "function",
-          "signature": "function composeCatalogs( ...catalogs: readonly (readonly WidgetCatalogEntry[])[] ): readonly WidgetCatalogEntry[]"
-        },
-        {
-          "name": "defaultWidgetCatalog",
-          "kind": "const",
-          "signature": "const defaultWidgetCatalog: readonly WidgetCatalogEntry[]"
+          "signature": "function resizeWidget( definition: DashboardDefinition, slug: string, size: WidgetSize, minSize: WidgetSize ="
         },
         {
           "name": "WidgetCatalogEntry",

--- a/packages/@granit/dashboards/src/types/widget-bridge.ts
+++ b/packages/@granit/dashboards/src/types/widget-bridge.ts
@@ -42,6 +42,9 @@ export const STRUCTURAL_WIDGET_FIELDS = Object.freeze([
   'position',
   'size',
   'requiredPermission',
+  // Persisted as a top-level column, not inside `configJson` — kept out of
+  // the serialized blob so it never round-trips into the config payload.
+  'titleLocalizationKey',
 ] as const);
 
 /**
@@ -185,6 +188,10 @@ export function widgetInstanceToDefinition(
     type: instance.widgetType.charAt(0).toLowerCase() + instance.widgetType.slice(1),
     position: instance.position,
     size: { width: instance.width, height: instance.height },
+    // Carry the persisted title key verbatim so the editor resolves the
+    // actual stored title instead of recomposing a convention that may
+    // not match (e.g. the backend's no-suffix `Widget:{Dashboard}.{Slug}`).
+    titleLocalizationKey: instance.titleLocalizationKey,
     ...(instance.requiredPermission === null
       ? undefined
       : { requiredPermission: instance.requiredPermission }),
@@ -238,7 +245,8 @@ export function widgetDefinitionToAddRequest(
     position: widget.position,
     width: widget.size.width,
     height: widget.size.height,
-    titleLocalizationKey: composeTitleLocalizationKey(dashboardName, widget.slug),
+    titleLocalizationKey:
+      widget.titleLocalizationKey ?? composeTitleLocalizationKey(dashboardName, widget.slug),
     configJson: widgetFieldsToConfigJson(widget),
     metricName,
     queryName,
@@ -262,7 +270,8 @@ export function widgetDefinitionToUpdateRequest(
     position: widget.position,
     width: widget.size.width,
     height: widget.size.height,
-    titleLocalizationKey: composeTitleLocalizationKey(dashboardName, widget.slug),
+    titleLocalizationKey:
+      widget.titleLocalizationKey ?? composeTitleLocalizationKey(dashboardName, widget.slug),
     configJson: widgetFieldsToConfigJson(widget),
   };
 }

--- a/packages/@granit/dashboards/src/types/widget-definition.ts
+++ b/packages/@granit/dashboards/src/types/widget-definition.ts
@@ -49,6 +49,16 @@ export interface WidgetDefinitionBase {
    * `null` or missing = the widget has no actions wired.
    */
   readonly actions?: readonly WidgetAction[] | null;
+  /**
+   * The widget's persisted title localization key, carried verbatim from
+   * {@link WidgetInstanceResponse.titleLocalizationKey} when a definition is
+   * bridged from a stored dashboard. Lets the editor resolve the *actual*
+   * title the backend stored (e.g. `Widget:{Dashboard}.{Slug}`) rather than
+   * recomposing a convention that may not match. Omitted for hand-authored
+   * definitions (catalog previews / fixtures), where the renderer falls back
+   * to the composed `Widget:{Dashboard}.{Slug}.Title` convention.
+   */
+  readonly titleLocalizationKey?: string;
 }
 
 /**

--- a/packages/@granit/react-analytics/src/editor/analytics-widget-catalog.ts
+++ b/packages/@granit/react-analytics/src/editor/analytics-widget-catalog.ts
@@ -31,12 +31,14 @@ export const analyticsWidgetCatalog: readonly WidgetCatalogEntry[] = Object.free
     type: 'kpi',
     labelLocalizationKey: 'Dashboard:Widget.Kpi.Label',
     iconKey: 'kpi',
-    defaultSize: { width: 3, height: 1 },
+    // Two rows so the framed tile fits its header + value without clipping.
+    defaultSize: { width: 3, height: 2 },
+    minSize: { width: 2, height: 2 },
     createDefaultWidget: (slug, position): KpiWidgetDefinition => ({
       slug,
       type: 'kpi',
       position,
-      size: { width: 3, height: 1 },
+      size: { width: 3, height: 2 },
       // Empty metric name — the user binds it in the config form. The
       // backend rejects empty metricName at construction, so a fresh
       // widget can't be saved before being configured (acceptable v1
@@ -49,6 +51,7 @@ export const analyticsWidgetCatalog: readonly WidgetCatalogEntry[] = Object.free
     labelLocalizationKey: 'Dashboard:Widget.Chart.Label',
     iconKey: 'chart',
     defaultSize: { width: 6, height: 3 },
+    minSize: { width: 3, height: 2 },
     createDefaultWidget: (slug, position): ChartWidgetDefinition => ({
       slug,
       type: 'chart',
@@ -66,6 +69,7 @@ export const analyticsWidgetCatalog: readonly WidgetCatalogEntry[] = Object.free
     labelLocalizationKey: 'Dashboard:Widget.Table.Label',
     iconKey: 'table',
     defaultSize: { width: 6, height: 3 },
+    minSize: { width: 3, height: 2 },
     createDefaultWidget: (slug, position): TableWidgetDefinition => ({
       slug,
       type: 'table',
@@ -81,6 +85,7 @@ export const analyticsWidgetCatalog: readonly WidgetCatalogEntry[] = Object.free
     labelLocalizationKey: 'Dashboard:Widget.Pivot.Label',
     iconKey: 'pivot',
     defaultSize: { width: 6, height: 3 },
+    minSize: { width: 3, height: 2 },
     createDefaultWidget: (slug, position): PivotWidgetDefinition => ({
       slug,
       type: 'pivot',

--- a/packages/@granit/react-dashboard-editor/src/__tests__/resize-widget.test.ts
+++ b/packages/@granit/react-dashboard-editor/src/__tests__/resize-widget.test.ts
@@ -65,6 +65,41 @@ describe('resizeWidget', () => {
     ).toBe(12);
   });
 
+  it('clamps width/height up to the supplied minSize floor', () => {
+    const next = resizeWidget(
+      baseDefinition,
+      'A',
+      { width: 1, height: 1 },
+      { width: 2, height: 2 }
+    );
+    expect(next.widgets[0]?.size).toEqual({ width: 2, height: 2 });
+  });
+
+  it('allows sizes at or above the minSize floor', () => {
+    const next = resizeWidget(
+      baseDefinition,
+      'A',
+      { width: 5, height: 3 },
+      { width: 2, height: 2 }
+    );
+    expect(next.widgets[0]?.size).toEqual({ width: 5, height: 3 });
+  });
+
+  it('clamps the minSize itself to the grid bounds (min never exceeds columns)', () => {
+    const next = resizeWidget(
+      baseDefinition,
+      'A',
+      { width: 1, height: 1 },
+      { width: 99, height: 1 }
+    );
+    expect(next.widgets[0]?.size.width).toBe(12);
+  });
+
+  it('defaults the minSize to 1x1 when omitted (historical behaviour)', () => {
+    const next = resizeWidget(baseDefinition, 'A', { width: 1, height: 1 });
+    expect(next.widgets[0]?.size).toEqual({ width: 1, height: 1 });
+  });
+
   it('preserves all non-size fields on the resized widget', () => {
     const next = resizeWidget(baseDefinition, 'A', { width: 6, height: 2 });
     const a = next.widgets[0];

--- a/packages/@granit/react-dashboard-editor/src/__tests__/widget-catalog.test.ts
+++ b/packages/@granit/react-dashboard-editor/src/__tests__/widget-catalog.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { addWidget, composeCatalogs, defaultWidgetCatalog } from '../lib/widget-catalog';
+import {
+  addWidget,
+  composeCatalogs,
+  defaultWidgetCatalog,
+  DEFAULT_MIN_WIDGET_SIZE,
+  resolveWidgetMinSize,
+} from '../lib/widget-catalog';
 
 import type { WidgetCatalogEntry } from '../lib/widget-catalog';
 import type { DashboardDefinition } from '@granit/dashboards';
@@ -13,6 +19,52 @@ const baseDefinition: DashboardDefinition = {
   layout: { columns: 12, rowHeight: 80 },
   widgets: [],
 };
+
+describe('resolveWidgetMinSize', () => {
+  const catalog: readonly WidgetCatalogEntry[] = [
+    {
+      type: 'kpi',
+      labelLocalizationKey: 'k',
+      defaultSize: { width: 3, height: 2 },
+      minSize: { width: 2, height: 2 },
+      createDefaultWidget: (slug, position) => ({
+        slug,
+        type: 'kpi',
+        position,
+        size: { width: 3, height: 2 },
+      }),
+    },
+  ];
+
+  it('returns the matching entry minSize', () => {
+    expect(resolveWidgetMinSize(catalog, 'kpi')).toEqual({ width: 2, height: 2 });
+  });
+
+  it('falls back to DEFAULT_MIN_WIDGET_SIZE for an unknown type', () => {
+    expect(resolveWidgetMinSize(catalog, 'chart')).toBe(DEFAULT_MIN_WIDGET_SIZE);
+  });
+
+  it('falls back to DEFAULT_MIN_WIDGET_SIZE when no catalog is supplied', () => {
+    expect(resolveWidgetMinSize(undefined, 'kpi')).toBe(DEFAULT_MIN_WIDGET_SIZE);
+  });
+
+  it('falls back to DEFAULT_MIN_WIDGET_SIZE when the entry omits minSize', () => {
+    const noMin: readonly WidgetCatalogEntry[] = [
+      {
+        type: 'bare',
+        labelLocalizationKey: 'b',
+        defaultSize: { width: 2, height: 2 },
+        createDefaultWidget: (slug, position) => ({
+          slug,
+          type: 'bare',
+          position,
+          size: { width: 2, height: 2 },
+        }),
+      },
+    ];
+    expect(resolveWidgetMinSize(noMin, 'bare')).toBe(DEFAULT_MIN_WIDGET_SIZE);
+  });
+});
 
 describe('defaultWidgetCatalog', () => {
   it('ships entries for the framework widget kinds (markdown / text / image)', () => {

--- a/packages/@granit/react-dashboard-editor/src/components/editable-dashboard.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/editable-dashboard.tsx
@@ -22,6 +22,7 @@ import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 
 import { reorderWidgets } from '../lib/reorder-widgets';
 import { resizeWidget } from '../lib/resize-widget';
+import { resolveWidgetMinSize, type WidgetCatalogEntry } from '../lib/widget-catalog';
 
 import { SortableWidgetCell } from './sortable-widget-cell';
 
@@ -62,6 +63,14 @@ export interface EditableDashboardProps {
   readonly className?: string;
   /** Override the row height (in pixels). Falls back to `definition.layout.rowHeight`. */
   readonly rowHeight?: number;
+  /**
+   * Widget catalog driving per-kind minimum sizes for the drag-resize
+   * clamp. When omitted (or a widget's type is absent), the floor is
+   * {@link DEFAULT_MIN_WIDGET_SIZE} (`1x1`) — the historical behaviour.
+   * Pass the same composed catalog the palette uses so a KPI can't be
+   * shrunk below the space its value needs, etc.
+   */
+  readonly catalog?: readonly WidgetCatalogEntry[];
 }
 
 export function EditableDashboard({
@@ -69,6 +78,7 @@ export function EditableDashboard({
   onChange,
   className,
   rowHeight,
+  catalog,
 }: EditableDashboardProps) {
   const breakpoint = useDashboardBreakpoint();
 
@@ -125,8 +135,8 @@ export function EditableDashboard({
     return () => observer.disconnect();
   }, [layout.columns]);
 
-  const handleResize = (slug: string, size: WidgetSize) => {
-    const next = resizeWidget(definition, slug, size);
+  const handleResize = (slug: string, size: WidgetSize, minSize: WidgetSize) => {
+    const next = resizeWidget(definition, slug, size, minSize);
     if (next !== definition) onChange(next);
   };
 
@@ -142,16 +152,20 @@ export function EditableDashboard({
             className={className}
             style={gridStyle}
           >
-            {orderedWidgets.map((widget) => (
-              <EditableCell
-                key={widget.slug}
-                widget={widget}
-                columnPx={columnPx}
-                rowPx={effectiveRowHeight}
-                maxColumns={layout.columns}
-                onResize={(size) => handleResize(widget.slug, size)}
-              />
-            ))}
+            {orderedWidgets.map((widget) => {
+              const minSize = resolveWidgetMinSize(catalog, widget.type);
+              return (
+                <EditableCell
+                  key={widget.slug}
+                  widget={widget}
+                  columnPx={columnPx}
+                  rowPx={effectiveRowHeight}
+                  maxColumns={layout.columns}
+                  minSize={minSize}
+                  onResize={(size) => handleResize(widget.slug, size, minSize)}
+                />
+              );
+            })}
           </div>
         </SortableContext>
       </DndContext>
@@ -164,12 +178,14 @@ function EditableCell({
   columnPx,
   rowPx,
   maxColumns,
+  minSize,
   onResize,
 }: {
   readonly widget: WidgetDefinition;
   readonly columnPx: number;
   readonly rowPx: number;
   readonly maxColumns: number;
+  readonly minSize: WidgetSize;
   readonly onResize: (size: WidgetSize) => void;
 }) {
   const cellStyle: CSSProperties = {
@@ -185,6 +201,8 @@ function EditableCell({
         rowPx={rowPx}
         gapPx={GRID_GAP_PX}
         maxWidth={maxColumns}
+        minWidth={minSize.width}
+        minHeight={minSize.height}
         onResize={onResize}
       >
         <WidgetRenderer widget={widget} />

--- a/packages/@granit/react-dashboard-editor/src/components/sortable-widget-cell.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/sortable-widget-cell.tsx
@@ -140,7 +140,7 @@ export function SortableWidgetCell({
       data-slot="sortable-widget-cell"
       data-widget-slug={id}
       data-dragging={isDragging || undefined}
-      className="group/cell relative"
+      className="group/cell relative h-full"
     >
       <button
         type="button"

--- a/packages/@granit/react-dashboard-editor/src/components/sortable-widget-cell.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/sortable-widget-cell.tsx
@@ -43,6 +43,10 @@ export interface SortableWidgetCellProps {
   readonly gapPx?: number;
   /** Maximum width in cells — typically `definition.layout.columns`. */
   readonly maxWidth?: number;
+  /** Minimum width in cells the resize gesture allows. Defaults to 1. */
+  readonly minWidth?: number;
+  /** Minimum height in cells the resize gesture allows. Defaults to 1. */
+  readonly minHeight?: number;
 }
 
 const MAX_HEIGHT = 12;
@@ -62,6 +66,8 @@ export function SortableWidgetCell({
   rowPx,
   gapPx = 16,
   maxWidth,
+  minWidth = 1,
+  minHeight = 1,
 }: SortableWidgetCellProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id,
@@ -93,8 +99,16 @@ export function SortableWidgetCell({
         const dy = ev.clientY - startRef.current.y;
         const stepX = columnPx + gapPx;
         const stepY = rowPx + gapPx;
-        const nextWidth = clamp(startRef.current.width + Math.round(dx / stepX), 1, maxWidth ?? 12);
-        const nextHeight = clamp(startRef.current.height + Math.round(dy / stepY), 1, MAX_HEIGHT);
+        const nextWidth = clamp(
+          startRef.current.width + Math.round(dx / stepX),
+          minWidth,
+          maxWidth ?? 12
+        );
+        const nextHeight = clamp(
+          startRef.current.height + Math.round(dy / stepY),
+          minHeight,
+          MAX_HEIGHT
+        );
         onResize({ width: nextWidth, height: nextHeight });
       };
       const onUp = (ev: PointerEvent) => {
@@ -108,7 +122,7 @@ export function SortableWidgetCell({
       globalThis.addEventListener('pointerup', onUp);
       globalThis.addEventListener('pointercancel', onUp);
     },
-    [onResize, size, columnPx, rowPx, gapPx, maxWidth]
+    [onResize, size, columnPx, rowPx, gapPx, maxWidth, minWidth, minHeight]
   );
 
   const style = {

--- a/packages/@granit/react-dashboard-editor/src/components/sortable-widget-cell.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/sortable-widget-cell.tsx
@@ -150,7 +150,7 @@ export function SortableWidgetCell({
         {...attributes}
         {...listeners}
       >
-        <GripVerticalIcon />
+        <MoveIcon />
       </button>
       {children}
       {canResize ? (
@@ -168,7 +168,8 @@ export function SortableWidgetCell({
   );
 }
 
-function GripVerticalIcon() {
+function MoveIcon() {
+  // lucide "move" — four-way arrows; clear drag-to-move affordance.
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -182,12 +183,12 @@ function GripVerticalIcon() {
       strokeLinejoin="round"
       aria-hidden
     >
-      <circle cx="9" cy="5" r="1" />
-      <circle cx="9" cy="12" r="1" />
-      <circle cx="9" cy="19" r="1" />
-      <circle cx="15" cy="5" r="1" />
-      <circle cx="15" cy="12" r="1" />
-      <circle cx="15" cy="19" r="1" />
+      <polyline points="5 9 2 12 5 15" />
+      <polyline points="9 5 12 2 15 5" />
+      <polyline points="15 19 12 22 9 19" />
+      <polyline points="19 9 22 12 19 15" />
+      <line x1="2" x2="22" y1="12" y2="12" />
+      <line x1="12" x2="12" y1="2" y2="22" />
     </svg>
   );
 }

--- a/packages/@granit/react-dashboard-editor/src/index.ts
+++ b/packages/@granit/react-dashboard-editor/src/index.ts
@@ -20,7 +20,13 @@ export { TextConfigForm } from './components/forms/text-config-form';
 // Pure helpers — exported for tests + custom palette / DnD wrappers
 export { reorderWidgets } from './lib/reorder-widgets';
 export { resizeWidget } from './lib/resize-widget';
-export { addWidget, composeCatalogs, defaultWidgetCatalog } from './lib/widget-catalog';
+export {
+  addWidget,
+  composeCatalogs,
+  defaultWidgetCatalog,
+  DEFAULT_MIN_WIDGET_SIZE,
+  resolveWidgetMinSize,
+} from './lib/widget-catalog';
 export type { WidgetCatalogEntry } from './lib/widget-catalog';
 export { removeWidget, updateWidget } from './lib/update-widget';
 export { defaultWidgetConfigFormRegistry } from './lib/default-widget-config-form-registry';

--- a/packages/@granit/react-dashboard-editor/src/lib/resize-widget.ts
+++ b/packages/@granit/react-dashboard-editor/src/lib/resize-widget.ts
@@ -21,11 +21,15 @@ function clamp(value: number, min: number, max: number): number {
 /**
  * Returns a fresh `DashboardDefinition` with the widget identified by
  * `slug` resized to `size`. Width is clamped to
- * `[1, definition.layout.columns]`; height is clamped to
- * `[1, MAX_HEIGHT_ROWS]`. Returns the original definition unchanged
- * when the slug is unknown or the clamped size is identical to the
- * widget's current size — lets callers diff cheaply with referential
- * equality.
+ * `[minSize.width, definition.layout.columns]`; height is clamped to
+ * `[minSize.height, MAX_HEIGHT_ROWS]`. `minSize` defaults to `1x1` (the
+ * historical floor); callers pass a per-widget minimum (resolved from the
+ * catalog via `resolveWidgetMinSize`) to stop users shrinking a tile below
+ * the space its content needs. The minimum is itself clamped to the grid
+ * bounds so an over-large `minSize` can never exceed the column count.
+ * Returns the original definition unchanged when the slug is unknown or the
+ * clamped size is identical to the widget's current size — lets callers diff
+ * cheaply with referential equality.
  *
  * Pure function — pairs with `reorderWidgets` and `addWidget` /
  * `removeWidget` from the same `lib/` namespace.
@@ -33,10 +37,13 @@ function clamp(value: number, min: number, max: number): number {
 export function resizeWidget(
   definition: DashboardDefinition,
   slug: string,
-  size: WidgetSize
+  size: WidgetSize,
+  minSize: WidgetSize = { width: 1, height: 1 }
 ): DashboardDefinition {
-  const targetWidth = clamp(size.width, 1, definition.layout.columns);
-  const targetHeight = clamp(size.height, 1, MAX_HEIGHT_ROWS);
+  const minWidth = clamp(minSize.width, 1, definition.layout.columns);
+  const minHeight = clamp(minSize.height, 1, MAX_HEIGHT_ROWS);
+  const targetWidth = clamp(size.width, minWidth, definition.layout.columns);
+  const targetHeight = clamp(size.height, minHeight, MAX_HEIGHT_ROWS);
   let mutated = false;
   const widgets = definition.widgets.map((widget) => {
     if (widget.slug !== slug) return widget;

--- a/packages/@granit/react-dashboard-editor/src/lib/widget-catalog.ts
+++ b/packages/@granit/react-dashboard-editor/src/lib/widget-catalog.ts
@@ -31,6 +31,15 @@ export interface WidgetCatalogEntry {
   /** Grid size assigned to a freshly added widget. */
   readonly defaultSize: WidgetSize;
   /**
+   * Smallest size a user may shrink this widget to via the editor's
+   * drag-resize handle. Prevents collapsing a tile below the space its
+   * content needs (e.g. a KPI clipping its value in a 1-row cell).
+   * Falls back to {@link DEFAULT_MIN_WIDGET_SIZE} when omitted. Must be
+   * `<= defaultSize` on both axes so a freshly added widget is never born
+   * below its own floor.
+   */
+  readonly minSize?: WidgetSize;
+  /**
    * Factory producing a fresh widget for this kind. Receives the slug +
    * position {@link addWidget} computed for it; the factory fills in the
    * kind-specific fields (content localization key, source URL, query
@@ -48,6 +57,28 @@ export interface WidgetCatalogEntry {
    * generation stays centralized.
    */
   readonly createDefaultWidget: (slug: string, position: number) => WidgetDefinitionBase;
+}
+
+/**
+ * Floor applied to widgets whose catalog entry (or whose type) declares no
+ * explicit {@link WidgetCatalogEntry.minSize}. `1x1` keeps the historical
+ * behaviour — only widgets that opt into a larger minimum get a tighter
+ * clamp, so existing callers without a catalog see no change.
+ */
+export const DEFAULT_MIN_WIDGET_SIZE: WidgetSize = Object.freeze({ width: 1, height: 1 });
+
+/**
+ * Resolves the minimum resize size for a widget `type` from a catalog.
+ * Returns the matching entry's {@link WidgetCatalogEntry.minSize}, else
+ * {@link DEFAULT_MIN_WIDGET_SIZE}. Used by `<EditableDashboard>` to clamp
+ * drag-resize gestures per widget kind.
+ */
+export function resolveWidgetMinSize(
+  catalog: readonly WidgetCatalogEntry[] | undefined,
+  type: string
+): WidgetSize {
+  const entry = catalog?.find((candidate) => candidate.type === type);
+  return entry?.minSize ?? DEFAULT_MIN_WIDGET_SIZE;
 }
 
 /**
@@ -148,6 +179,7 @@ export const defaultWidgetCatalog: readonly WidgetCatalogEntry[] = Object.freeze
     labelLocalizationKey: 'Dashboard:Widget.Markdown.Label',
     iconKey: 'markdown',
     defaultSize: WIDGET_SIZE.FULL_WIDTH_ROW,
+    minSize: { width: 2, height: 1 },
     createDefaultWidget: (slug, position) => ({
       slug,
       type: 'markdown',
@@ -161,6 +193,7 @@ export const defaultWidgetCatalog: readonly WidgetCatalogEntry[] = Object.freeze
     labelLocalizationKey: 'Dashboard:Widget.Text.Label',
     iconKey: 'text',
     defaultSize: { width: 3, height: 1 },
+    minSize: { width: 2, height: 1 },
     createDefaultWidget: (slug, position) => ({
       slug,
       type: 'text',
@@ -175,6 +208,7 @@ export const defaultWidgetCatalog: readonly WidgetCatalogEntry[] = Object.freeze
     labelLocalizationKey: 'Dashboard:Widget.Image.Label',
     iconKey: 'image',
     defaultSize: WIDGET_SIZE.MEDIA_TILE,
+    minSize: { width: 2, height: 2 },
     createDefaultWidget: (slug, position) => ({
       slug,
       type: 'image',

--- a/packages/@granit/react-dashboards/src/components/widget-renderer.tsx
+++ b/packages/@granit/react-dashboards/src/components/widget-renderer.tsx
@@ -44,9 +44,15 @@ export function WidgetRenderer({ widget, framed = true }: WidgetRendererProps) {
 
   if (!framed) return body;
 
-  const titleKey = dashboardCtx
-    ? `Widget:${dashboardCtx.dashboardName}.${widget.slug}.Title`
-    : `Widget:${widget.slug}.Title`;
+  // Prefer the widget's persisted title key (carried through the
+  // definition bridge from a stored dashboard); fall back to the composed
+  // `Widget:{Dashboard}.{Slug}.Title` convention for hand-authored
+  // definitions (catalog previews / fixtures) that don't carry one.
+  const titleKey =
+    widget.titleLocalizationKey ??
+    (dashboardCtx
+      ? `Widget:${dashboardCtx.dashboardName}.${widget.slug}.Title`
+      : `Widget:${widget.slug}.Title`);
   const title = t(titleKey, { defaultValue: '' });
 
   return <WidgetCard title={title || undefined}>{body}</WidgetCard>;

--- a/packages/@granit/react-map/src/editor/map-widget-catalog.ts
+++ b/packages/@granit/react-map/src/editor/map-widget-catalog.ts
@@ -26,6 +26,7 @@ export const mapWidgetCatalog: readonly WidgetCatalogEntry[] = Object.freeze([
     labelLocalizationKey: 'Dashboard:Widget.Map.Label',
     iconKey: 'map',
     defaultSize: { width: 6, height: 4 },
+    minSize: { width: 3, height: 3 },
     createDefaultWidget: (slug, position): MapWidgetDefinition => ({
       slug,
       type: 'map',

--- a/packages/@granit/react-ui-dashboards/src/dashboard-edit-page.tsx
+++ b/packages/@granit/react-ui-dashboards/src/dashboard-edit-page.tsx
@@ -296,7 +296,7 @@ export function DashboardEditPage() {
       </div>
 
       <div ref={editorRef}>
-        <EditableDashboard definition={local} onChange={setLocal} />
+        <EditableDashboard definition={local} onChange={setLocal} catalog={catalog} />
       </div>
 
       <Dialog open={addOpen} onOpenChange={setAddOpen}>


### PR DESCRIPTION
## What

Four dashboard-editor correctness fixes surfaced by testing the editor against a real persisted dashboard:

- **Minimum widget size on resize** — widgets could be shrunk to 1×1, clipping content (e.g. a KPI cutting off its value in an 80px row). `WidgetCatalogEntry` gains an optional `minSize`; the resize gesture (`SortableWidgetCell`) and `resizeWidget` clamp to a per-kind floor resolved from the composed catalog. Built-in / analytics / map catalogs declare sensible minimums; the KPI default is bumped to 3×2 so a fresh tile isn't born clipped.
- **Cell fills its grid track** — the editor's `SortableWidgetCell` wrapper had no height, so a widget card's `h-full` resolved against its content instead of the (resized) grid cell. Added `h-full` to match the read-mode `RenderedDashboard` cell.
- **Widget labels in the editor** — the definition-path renderer composed `Widget:{Dashboard}.{Slug}.Title`, but stored dashboards key titles as `Widget:{Dashboard}.{Slug}` and the bridge dropped the persisted key. `WidgetDefinitionBase` now carries `titleLocalizationKey`; the bridge reads it and prefers it on write; `WidgetRenderer` uses it (falling back to the composed `.Title` convention for hand-authored fixtures).
- **Drag handle icon** — the six-dot grip becomes a four-arrow "move" icon.

## Tests
`tsc`, lint, vitest all green; full pre-commit hook passed.
