### PR TITLE
refactor(analytics): KPI widget editor fields on shadcn Combobox / Select

### DIFF
--- a/packages/@granit/react-analytics/src/__tests__/kpi-config-form.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/kpi-config-form.test.tsx
@@ -1,5 +1,8 @@
 import { Datasource } from '@granit/dashboards';
-import { fireEvent, render } from '@testing-library/react';
+import { createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import i18n from 'i18next';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { describe, expect, it, vi } from 'vitest';
@@ -20,7 +23,12 @@ void testI18n.use(initReactI18next).init({
 });
 
 function wrap(node: ReactNode) {
-  return render(<I18nextProvider i18n={testI18n}>{node}</I18nextProvider>);
+  const queryClient = createTestQueryClient();
+  return render(
+    <I18nextProvider i18n={testI18n}>
+      <QueryClientProvider client={queryClient}>{node}</QueryClientProvider>
+    </I18nextProvider>
+  );
 }
 
 const baseKpi: KpiWidgetDefinition = {
@@ -32,33 +40,41 @@ const baseKpi: KpiWidgetDefinition = {
 };
 
 describe('KpiConfigForm', () => {
-  it('shows the metric-name input when bound to a metric datasource', () => {
+  it('shows the metric combobox when bound to a metric datasource', () => {
     const { container } = wrap(<KpiConfigForm widget={baseKpi} onChange={vi.fn()} />);
     expect(container.querySelector('[data-slot="kpi-metric-name"]')).not.toBeNull();
     expect(container.querySelector('[data-slot="kpi-query-name"]')).toBeNull();
   });
 
-  it('emits an updated metric-name on change', () => {
+  it('emits a typed metric name via the searchable combobox', async () => {
+    const user = userEvent.setup();
     const onChange = vi.fn();
     const { container } = wrap(<KpiConfigForm widget={baseKpi} onChange={onChange} />);
-    const input = container.querySelector('[data-slot="kpi-metric-name"]');
-    if (!(input instanceof HTMLInputElement)) throw new Error('input not found');
-    fireEvent.change(input, { target: { value: 'Granit.Test.NewMetric' } });
-    expect(onChange.mock.calls[0]?.[0]?.datasource).toEqual(
+
+    await user.click(container.querySelector('[data-slot="kpi-metric-name"]')!);
+    await user.type(
+      await screen.findByPlaceholderText('Search or type a metric name…'),
+      'Granit.Test.NewMetric'
+    );
+    await user.click(await screen.findByRole('option', { name: /Granit\.Test\.NewMetric/ }));
+
+    expect(onChange.mock.calls.at(-1)?.[0]?.datasource).toEqual(
       Datasource.metric('Granit.Test.NewMetric')
     );
   });
 
-  it('switches to query-aggregate when the kind selector changes', () => {
+  it('switches to query-aggregate from the kind select', async () => {
+    const user = userEvent.setup();
     const onChange = vi.fn();
     const { container } = wrap(<KpiConfigForm widget={baseKpi} onChange={onChange} />);
-    const select = container.querySelector('[data-slot="kpi-datasource-kind"]');
-    if (!(select instanceof HTMLSelectElement)) throw new Error('select not found');
-    fireEvent.change(select, { target: { value: 'query-aggregate' } });
-    expect(onChange.mock.calls[0]?.[0]?.datasource?.kind).toBe('query-aggregate');
+
+    await user.click(container.querySelector('[data-slot="kpi-datasource-kind"]')!);
+    await user.click(await screen.findByRole('option', { name: 'Query aggregate' }));
+
+    expect(onChange.mock.calls.at(-1)?.[0]?.datasource?.kind).toBe('query-aggregate');
   });
 
-  it('shows query-name + aggregation inputs when bound to query-aggregate', () => {
+  it('shows the query combobox + aggregation when bound to query-aggregate', () => {
     const queryKpi: KpiWidgetDefinition = {
       ...baseKpi,
       datasource: Datasource.queryAggregate('Granit.Test.Query', 'Sum'),

--- a/packages/@granit/react-analytics/src/editor/kpi-config-form.tsx
+++ b/packages/@granit/react-analytics/src/editor/kpi-config-form.tsx
@@ -1,14 +1,28 @@
 import { Datasource, isMetricDatasource, isQueryAggregateDatasource } from '@granit/dashboards';
+import { Combobox } from '@granit/react-ui';
 import { useTranslation } from 'react-i18next';
+
+import { EnumSelect, QueryNameCombobox, useQueryFieldMetadata } from './query-field-controls';
 
 import type { KpiWidgetDefinition } from '@granit/analytics';
 import type { AggregateFunction } from '@granit/dashboards';
 import type { WidgetConfigFormProps } from '@granit/react-dashboard-editor';
 
+const KIND_OPTIONS = [
+  { value: 'metric', label: 'Metric' },
+  { value: 'query-aggregate', label: 'Query aggregate' },
+] as const;
+
+const AGGREGATIONS: readonly AggregateFunction[] = ['Sum', 'Avg', 'Min', 'Max', 'Count'];
+
 /**
  * Built-in config form for {@link KpiWidgetDefinition}. v1 covers the two
  * common datasource flavours — Metric (the typical case) and
  * QueryAggregate (ad-hoc admin pages reusing the widget).
+ *
+ * The query-aggregate query field is a catalogue-backed combobox (like the
+ * chart/table/pivot forms); the metric field is a searchable combobox that
+ * also accepts a typed value (there is no metric catalogue yet).
  *
  * Telemetry datasources are out of scope for the form: those carry an
  * `entityAlias` that only makes sense in an IoT context. Apps wanting to
@@ -19,7 +33,10 @@ export function KpiConfigForm({ widget, onChange }: WidgetConfigFormProps<KpiWid
   const { t } = useTranslation();
   const { datasource } = widget;
 
-  const handleKindChange = (kind: 'metric' | 'query-aggregate') => {
+  const queryName = isQueryAggregateDatasource(datasource) ? datasource.queryName : '';
+  const { catalogEntries } = useQueryFieldMetadata(queryName);
+
+  const handleKindChange = (kind: string) => {
     if (kind === 'metric') {
       onChange({ ...widget, datasource: Datasource.metric('') });
     } else {
@@ -33,15 +50,12 @@ export function KpiConfigForm({ widget, onChange }: WidgetConfigFormProps<KpiWid
         <span className="mb-1 block text-muted-foreground">
           {t('Dashboard:Widget.Kpi.DatasourceKind.Label')}
         </span>
-        <select
-          data-slot="kpi-datasource-kind"
+        <EnumSelect
+          slot="kpi-datasource-kind"
           value={datasource.kind === 'iot-telemetry' ? 'metric' : datasource.kind}
-          onChange={(event) => handleKindChange(event.target.value as 'metric' | 'query-aggregate')}
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
-        >
-          <option value="metric">Metric</option>
-          <option value="query-aggregate">Query aggregate</option>
-        </select>
+          options={KIND_OPTIONS}
+          onChange={handleKindChange}
+        />
       </label>
 
       {isMetricDatasource(datasource) && (
@@ -49,14 +63,14 @@ export function KpiConfigForm({ widget, onChange }: WidgetConfigFormProps<KpiWid
           <span className="mb-1 block text-muted-foreground">
             {t('Dashboard:Widget.Kpi.MetricName.Label')}
           </span>
-          <input
-            type="text"
-            data-slot="kpi-metric-name"
+          <Combobox
+            slot="kpi-metric-name"
             value={datasource.metricName}
-            onChange={(event) =>
-              onChange({ ...widget, datasource: Datasource.metric(event.target.value) })
-            }
-            className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+            options={[]}
+            allowCustomValue
+            onValueChange={(value) => onChange({ ...widget, datasource: Datasource.metric(value) })}
+            placeholder="Select a metric…"
+            searchPlaceholder="Search or type a metric name…"
           />
         </label>
       )}
@@ -67,48 +81,41 @@ export function KpiConfigForm({ widget, onChange }: WidgetConfigFormProps<KpiWid
             <span className="mb-1 block text-muted-foreground">
               {t('Dashboard:Widget.Kpi.QueryName.Label')}
             </span>
-            <input
-              type="text"
-              data-slot="kpi-query-name"
+            <QueryNameCombobox
+              slot="kpi-query-name"
               value={datasource.queryName}
-              onChange={(event) =>
+              onChange={(value) =>
                 onChange({
                   ...widget,
                   datasource: Datasource.queryAggregate(
-                    event.target.value,
+                    value,
                     datasource.aggregation,
                     datasource.field
                   ),
                 })
               }
-              className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+              entries={catalogEntries}
             />
           </label>
           <label className="block text-sm">
             <span className="mb-1 block text-muted-foreground">
               {t('Dashboard:Widget.Kpi.Aggregation.Label')}
             </span>
-            <select
-              data-slot="kpi-aggregation"
+            <EnumSelect
+              slot="kpi-aggregation"
               value={datasource.aggregation}
-              onChange={(event) =>
+              options={AGGREGATIONS}
+              onChange={(value) =>
                 onChange({
                   ...widget,
                   datasource: Datasource.queryAggregate(
                     datasource.queryName,
-                    event.target.value as AggregateFunction,
+                    value as AggregateFunction,
                     datasource.field
                   ),
                 })
               }
-              className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
-            >
-              <option value="Sum">Sum</option>
-              <option value="Avg">Avg</option>
-              <option value="Min">Min</option>
-              <option value="Max">Max</option>
-              <option value="Count">Count</option>
-            </select>
+            />
           </label>
         </>
       )}

--- a/packages/@granit/react-analytics/src/editor/query-field-controls.tsx
+++ b/packages/@granit/react-analytics/src/editor/query-field-controls.tsx
@@ -207,7 +207,8 @@ export function EnumSelect({
 }: {
   readonly slot: string;
   readonly value: string;
-  readonly options: readonly string[];
+  /** Bare values (label === value) or explicit `{ value, label }` pairs. */
+  readonly options: readonly (string | { readonly value: string; readonly label: string })[];
   readonly onChange: (value: string) => void;
 }) {
   return (
@@ -216,11 +217,15 @@ export function EnumSelect({
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
-        {options.map((option) => (
-          <SelectItem key={option} value={option}>
-            {option}
-          </SelectItem>
-        ))}
+        {options.map((option) => {
+          const { value: optionValue, label } =
+            typeof option === 'string' ? { value: option, label: option } : option;
+          return (
+            <SelectItem key={optionValue} value={optionValue}>
+              {label}
+            </SelectItem>
+          );
+        })}
       </SelectContent>
     </Select>
   );


### PR DESCRIPTION
## Why

The chart / table / pivot config forms moved to shadcn Combobox / Select (#822), but the **KPI (metric) config form** was left on native `<input>` / `<select>`. So editing a KPI widget still showed a plain **textbox** for the metric name instead of a searchable combobox — inconsistent with the rest of the editor.

## What

- **Metric name** → searchable shadcn `Combobox` (`allowCustomValue`). There is no metric catalogue endpoint yet, so it stays free-text-with-search (typeable), but now reads/looks like the other pickers.
- **Query-aggregate query name** → catalogue-backed `QueryNameCombobox` (same picker as chart/table/pivot — suggests registered queries).
- **Datasource kind** + **aggregation** → shadcn `Select` via `EnumSelect`.
- `EnumSelect` now also accepts `{ value, label }` options (for the kind labels "Metric" / "Query aggregate"), keeping the bare-string call sites unchanged.

## Tests

`kpi-config-form` test rewritten to drive the Combobox/Select via `userEvent` + roles (metric custom-value entry, kind switch, query-aggregate fields). `tsc`, `eslint --max-warnings 0` clean; the form's suite green (4 tests).

## Note

No metric catalogue exists (front or backend) — a follow-up could add a `metrics` catalogue endpoint (mirroring the query `/catalog`) to make the metric field a true catalogue dropdown.