### PR TITLE
feat(dashboards): catalogue-backed dropdowns in the table & pivot widget editors

### DIFF
--- a/packages/@granit/react-analytics/src/__tests__/pivot-config-form.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/pivot-config-form.test.tsx
@@ -1,0 +1,125 @@
+import { QueryCatalogProvider } from '@granit/react-query-engine';
+import { createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { PivotConfigForm } from '../editor/pivot-config-form';
+
+import type { PivotWidgetDefinition } from '@granit/analytics';
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: {} } },
+  interpolation: { escapeValue: false },
+});
+
+const basePivot: PivotWidgetDefinition = {
+  slug: 'P',
+  type: 'pivot',
+  position: 0,
+  size: { width: 6, height: 3 },
+  queryName: 'Granit.Test.Query',
+  rowFields: ['Status'],
+  columnFields: [],
+  valueField: 'Amount',
+  valueAggregation: 'Sum',
+};
+
+function mockCatalogClient() {
+  const client = axios.create();
+  vi.spyOn(client, 'get').mockImplementation((url: string) => {
+    if (url.endsWith('/catalog')) {
+      return Promise.resolve({
+        data: [{ name: 'Granit.Test.Query', basePath: '/api/v1/patients', label: 'Patients' }],
+      });
+    }
+    if (url.endsWith('/meta')) {
+      return Promise.resolve({
+        data: {
+          columns: [
+            { name: 'Amount', label: 'Amount', type: 'Decimal' },
+            { name: 'Name', label: 'Name', type: 'String' },
+          ],
+          groupByFields: [
+            { name: 'Status', type: 'String' },
+            { name: 'Region', type: 'String' },
+          ],
+        },
+      });
+    }
+    return Promise.reject(new Error(`unexpected url ${url}`));
+  });
+  return client as AxiosInstance;
+}
+
+function wrap(node: ReactNode, client?: AxiosInstance) {
+  const queryClient = createTestQueryClient();
+  return render(
+    <I18nextProvider i18n={testI18n}>
+      <QueryClientProvider client={queryClient}>
+        {client ? (
+          <QueryCatalogProvider config={{ client, basePath: '/api/v1' }}>
+            {node}
+          </QueryCatalogProvider>
+        ) : (
+          node
+        )}
+      </QueryClientProvider>
+    </I18nextProvider>
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('PivotConfigForm', () => {
+  it('falls back to free-text inputs without a catalogue provider', () => {
+    const { container } = wrap(<PivotConfigForm widget={basePivot} onChange={vi.fn()} />);
+    expect(container.querySelector('input[data-slot="pivot-row-fields"]')).not.toBeNull();
+    expect(container.querySelector('input[data-slot="pivot-value-field"]')).not.toBeNull();
+  });
+
+  it('disables the value field for Count aggregation', () => {
+    const countPivot: PivotWidgetDefinition = {
+      ...basePivot,
+      valueAggregation: 'Count',
+      valueField: null,
+    };
+    const { container } = wrap(<PivotConfigForm widget={countPivot} onChange={vi.fn()} />);
+    const field = container.querySelector('[data-slot="pivot-value-field"]');
+    expect((field as HTMLInputElement).disabled).toBe(true);
+  });
+
+  it('sources dimensions from group-by fields and value field from numeric columns', async () => {
+    const { container } = wrap(
+      <PivotConfigForm widget={basePivot} onChange={vi.fn()} />,
+      mockCatalogClient()
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector('select[data-slot="pivot-row-fields"]')).not.toBeNull()
+    );
+    const rowFields = container.querySelector('select[data-slot="pivot-row-fields"]');
+    expect(rowFields?.hasAttribute('multiple')).toBe(true);
+    expect(rowFields?.querySelector('option[value="Status"]')).not.toBeNull();
+    expect(rowFields?.querySelector('option[value="Region"]')).not.toBeNull();
+
+    // Value field is a single-select of numeric columns only.
+    const valueField = container.querySelector('select[data-slot="pivot-value-field"]');
+    expect(valueField).not.toBeNull();
+    expect(valueField?.hasAttribute('multiple')).toBe(false);
+    expect(valueField?.querySelector('option[value="Amount"]')).not.toBeNull();
+    expect(valueField?.querySelector('option[value="Name"]')).toBeNull();
+  });
+});

--- a/packages/@granit/react-analytics/src/__tests__/table-config-form.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/table-config-form.test.tsx
@@ -1,0 +1,110 @@
+import { QueryCatalogProvider } from '@granit/react-query-engine';
+import { createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { TableConfigForm } from '../editor/table-config-form';
+
+import type { TableWidgetDefinition } from '@granit/analytics';
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: {} } },
+  interpolation: { escapeValue: false },
+});
+
+const baseTable: TableWidgetDefinition = {
+  slug: 'T',
+  type: 'table',
+  position: 0,
+  size: { width: 6, height: 3 },
+  queryName: 'Granit.Test.Query',
+  visibleColumns: null,
+  pageSize: 25,
+};
+
+function mockCatalogClient() {
+  const client = axios.create();
+  vi.spyOn(client, 'get').mockImplementation((url: string) => {
+    if (url.endsWith('/catalog')) {
+      return Promise.resolve({
+        data: [{ name: 'Granit.Test.Query', basePath: '/api/v1/patients', label: 'Patients' }],
+      });
+    }
+    if (url.endsWith('/meta')) {
+      return Promise.resolve({
+        data: {
+          columns: [
+            { name: 'Name', label: 'Name', type: 'String' },
+            { name: 'Amount', label: 'Amount', type: 'Decimal' },
+          ],
+          groupByFields: [],
+        },
+      });
+    }
+    return Promise.reject(new Error(`unexpected url ${url}`));
+  });
+  return client as AxiosInstance;
+}
+
+function wrap(node: ReactNode, client?: AxiosInstance) {
+  const queryClient = createTestQueryClient();
+  return render(
+    <I18nextProvider i18n={testI18n}>
+      <QueryClientProvider client={queryClient}>
+        {client ? (
+          <QueryCatalogProvider config={{ client, basePath: '/api/v1' }}>
+            {node}
+          </QueryCatalogProvider>
+        ) : (
+          node
+        )}
+      </QueryClientProvider>
+    </I18nextProvider>
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('TableConfigForm', () => {
+  it('falls back to free-text inputs without a catalogue provider', () => {
+    const { container } = wrap(<TableConfigForm widget={baseTable} onChange={vi.fn()} />);
+    expect(container.querySelector('input[data-slot="table-query-name"]')).not.toBeNull();
+    expect(container.querySelector('input[data-slot="table-visible-columns"]')).not.toBeNull();
+  });
+
+  it('parses comma-separated columns into the visibleColumns array', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(<TableConfigForm widget={baseTable} onChange={onChange} />);
+    const input = container.querySelector('[data-slot="table-visible-columns"]');
+    if (!(input instanceof HTMLInputElement)) throw new Error('input not found');
+    fireEvent.change(input, { target: { value: 'Name, Amount' } });
+    expect(onChange.mock.calls[0]?.[0]?.visibleColumns).toEqual(['Name', 'Amount']);
+  });
+
+  it('renders a column multi-select from query metadata', async () => {
+    const { container } = wrap(
+      <TableConfigForm widget={baseTable} onChange={vi.fn()} />,
+      mockCatalogClient()
+    );
+    await waitFor(() =>
+      expect(container.querySelector('select[data-slot="table-visible-columns"]')).not.toBeNull()
+    );
+    const select = container.querySelector('select[data-slot="table-visible-columns"]');
+    expect(select?.hasAttribute('multiple')).toBe(true);
+    expect(select?.querySelector('option[value="Name"]')).not.toBeNull();
+    expect(select?.querySelector('option[value="Amount"]')).not.toBeNull();
+  });
+});

--- a/packages/@granit/react-analytics/src/editor/chart-config-form.tsx
+++ b/packages/@granit/react-analytics/src/editor/chart-config-form.tsx
@@ -1,5 +1,11 @@
-import { useQueryCatalog, useQueryMetaAt } from '@granit/react-query-engine';
 import { useTranslation } from 'react-i18next';
+
+import {
+  CONTROL_CLASS,
+  MetaFieldInput,
+  QueryNameCombobox,
+  useQueryFieldMetadata,
+} from './query-field-controls';
 
 import type { ChartType, ChartWidgetDefinition } from '@granit/analytics';
 import type { AggregateFunction } from '@granit/dashboards';
@@ -7,84 +13,6 @@ import type { WidgetConfigFormProps } from '@granit/react-dashboard-editor';
 
 const CHART_TYPES: readonly ChartType[] = ['Bar', 'HorizontalBar', 'Line', 'Area', 'Pie', 'Donut'];
 const AGGREGATIONS: readonly AggregateFunction[] = ['Count', 'Sum', 'Avg', 'Min', 'Max'];
-
-/** CLR type names eligible for numeric aggregation (Sum/Avg/Min/Max). */
-const NUMERIC_CLR_TYPES = new Set([
-  'Byte',
-  'SByte',
-  'Int16',
-  'UInt16',
-  'Int32',
-  'UInt32',
-  'Int64',
-  'UInt64',
-  'Single',
-  'Double',
-  'Decimal',
-]);
-
-const CONTROL_CLASS =
-  'w-full rounded-md border bg-background px-3 py-1.5 text-sm disabled:opacity-50';
-
-interface FieldOption {
-  readonly name: string;
-  readonly label?: string;
-}
-
-/**
- * Renders a `<select>` over query-metadata field options, or falls back to a
- * free-text `<input>` when no metadata is available (no catalogue provider, an
- * unrouted query, or a query whose meta has not loaded). The current `value` is
- * always preserved as an option even when absent from `options`, so switching
- * queries never silently drops a previously bound field.
- */
-function MetaFieldInput({
-  slot,
-  value,
-  options,
-  onChange,
-  disabled = false,
-  allowEmpty = false,
-}: {
-  readonly slot: string;
-  readonly value: string;
-  readonly options: readonly FieldOption[];
-  readonly onChange: (value: string) => void;
-  readonly disabled?: boolean;
-  readonly allowEmpty?: boolean;
-}) {
-  if (options.length === 0) {
-    return (
-      <input
-        type="text"
-        data-slot={slot}
-        value={value}
-        disabled={disabled}
-        onChange={(event) => onChange(event.target.value)}
-        className={CONTROL_CLASS}
-      />
-    );
-  }
-
-  const knownValue = value === '' || options.some((option) => option.name === value);
-  return (
-    <select
-      data-slot={slot}
-      value={value}
-      disabled={disabled}
-      onChange={(event) => onChange(event.target.value)}
-      className={CONTROL_CLASS}
-    >
-      {allowEmpty && <option value="">—</option>}
-      {!knownValue && <option value={value}>{value}</option>}
-      {options.map((option) => (
-        <option key={option.name} value={option.name}>
-          {option.label ?? option.name}
-        </option>
-      ))}
-    </select>
-  );
-}
 
 /**
  * Built-in config form for {@link ChartWidgetDefinition}. Edits the
@@ -103,18 +31,10 @@ export function ChartConfigForm({
   onChange,
 }: WidgetConfigFormProps<ChartWidgetDefinition>) {
   const { t } = useTranslation();
-
-  const { data: catalog } = useQueryCatalog();
-  const selectedEntry = catalog?.find((entry) => entry.name === widget.queryName) ?? null;
-  const { data: meta } = useQueryMetaAt(selectedEntry?.basePath ?? null);
-
-  const groupByOptions: readonly FieldOption[] = meta?.groupByFields ?? [];
-  const fieldOptions: readonly FieldOption[] = (meta?.columns ?? [])
-    .filter((column) => NUMERIC_CLR_TYPES.has(column.type))
-    .map((column) => ({ name: column.name, label: column.label }));
+  const { catalogEntries, hasCatalog, groupByOptions, numericColumnOptions } =
+    useQueryFieldMetadata(widget.queryName);
 
   const isCount = widget.aggregation === 'Count';
-  const hasCatalog = catalog != null && catalog.length > 0;
 
   return (
     <div data-slot="chart-config-form" className="space-y-3">
@@ -122,23 +42,14 @@ export function ChartConfigForm({
         <span className="mb-1 block text-muted-foreground">
           {t('Dashboard:Widget.Chart.QueryName.Label')}
         </span>
-        <input
-          type="text"
-          data-slot="chart-query-name"
-          list={hasCatalog ? 'chart-query-name-options' : undefined}
+        <QueryNameCombobox
+          slot="chart-query-name"
+          datalistId="chart-query-name-options"
           value={widget.queryName}
-          onChange={(event) => onChange({ ...widget, queryName: event.target.value })}
-          className={CONTROL_CLASS}
+          onChange={(value) => onChange({ ...widget, queryName: value })}
+          entries={catalogEntries}
+          hasCatalog={hasCatalog}
         />
-        {hasCatalog && (
-          <datalist id="chart-query-name-options">
-            {catalog.map((entry) => (
-              <option key={entry.name} value={entry.name}>
-                {entry.label}
-              </option>
-            ))}
-          </datalist>
-        )}
       </label>
       <label className="block text-sm">
         <span className="mb-1 block text-muted-foreground">
@@ -178,7 +89,7 @@ export function ChartConfigForm({
         <MetaFieldInput
           slot="chart-field"
           value={widget.field ?? ''}
-          options={fieldOptions}
+          options={numericColumnOptions}
           disabled={isCount}
           allowEmpty
           onChange={(value) => onChange({ ...widget, field: value === '' ? null : value })}

--- a/packages/@granit/react-analytics/src/editor/pivot-config-form.tsx
+++ b/packages/@granit/react-analytics/src/editor/pivot-config-form.tsx
@@ -1,85 +1,86 @@
 import { useTranslation } from 'react-i18next';
 
+import {
+  CONTROL_CLASS,
+  MetaFieldInput,
+  MetaMultiFieldInput,
+  QueryNameCombobox,
+  useQueryFieldMetadata,
+} from './query-field-controls';
+
 import type { PivotWidgetDefinition } from '@granit/analytics';
 import type { AggregateFunction } from '@granit/dashboards';
 import type { WidgetConfigFormProps } from '@granit/react-dashboard-editor';
 
 const AGGREGATIONS: readonly AggregateFunction[] = ['Count', 'Sum', 'Avg', 'Min', 'Max'];
 
-const splitFields = (raw: string) =>
-  raw
-    .split(',')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
-
 /**
  * Built-in config form for {@link PivotWidgetDefinition}. Edits the
- * query binding, the row + column dimension lists (comma-separated), the
- * aggregated value field, and the aggregation function. v1 keeps fields
- * as plain text — column-pickers / drag-and-drop dimension reorder ship
- * via custom forms registered downstream.
+ * query binding, the row + column dimension lists, the aggregated value
+ * field, and the aggregation function.
+ *
+ * Under a `<QueryCatalogProvider>` the query field is a catalogue-backed
+ * combobox, the row/column dimensions are multi-selects sourced from the
+ * query's group-by fields, and the value field is a numeric-column dropdown;
+ * otherwise everything degrades to free-text. Column-pickers / drag-and-drop
+ * dimension reorder ship via custom forms registered downstream.
  */
 export function PivotConfigForm({
   widget,
   onChange,
 }: WidgetConfigFormProps<PivotWidgetDefinition>) {
   const { t } = useTranslation();
+  const { catalogEntries, hasCatalog, groupByOptions, numericColumnOptions } =
+    useQueryFieldMetadata(widget.queryName);
+
   return (
     <div data-slot="pivot-config-form" className="space-y-3">
       <label className="block text-sm">
         <span className="mb-1 block text-muted-foreground">
           {t('Dashboard:Widget.Pivot.QueryName.Label')}
         </span>
-        <input
-          type="text"
-          data-slot="pivot-query-name"
+        <QueryNameCombobox
+          slot="pivot-query-name"
+          datalistId="pivot-query-name-options"
           value={widget.queryName}
-          onChange={(event) => onChange({ ...widget, queryName: event.target.value })}
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+          onChange={(value) => onChange({ ...widget, queryName: value })}
+          entries={catalogEntries}
+          hasCatalog={hasCatalog}
         />
       </label>
       <label className="block text-sm">
         <span className="mb-1 block text-muted-foreground">
           {t('Dashboard:Widget.Pivot.RowFields.Label')}
         </span>
-        <input
-          type="text"
-          data-slot="pivot-row-fields"
-          value={widget.rowFields.join(', ')}
-          onChange={(event) => onChange({ ...widget, rowFields: splitFields(event.target.value) })}
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        <MetaMultiFieldInput
+          slot="pivot-row-fields"
+          values={widget.rowFields}
+          options={groupByOptions}
+          onChange={(values) => onChange({ ...widget, rowFields: values })}
         />
       </label>
       <label className="block text-sm">
         <span className="mb-1 block text-muted-foreground">
           {t('Dashboard:Widget.Pivot.ColumnFields.Label')}
         </span>
-        <input
-          type="text"
-          data-slot="pivot-column-fields"
-          value={widget.columnFields.join(', ')}
-          onChange={(event) =>
-            onChange({ ...widget, columnFields: splitFields(event.target.value) })
-          }
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        <MetaMultiFieldInput
+          slot="pivot-column-fields"
+          values={widget.columnFields}
+          options={groupByOptions}
+          onChange={(values) => onChange({ ...widget, columnFields: values })}
         />
       </label>
       <label className="block text-sm">
         <span className="mb-1 block text-muted-foreground">
           {t('Dashboard:Widget.Pivot.ValueField.Label')}
         </span>
-        <input
-          type="text"
-          data-slot="pivot-value-field"
+        <MetaFieldInput
+          slot="pivot-value-field"
           value={widget.valueField ?? ''}
-          onChange={(event) =>
-            onChange({
-              ...widget,
-              valueField: event.target.value === '' ? null : event.target.value,
-            })
-          }
+          options={numericColumnOptions}
           disabled={widget.valueAggregation === 'Count'}
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm disabled:opacity-50"
+          allowEmpty
+          onChange={(value) => onChange({ ...widget, valueField: value === '' ? null : value })}
         />
       </label>
       <label className="block text-sm">
@@ -92,7 +93,7 @@ export function PivotConfigForm({
           onChange={(event) =>
             onChange({ ...widget, valueAggregation: event.target.value as AggregateFunction })
           }
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+          className={CONTROL_CLASS}
         >
           {AGGREGATIONS.map((agg) => (
             <option key={agg} value={agg}>

--- a/packages/@granit/react-analytics/src/editor/query-field-controls.tsx
+++ b/packages/@granit/react-analytics/src/editor/query-field-controls.tsx
@@ -1,0 +1,229 @@
+// ---------------------------------------------------------------------------
+// Shared editor controls — catalogue-backed query picker + metadata-backed
+// field selectors used by the chart / table / pivot config forms.
+//
+// All controls degrade to free-text when no <QueryCatalogProvider> is present
+// (or the selected query has no resolvable metadata), so the forms keep working
+// in any host. A <QueryClientProvider> is required.
+// ---------------------------------------------------------------------------
+
+import { useQueryCatalog, useQueryMetaAt } from '@granit/react-query-engine';
+
+import type { QueryCatalogEntryResponse } from '@granit/query-engine';
+
+export const CONTROL_CLASS =
+  'w-full rounded-md border bg-background px-3 py-1.5 text-sm disabled:opacity-50';
+
+/** CLR type names eligible for numeric aggregation (Sum/Avg/Min/Max). */
+const NUMERIC_CLR_TYPES = new Set([
+  'Byte',
+  'SByte',
+  'Int16',
+  'UInt16',
+  'Int32',
+  'UInt32',
+  'Int64',
+  'UInt64',
+  'Single',
+  'Double',
+  'Decimal',
+]);
+
+export interface FieldOption {
+  readonly name: string;
+  readonly label?: string;
+}
+
+export interface QueryFieldMetadata {
+  /** Catalogue entries for the query combobox, or `undefined` with no provider. */
+  readonly catalogEntries: readonly QueryCatalogEntryResponse[] | undefined;
+  readonly hasCatalog: boolean;
+  /** Group-by-able dimensions of the selected query. */
+  readonly groupByOptions: readonly FieldOption[];
+  /** Numeric columns of the selected query (aggregation targets). */
+  readonly numericColumnOptions: readonly FieldOption[];
+  /** All columns of the selected query. */
+  readonly columnOptions: readonly FieldOption[];
+}
+
+/**
+ * Resolves the query catalogue and the selected query's metadata into the
+ * field-option lists the config forms render. Returns empty option lists until
+ * a catalogue entry matching `queryName` resolves its metadata.
+ */
+export function useQueryFieldMetadata(queryName: string): QueryFieldMetadata {
+  const { data: catalog } = useQueryCatalog();
+  const selectedEntry = catalog?.find((entry) => entry.name === queryName) ?? null;
+  const { data: meta } = useQueryMetaAt(selectedEntry?.basePath ?? null);
+
+  const columns = meta?.columns ?? [];
+  return {
+    catalogEntries: catalog,
+    hasCatalog: catalog != null && catalog.length > 0,
+    groupByOptions: meta?.groupByFields ?? [],
+    numericColumnOptions: columns
+      .filter((column) => NUMERIC_CLR_TYPES.has(column.type))
+      .map((column) => ({ name: column.name, label: column.label })),
+    columnOptions: columns.map((column) => ({ name: column.name, label: column.label })),
+  };
+}
+
+/** Splits a comma-separated free-text field list into trimmed, non-empty names. */
+export function splitFields(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+}
+
+/**
+ * Free-text query name input augmented with a `<datalist>` of catalogue
+ * suggestions when a provider is present. Keeps arbitrary values typeable.
+ */
+export function QueryNameCombobox({
+  slot,
+  datalistId,
+  value,
+  onChange,
+  entries,
+  hasCatalog,
+}: {
+  readonly slot: string;
+  readonly datalistId: string;
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+  readonly entries: readonly QueryCatalogEntryResponse[] | undefined;
+  readonly hasCatalog: boolean;
+}) {
+  return (
+    <>
+      <input
+        type="text"
+        data-slot={slot}
+        list={hasCatalog ? datalistId : undefined}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className={CONTROL_CLASS}
+      />
+      {hasCatalog && entries && (
+        <datalist id={datalistId}>
+          {entries.map((entry) => (
+            <option key={entry.name} value={entry.name}>
+              {entry.label}
+            </option>
+          ))}
+        </datalist>
+      )}
+    </>
+  );
+}
+
+/**
+ * Single-value field picker: a `<select>` over metadata options, falling back
+ * to a free-text `<input>` when no options are available. The current `value`
+ * is always preserved as an option, so switching queries never silently drops
+ * a previously bound field.
+ */
+export function MetaFieldInput({
+  slot,
+  value,
+  options,
+  onChange,
+  disabled = false,
+  allowEmpty = false,
+}: {
+  readonly slot: string;
+  readonly value: string;
+  readonly options: readonly FieldOption[];
+  readonly onChange: (value: string) => void;
+  readonly disabled?: boolean;
+  readonly allowEmpty?: boolean;
+}) {
+  if (options.length === 0) {
+    return (
+      <input
+        type="text"
+        data-slot={slot}
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+        className={CONTROL_CLASS}
+      />
+    );
+  }
+
+  const knownValue = value === '' || options.some((option) => option.name === value);
+  return (
+    <select
+      data-slot={slot}
+      value={value}
+      disabled={disabled}
+      onChange={(event) => onChange(event.target.value)}
+      className={CONTROL_CLASS}
+    >
+      {allowEmpty && <option value="">—</option>}
+      {!knownValue && <option value={value}>{value}</option>}
+      {options.map((option) => (
+        <option key={option.name} value={option.name}>
+          {option.label ?? option.name}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+/**
+ * Multi-value field picker: a native multiple-`<select>` over metadata options,
+ * falling back to comma-separated free-text when no options are available.
+ * Current values absent from `options` are preserved as leading entries.
+ */
+export function MetaMultiFieldInput({
+  slot,
+  values,
+  options,
+  onChange,
+  placeholder,
+}: {
+  readonly slot: string;
+  readonly values: readonly string[];
+  readonly options: readonly FieldOption[];
+  readonly onChange: (values: string[]) => void;
+  readonly placeholder?: string;
+}) {
+  if (options.length === 0) {
+    return (
+      <input
+        type="text"
+        data-slot={slot}
+        value={values.join(', ')}
+        placeholder={placeholder}
+        onChange={(event) => onChange(splitFields(event.target.value))}
+        className={CONTROL_CLASS}
+      />
+    );
+  }
+
+  const unknownValues = values.filter((value) => !options.some((option) => option.name === value));
+  return (
+    <select
+      multiple
+      data-slot={slot}
+      value={values as string[]}
+      onChange={(event) =>
+        onChange(Array.from(event.target.selectedOptions, (option) => option.value))
+      }
+      className={CONTROL_CLASS}
+    >
+      {unknownValues.map((value) => (
+        <option key={value} value={value}>
+          {value}
+        </option>
+      ))}
+      {options.map((option) => (
+        <option key={option.name} value={option.name}>
+          {option.label ?? option.name}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/packages/@granit/react-analytics/src/editor/table-config-form.tsx
+++ b/packages/@granit/react-analytics/src/editor/table-config-form.tsx
@@ -1,20 +1,31 @@
 import { useTranslation } from 'react-i18next';
 
+import {
+  CONTROL_CLASS,
+  MetaMultiFieldInput,
+  QueryNameCombobox,
+  useQueryFieldMetadata,
+} from './query-field-controls';
+
 import type { TableWidgetDefinition } from '@granit/analytics';
 import type { WidgetConfigFormProps } from '@granit/react-dashboard-editor';
 
 /**
  * Built-in config form for {@link TableWidgetDefinition}. Edits the
- * query binding + page size. Column visibility (`visibleColumns`) is
- * left as comma-separated input — apps wanting a column-picker dialog
- * register their own form via `composeWidgetConfigFormRegistries`.
+ * query binding, visible columns + page size.
+ *
+ * Under a `<QueryCatalogProvider>` the query field is a catalogue-backed
+ * combobox and the visible-columns picker is a multi-select sourced from the
+ * query's columns; otherwise both degrade to free-text (comma-separated for
+ * columns). Apps wanting a richer column-picker dialog register their own form
+ * via `composeWidgetConfigFormRegistries`.
  */
 export function TableConfigForm({
   widget,
   onChange,
 }: WidgetConfigFormProps<TableWidgetDefinition>) {
   const { t } = useTranslation();
-  const visibleColumnsValue = widget.visibleColumns?.join(', ') ?? '';
+  const { catalogEntries, hasCatalog, columnOptions } = useQueryFieldMetadata(widget.queryName);
 
   return (
     <div data-slot="table-config-form" className="space-y-3">
@@ -22,35 +33,27 @@ export function TableConfigForm({
         <span className="mb-1 block text-muted-foreground">
           {t('Dashboard:Widget.Table.QueryName.Label')}
         </span>
-        <input
-          type="text"
-          data-slot="table-query-name"
+        <QueryNameCombobox
+          slot="table-query-name"
+          datalistId="table-query-name-options"
           value={widget.queryName}
-          onChange={(event) => onChange({ ...widget, queryName: event.target.value })}
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+          onChange={(value) => onChange({ ...widget, queryName: value })}
+          entries={catalogEntries}
+          hasCatalog={hasCatalog}
         />
       </label>
       <label className="block text-sm">
         <span className="mb-1 block text-muted-foreground">
           {t('Dashboard:Widget.Table.VisibleColumns.Label')}
         </span>
-        <input
-          type="text"
-          data-slot="table-visible-columns"
-          value={visibleColumnsValue}
+        <MetaMultiFieldInput
+          slot="table-visible-columns"
+          values={widget.visibleColumns ?? []}
+          options={columnOptions}
           placeholder="leave empty for all columns"
-          onChange={(event) => {
-            const raw = event.target.value.trim();
-            const next =
-              raw === ''
-                ? null
-                : raw
-                    .split(',')
-                    .map((s) => s.trim())
-                    .filter((s) => s.length > 0);
-            onChange({ ...widget, visibleColumns: next });
-          }}
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+          onChange={(values) =>
+            onChange({ ...widget, visibleColumns: values.length > 0 ? values : null })
+          }
         />
       </label>
       <label className="block text-sm">
@@ -65,7 +68,7 @@ export function TableConfigForm({
           onChange={(event) =>
             onChange({ ...widget, pageSize: Number.parseInt(event.target.value, 10) || 1 })
           }
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+          className={CONTROL_CLASS}
         />
       </label>
     </div>


### PR DESCRIPTION
## Why

Follow-up to #820, which gave the **Chart** widget editor a catalogue-backed query picker and metadata-driven Group By / Field dropdowns. The **Table** and **Pivot** config forms still bound everything with free-text. This extends the same treatment to them and factors out the shared controls so the three forms stay consistent.

## What

- **`react-analytics/editor/query-field-controls`** (new, internal) — the shared building blocks:
  - `useQueryFieldMetadata(queryName)` — resolves the catalogue + selected query's metadata into `groupByOptions` / `numericColumnOptions` / `columnOptions`.
  - `QueryNameCombobox` — free-text input + `<datalist>` of catalogue suggestions.
  - `MetaFieldInput` — single-value `<select>` with free-text fallback (preserves current value).
  - `MetaMultiFieldInput` — multiple-`<select>` with comma-separated free-text fallback.
- **`ChartConfigForm`** — refactored onto the shared controls; behaviour unchanged (its tests pass as-is).
- **`TableConfigForm`** — query combobox + **visible-columns** multi-select from the query's columns.
- **`PivotConfigForm`** — query combobox + **row/column** dimension multi-selects (group-by fields) + numeric **value-field** dropdown (disabled for `Count`).

## Backward compatibility

Every control degrades to the prior free-text input (comma-separated for the multi-value lists) when no `<QueryCatalogProvider>` is in the tree, so existing hosts are unaffected. A `QueryClientProvider` is required (already app-wide).

## Notes

- Multi-value pickers use a native `multiple` `<select>` for v1 — functional and lightweight; downstream apps can still register a richer column-picker / drag-reorder form via `composeWidgetConfigFormRegistries`.

## Follow-up (unchanged from #820)

- Showcase wiring: wrap the dashboard editor page in `<QueryCatalogProvider>` (separate showcase MR).

## Tests

New `table-config-form` and `pivot-config-form` suites (free-text fallback, parsing, catalogue multi-selects, numeric value-field filtering, Count-disabled). Full `@granit/react-analytics` suite green (64 tests). `tsc`, `eslint --max-warnings 0` clean; pre-commit (gitleaks + tsc -r + front-index) passed.