### PR TITLE
fix(analytics): move per-widget render endpoints under /analytics/widgets

### DIFF
--- a/packages/@granit/dashboards/src/api/dashboards-api.ts
+++ b/packages/@granit/dashboards/src/api/dashboards-api.ts
@@ -292,7 +292,7 @@ export async function deleteWidget(
  * {@link DashboardRenderedWidget} envelope.
  *
  * Note: `widgetsBasePath` is independent of the dashboards `basePath` — it
- * targets the per-widget API (default `/api/v1/widgets`).
+ * targets the per-widget API (default `/api/v1/analytics/widgets`).
  */
 export async function renderWidget<TDefinition extends WidgetDefinitionBase>(
   client: AxiosInstance,

--- a/packages/@granit/react-analytics/src/components/chart-tile.tsx
+++ b/packages/@granit/react-analytics/src/components/chart-tile.tsx
@@ -11,7 +11,7 @@ import type { ChartWidgetDefinition } from '@granit/analytics';
  * `ChartWidgetDefinition` (`type: 'chart'`) in the analytics widget
  * registry (definition path).
  *
- * Calls `POST /widgets/chart/render` via {@link useWidgetRender}, then
+ * Calls `POST /analytics/widgets/chart/render` via {@link useWidgetRender}, then
  * dispatches the resulting envelope through `<RenderedWidget>` — same
  * snapshot widget the bundle path uses (`<ChartSnapshotWidget>`).
  * Symmetry-by-construction: zero kind-specific transformation

--- a/packages/@granit/react-analytics/src/components/pivot-tile.tsx
+++ b/packages/@granit/react-analytics/src/components/pivot-tile.tsx
@@ -12,7 +12,7 @@ import type { PivotWidgetDefinition } from '@granit/analytics';
  * registry (definition path).
  *
  * Symmetric with `<ChartTile>` / `<TableTile>` / `<MapTile>`: calls
- * `POST /widgets/pivot/render` via {@link useWidgetRender}, dispatches
+ * `POST /analytics/widgets/pivot/render` via {@link useWidgetRender}, dispatches
  * through `<RenderedWidget>`, leverages the same `<PivotSnapshotWidget>`
  * the bundle path uses.
  */

--- a/packages/@granit/react-analytics/src/components/table-tile.tsx
+++ b/packages/@granit/react-analytics/src/components/table-tile.tsx
@@ -12,7 +12,7 @@ import type { TableWidgetDefinition } from '@granit/analytics';
  * registry (definition path).
  *
  * Symmetric with `<ChartTile>` / `<PivotTile>` / `<MapTile>`: calls
- * `POST /widgets/table/render` via {@link useWidgetRender}, dispatches
+ * `POST /analytics/widgets/table/render` via {@link useWidgetRender}, dispatches
  * through `<RenderedWidget>`, leverages the same `<TableSnapshotWidget>`
  * the bundle path uses.
  */

--- a/packages/@granit/react-analytics/src/index.ts
+++ b/packages/@granit/react-analytics/src/index.ts
@@ -10,7 +10,7 @@ export type { UseMetricOptions } from './hooks/use-metric';
 // per-widget render endpoint (P3) and uses the `useMetric` path which
 // works against `POST /metrics/{name}` — kept stable for callers
 // outside dashboards. Chart / Table / Pivot use the new
-// `POST /widgets/{kind}/render` endpoints via `useWidgetRender` (P3),
+// `POST /analytics/widgets/{kind}/render` endpoints via `useWidgetRender` (P3),
 // which keeps SSOT with the bundle path's snapshot widgets.
 export { KpiTile } from './components/kpi-tile';
 export type { KpiTileProps } from './components/kpi-tile';

--- a/packages/@granit/react-analytics/src/registry/default-analytics-widget-registry.ts
+++ b/packages/@granit/react-analytics/src/registry/default-analytics-widget-registry.ts
@@ -13,7 +13,7 @@ import type { WidgetRegistry, WidgetRendererFn } from '@granit/react-dashboards'
  * without per-app re-registration.
  *
  * Definition-path renderers — fetch their own data via the per-kind
- * render endpoints (`POST /widgets/{kind}/render`, backend P3) and
+ * render endpoints (`POST /analytics/widgets/{kind}/render`, backend P3) and
  * dispatch through `<RenderedWidget>` for chrome / action symmetry
  * with the bundle path. KPI keeps the `useMetric` path because
  * standalone KPI tiles outside dashboards (admin pages) consume

--- a/packages/@granit/react-dashboards/src/__tests__/use-widget-render.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-widget-render.test.tsx
@@ -46,7 +46,7 @@ const ENVELOPE: DashboardRenderedWidget = {
 let lastBody: unknown = null;
 
 const server = setupServer(
-  http.post('http://localhost/api/v1/widgets/markdown/render', async ({ request }) => {
+  http.post('http://localhost/api/v1/analytics/widgets/markdown/render', async ({ request }) => {
     lastBody = await request.json();
     return HttpResponse.json(ENVELOPE);
   })
@@ -55,7 +55,7 @@ const server = setupServer(
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => {
   server.resetHandlers(
-    http.post('http://localhost/api/v1/widgets/markdown/render', async ({ request }) => {
+    http.post('http://localhost/api/v1/analytics/widgets/markdown/render', async ({ request }) => {
       lastBody = await request.json();
       return HttpResponse.json(ENVELOPE);
     })

--- a/packages/@granit/react-dashboards/src/hooks/use-widget-render.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-widget-render.ts
@@ -13,7 +13,7 @@ import type {
   WidgetDefinitionBase,
 } from '@granit/dashboards';
 
-const WIDGET_RENDER_PATH = '/api/v1/widgets';
+const WIDGET_RENDER_PATH = '/api/v1/analytics/widgets';
 
 /**
  * Polling cadence per {@link RefreshHint} for the per-widget render
@@ -53,7 +53,7 @@ export interface WidgetRenderContext {
 
 /**
  * Wire-format kinds the P3 backend endpoints accept. Lowercase
- * matches the URL path slug (`/widgets/{kind}/render`) and the
+ * matches the URL path slug (`/analytics/widgets/{kind}/render`) and the
  * `WidgetDefinition.type` discriminator.
  */
 export type WidgetRenderKind = 'kpi' | 'chart' | 'table' | 'pivot' | 'map';
@@ -81,7 +81,7 @@ export interface UseWidgetRenderOptions {
 }
 
 /**
- * Calls `POST /widgets/{kind}/render` (backend P3 — symmetric with
+ * Calls `POST /analytics/widgets/{kind}/render` (backend P3 — symmetric with
  * the bundle path) and returns a single
  * {@link DashboardRenderedWidget} envelope.
  *

--- a/packages/@granit/react-dashboards/src/testing/data.ts
+++ b/packages/@granit/react-dashboards/src/testing/data.ts
@@ -526,7 +526,7 @@ export function createDashboardsStore(): Map<string, StoredDashboard> {
 
 // ---------------------------------------------------------------------------
 // Per-kind synthetic snapshot fixtures — back the P3 single-widget render
-// endpoints (POST /widgets/{kind}/render).
+// endpoints (POST /analytics/widgets/{kind}/render).
 // ---------------------------------------------------------------------------
 
 export const SYNTHETIC_ENVELOPES: Readonly<

--- a/packages/@granit/react-dashboards/src/testing/handlers.ts
+++ b/packages/@granit/react-dashboards/src/testing/handlers.ts
@@ -70,9 +70,9 @@ const VIEW_SLUG_FILTERS: Readonly<Record<string, readonly string[]>> = {
  * @param baseUrl - API base path (default: `/api/v1/dashboards`)
  */
 export function createDashboardsHandlers(baseUrl = DEFAULT_BASE_PATH) {
-  // Per-widget render endpoints live on a sibling `/widgets` base — derived
+  // Per-widget render endpoints live on the analytics `/widgets` base — derived
   // from the dashboards base so a single `baseUrl` override moves both.
-  const widgetsBase = baseUrl.replace(/\/dashboards$/, '/widgets');
+  const widgetsBase = baseUrl.replace(/\/dashboards$/, '/analytics/widgets');
 
   const store = createDashboardsStore();
 
@@ -478,7 +478,7 @@ export function createDashboardsHandlers(baseUrl = DEFAULT_BASE_PATH) {
     }),
 
     // -----------------------------------------------------------------------
-    // P3 — per-widget render endpoints (POST /widgets/{kind}/render). Symmetric
+    // P3 — per-widget render endpoints (POST /analytics/widgets/{kind}/render). Symmetric
     // with the bundle path: same envelope shape, same snapshot widgets dispatched
     // by `<RenderedWidget>`. The mock synthesizes a canned snapshot per kind —
     // good enough for a live preview.

--- a/packages/@granit/react-map/src/components/map-tile.tsx
+++ b/packages/@granit/react-map/src/components/map-tile.tsx
@@ -12,7 +12,7 @@ import type { MapWidgetDefinition } from '@granit/analytics';
  * (definition path).
  *
  * Symmetric with the analytics tiles (`<ChartTile>`, `<TableTile>`,
- * `<PivotTile>`): calls `POST /widgets/map/render` via
+ * `<PivotTile>`): calls `POST /analytics/widgets/map/render` via
  * {@link useWidgetRender}, dispatches through `<RenderedWidget>`,
  * leverages the same `<MapSnapshotWidget>` the bundle path uses.
  *

--- a/packages/@granit/react-map/src/index.ts
+++ b/packages/@granit/react-map/src/index.ts
@@ -6,7 +6,7 @@
 export { MapSnapshotWidget } from './snapshot/map-snapshot-widget';
 export { defaultMapSnapshotWidgetRegistry } from './snapshot/default-map-snapshot-widget-registry';
 
-// Definition-path renderer (P3) — fetches via POST /widgets/map/render
+// Definition-path renderer (P3) — fetches via POST /analytics/widgets/map/render
 export { MapTile } from './components/map-tile';
 export type { MapTileProps } from './components/map-tile';
 export { defaultMapWidgetRegistry } from './registry/default-map-widget-registry';

--- a/packages/@granit/react-map/src/registry/default-map-widget-registry.ts
+++ b/packages/@granit/react-map/src/registry/default-map-widget-registry.ts
@@ -15,7 +15,7 @@ import type { WidgetRegistry, WidgetRendererFn } from '@granit/react-dashboards'
  *       ]}
  *     >...</WidgetRegistryProvider>
  *
- * Definition-path renderer — fetches via `POST /widgets/map/render`
+ * Definition-path renderer — fetches via `POST /analytics/widgets/map/render`
  * (backend P3) through {@link useWidgetRender}, then dispatches
  * through `<RenderedWidget>` for chrome / action symmetry with the
  * bundle path's `<MapSnapshotWidget>`.


### PR DESCRIPTION
## Summary

Aligns the P3 single-widget render path with the backend. The per-kind render endpoints now live under the analytics base — `POST /analytics/widgets/{kind}/render` — instead of a sibling `/widgets` base.

## Changes

- `useWidgetRender` hook: `WIDGET_RENDER_PATH` → `/api/v1/analytics/widgets`
- MSW testing handlers: `widgetsBase` now derived as `/analytics/widgets` so a single `baseUrl` override moves both dashboards + widgets
- Updated test server handler URL + synthetic fixtures comment
- Doc-comment parity across chart/table/pivot/map tiles, registries, and barrel exports

No runtime behaviour change beyond the endpoint path; envelope shape and snapshot dispatch are unchanged.

## Test plan

- [ ] `pnpm --filter @granit/react-dashboards test` (use-widget-render handler URL updated)
- [ ] `pnpm tsc` / `pnpm lint`