### PR TITLE
feat(dashboards): query-catalogue dropdowns in the chart widget editor

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2556,6 +2556,11 @@
           "signature": "async function getPage<T>( client: AxiosInstance, basePath: string, request: QueryRequest, options?:"
         },
         {
+          "name": "getQueryCatalog",
+          "kind": "function",
+          "signature": "async function getQueryCatalog( client: AxiosInstance, basePath: string, options?:"
+        },
+        {
           "name": "getQueryMeta",
           "kind": "function",
           "signature": "async function getQueryMeta( client: AxiosInstance, basePath: string, options?:"
@@ -7105,9 +7110,19 @@
           "signature": "function useQueryEndpointReducer(initialParams?: QueryRequest): QueryEndpointState"
         },
         {
+          "name": "useQueryCatalog",
+          "kind": "function",
+          "signature": "function useQueryCatalog(): UseQueryResult<readonly QueryCatalogEntryResponse[]>"
+        },
+        {
           "name": "useQueryMeta",
           "kind": "function",
           "signature": "function useQueryMeta(): UseQueryResult<QueryMetadata>"
+        },
+        {
+          "name": "useQueryMetaAt",
+          "kind": "function",
+          "signature": "function useQueryMetaAt(basePath: string | null): UseQueryResult<QueryMetadata>"
         },
         {
           "name": "useSmartFilter",

--- a/contracts/openapi/query-engine.json
+++ b/contracts/openapi/query-engine.json
@@ -1,0 +1,111 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "query-engine",
+    "version": "1"
+  },
+  "paths": {
+    "/catalog": {
+      "get": {
+        "tags": ["Query Engine"],
+        "summary": "Lists every registered QueryDefinition.",
+        "description": "Returns the full query catalogue surfaced by IQueryDefinitionRegistry so a dashboard editor can offer a dropdown of queries instead of a free-text queryName. Each entry carries the wire identifier and, when a MapGranitQuery route exposes it, the resolved base path of its list endpoint. Registration and routing are decoupled: a query registered without a mapped route is returned with a null base path rather than a forged URL.",
+        "operationId": "ListQueryCatalog",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QueryCatalogEntryResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "QueryCatalogEntryResponse": {
+        "required": ["name", "basePath", "label"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "basePath": {
+            "type": ["null", "string"]
+          },
+          "label": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Query Engine"
+    }
+  ]
+}

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -36,6 +36,10 @@ export const CONTRACTS: readonly ModuleContract[] = [
     checkEndpoints: true,
   },
   { slug: 'bff', package: 'bff', types: ['BffCsrfTokenResponse'] },
+  // The query-engine generic surface. Only the catalogue DTO is hand-written;
+  // the QueryMetadata family (columns, group-by, …) is a shared schema owned by
+  // the package and verified indirectly, per the header note.
+  { slug: 'query-engine', package: 'query-engine', types: ['QueryCatalogEntryResponse'] },
   {
     // Only the self-service session/device schemas are published; the provider
     // admin + user-cache surfaces are conditionally registered and absent from

--- a/packages/@granit/query-engine/src/__tests__/api.test.ts
+++ b/packages/@granit/query-engine/src/__tests__/api.test.ts
@@ -1,7 +1,7 @@
 import { createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { getGrouped, getPage, getQueryMeta } from '../api/query-api';
+import { getGrouped, getPage, getQueryCatalog, getQueryMeta } from '../api/query-api';
 import {
   createSavedView,
   deleteSavedView,
@@ -83,6 +83,25 @@ describe('query-api', () => {
     const { signal } = new AbortController();
     await getQueryMeta(client, '/api/v1/patients', { signal });
     expect(client.get).toHaveBeenCalledWith('/api/v1/patients/meta', { signal });
+  });
+
+  it('getQueryCatalog calls GET /catalog', async () => {
+    const client = createMockClient();
+    const catalog = [
+      { name: 'Granit.Test.Query', basePath: '/api/v1/patients', label: 'Patients' },
+    ];
+    vi.mocked(client.get).mockResolvedValueOnce({ data: catalog });
+    const result = await getQueryCatalog(client, '/api/v1');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/catalog', undefined);
+    expect(result).toEqual(catalog);
+  });
+
+  it('getQueryCatalog forwards the abort signal', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
+    const { signal } = new AbortController();
+    await getQueryCatalog(client, '/api/v1', { signal });
+    expect(client.get).toHaveBeenCalledWith('/api/v1/catalog', { signal });
   });
 });
 

--- a/packages/@granit/query-engine/src/api/query-api.ts
+++ b/packages/@granit/query-engine/src/api/query-api.ts
@@ -4,6 +4,7 @@
 
 import { serializeQueryRequest } from './query-param-serializer';
 
+import type { QueryCatalogEntryResponse } from '../types/query-catalog';
 import type { QueryMetadata } from '../types/query-metadata';
 import type { QueryRequest } from '../types/query-params';
 import type { GroupedResult, PagedResult } from '../types/query-results';
@@ -59,5 +60,27 @@ export async function getQueryMeta(
   options?: { readonly signal?: AbortSignal }
 ): Promise<QueryMetadata> {
   const response = await client.get<QueryMetadata>(`${basePath}/meta`, options);
+  return response.data;
+}
+
+/**
+ * List every registered query definition (the query catalogue).
+ *
+ * Powers a query picker in the dashboard editor instead of a free-text
+ * `queryName`. Each entry's `basePath` (when non-null) can be passed to
+ * {@link getQueryMeta} to load that query's fields.
+ *
+ * @param client - Axios instance (from @granit/api-client)
+ * @param basePath - Query-engine root path where `/catalog` is mounted
+ */
+export async function getQueryCatalog(
+  client: AxiosInstance,
+  basePath: string,
+  options?: { readonly signal?: AbortSignal }
+): Promise<readonly QueryCatalogEntryResponse[]> {
+  const response = await client.get<readonly QueryCatalogEntryResponse[]>(
+    `${basePath}/catalog`,
+    options
+  );
   return response.data;
 }

--- a/packages/@granit/query-engine/src/index.ts
+++ b/packages/@granit/query-engine/src/index.ts
@@ -23,6 +23,7 @@ export type {
   PagedResult,
   PaginationMeta,
   PresetMeta,
+  QueryCatalogEntryResponse,
   QueryMetadata,
   QueryRequest,
   QuickFilterMeta,
@@ -54,7 +55,7 @@ export { QUERY_LIMITS } from './validation/query-limits';
 export { validateQueryRequest } from './validation/validate-query-request';
 
 // API
-export { getGrouped, getPage, getQueryMeta } from './api/query-api';
+export { getGrouped, getPage, getQueryCatalog, getQueryMeta } from './api/query-api';
 export { parseQueryRequest, serializeQueryRequest } from './api/query-param-serializer';
 export {
   createSavedView,

--- a/packages/@granit/query-engine/src/types/index.ts
+++ b/packages/@granit/query-engine/src/types/index.ts
@@ -25,6 +25,8 @@ export type {
   SortableField,
 } from './query-metadata';
 
+export type { QueryCatalogEntryResponse } from './query-catalog';
+
 export type { GroupEntry, GroupedResult, PagedResult } from './query-results';
 
 export type {

--- a/packages/@granit/query-engine/src/types/query-catalog.ts
+++ b/packages/@granit/query-engine/src/types/query-catalog.ts
@@ -1,0 +1,22 @@
+// ---------------------------------------------------------------------------
+// Query catalogue — mirrors Granit.QueryEngine.QueryCatalogEntryResponse (.NET)
+// Returned by GET {basePath}/catalog
+// ---------------------------------------------------------------------------
+
+/**
+ * One registered query definition, surfaced by `GET {basePath}/catalog` so a
+ * dashboard editor can offer a dropdown of queries instead of a free-text
+ * `queryName`.
+ */
+export interface QueryCatalogEntryResponse {
+  /** Wire identifier of the query (e.g. `Granit.Invoicing.InvoiceQuery`). */
+  readonly name: string;
+  /**
+   * Resolved base path of the query's list endpoint (e.g. `/api/v1/invoices`),
+   * or `null` when the query is registered without a mapped route. Append
+   * `/meta` to fetch its {@link QueryMetadata}.
+   */
+  readonly basePath: string | null;
+  /** Human-readable label (falls back to {@link QueryCatalogEntryResponse.name} backend-side). */
+  readonly label: string;
+}

--- a/packages/@granit/react-analytics/package.json
+++ b/packages/@granit/react-analytics/package.json
@@ -22,6 +22,8 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/react-dashboard-editor": "workspace:*",
     "@granit/react-dashboards": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "lucide-react": "^1.0.0",
@@ -61,7 +63,9 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/react-dashboard-editor": "workspace:*",
     "@granit/react-dashboards": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@granit/react-testing": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*",
     "msw": "^2.14.6"

--- a/packages/@granit/react-analytics/src/__tests__/chart-config-form.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/chart-config-form.test.tsx
@@ -1,0 +1,135 @@
+import { QueryCatalogProvider } from '@granit/react-query-engine';
+import { createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ChartConfigForm } from '../editor/chart-config-form';
+
+import type { ChartWidgetDefinition } from '@granit/analytics';
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: {} } },
+  interpolation: { escapeValue: false },
+});
+
+const baseChart: ChartWidgetDefinition = {
+  slug: 'C',
+  type: 'chart',
+  position: 0,
+  size: { width: 6, height: 3 },
+  queryName: 'Granit.Test.Query',
+  groupBy: 'Status',
+  aggregation: 'Sum',
+  field: 'Amount',
+  chartType: 'Bar',
+};
+
+/** A mock client answering /catalog and /meta by URL. */
+function mockCatalogClient() {
+  const client = axios.create();
+  vi.spyOn(client, 'get').mockImplementation((url: string) => {
+    if (url.endsWith('/catalog')) {
+      return Promise.resolve({
+        data: [{ name: 'Granit.Test.Query', basePath: '/api/v1/patients', label: 'Patients' }],
+      });
+    }
+    if (url.endsWith('/meta')) {
+      return Promise.resolve({
+        data: {
+          columns: [
+            { name: 'Amount', label: 'Amount', type: 'Decimal' },
+            { name: 'Name', label: 'Name', type: 'String' },
+          ],
+          groupByFields: [{ name: 'Status', type: 'String' }],
+        },
+      });
+    }
+    return Promise.reject(new Error(`unexpected url ${url}`));
+  });
+  return client as AxiosInstance;
+}
+
+function wrap(node: ReactNode, client?: AxiosInstance) {
+  const queryClient = createTestQueryClient();
+  return render(
+    <I18nextProvider i18n={testI18n}>
+      <QueryClientProvider client={queryClient}>
+        {client ? (
+          <QueryCatalogProvider config={{ client, basePath: '/api/v1' }}>
+            {node}
+          </QueryCatalogProvider>
+        ) : (
+          node
+        )}
+      </QueryClientProvider>
+    </I18nextProvider>
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ChartConfigForm', () => {
+  it('falls back to free-text inputs without a catalogue provider', () => {
+    const { container } = wrap(<ChartConfigForm widget={baseChart} onChange={vi.fn()} />);
+    expect(container.querySelector('input[data-slot="chart-query-name"]')).not.toBeNull();
+    expect(container.querySelector('input[data-slot="chart-group-by"]')).not.toBeNull();
+    expect(container.querySelector('input[data-slot="chart-field"]')).not.toBeNull();
+    // No catalogue → no suggestions datalist.
+    expect(container.querySelector('#chart-query-name-options')).toBeNull();
+  });
+
+  it('emits queryName changes from the free-text input', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(<ChartConfigForm widget={baseChart} onChange={onChange} />);
+    const input = container.querySelector('[data-slot="chart-query-name"]');
+    if (!(input instanceof HTMLInputElement)) throw new Error('input not found');
+    fireEvent.change(input, { target: { value: 'Granit.Other.Query' } });
+    expect(onChange.mock.calls[0]?.[0]?.queryName).toBe('Granit.Other.Query');
+  });
+
+  it('renders catalogue suggestions and metadata-backed dropdowns', async () => {
+    const { container } = wrap(
+      <ChartConfigForm widget={baseChart} onChange={vi.fn()} />,
+      mockCatalogClient()
+    );
+
+    // Query combobox gains a suggestions datalist.
+    await waitFor(() =>
+      expect(container.querySelector('#chart-query-name-options')).not.toBeNull()
+    );
+
+    // Group by + field become <select> sourced from metadata.
+    await waitFor(() =>
+      expect(container.querySelector('select[data-slot="chart-group-by"]')).not.toBeNull()
+    );
+    const groupBy = container.querySelector('select[data-slot="chart-group-by"]');
+    expect(groupBy?.querySelector('option[value="Status"]')).not.toBeNull();
+
+    const field = container.querySelector('select[data-slot="chart-field"]');
+    expect(field).not.toBeNull();
+    // Numeric column offered; string column filtered out.
+    expect(field?.querySelector('option[value="Amount"]')).not.toBeNull();
+    expect(field?.querySelector('option[value="Name"]')).toBeNull();
+  });
+
+  it('disables the field control for Count aggregation', () => {
+    const countChart: ChartWidgetDefinition = { ...baseChart, aggregation: 'Count', field: null };
+    const { container } = wrap(<ChartConfigForm widget={countChart} onChange={vi.fn()} />);
+    const field = container.querySelector('[data-slot="chart-field"]');
+    expect(field).not.toBeNull();
+    expect((field as HTMLInputElement).disabled).toBe(true);
+  });
+});

--- a/packages/@granit/react-analytics/src/editor/chart-config-form.tsx
+++ b/packages/@granit/react-analytics/src/editor/chart-config-form.tsx
@@ -1,3 +1,4 @@
+import { useQueryCatalog, useQueryMetaAt } from '@granit/react-query-engine';
 import { useTranslation } from 'react-i18next';
 
 import type { ChartType, ChartWidgetDefinition } from '@granit/analytics';
@@ -7,18 +8,114 @@ import type { WidgetConfigFormProps } from '@granit/react-dashboard-editor';
 const CHART_TYPES: readonly ChartType[] = ['Bar', 'HorizontalBar', 'Line', 'Area', 'Pie', 'Donut'];
 const AGGREGATIONS: readonly AggregateFunction[] = ['Count', 'Sum', 'Avg', 'Min', 'Max'];
 
+/** CLR type names eligible for numeric aggregation (Sum/Avg/Min/Max). */
+const NUMERIC_CLR_TYPES = new Set([
+  'Byte',
+  'SByte',
+  'Int16',
+  'UInt16',
+  'Int32',
+  'UInt32',
+  'Int64',
+  'UInt64',
+  'Single',
+  'Double',
+  'Decimal',
+]);
+
+const CONTROL_CLASS =
+  'w-full rounded-md border bg-background px-3 py-1.5 text-sm disabled:opacity-50';
+
+interface FieldOption {
+  readonly name: string;
+  readonly label?: string;
+}
+
+/**
+ * Renders a `<select>` over query-metadata field options, or falls back to a
+ * free-text `<input>` when no metadata is available (no catalogue provider, an
+ * unrouted query, or a query whose meta has not loaded). The current `value` is
+ * always preserved as an option even when absent from `options`, so switching
+ * queries never silently drops a previously bound field.
+ */
+function MetaFieldInput({
+  slot,
+  value,
+  options,
+  onChange,
+  disabled = false,
+  allowEmpty = false,
+}: {
+  readonly slot: string;
+  readonly value: string;
+  readonly options: readonly FieldOption[];
+  readonly onChange: (value: string) => void;
+  readonly disabled?: boolean;
+  readonly allowEmpty?: boolean;
+}) {
+  if (options.length === 0) {
+    return (
+      <input
+        type="text"
+        data-slot={slot}
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+        className={CONTROL_CLASS}
+      />
+    );
+  }
+
+  const knownValue = value === '' || options.some((option) => option.name === value);
+  return (
+    <select
+      data-slot={slot}
+      value={value}
+      disabled={disabled}
+      onChange={(event) => onChange(event.target.value)}
+      className={CONTROL_CLASS}
+    >
+      {allowEmpty && <option value="">—</option>}
+      {!knownValue && <option value={value}>{value}</option>}
+      {options.map((option) => (
+        <option key={option.name} value={option.name}>
+          {option.label ?? option.name}
+        </option>
+      ))}
+    </select>
+  );
+}
+
 /**
  * Built-in config form for {@link ChartWidgetDefinition}. Edits the
  * essential fields needed to bind a query: queryName, groupBy, the
  * aggregation function, the optional aggregated field, and the chart
  * type. Visual styling (palette, theme) is inherited from the active
  * `<EChartsThemeProvider>` and stays out of scope for the form.
+ *
+ * When wrapped in a `<QueryCatalogProvider>`, the query field offers a
+ * catalogue-backed combobox and groupBy/field become dropdowns sourced from
+ * the selected query's metadata. Without a provider it degrades to the
+ * free-text inputs, so the form keeps working in any host.
  */
 export function ChartConfigForm({
   widget,
   onChange,
 }: WidgetConfigFormProps<ChartWidgetDefinition>) {
   const { t } = useTranslation();
+
+  const { data: catalog } = useQueryCatalog();
+  const selectedEntry = catalog?.find((entry) => entry.name === widget.queryName) ?? null;
+  const { data: meta } = useQueryMetaAt(selectedEntry?.basePath ?? null);
+
+  const groupByOptions: readonly FieldOption[] = meta?.groupByFields ?? [];
+  const fieldOptions: readonly FieldOption[] = (meta?.columns ?? [])
+    .filter((column) => NUMERIC_CLR_TYPES.has(column.type))
+    .map((column) => ({ name: column.name, label: column.label }));
+
+  const isCount = widget.aggregation === 'Count';
+  const hasCatalog = catalog != null && catalog.length > 0;
+
   return (
     <div data-slot="chart-config-form" className="space-y-3">
       <label className="block text-sm">
@@ -28,21 +125,30 @@ export function ChartConfigForm({
         <input
           type="text"
           data-slot="chart-query-name"
+          list={hasCatalog ? 'chart-query-name-options' : undefined}
           value={widget.queryName}
           onChange={(event) => onChange({ ...widget, queryName: event.target.value })}
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+          className={CONTROL_CLASS}
         />
+        {hasCatalog && (
+          <datalist id="chart-query-name-options">
+            {catalog.map((entry) => (
+              <option key={entry.name} value={entry.name}>
+                {entry.label}
+              </option>
+            ))}
+          </datalist>
+        )}
       </label>
       <label className="block text-sm">
         <span className="mb-1 block text-muted-foreground">
           {t('Dashboard:Widget.Chart.GroupBy.Label')}
         </span>
-        <input
-          type="text"
-          data-slot="chart-group-by"
+        <MetaFieldInput
+          slot="chart-group-by"
           value={widget.groupBy}
-          onChange={(event) => onChange({ ...widget, groupBy: event.target.value })}
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+          options={groupByOptions}
+          onChange={(value) => onChange({ ...widget, groupBy: value })}
         />
       </label>
       <label className="block text-sm">
@@ -55,7 +161,7 @@ export function ChartConfigForm({
           onChange={(event) =>
             onChange({ ...widget, aggregation: event.target.value as AggregateFunction })
           }
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+          className={CONTROL_CLASS}
         >
           {AGGREGATIONS.map((agg) => (
             <option key={agg} value={agg}>
@@ -69,15 +175,13 @@ export function ChartConfigForm({
         <span className="mb-1 block text-muted-foreground">
           {t('Dashboard:Widget.Chart.Field.Label')}
         </span>
-        <input
-          type="text"
-          data-slot="chart-field"
+        <MetaFieldInput
+          slot="chart-field"
           value={widget.field ?? ''}
-          onChange={(event) =>
-            onChange({ ...widget, field: event.target.value === '' ? null : event.target.value })
-          }
-          disabled={widget.aggregation === 'Count'}
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm disabled:opacity-50"
+          options={fieldOptions}
+          disabled={isCount}
+          allowEmpty
+          onChange={(value) => onChange({ ...widget, field: value === '' ? null : value })}
         />
       </label>
       <label className="block text-sm">
@@ -88,7 +192,7 @@ export function ChartConfigForm({
           data-slot="chart-type"
           value={widget.chartType}
           onChange={(event) => onChange({ ...widget, chartType: event.target.value as ChartType })}
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+          className={CONTROL_CLASS}
         >
           {CHART_TYPES.map((type) => (
             <option key={type} value={type}>

--- a/packages/@granit/react-query-engine/package.json
+++ b/packages/@granit/react-query-engine/package.json
@@ -14,6 +14,7 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/data-lookup": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
@@ -46,6 +47,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/react-testing": "workspace:*"
   }

--- a/packages/@granit/react-query-engine/src/__tests__/use-query-catalog.test.tsx
+++ b/packages/@granit/react-query-engine/src/__tests__/use-query-catalog.test.tsx
@@ -1,0 +1,82 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useQueryCatalog } from '../hooks/use-query-catalog';
+import { useQueryMetaAt } from '../hooks/use-query-meta-at';
+import { QueryCatalogProvider } from '../providers/query-catalog-provider';
+
+import type { QueryCatalogConfig } from '../providers/query-catalog-provider';
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+function createWrapper(config?: QueryCatalogConfig) {
+  const queryClient = createTestQueryClient();
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {config ? (
+          <QueryCatalogProvider config={config}>{children}</QueryCatalogProvider>
+        ) : (
+          children
+        )}
+      </QueryClientProvider>
+    );
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useQueryCatalog', () => {
+  it('fetches the catalogue from the provider root', async () => {
+    const client = axios.create();
+    const catalog = [
+      { name: 'Granit.Test.Query', basePath: '/api/v1/patients', label: 'Patients' },
+    ];
+    vi.spyOn(client, 'get').mockResolvedValue({ data: catalog });
+
+    const { result } = renderHook(() => useQueryCatalog(), {
+      wrapper: createWrapper({ client: client as AxiosInstance, basePath: '/api/v1' }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/catalog', undefined);
+    expect(result.current.data).toEqual(catalog);
+  });
+
+  it('is disabled without a provider', () => {
+    const { result } = renderHook(() => useQueryCatalog(), { wrapper: createWrapper() });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(result.current.data).toBeUndefined();
+  });
+});
+
+describe('useQueryMetaAt', () => {
+  it('fetches metadata for the given base path', async () => {
+    const client = axios.create();
+    const meta = { columns: [], groupByFields: [{ name: 'status', type: 'String' }] };
+    vi.spyOn(client, 'get').mockResolvedValue({ data: meta });
+
+    const { result } = renderHook(() => useQueryMetaAt('/api/v1/patients'), {
+      wrapper: createWrapper({ client: client as AxiosInstance, basePath: '/api/v1' }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/patients/meta', undefined);
+    expect(result.current.data).toEqual(meta);
+  });
+
+  it('is disabled when base path is null', () => {
+    const client = axios.create();
+    const spy = vi.spyOn(client, 'get');
+    const { result } = renderHook(() => useQueryMetaAt(null), {
+      wrapper: createWrapper({ client: client as AxiosInstance, basePath: '/api/v1' }),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@granit/react-query-engine/src/hooks/use-query-catalog.ts
+++ b/packages/@granit/react-query-engine/src/hooks/use-query-catalog.ts
@@ -1,0 +1,34 @@
+// ---------------------------------------------------------------------------
+// useQueryCatalog — list every registered query definition (the catalogue)
+// ---------------------------------------------------------------------------
+
+import { getQueryCatalog } from '@granit/query-engine';
+import { useQuery } from '@tanstack/react-query';
+
+import { useOptionalQueryCatalogConfig } from '../providers/query-catalog-provider';
+
+import type { QueryCatalogEntryResponse } from '@granit/query-engine';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Fetch the query catalogue from the nearest {@link QueryCatalogProvider}.
+ *
+ * The catalogue is static and cached with `staleTime: Infinity`. The query is
+ * disabled (and stays `pending` with no data) when no provider is present, so
+ * a query picker can fall back to free-text input.
+ *
+ * @example
+ * ```tsx
+ * const { data: queries } = useQueryCatalog();
+ * ```
+ */
+export function useQueryCatalog(): UseQueryResult<readonly QueryCatalogEntryResponse[]> {
+  const config = useOptionalQueryCatalogConfig();
+
+  return useQuery({
+    queryKey: ['query-catalog', config?.basePath],
+    queryFn: () => getQueryCatalog(config!.client, config!.basePath),
+    enabled: config != null,
+    staleTime: Infinity,
+  });
+}

--- a/packages/@granit/react-query-engine/src/hooks/use-query-meta-at.ts
+++ b/packages/@granit/react-query-engine/src/hooks/use-query-meta-at.ts
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------------------
+// useQueryMetaAt — fetch metadata for an arbitrary query base path
+//
+// Companion to useQueryMeta (which reads the single endpoint from
+// QueryProvider). Here the base path is chosen at runtime — typically a
+// catalogue entry's resolved `basePath` — so an editor can load the fields
+// of whichever query the user just selected.
+// ---------------------------------------------------------------------------
+
+import { getQueryMeta } from '@granit/query-engine';
+import { useQuery } from '@tanstack/react-query';
+
+import { useOptionalQueryCatalogConfig } from '../providers/query-catalog-provider';
+
+import type { QueryMetadata } from '@granit/query-engine';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Fetch query metadata for a base path resolved at runtime (e.g. a catalogue
+ * entry). The Axios client comes from the nearest {@link QueryCatalogProvider}.
+ *
+ * Disabled (no data, no fetch) when `basePath` is `null` or no provider is
+ * present — callers gate their field pickers on the returned `data`.
+ *
+ * @param basePath - The query's list-endpoint base path, or `null` when none
+ *   is selected yet.
+ */
+export function useQueryMetaAt(basePath: string | null): UseQueryResult<QueryMetadata> {
+  const config = useOptionalQueryCatalogConfig();
+  const client = config?.client;
+
+  return useQuery({
+    queryKey: ['query-meta-at', basePath],
+    queryFn: () => getQueryMeta(client!, basePath!),
+    enabled: client != null && basePath != null,
+    staleTime: Infinity,
+  });
+}

--- a/packages/@granit/react-query-engine/src/index.ts
+++ b/packages/@granit/react-query-engine/src/index.ts
@@ -7,6 +7,15 @@ export {
   useQueryEndpointStateContext,
 } from './providers/query-endpoint-state-provider';
 export type { QueryEndpointStateProviderProps } from './providers/query-endpoint-state-provider';
+export {
+  QueryCatalogProvider,
+  useOptionalQueryCatalogConfig,
+} from './providers/query-catalog-provider';
+export type {
+  QueryCatalogConfig,
+  QueryCatalogProviderProps,
+  ResolvedQueryCatalogConfig,
+} from './providers/query-catalog-provider';
 
 // Pagination primitives
 export { useInfiniteScroll } from './hooks/use-infinite-scroll';
@@ -30,7 +39,9 @@ export type {
   QueryEndpointDispatchers,
   QueryEndpointState,
 } from './hooks/use-query-endpoint-reducer';
+export { useQueryCatalog } from './hooks/use-query-catalog';
 export { useQueryMeta } from './hooks/use-query-meta';
+export { useQueryMetaAt } from './hooks/use-query-meta-at';
 export { useSmartFilter } from './hooks/use-smart-filter';
 export type { UseSmartFilterOptions, UseSmartFilterReturn } from './hooks/use-smart-filter';
 

--- a/packages/@granit/react-query-engine/src/providers/query-catalog-provider.tsx
+++ b/packages/@granit/react-query-engine/src/providers/query-catalog-provider.tsx
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------------------
+// QueryCatalogProvider — React context for the query-engine catalogue root
+//
+// Distinct from QueryProvider (a single query endpoint): this points at the
+// query-engine root where `GET /catalog` is mounted, so an editor can list
+// every registered query and then load a chosen query's metadata by its
+// resolved `basePath`. Optional by design — consumers degrade to free-text
+// when no provider is present.
+// ---------------------------------------------------------------------------
+
+import { useOptionalGranitClient } from '@granit/react-api-client';
+import { createContext, useContext, useMemo } from 'react';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+/** Configuration for the query-engine catalogue surface. */
+export interface QueryCatalogConfig {
+  /**
+   * Axios instance (from @granit/api-client).
+   *
+   * Optional when a `GranitClientProvider` from `@granit/react-api-client`
+   * is present higher in the React tree — the provider resolves it from context.
+   */
+  readonly client?: AxiosInstance;
+  /** Query-engine root path where `/catalog` is mounted (e.g. "/api/v1"). */
+  readonly basePath: string;
+}
+
+/** Resolved config where client is guaranteed to be set. */
+export type ResolvedQueryCatalogConfig = QueryCatalogConfig & { readonly client: AxiosInstance };
+
+const QueryCatalogContext = createContext<ResolvedQueryCatalogConfig | null>(null);
+
+export interface QueryCatalogProviderProps {
+  readonly config: QueryCatalogConfig;
+  readonly children: ReactNode;
+}
+
+/**
+ * Provides the query catalogue root to the query-picker hooks below in the tree.
+ *
+ * When `config.client` is omitted, the provider resolves it from the nearest
+ * `GranitClientProvider`. If neither is available, an error is thrown.
+ *
+ * @example
+ * ```tsx
+ * <QueryCatalogProvider config={{ basePath: '/api/v1' }}>
+ *   <WidgetConfigDrawer … />
+ * </QueryCatalogProvider>
+ * ```
+ */
+export function QueryCatalogProvider({ config, children }: Readonly<QueryCatalogProviderProps>) {
+  const contextClient = useOptionalGranitClient();
+
+  const value = useMemo<ResolvedQueryCatalogConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'QueryCatalogProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return { ...config, client };
+  }, [config, contextClient]);
+
+  return <QueryCatalogContext value={value}>{children}</QueryCatalogContext>;
+}
+
+/**
+ * Access the catalogue config from the nearest {@link QueryCatalogProvider}, or
+ * `null` when there is none. Lets query pickers degrade to free-text input
+ * rather than throw when the editor host has not opted into the catalogue.
+ */
+export function useOptionalQueryCatalogConfig(): ResolvedQueryCatalogConfig | null {
+  return useContext(QueryCatalogContext);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1360,6 +1360,9 @@ importers:
       '@granit/dashboards':
         specifier: workspace:*
         version: link:../dashboards
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
       '@granit/react-api-client':
         specifier: workspace:*
         version: link:../react-api-client
@@ -1369,6 +1372,9 @@ importers:
       '@granit/react-dashboards':
         specifier: workspace:*
         version: link:../react-dashboards
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -3145,6 +3151,9 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing


### PR DESCRIPTION
## Why

The dashboard widget editor (see the *Modifier le widget* dialog) bound a chart to a query with **free-text** inputs for *Query*, *Group by* and *Field* — users had to know the exact `QueryDefinition` name and field names by heart. This wires the new query-engine `GET /catalog` endpoint into the editor so those fields become discoverable dropdowns.

Backend counterpart: `GET /catalog` in `Granit.QueryEngine.AspNetCore` returning `QueryCatalogEntryResponse[]` (`{ name, basePath, label }`).

## What

- **`@granit/query-engine`** — `QueryCatalogEntryResponse` type + `getQueryCatalog(client, basePath)` (`GET {basePath}/catalog`).
- **`@granit/react-query-engine`** — `QueryCatalogProvider` (points at the query-engine root where `/catalog` is mounted) + `useQueryCatalog()` and `useQueryMetaAt(basePath)` hooks. Both degrade gracefully (disabled, no fetch) without a provider.
- **`@granit/react-analytics`** — `ChartConfigForm`:
  - **Query** → combobox (free-text `<input>` + `<datalist>` of catalogue entries).
  - **Group by** → `<select>` from the selected query's `groupByFields`.
  - **Field** → `<select>` of **numeric** columns only; disabled for `Count`.
  - The current value is always preserved as an option, so switching queries never silently drops a binding.
- **`@granit/contract-tests`** — vendored `query-engine.json` spec + manifest entry; the catalogue DTO is now oracle-checked against the backend schema.

## Backward compatibility

The form is a **graceful enhancement**: with no `<QueryCatalogProvider>` in the tree it renders the original free-text inputs, so existing hosts keep working. A `QueryClientProvider` (already app-wide across the framework) is required.

## Follow-ups (not in this PR)

- Showcase wiring: wrap the dashboard editor page in `<QueryCatalogProvider>` (separate showcase MR, after this merges).
- Apply the same catalogue/metadata dropdowns to the **Table** and **Pivot** config forms.

## Tests

`getQueryCatalog` (api), `useQueryCatalog` / `useQueryMetaAt` (hooks, incl. disabled-without-provider), and `ChartConfigForm` (free-text fallback, catalogue suggestions, metadata dropdowns, numeric filtering, Count-disabled). Full suites for the touched packages + arch + contract conformance green (3946 tests). `tsc`, `eslint --max-warnings 0` clean.