### PR TITLE
test(shell): fix colour-theme tests for the ThemeDescriptor[] store shape

### DIFF
--- a/packages/@granit/react-shell-core/src/__tests__/color-theme.test.tsx
+++ b/packages/@granit/react-shell-core/src/__tests__/color-theme.test.tsx
@@ -4,7 +4,12 @@ import { type ReactNode } from 'react';
 
 import { ColorThemeStoreProvider, useColorThemeStore } from '../color-theme';
 
-const THEMES = ['blue', 'teal'] as const;
+// The store now offers ThemeDescriptor[] (id/label/swatch), not bare ids — its
+// `setColorTheme` rejects ids absent from this list, so they must be descriptors.
+const THEMES = [
+  { id: 'blue', label: 'Blue', swatch: '#1e40af' },
+  { id: 'teal', label: 'Teal', swatch: '#0f766e' },
+] as const;
 
 function makeWrapper(store: ReturnType<typeof createColorThemeStore>) {
   return ({ children }: { children: ReactNode }) => (
@@ -22,7 +27,11 @@ describe('useColorThemeStore', () => {
   });
 
   it('re-renders when the store updates', () => {
-    const store = createColorThemeStore({ storageKey: 'ct2', defaultTheme: 'blue', themes: THEMES });
+    const store = createColorThemeStore({
+      storageKey: 'ct2',
+      defaultTheme: 'blue',
+      themes: THEMES,
+    });
     const { result } = renderHook(() => useColorThemeStore((s) => s.colorTheme), {
       wrapper: makeWrapper(store),
     });

--- a/packages/@granit/react-ui-shell-admin/src/__tests__/nav-user-theme-menu.test.tsx
+++ b/packages/@granit/react-ui-shell-admin/src/__tests__/nav-user-theme-menu.test.tsx
@@ -1,4 +1,5 @@
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@granit/react-ui';
+import { COLOR_THEME_CATALOG } from '@granit/ui-theme';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -18,7 +19,13 @@ vi.mock('@granit/react-shell-core', () => ({
 const setThemeMock = vi.fn();
 const setColorThemeMock = vi.fn();
 let themeValue = 'system';
-const colorState = { colorTheme: 'blue', setColorTheme: setColorThemeMock };
+// The menu reads the offered themes as ThemeDescriptor[] from the store. Mirror a
+// real app: surface the @granit/ui-theme catalogue (includes Blue / Teal / Slate).
+const colorState = {
+  colorTheme: 'blue',
+  setColorTheme: setColorThemeMock,
+  themes: COLOR_THEME_CATALOG,
+};
 
 const { NavUserThemeMenu } = await import('../nav-user-theme-menu');
 


### PR DESCRIPTION
## Why

CI on develop is red: 5 tests fail in the colour-theme workstream. The catalogue work moved the store's `themes` from bare ids to `ThemeDescriptor[]` (`{ id, label, swatch }`), but two test files still feed plain strings:

- **`react-shell-core` color-theme** — `setColorTheme('teal')` is rejected because `'teal'` is not a descriptor in the offered list, so the store keeps the default → `expected 'blue' to be 'teal'`.
- **`react-ui-shell-admin` nav-user-theme-menu** — the mocked store omits `themes`, so `NavUserThemeMenu` crashes on `themes.map(...)` (`Cannot read properties of undefined`).

These are unrelated to any feature change — purely test data out of sync with the current store contract.

## What

- color-theme test: `THEMES` is now `ThemeDescriptor[]` (`blue` / `teal` descriptors).
- nav-user-theme-menu test: the mocked store exposes `themes: COLOR_THEME_CATALOG` (the real `@granit/ui-theme` catalogue, which includes Blue / Teal / Slate).

## Tests

Both suites green (7 tests). No runtime/source change — test fixtures only.