### PR TITLE
feat(contract-tests): flatten interface heritage in the conformance oracle

### DIFF
--- a/packages/@granit/contract-tests/src/__tests__/conformance.test.ts
+++ b/packages/@granit/contract-tests/src/__tests__/conformance.test.ts
@@ -352,3 +352,105 @@ describe('conformance oracle — discriminated unions', () => {
     );
   });
 });
+
+describe('conformance oracle — interface heritage (`extends`)', () => {
+  // Spec inlines every property, domain fields first then the shared audit
+  // quartet last — the shape produced when a .NET DTO appends audit columns.
+  const auditSpec: OpenApiDocument = {
+    components: {
+      schemas: {
+        Entity: {
+          type: 'object',
+          required: ['id', 'createdAt', 'createdBy', 'modifiedAt', 'modifiedBy'],
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            createdAt: { type: 'string', format: 'date-time' },
+            createdBy: { type: 'string' },
+            modifiedAt: { type: ['null', 'string'], format: 'date-time' },
+            modifiedBy: { type: ['null', 'string'] },
+          },
+        },
+      },
+    },
+  };
+  const checkEntity = (source: string) =>
+    checkSchemaConformance({
+      spec: auditSpec,
+      schemaName: 'Entity',
+      sourceText: source,
+      fileName: file,
+    });
+
+  it('flattens an inherited base so its fields satisfy the inlined spec', () => {
+    const src = `
+      type ISODateString = string & { __brand: 'iso' };
+      interface AuditFields {
+        readonly createdAt: ISODateString;
+        readonly createdBy: string;
+        readonly modifiedAt: ISODateString | null;
+        readonly modifiedBy: string | null;
+      }
+      export interface Entity extends AuditFields {
+        readonly id: string;
+      }`;
+    expect(checkEntity(src)).toEqual([]);
+  });
+
+  it('orders own members before inherited ones (trailing mixin convention)', () => {
+    // Own `id` first, inherited audit fields appended last — matches the spec
+    // order; a base-first flattening would trip the field-order rule.
+    const src = `
+      type ISODateString = string & { __brand: 'iso' };
+      interface AuditFields {
+        readonly createdAt: ISODateString;
+        readonly createdBy: string;
+        readonly modifiedAt: ISODateString | null;
+        readonly modifiedBy: string | null;
+      }
+      export interface Entity extends AuditFields {
+        readonly id: string;
+      }`;
+    expect(checkEntity(src)).not.toContainEqual(expect.objectContaining({ rule: 'field-order' }));
+  });
+
+  it('still flags a required field that neither the interface nor its base declares', () => {
+    const src = `
+      type ISODateString = string & { __brand: 'iso' };
+      interface AuditFields {
+        readonly createdAt: ISODateString;
+        readonly createdBy: string;
+        readonly modifiedAt: ISODateString | null;
+      }
+      export interface Entity extends AuditFields {
+        readonly id: string;
+      }`; // base drops modifiedBy
+    expect(checkEntity(src)).toContainEqual(
+      expect.objectContaining({ rule: 'missing-field', field: 'modifiedBy' })
+    );
+  });
+
+  it('skips an unflattening base (utility type) and checks own members only', () => {
+    // `extends Partial<X>` is not a named object decl the oracle can flatten;
+    // it must fall back to own-members-only rather than report type-missing.
+    const ownOnlySpec: OpenApiDocument = {
+      components: {
+        schemas: {
+          Entity: { type: 'object', required: ['id'], properties: { id: { type: 'string' } } },
+        },
+      },
+    };
+    const src = `
+      interface Labels { readonly name?: string; }
+      export interface Entity extends Partial<Labels> {
+        readonly id: string;
+      }`;
+    expect(
+      checkSchemaConformance({
+        spec: ownOnlySpec,
+        schemaName: 'Entity',
+        sourceText: src,
+        fileName: file,
+      })
+    ).toEqual([]);
+  });
+});

--- a/packages/@granit/contract-tests/src/conformance.ts
+++ b/packages/@granit/contract-tests/src/conformance.ts
@@ -236,6 +236,13 @@ interface SymbolDecl {
   readonly members?: readonly ts.TypeElement[];
   /** Present for an alias that forwards to another named type. */
   readonly aliasTarget?: ts.TypeNode;
+  /**
+   * `extends` base types of an interface (possibly generic, possibly
+   * cross-package). Flattened into the member list so a DTO that inherits
+   * shared fields (e.g. `extends AuditFields`) is checked against the full
+   * inlined spec schema rather than its own members alone.
+   */
+  readonly heritage?: readonly ts.ExpressionWithTypeArguments[];
 }
 type DeclMap = ReadonlyMap<string, SymbolDecl>;
 
@@ -269,9 +276,13 @@ function parseInfo(fileName: string, sourceText: string): FileInfo {
           : { typeParams, aliasTarget: node.type }
       );
     } else if (ts.isInterfaceDeclaration(node)) {
+      const heritage = node.heritageClauses
+        ?.filter((clause) => clause.token === ts.SyntaxKind.ExtendsKeyword)
+        .flatMap((clause) => clause.types);
       decls.set(node.name.text, {
         typeParams: node.typeParameters?.map((p) => p.name.text) ?? [],
         members: node.members,
+        heritage: heritage && heritage.length > 0 ? heritage : undefined,
       });
     } else if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
       imports.push(node.moduleSpecifier.text);
@@ -399,7 +410,37 @@ function resolveDeclMembers(
     const arg = typeArgs[i];
     if (arg) bound.set(param, arg);
   });
-  if (decl.members) return { members: decl.members, aliases: bound };
+  if (decl.members) {
+    if (!decl.heritage) return { members: decl.members, aliases: bound };
+    // Flatten `extends` bases so an inherited field (e.g. `extends AuditFields`)
+    // is checked against the inlined spec schema. Own members come FIRST, then
+    // each base in declaration order: shared mixins in this codebase (audit /
+    // concurrency stamp) are trailing fields on the .NET DTO, so the spec lists
+    // them last — own-first preserves that relative order for the field-order
+    // rule. A base the oracle cannot flatten (e.g. `extends Partial<X>`, a
+    // utility type, or an unresolved external) is skipped, preserving the
+    // pre-heritage behaviour of checking own members only rather than failing.
+    const ownNames = new Set(
+      decl.members.map((m) => m.name?.getText()).filter((n): n is string => n !== undefined)
+    );
+    const merged: ts.TypeElement[] = [...decl.members];
+    let mergedAliases: AliasMap = bound;
+    for (const base of decl.heritage) {
+      const baseResolved = resolveDeclMembers(
+        base.expression.getText(),
+        base.typeArguments ?? [],
+        decls,
+        bound,
+        depth + 1
+      );
+      if (!baseResolved) continue;
+      // Own members override inherited ones (TS semantics); skip a base field
+      // the interface redeclares so the own type/order wins.
+      merged.push(...baseResolved.members.filter((m) => !ownNames.has(m.name?.getText() ?? '')));
+      mergedAliases = new Map([...baseResolved.aliases, ...mergedAliases]);
+    }
+    return { members: merged, aliases: mergedAliases };
+  }
   if (decl.aliasTarget && ts.isTypeReferenceNode(decl.aliasTarget)) {
     return resolveDeclMembers(
       decl.aliasTarget.typeName.getText(),


### PR DESCRIPTION
## What

Teaches the `@granit/contract-tests` conformance oracle to flatten interface `extends` clauses. Previously `resolveDeclMembers` returned an interface's **own** members only and ignored heritage, so any DTO inheriting shared fields was invisible to the oracle — which is why several `extends`-based DTOs are deliberately excluded from the conformance manifest (see the `CategoryDetailResponse` note in `manifest.ts`).

## How

`resolveDeclMembers` now flattens each `extends` base into the member list:
- **Own members first, bases appended last** — shared mixins (audit / concurrency) are trailing fields on the .NET record, so the inlined spec lists them last; own-first preserves that relative order for the `field-order` rule.
- **Own members override inherited ones** on name collision (TS semantics).
- A base the oracle **cannot flatten** (utility types like `Partial<X>`, unresolved externals) is **skipped**, preserving the prior own-members-only behaviour rather than failing.

## Why

Standalone improvement to the contract safety net. Lifts a latent limitation and unblocks registering the `extends`-based DTOs that were previously left out of conformance coverage.

## Tests

4 dedicated tests lock the flatten order, missing-field detection through a base, and the skip-unflattening-base fallback. Full suite green (572 tests).

## Context

Discovered while scoping a shared-types dedup (`extends AuditFields`). That dedup turned out **non-viable** (inconsistent .NET audit serialization order vs the oracle's field-order rule — a backend `granit-dotnet` issue to revisit), so only this oracle improvement is shipped here.