### PR TITLE
feat(react-api-client): createConfigProvider factory + adopt across 33 packages

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2584,14 +2584,13 @@
         {
           "name": "AccountConfig",
           "kind": "interface",
-          "signature": "interface AccountConfig",
+          "signature": "interface AccountConfig extends GranitProviderConfig",
           "members": []
         },
         {
           "name": "AccountProviderProps",
-          "kind": "interface",
-          "signature": "interface AccountProviderProps",
-          "members": []
+          "kind": "type",
+          "signature": "type AccountProviderProps = GranitProviderProps<AccountConfig>"
         },
         {
           "name": "useAccountSettings",
@@ -2806,25 +2805,24 @@
       "exports": [
         {
           "name": "AIProvider",
-          "kind": "function",
-          "signature": "function AIProvider("
+          "kind": "const",
+          "signature": "const AIProvider"
         },
         {
           "name": "useAIConfig",
-          "kind": "function",
-          "signature": "function useAIConfig(): ResolvedAIConfig"
+          "kind": "const",
+          "signature": "const useAIConfig"
         },
         {
           "name": "AIConfig",
           "kind": "interface",
-          "signature": "interface AIConfig",
+          "signature": "interface AIConfig extends GranitProviderConfig",
           "members": []
         },
         {
           "name": "AIProviderProps",
-          "kind": "interface",
-          "signature": "interface AIProviderProps",
-          "members": []
+          "kind": "type",
+          "signature": "type AIProviderProps = GranitProviderProps<AIConfig>"
         },
         {
           "name": "ResolvedAIConfig",
@@ -3257,13 +3255,13 @@
       "exports": [
         {
           "name": "AIPromptsProvider",
-          "kind": "function",
-          "signature": "function AIPromptsProvider("
+          "kind": "const",
+          "signature": "const AIPromptsProvider"
         },
         {
           "name": "useAIPromptsConfig",
-          "kind": "function",
-          "signature": "function useAIPromptsConfig(): ResolvedAIPromptsConfig"
+          "kind": "const",
+          "signature": "const useAIPromptsConfig"
         },
         {
           "name": "promptKeys",
@@ -4324,18 +4322,18 @@
         },
         {
           "name": "CmsProvider",
-          "kind": "function",
-          "signature": "function CmsProvider("
+          "kind": "const",
+          "signature": "const CmsProvider"
         },
         {
           "name": "useCmsConfig",
-          "kind": "function",
-          "signature": "function useCmsConfig(): ResolvedCmsConfig"
+          "kind": "const",
+          "signature": "const useCmsConfig"
         },
         {
           "name": "CmsConfig",
           "kind": "interface",
-          "signature": "interface CmsConfig",
+          "signature": "interface CmsConfig extends GranitProviderConfig",
           "members": []
         },
         {
@@ -4346,9 +4344,8 @@
         },
         {
           "name": "CmsProviderProps",
-          "kind": "interface",
-          "signature": "interface CmsProviderProps",
-          "members": []
+          "kind": "type",
+          "signature": "type CmsProviderProps = GranitProviderProps<CmsConfig>"
         },
         {
           "name": "cmsKeys",
@@ -4453,13 +4450,13 @@
       "exports": [
         {
           "name": "CmsHostnamesProvider",
-          "kind": "function",
-          "signature": "function CmsHostnamesProvider("
+          "kind": "const",
+          "signature": "const CmsHostnamesProvider"
         },
         {
           "name": "useCmsHostnamesConfig",
-          "kind": "function",
-          "signature": "function useCmsHostnamesConfig(): ResolvedCmsHostnamesConfig"
+          "kind": "const",
+          "signature": "const useCmsHostnamesConfig"
         },
         {
           "name": "cmsHostnamesKeys",
@@ -4484,13 +4481,13 @@
       "exports": [
         {
           "name": "CmsRedirectsProvider",
-          "kind": "function",
-          "signature": "function CmsRedirectsProvider("
+          "kind": "const",
+          "signature": "const CmsRedirectsProvider"
         },
         {
           "name": "useCmsRedirectsConfig",
-          "kind": "function",
-          "signature": "function useCmsRedirectsConfig(): ResolvedCmsRedirectsConfig"
+          "kind": "const",
+          "signature": "const useCmsRedirectsConfig"
         },
         {
           "name": "cmsRedirectsKeys",
@@ -4505,13 +4502,13 @@
       "exports": [
         {
           "name": "CmsSeoProvider",
-          "kind": "function",
-          "signature": "function CmsSeoProvider("
+          "kind": "const",
+          "signature": "const CmsSeoProvider"
         },
         {
           "name": "useCmsSeoConfig",
-          "kind": "function",
-          "signature": "function useCmsSeoConfig(): ResolvedCmsSeoConfig"
+          "kind": "const",
+          "signature": "const useCmsSeoConfig"
         },
         {
           "name": "cmsSeoKeys",
@@ -7005,14 +7002,13 @@
         {
           "name": "PrivacyConfig",
           "kind": "interface",
-          "signature": "interface PrivacyConfig",
+          "signature": "interface PrivacyConfig extends GranitProviderConfig",
           "members": []
         },
         {
           "name": "PrivacyProviderProps",
-          "kind": "interface",
-          "signature": "interface PrivacyProviderProps",
-          "members": []
+          "kind": "type",
+          "signature": "type PrivacyProviderProps = GranitProviderProps<PrivacyConfig>"
         },
         {
           "name": "useApplicableRegulation",
@@ -7603,25 +7599,24 @@
       "exports": [
         {
           "name": "TemplatingProvider",
-          "kind": "function",
-          "signature": "function TemplatingProvider("
+          "kind": "const",
+          "signature": "const TemplatingProvider"
         },
         {
           "name": "useTemplatingConfig",
-          "kind": "function",
-          "signature": "function useTemplatingConfig(): ResolvedTemplatingConfig"
+          "kind": "const",
+          "signature": "const useTemplatingConfig"
         },
         {
           "name": "TemplatingConfig",
           "kind": "interface",
-          "signature": "interface TemplatingConfig",
+          "signature": "interface TemplatingConfig extends GranitProviderConfig",
           "members": []
         },
         {
           "name": "TemplatingProviderProps",
-          "kind": "interface",
-          "signature": "interface TemplatingProviderProps",
-          "members": []
+          "kind": "type",
+          "signature": "type TemplatingProviderProps = GranitProviderProps<TemplatingConfig>"
         },
         {
           "name": "useTemplate",
@@ -7708,14 +7703,13 @@
         {
           "name": "TimelineProviderConfig",
           "kind": "interface",
-          "signature": "interface TimelineProviderConfig",
+          "signature": "interface TimelineProviderConfig extends GranitProviderConfig",
           "members": []
         },
         {
           "name": "TimelineProviderProps",
-          "kind": "interface",
-          "signature": "interface TimelineProviderProps",
-          "members": []
+          "kind": "type",
+          "signature": "type TimelineProviderProps = GranitProviderProps<TimelineProviderConfig>"
         },
         {
           "name": "useTimeline",

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -6013,13 +6013,13 @@
       "exports": [
         {
           "name": "HostnamesProvider",
-          "kind": "function",
-          "signature": "function HostnamesProvider("
+          "kind": "const",
+          "signature": "const HostnamesProvider"
         },
         {
           "name": "useHostnamesConfig",
-          "kind": "function",
-          "signature": "function useHostnamesConfig(): ResolvedHostnamesConfig"
+          "kind": "const",
+          "signature": "const useHostnamesConfig"
         },
         {
           "name": "useHostnames",

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3863,25 +3863,23 @@
       "exports": [
         {
           "name": "LocalAuthProvider",
-          "kind": "function",
-          "signature": "function LocalAuthProvider("
+          "kind": "const",
+          "signature": "const LocalAuthProvider"
         },
         {
           "name": "useLocalAuthConfig",
-          "kind": "function",
-          "signature": "function useLocalAuthConfig(): ResolvedLocalAuthConfig"
+          "kind": "const",
+          "signature": "const useLocalAuthConfig"
         },
         {
           "name": "LocalAuthConfig",
-          "kind": "interface",
-          "signature": "interface LocalAuthConfig",
-          "members": []
+          "kind": "type",
+          "signature": "type LocalAuthConfig = GranitProviderConfig"
         },
         {
           "name": "LocalAuthProviderProps",
-          "kind": "interface",
-          "signature": "interface LocalAuthProviderProps",
-          "members": []
+          "kind": "type",
+          "signature": "type LocalAuthProviderProps = GranitProviderProps<LocalAuthConfig>"
         },
         {
           "name": "useLogin",
@@ -4068,13 +4066,13 @@
       "exports": [
         {
           "name": "BlobStorageProvider",
-          "kind": "function",
-          "signature": "function BlobStorageProvider("
+          "kind": "const",
+          "signature": "const BlobStorageProvider"
         },
         {
           "name": "useBlobStorageConfig",
-          "kind": "function",
-          "signature": "function useBlobStorageConfig(): ResolvedBlobStorageConfig"
+          "kind": "const",
+          "signature": "const useBlobStorageConfig"
         },
         {
           "name": "BlobImage",
@@ -4725,13 +4723,13 @@
       "exports": [
         {
           "name": "DashboardsProvider",
-          "kind": "function",
-          "signature": "function DashboardsProvider("
+          "kind": "const",
+          "signature": "const DashboardsProvider"
         },
         {
           "name": "useDashboardsConfig",
-          "kind": "function",
-          "signature": "function useDashboardsConfig(): ResolvedDashboardsConfig"
+          "kind": "const",
+          "signature": "const useDashboardsConfig"
         },
         {
           "name": "UseDashboardRenderOptions",
@@ -5991,14 +5989,13 @@
         {
           "name": "FeaturesConfig",
           "kind": "interface",
-          "signature": "interface FeaturesConfig",
+          "signature": "interface FeaturesConfig extends GranitProviderConfig",
           "members": []
         },
         {
           "name": "FeaturesProviderProps",
-          "kind": "interface",
-          "signature": "interface FeaturesProviderProps",
-          "members": []
+          "kind": "type",
+          "signature": "type FeaturesProviderProps = GranitProviderProps<FeaturesConfig>"
         },
         {
           "name": "SetFeatureOverrideVariables",
@@ -6635,13 +6632,13 @@
         },
         {
           "name": "MobilePushProvider",
-          "kind": "function",
-          "signature": "function MobilePushProvider("
+          "kind": "const",
+          "signature": "const MobilePushProvider"
         },
         {
           "name": "useMobilePushConfig",
-          "kind": "function",
-          "signature": "function useMobilePushConfig(): ResolvedMobilePushProviderConfig"
+          "kind": "const",
+          "signature": "const useMobilePushConfig"
         }
       ]
     },
@@ -6750,14 +6747,13 @@
         {
           "name": "PartiesConfig",
           "kind": "interface",
-          "signature": "interface PartiesConfig",
+          "signature": "interface PartiesConfig extends GranitProviderConfig",
           "members": []
         },
         {
           "name": "PartiesProviderProps",
-          "kind": "interface",
-          "signature": "interface PartiesProviderProps",
-          "members": []
+          "kind": "type",
+          "signature": "type PartiesProviderProps = GranitProviderProps<PartiesConfig>"
         },
         {
           "name": "PartiesListProvider",
@@ -7237,25 +7233,24 @@
       "exports": [
         {
           "name": "SchedulingProvider",
-          "kind": "function",
-          "signature": "function SchedulingProvider("
+          "kind": "const",
+          "signature": "const SchedulingProvider"
         },
         {
           "name": "useSchedulingConfig",
-          "kind": "function",
-          "signature": "function useSchedulingConfig(): ResolvedSchedulingConfig"
+          "kind": "const",
+          "signature": "const useSchedulingConfig"
         },
         {
           "name": "SchedulingConfig",
           "kind": "interface",
-          "signature": "interface SchedulingConfig",
+          "signature": "interface SchedulingConfig extends GranitProviderConfig",
           "members": []
         },
         {
           "name": "SchedulingProviderProps",
-          "kind": "interface",
-          "signature": "interface SchedulingProviderProps",
-          "members": []
+          "kind": "type",
+          "signature": "type SchedulingProviderProps = GranitProviderProps<SchedulingConfig>"
         },
         {
           "name": "buildSchedulingQueryKey",
@@ -7409,8 +7404,8 @@
       "exports": [
         {
           "name": "TaxProvider",
-          "kind": "function",
-          "signature": "function TaxProvider("
+          "kind": "const",
+          "signature": "const TaxProvider"
         },
         {
           "name": "buildTaxQueryKey",
@@ -7419,20 +7414,19 @@
         },
         {
           "name": "useTaxConfig",
-          "kind": "function",
-          "signature": "function useTaxConfig(): ResolvedTaxConfig"
+          "kind": "const",
+          "signature": "const useTaxConfig"
         },
         {
           "name": "TaxConfig",
           "kind": "interface",
-          "signature": "interface TaxConfig",
+          "signature": "interface TaxConfig extends GranitProviderConfig",
           "members": []
         },
         {
           "name": "TaxProviderProps",
-          "kind": "interface",
-          "signature": "interface TaxProviderProps",
-          "members": []
+          "kind": "type",
+          "signature": "type TaxProviderProps = GranitProviderProps<TaxConfig>"
         }
       ]
     },
@@ -11299,13 +11293,13 @@
       "exports": [
         {
           "name": "WebhooksProvider",
-          "kind": "function",
-          "signature": "function WebhooksProvider("
+          "kind": "const",
+          "signature": "const WebhooksProvider"
         },
         {
           "name": "useWebhooksConfig",
-          "kind": "function",
-          "signature": "function useWebhooksConfig(): ResolvedWebhooksConfig"
+          "kind": "const",
+          "signature": "const useWebhooksConfig"
         },
         {
           "name": "useSubscription",

--- a/packages/@granit/react-account/src/__tests__/account-provider.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/account-provider.test.tsx
@@ -53,7 +53,7 @@ describe('AccountProvider', () => {
   it('should throw when used outside provider', () => {
     expect(() => {
       renderHook(() => useAccountConfig());
-    }).toThrow('useAccountConfig must be used within an AccountProvider');
+    }).toThrow('useAccountConfig must be used within a <AccountProvider>');
   });
 });
 

--- a/packages/@granit/react-account/src/providers/account-provider.tsx
+++ b/packages/@granit/react-account/src/providers/account-provider.tsx
@@ -1,14 +1,11 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type { GranitProviderConfig, GranitProviderProps } from '@granit/react-api-client';
 
-export interface AccountConfig {
-  readonly client?: AxiosInstance;
-  readonly basePath?: string;
+export interface AccountConfig extends GranitProviderConfig {
   readonly queryKeyPrefix?: readonly string[];
 }
 
@@ -20,19 +17,13 @@ export interface ResolvedAccountConfig extends AccountConfig {
   readonly client: AxiosInstance;
 }
 
-export interface AccountProviderProps {
-  readonly config: AccountConfig;
-  readonly children: ReactNode;
-}
+export type AccountProviderProps = GranitProviderProps<AccountConfig>;
 
 const DEFAULT_KEY_PREFIX = ['account'] as const;
 
-const AccountContext = createContext<ResolvedAccountConfig | null>(null);
-
-export function useAccountConfig(): ResolvedAccountConfig {
-  const config = useContext(AccountContext);
-  if (!config) throw new Error('useAccountConfig must be used within an AccountProvider');
-  return config;
+interface FullyResolvedAccountConfig extends ResolvedAccountConfig {
+  readonly basePath: string;
+  readonly queryKeyPrefix: readonly string[];
 }
 
 export function buildAccountQueryKey(
@@ -42,22 +33,15 @@ export function buildAccountQueryKey(
   return [...(config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX), ...segments];
 }
 
-export function AccountProvider({ config, children }: AccountProviderProps) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'AccountProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
-      client,
-    };
-  }, [config, contextClient]);
+const { Provider, useConfig } = createConfigProvider<AccountConfig, FullyResolvedAccountConfig>({
+  name: 'Account',
+  defaultBasePath: DEFAULT_BASE_PATH,
+  resolve: (base) => ({
+    ...base,
+    queryKeyPrefix: base.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
+  }),
+});
 
-  return <AccountContext value={value}>{children}</AccountContext>;
-}
+export const AccountProvider = Provider;
+
+export const useAccountConfig: () => ResolvedAccountConfig = useConfig;

--- a/packages/@granit/react-ai-chat/src/providers/ai-chat-provider.tsx
+++ b/packages/@granit/react-ai-chat/src/providers/ai-chat-provider.tsx
@@ -3,20 +3,15 @@
 // conversation hooks. Mirrors the @granit/react-ai provider pattern.
 // ---------------------------------------------------------------------------
 
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX } from '../constants';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type { GranitProviderConfig, GranitProviderProps } from '@granit/react-api-client';
 
 /** Configuration for {@link AIChatProvider}. */
-export interface AIChatConfig {
-  /** Axios client with auth, CSRF, and tenant interceptors. */
-  readonly client?: AxiosInstance;
-  /** Base path for the conversation endpoints (default: `/api/v1/conversations`). */
-  readonly basePath?: string;
+export interface AIChatConfig extends GranitProviderConfig {
   /** React Query key prefix (default: `['ai-chat']`). */
   readonly queryKeyPrefix?: readonly string[];
   /**
@@ -36,48 +31,30 @@ export interface ResolvedAIChatConfig extends AIChatConfig {
   readonly showMessageMetrics: boolean;
 }
 
-export interface AIChatProviderProps {
-  readonly config: AIChatConfig;
-  readonly children: ReactNode;
-}
+export type AIChatProviderProps = GranitProviderProps<AIChatConfig>;
 
-const AIChatConfigContext = createContext<ResolvedAIChatConfig | null>(null);
+const { Provider, useConfig, useOptionalConfig } = createConfigProvider<
+  AIChatConfig,
+  ResolvedAIChatConfig
+>({
+  name: 'AIChat',
+  defaultBasePath: DEFAULT_BASE_PATH,
+  resolve: (base) => ({
+    ...base,
+    queryKeyPrefix: base.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
+    showMessageMetrics: base.showMessageMetrics ?? false,
+  }),
+});
 
 /** Provides chat configuration to child components and hooks. */
-export function AIChatProvider({ config, children }: Readonly<AIChatProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedAIChatConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'AIChatProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      client,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
-      showMessageMetrics: config.showMessageMetrics ?? false,
-    };
-  }, [config, contextClient]);
-  return <AIChatConfigContext value={value}>{children}</AIChatConfigContext>;
-}
+export const AIChatProvider = Provider;
 
 /** Returns the chat configuration from the nearest {@link AIChatProvider}. */
-export function useAIChatConfig(): ResolvedAIChatConfig {
-  const ctx = useContext(AIChatConfigContext);
-  if (!ctx) {
-    throw new Error('useAIChatConfig must be used within an AIChatProvider');
-  }
-  return ctx;
-}
+export const useAIChatConfig = useConfig;
 
 /**
  * Like {@link useAIChatConfig} but returns `null` outside a provider instead of
  * throwing — for presentational components (e.g. `ConversationThread`) that
  * read an optional flag yet must still render standalone in tests/Storybook.
  */
-export function useOptionalAIChatConfig(): ResolvedAIChatConfig | null {
-  return useContext(AIChatConfigContext);
-}
+export const useOptionalAIChatConfig = useOptionalConfig;

--- a/packages/@granit/react-ai-prompts/src/providers/ai-prompts-provider.tsx
+++ b/packages/@granit/react-ai-prompts/src/providers/ai-prompts-provider.tsx
@@ -3,20 +3,15 @@
 // catalogue hooks. Mirrors the @granit/react-ai-chat provider pattern.
 // ---------------------------------------------------------------------------
 
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX } from '../constants';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type { GranitProviderConfig, GranitProviderProps } from '@granit/react-api-client';
 
 /** Configuration for {@link AIPromptsProvider}. */
-export interface AIPromptsConfig {
-  /** Axios client with auth, CSRF, and tenant interceptors. */
-  readonly client?: AxiosInstance;
-  /** Base path for the catalogue endpoints (default: `/api/v1/prompts`). */
-  readonly basePath?: string;
+export interface AIPromptsConfig extends GranitProviderConfig {
   /** React Query key prefix (default: `['ai-prompts']`). */
   readonly queryKeyPrefix?: readonly string[];
 }
@@ -28,38 +23,19 @@ export interface ResolvedAIPromptsConfig extends AIPromptsConfig {
   readonly queryKeyPrefix: readonly string[];
 }
 
-export interface AIPromptsProviderProps {
-  readonly config: AIPromptsConfig;
-  readonly children: ReactNode;
-}
+export type AIPromptsProviderProps = GranitProviderProps<AIPromptsConfig>;
 
-const AIPromptsConfigContext = createContext<ResolvedAIPromptsConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<AIPromptsConfig, ResolvedAIPromptsConfig>({
+  name: 'AIPrompts',
+  defaultBasePath: DEFAULT_BASE_PATH,
+  resolve: (base) => ({
+    ...base,
+    queryKeyPrefix: base.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
+  }),
+});
 
 /** Provides catalogue configuration to child components and hooks. */
-export function AIPromptsProvider({ config, children }: Readonly<AIPromptsProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedAIPromptsConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'AIPromptsProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      client,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
-    };
-  }, [config, contextClient]);
-  return <AIPromptsConfigContext value={value}>{children}</AIPromptsConfigContext>;
-}
+export const AIPromptsProvider = Provider;
 
-/** Returns the catalogue configuration from the nearest {@link AIPromptsProvider}. */
-export function useAIPromptsConfig(): ResolvedAIPromptsConfig {
-  const ctx = useContext(AIPromptsConfigContext);
-  if (!ctx) {
-    throw new Error('useAIPromptsConfig must be used within an AIPromptsProvider');
-  }
-  return ctx;
-}
+/** Returns the catalogue configuration from the nearest `AIPromptsProvider`. */
+export const useAIPromptsConfig = useConfig;

--- a/packages/@granit/react-ai/src/__tests__/ai-provider.test.tsx
+++ b/packages/@granit/react-ai/src/__tests__/ai-provider.test.tsx
@@ -30,6 +30,6 @@ describe('AIProvider', () => {
   it('should throw when used outside provider', () => {
     expect(() => {
       renderHook(() => useAIConfig());
-    }).toThrow('useAIConfig must be used within an AIProvider');
+    }).toThrow('useAIConfig must be used within a <AIProvider>');
   });
 });

--- a/packages/@granit/react-ai/src/providers/ai-provider.tsx
+++ b/packages/@granit/react-ai/src/providers/ai-provider.tsx
@@ -2,20 +2,15 @@
 // AI context provider — supplies Axios client and config to all AI hooks.
 // ---------------------------------------------------------------------------
 
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX } from '../constants';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type { GranitProviderConfig, GranitProviderProps } from '@granit/react-api-client';
 
 /** Configuration for the AI provider. */
-export interface AIConfig {
-  /** Axios client with auth and tenant interceptors. */
-  readonly client?: AxiosInstance;
-  /** Base path for AI endpoints (default: `/api/v1/ai`). */
-  readonly basePath?: string;
+export interface AIConfig extends GranitProviderConfig {
   /** Custom React Query key prefix (default: `['ai']`). */
   readonly queryKeyPrefix?: readonly string[];
 }
@@ -31,38 +26,19 @@ export interface ResolvedAIConfig extends AIConfig {
   readonly queryKeyPrefix: readonly string[];
 }
 
-export interface AIProviderProps {
-  readonly config: AIConfig;
-  readonly children: ReactNode;
-}
+export type AIProviderProps = GranitProviderProps<AIConfig>;
 
-const AIConfigContext = createContext<ResolvedAIConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<AIConfig, ResolvedAIConfig>({
+  name: 'AI',
+  defaultBasePath: DEFAULT_BASE_PATH,
+  resolve: (base) => ({
+    ...base,
+    queryKeyPrefix: base.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
+  }),
+});
 
 /** Provides AI configuration to child components and hooks. */
-export function AIProvider({ config, children }: Readonly<AIProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedAIConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'AIProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      client,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
-    };
-  }, [config, contextClient]);
-  return <AIConfigContext value={value}>{children}</AIConfigContext>;
-}
+export const AIProvider = Provider;
 
 /** Returns the AI configuration from the nearest `AIProvider`. */
-export function useAIConfig(): ResolvedAIConfig {
-  const ctx = useContext(AIConfigContext);
-  if (!ctx) {
-    throw new Error('useAIConfig must be used within an AIProvider');
-  }
-  return ctx;
-}
+export const useAIConfig = useConfig;

--- a/packages/@granit/react-api-client/src/__tests__/create-config-provider.test.tsx
+++ b/packages/@granit/react-api-client/src/__tests__/create-config-provider.test.tsx
@@ -6,6 +6,7 @@ import { createConfigProvider } from '../providers/create-config-provider';
 import { GranitClientProvider } from '../providers/granit-client-provider';
 
 import type { GranitProviderConfig } from '../providers/create-config-provider';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 interface WidgetsConfig extends GranitProviderConfig {
@@ -66,5 +67,63 @@ describe('createConfigProvider', () => {
     expect(() => renderHook(() => useWidgetsConfig())).toThrow(
       'useWidgetsConfig must be used within a <WidgetsProvider>'
     );
+  });
+});
+
+interface GadgetsConfig extends GranitProviderConfig {
+  readonly queryKeyPrefix?: readonly string[];
+}
+interface ResolvedGadgetsConfig extends GadgetsConfig {
+  readonly client: AxiosInstance;
+  readonly basePath: string;
+  readonly queryKeyPrefix: readonly string[];
+}
+
+const {
+  Provider: GadgetsProvider,
+  useConfig: useGadgetsConfig,
+  useOptionalConfig: useOptionalGadgetsConfig,
+} = createConfigProvider<GadgetsConfig, ResolvedGadgetsConfig>({
+  name: 'Gadgets',
+  defaultBasePath: '/api/v1/gadgets',
+  resolve: (base) => ({ ...base, queryKeyPrefix: base.queryKeyPrefix ?? ['gadgets'] }),
+});
+
+describe('createConfigProvider — resolve hook & useOptionalConfig', () => {
+  it('defaults an extra field via the resolve hook', () => {
+    const client = axios.create();
+    const { result } = renderHook(() => useGadgetsConfig(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <GadgetsProvider config={{ client }}>{children}</GadgetsProvider>
+      ),
+    });
+    expect(result.current.queryKeyPrefix).toEqual(['gadgets']);
+  });
+
+  it('keeps a caller-supplied extra field through resolve', () => {
+    const client = axios.create();
+    const { result } = renderHook(() => useGadgetsConfig(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <GadgetsProvider config={{ client, queryKeyPrefix: ['custom'] }}>
+          {children}
+        </GadgetsProvider>
+      ),
+    });
+    expect(result.current.queryKeyPrefix).toEqual(['custom']);
+  });
+
+  it('useOptionalConfig returns the value inside the provider', () => {
+    const client = axios.create();
+    const { result } = renderHook(() => useOptionalGadgetsConfig(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <GadgetsProvider config={{ client }}>{children}</GadgetsProvider>
+      ),
+    });
+    expect(result.current?.basePath).toBe('/api/v1/gadgets');
+  });
+
+  it('useOptionalConfig returns null outside the provider (no throw)', () => {
+    const { result } = renderHook(() => useOptionalGadgetsConfig());
+    expect(result.current).toBeNull();
   });
 });

--- a/packages/@granit/react-api-client/src/__tests__/create-config-provider.test.tsx
+++ b/packages/@granit/react-api-client/src/__tests__/create-config-provider.test.tsx
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react';
+import axios from 'axios';
+import { describe, expect, it } from 'vitest';
+
+import { createConfigProvider } from '../providers/create-config-provider';
+import { GranitClientProvider } from '../providers/granit-client-provider';
+
+import type { GranitProviderConfig } from '../providers/create-config-provider';
+import type { ReactNode } from 'react';
+
+interface WidgetsConfig extends GranitProviderConfig {
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+const { Provider: WidgetsProvider, useConfig: useWidgetsConfig } =
+  createConfigProvider<WidgetsConfig>({ name: 'Widgets', defaultBasePath: '/api/v1/widgets' });
+
+describe('createConfigProvider', () => {
+  it('resolves the client from config and defaults the basePath', () => {
+    const client = axios.create();
+    const { result } = renderHook(() => useWidgetsConfig(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <WidgetsProvider config={{ client }}>{children}</WidgetsProvider>
+      ),
+    });
+    expect(result.current.client).toBe(client);
+    expect(result.current.basePath).toBe('/api/v1/widgets');
+  });
+
+  it('keeps an explicit basePath and passes through extra config fields', () => {
+    const client = axios.create();
+    const { result } = renderHook(() => useWidgetsConfig(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <WidgetsProvider config={{ client, basePath: '/custom', queryKeyPrefix: ['w'] }}>
+          {children}
+        </WidgetsProvider>
+      ),
+    });
+    expect(result.current.basePath).toBe('/custom');
+    expect(result.current.queryKeyPrefix).toEqual(['w']);
+  });
+
+  it('falls back to the client from the nearest GranitClientProvider', () => {
+    const client = axios.create();
+    const { result } = renderHook(() => useWidgetsConfig(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <GranitClientProvider client={client}>
+          <WidgetsProvider config={{}}>{children}</WidgetsProvider>
+        </GranitClientProvider>
+      ),
+    });
+    expect(result.current.client).toBe(client);
+  });
+
+  it('throws when no client is available from config or context', () => {
+    expect(() =>
+      renderHook(() => useWidgetsConfig(), {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <WidgetsProvider config={{}}>{children}</WidgetsProvider>
+        ),
+      })
+    ).toThrow('WidgetsProvider requires an Axios client');
+  });
+
+  it('throws when the hook is used outside its provider', () => {
+    expect(() => renderHook(() => useWidgetsConfig())).toThrow(
+      'useWidgetsConfig must be used within a <WidgetsProvider>'
+    );
+  });
+});

--- a/packages/@granit/react-api-client/src/index.ts
+++ b/packages/@granit/react-api-client/src/index.ts
@@ -4,3 +4,11 @@ export {
   useGranitClient,
   useOptionalGranitClient,
 } from './providers/granit-client-provider';
+export {
+  type ConfigProvider,
+  type CreateConfigProviderOptions,
+  type GranitProviderConfig,
+  type GranitProviderProps,
+  type ResolvedGranitProviderConfig,
+  createConfigProvider,
+} from './providers/create-config-provider';

--- a/packages/@granit/react-api-client/src/providers/create-config-provider.tsx
+++ b/packages/@granit/react-api-client/src/providers/create-config-provider.tsx
@@ -32,7 +32,10 @@ export interface GranitProviderProps<TConfig extends GranitProviderConfig> {
   readonly children: ReactNode;
 }
 
-export interface CreateConfigProviderOptions {
+export interface CreateConfigProviderOptions<
+  TConfig extends GranitProviderConfig,
+  TResolved extends ResolvedGranitProviderConfig<TConfig>,
+> {
   /**
    * PascalCase domain name used to build the component `displayName` and the
    * error messages (`<Name>Provider requires…`, `use<Name>Config must be used…`).
@@ -40,13 +43,26 @@ export interface CreateConfigProviderOptions {
   readonly name: string;
   /** Base path applied when `config.basePath` is omitted. */
   readonly defaultBasePath: string;
+  /**
+   * Optional hook to derive fields beyond `client`/`basePath` (e.g. default a
+   * `queryKeyPrefix`). Receives the base-resolved config (client + basePath
+   * applied) and the raw config, and returns the fully-resolved value.
+   * **Required whenever `TResolved` adds fields** beyond the base resolution —
+   * without it the provider would expose a value missing those fields.
+   */
+  readonly resolve?: (base: ResolvedGranitProviderConfig<TConfig>, raw: TConfig) => TResolved;
 }
 
-export interface ConfigProvider<TConfig extends GranitProviderConfig> {
-  /** Context provider resolving `client`/`basePath` for descendant hooks. */
+export interface ConfigProvider<
+  TConfig extends GranitProviderConfig,
+  TResolved extends ResolvedGranitProviderConfig<TConfig> = ResolvedGranitProviderConfig<TConfig>,
+> {
+  /** Context provider resolving `client`/`basePath` (and `resolve` extras) for descendant hooks. */
   readonly Provider: (props: GranitProviderProps<TConfig>) => ReactNode;
   /** Reads the resolved config from the nearest matching provider; throws if absent. */
-  readonly useConfig: () => ResolvedGranitProviderConfig<TConfig>;
+  readonly useConfig: () => TResolved;
+  /** Reads the resolved config from the nearest matching provider, or `null` if absent. */
+  readonly useOptionalConfig: () => TResolved | null;
 }
 
 /**
@@ -59,45 +75,61 @@ export interface ConfigProvider<TConfig extends GranitProviderConfig> {
  * Re-export the returned members under the package's public names so consumers
  * (e.g. showcase-admin-react) see no API change:
  *
+ * For a config that defaults extra fields, pass an explicit resolved type and a
+ * `resolve` hook:
+ *
  * @example
  * ```tsx
- * export interface HostnamesConfig extends GranitProviderConfig {
+ * export interface DocumentsConfig extends GranitProviderConfig {
  *   readonly queryKeyPrefix?: readonly string[];
  * }
- * export type ResolvedHostnamesConfig = ResolvedGranitProviderConfig<HostnamesConfig>;
+ * export interface ResolvedDocumentsConfig extends DocumentsConfig {
+ *   readonly client: AxiosInstance;
+ *   readonly basePath: string;
+ *   readonly queryKeyPrefix: readonly string[];
+ * }
  *
- * const { Provider, useConfig } = createConfigProvider<HostnamesConfig>({
- *   name: 'Hostnames',
+ * const { Provider, useConfig } = createConfigProvider<DocumentsConfig, ResolvedDocumentsConfig>({
+ *   name: 'Documents',
  *   defaultBasePath: DEFAULT_BASE_PATH,
+ *   resolve: (base) => ({ ...base, queryKeyPrefix: base.queryKeyPrefix ?? [...DEFAULT_QUERY_KEY_PREFIX] }),
  * });
- * export const HostnamesProvider = Provider;
- * export const useHostnamesConfig = useConfig;
+ * export const DocumentsProvider = Provider;
+ * export const useDocumentsConfig = useConfig;
  * ```
  */
-export function createConfigProvider<TConfig extends GranitProviderConfig>({
+export function createConfigProvider<
+  TConfig extends GranitProviderConfig,
+  TResolved extends ResolvedGranitProviderConfig<TConfig> = ResolvedGranitProviderConfig<TConfig>,
+>({
   name,
   defaultBasePath,
-}: CreateConfigProviderOptions): ConfigProvider<TConfig> {
-  type Resolved = ResolvedGranitProviderConfig<TConfig>;
-  const Context = createContext<Resolved | null>(null);
+  resolve,
+}: CreateConfigProviderOptions<TConfig, TResolved>): ConfigProvider<TConfig, TResolved> {
+  const Context = createContext<TResolved | null>(null);
   Context.displayName = `${name}ConfigContext`;
 
   function Provider({ config, children }: GranitProviderProps<TConfig>) {
     const contextClient = useOptionalGranitClient();
-    const value = useMemo<Resolved>(() => {
+    const value = useMemo<TResolved>(() => {
       const client = config.client ?? contextClient;
       if (!client) {
         throw new Error(
           `${name}Provider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.`
         );
       }
-      return { ...config, client, basePath: config.basePath ?? defaultBasePath };
+      const base = {
+        ...config,
+        client,
+        basePath: config.basePath ?? defaultBasePath,
+      } as ResolvedGranitProviderConfig<TConfig>;
+      return (resolve ? resolve(base, config) : base) as TResolved;
     }, [config, contextClient]);
     return <Context value={value}>{children}</Context>;
   }
   Provider.displayName = `${name}Provider`;
 
-  function useConfig(): Resolved {
+  function useConfig(): TResolved {
     const ctx = useContext(Context);
     if (!ctx) {
       throw new Error(`use${name}Config must be used within a <${name}Provider>`);
@@ -105,5 +137,9 @@ export function createConfigProvider<TConfig extends GranitProviderConfig>({
     return ctx;
   }
 
-  return { Provider, useConfig };
+  function useOptionalConfig(): TResolved | null {
+    return useContext(Context);
+  }
+
+  return { Provider, useConfig, useOptionalConfig };
 }

--- a/packages/@granit/react-api-client/src/providers/create-config-provider.tsx
+++ b/packages/@granit/react-api-client/src/providers/create-config-provider.tsx
@@ -1,0 +1,109 @@
+import { createContext, useContext, useMemo } from 'react';
+
+import { useOptionalGranitClient } from './granit-client-provider';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+/**
+ * Minimal config every Granit domain provider accepts: an optional Axios
+ * `client` (falls back to the nearest `<GranitClientProvider>`) and an optional
+ * `basePath` (falls back to the package default). Domain configs extend this
+ * with their own optional fields (e.g. `queryKeyPrefix`).
+ */
+export interface GranitProviderConfig {
+  readonly client?: AxiosInstance;
+  readonly basePath?: string;
+}
+
+/**
+ * A domain config after the provider has resolved `client` and `basePath`, so
+ * hooks read both without a non-null assertion. Extra fields on `TConfig` flow
+ * through unchanged.
+ */
+export type ResolvedGranitProviderConfig<TConfig extends GranitProviderConfig> = TConfig & {
+  readonly client: AxiosInstance;
+  readonly basePath: string;
+};
+
+/** Props of a provider produced by {@link createConfigProvider}. */
+export interface GranitProviderProps<TConfig extends GranitProviderConfig> {
+  readonly config: TConfig;
+  readonly children: ReactNode;
+}
+
+export interface CreateConfigProviderOptions {
+  /**
+   * PascalCase domain name used to build the component `displayName` and the
+   * error messages (`<Name>Provider requires…`, `use<Name>Config must be used…`).
+   */
+  readonly name: string;
+  /** Base path applied when `config.basePath` is omitted. */
+  readonly defaultBasePath: string;
+}
+
+export interface ConfigProvider<TConfig extends GranitProviderConfig> {
+  /** Context provider resolving `client`/`basePath` for descendant hooks. */
+  readonly Provider: (props: GranitProviderProps<TConfig>) => ReactNode;
+  /** Reads the resolved config from the nearest matching provider; throws if absent. */
+  readonly useConfig: () => ResolvedGranitProviderConfig<TConfig>;
+}
+
+/**
+ * Builds the standard Granit domain-provider triplet — context, `<Provider>`,
+ * and `use…Config` hook — that every `@granit/react-*` package otherwise
+ * hand-writes verbatim. The provider resolves `client` from `config.client` or
+ * the nearest `<GranitClientProvider>` (throwing when neither is present) and
+ * defaults `basePath`; the hook throws when used outside its provider.
+ *
+ * Re-export the returned members under the package's public names so consumers
+ * (e.g. showcase-admin-react) see no API change:
+ *
+ * @example
+ * ```tsx
+ * export interface HostnamesConfig extends GranitProviderConfig {
+ *   readonly queryKeyPrefix?: readonly string[];
+ * }
+ * export type ResolvedHostnamesConfig = ResolvedGranitProviderConfig<HostnamesConfig>;
+ *
+ * const { Provider, useConfig } = createConfigProvider<HostnamesConfig>({
+ *   name: 'Hostnames',
+ *   defaultBasePath: DEFAULT_BASE_PATH,
+ * });
+ * export const HostnamesProvider = Provider;
+ * export const useHostnamesConfig = useConfig;
+ * ```
+ */
+export function createConfigProvider<TConfig extends GranitProviderConfig>({
+  name,
+  defaultBasePath,
+}: CreateConfigProviderOptions): ConfigProvider<TConfig> {
+  type Resolved = ResolvedGranitProviderConfig<TConfig>;
+  const Context = createContext<Resolved | null>(null);
+  Context.displayName = `${name}ConfigContext`;
+
+  function Provider({ config, children }: GranitProviderProps<TConfig>) {
+    const contextClient = useOptionalGranitClient();
+    const value = useMemo<Resolved>(() => {
+      const client = config.client ?? contextClient;
+      if (!client) {
+        throw new Error(
+          `${name}Provider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.`
+        );
+      }
+      return { ...config, client, basePath: config.basePath ?? defaultBasePath };
+    }, [config, contextClient]);
+    return <Context value={value}>{children}</Context>;
+  }
+  Provider.displayName = `${name}Provider`;
+
+  function useConfig(): Resolved {
+    const ctx = useContext(Context);
+    if (!ctx) {
+      throw new Error(`use${name}Config must be used within a <${name}Provider>`);
+    }
+    return ctx;
+  }
+
+  return { Provider, useConfig };
+}

--- a/packages/@granit/react-authentication-local/src/__tests__/local-auth-provider.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/local-auth-provider.test.tsx
@@ -40,7 +40,7 @@ describe('LocalAuthProvider', () => {
 
   it('should throw when used outside provider', () => {
     expect(() => renderHook(() => useLocalAuthConfig())).toThrowError(
-      'useLocalAuthConfig must be used within a LocalAuthProvider'
+      'useLocalAuthConfig must be used within a <LocalAuthProvider>'
     );
   });
 });

--- a/packages/@granit/react-authentication-local/src/providers/local-auth-provider.tsx
+++ b/packages/@granit/react-authentication-local/src/providers/local-auth-provider.tsx
@@ -1,57 +1,27 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
-export interface LocalAuthConfig {
-  /**
-   * Axios instance for API calls.
-   * Must have `withCredentials: true` — the login endpoint sets an
-   * ASP.NET Core Identity session cookie (not a token).
-   */
-  readonly client?: AxiosInstance;
-  readonly basePath?: string;
-}
+export type LocalAuthConfig = GranitProviderConfig;
 
 /**
  * LocalAuthConfig after the provider has resolved `client` from
  * `config.client` or the nearest `<GranitClientProvider>`.
  */
-export interface ResolvedLocalAuthConfig extends LocalAuthConfig {
-  readonly client: AxiosInstance;
-}
+export type ResolvedLocalAuthConfig = ResolvedGranitProviderConfig<LocalAuthConfig>;
 
-export interface LocalAuthProviderProps {
-  readonly config: LocalAuthConfig;
-  readonly children: ReactNode;
-}
+export type LocalAuthProviderProps = GranitProviderProps<LocalAuthConfig>;
 
-const LocalAuthContext = createContext<ResolvedLocalAuthConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<LocalAuthConfig>({
+  name: 'LocalAuth',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
-export function useLocalAuthConfig(): ResolvedLocalAuthConfig {
-  const config = useContext(LocalAuthContext);
-  if (!config) throw new Error('useLocalAuthConfig must be used within a LocalAuthProvider');
-  return config;
-}
-
-export function LocalAuthProvider({ config, children }: LocalAuthProviderProps) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'LocalAuthProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      client,
-    };
-  }, [config, contextClient]);
-
-  return <LocalAuthContext value={value}>{children}</LocalAuthContext>;
-}
+export const LocalAuthProvider = Provider;
+export const useLocalAuthConfig = useConfig;

--- a/packages/@granit/react-authorization/src/providers/authorization-provider.tsx
+++ b/packages/@granit/react-authorization/src/providers/authorization-provider.tsx
@@ -1,52 +1,26 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
-export interface AuthorizationConfig {
-  readonly client?: AxiosInstance;
-  readonly basePath?: string;
+export interface AuthorizationConfig extends GranitProviderConfig {
   readonly queryKeyPrefix?: readonly string[];
 }
 
-export interface ResolvedAuthorizationConfig {
-  readonly client: AxiosInstance;
-  readonly basePath: string;
-  readonly queryKeyPrefix?: readonly string[];
-}
+export type ResolvedAuthorizationConfig = ResolvedGranitProviderConfig<AuthorizationConfig>;
 
-export interface AuthorizationProviderProps {
-  readonly config: AuthorizationConfig;
-  readonly children: ReactNode;
-}
+export type AuthorizationProviderProps = GranitProviderProps<AuthorizationConfig>;
 
-const AuthorizationConfigContext = createContext<ResolvedAuthorizationConfig | null>(null);
+const { Provider, useConfig, useOptionalConfig } = createConfigProvider<AuthorizationConfig>({
+  name: 'Authorization',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
-export function AuthorizationProvider({ config, children }: Readonly<AuthorizationProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedAuthorizationConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'AuthorizationProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return { ...config, client, basePath: config.basePath ?? DEFAULT_BASE_PATH };
-  }, [config, contextClient]);
-  return <AuthorizationConfigContext value={value}>{children}</AuthorizationConfigContext>;
-}
-
-export function useAuthorizationConfig(): ResolvedAuthorizationConfig {
-  const ctx = useContext(AuthorizationConfigContext);
-  if (!ctx) {
-    throw new Error('useAuthorizationConfig must be used within an <AuthorizationProvider>');
-  }
-  return ctx;
-}
-
-export function useOptionalAuthorizationConfig(): ResolvedAuthorizationConfig | null {
-  return useContext(AuthorizationConfigContext);
-}
+export const AuthorizationProvider = Provider;
+export const useAuthorizationConfig = useConfig;
+export const useOptionalAuthorizationConfig = useOptionalConfig;

--- a/packages/@granit/react-background-jobs/src/__tests__/background-jobs-provider.test.tsx
+++ b/packages/@granit/react-background-jobs/src/__tests__/background-jobs-provider.test.tsx
@@ -40,6 +40,6 @@ describe('BackgroundJobsProvider', () => {
   it('should throw when used outside provider', () => {
     expect(() => {
       renderHook(() => useBackgroundJobsConfig());
-    }).toThrow('useBackgroundJobsConfig must be used within a BackgroundJobsProvider');
+    }).toThrow('useBackgroundJobsConfig must be used within a <BackgroundJobsProvider>');
   });
 });

--- a/packages/@granit/react-background-jobs/src/providers/background-jobs-provider.tsx
+++ b/packages/@granit/react-background-jobs/src/providers/background-jobs-provider.tsx
@@ -1,60 +1,31 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
 /** Configuration for the background jobs provider. */
-export interface BackgroundJobsConfig {
-  readonly client?: AxiosInstance;
-  /** Base path for background-jobs endpoints (default: `/api/v1/background-jobs`). */
-  readonly basePath?: string;
-}
+export type BackgroundJobsConfig = GranitProviderConfig;
 
 /**
  * BackgroundJobsConfig after the provider has resolved `client` from
  * `config.client` or the nearest `<GranitClientProvider>`.
  */
-export interface ResolvedBackgroundJobsConfig extends BackgroundJobsConfig {
-  readonly client: AxiosInstance;
-}
+export type ResolvedBackgroundJobsConfig = ResolvedGranitProviderConfig<BackgroundJobsConfig>;
 
-export interface BackgroundJobsProviderProps {
-  readonly config: BackgroundJobsConfig;
-  readonly children: ReactNode;
-}
+export type BackgroundJobsProviderProps = GranitProviderProps<BackgroundJobsConfig>;
 
-const BackgroundJobsConfigContext = createContext<ResolvedBackgroundJobsConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<BackgroundJobsConfig>({
+  name: 'BackgroundJobs',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
 /** Provides background jobs configuration to child components and hooks. */
-export function BackgroundJobsProvider({
-  config,
-  children,
-}: Readonly<BackgroundJobsProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedBackgroundJobsConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'BackgroundJobsProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      client,
-    };
-  }, [config, contextClient]);
-  return <BackgroundJobsConfigContext value={value}>{children}</BackgroundJobsConfigContext>;
-}
+export const BackgroundJobsProvider = Provider;
 
 /** Returns the background jobs configuration from the nearest `BackgroundJobsProvider`. */
-export function useBackgroundJobsConfig(): ResolvedBackgroundJobsConfig {
-  const ctx = useContext(BackgroundJobsConfigContext);
-  if (!ctx) {
-    throw new Error('useBackgroundJobsConfig must be used within a BackgroundJobsProvider');
-  }
-  return ctx;
-}
+export const useBackgroundJobsConfig = useConfig;

--- a/packages/@granit/react-bank-accounts/src/__tests__/bank-accounts-provider.test.tsx
+++ b/packages/@granit/react-bank-accounts/src/__tests__/bank-accounts-provider.test.tsx
@@ -44,7 +44,7 @@ describe('BankAccountsProvider', () => {
   it('should throw when used outside provider', () => {
     expect(() => {
       renderHook(() => useBankAccountsConfig());
-    }).toThrow('useBankAccountsConfig must be used within a BankAccountsProvider');
+    }).toThrow('useBankAccountsConfig must be used within a <BankAccountsProvider>');
   });
 
   it('should throw when no client is available', () => {

--- a/packages/@granit/react-bank-accounts/src/providers/bank-accounts-provider.tsx
+++ b/packages/@granit/react-bank-accounts/src/providers/bank-accounts-provider.tsx
@@ -1,16 +1,15 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
 /** Configuration for the bank accounts provider. */
-export interface BankAccountsConfig {
-  readonly client?: AxiosInstance;
-  /** Base path for bank account endpoints (default: `/api/v1/bank-accounts`). */
-  readonly basePath?: string;
+export interface BankAccountsConfig extends GranitProviderConfig {
   readonly queryKeyPrefix?: readonly string[];
 }
 
@@ -20,45 +19,20 @@ export interface BankAccountsConfig {
  * `basePath`. Both are guaranteed present, so hooks read them without a
  * non-null assertion.
  */
-export interface ResolvedBankAccountsConfig extends BankAccountsConfig {
-  readonly client: AxiosInstance;
-  readonly basePath: string;
-}
+export type ResolvedBankAccountsConfig = ResolvedGranitProviderConfig<BankAccountsConfig>;
 
-export interface BankAccountsProviderProps {
-  readonly config: BankAccountsConfig;
-  readonly children: ReactNode;
-}
+export type BankAccountsProviderProps = GranitProviderProps<BankAccountsConfig>;
 
-const BankAccountsConfigContext = createContext<ResolvedBankAccountsConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<BankAccountsConfig>({
+  name: 'BankAccounts',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
 /** Provides bank accounts configuration to child components and hooks. */
-export function BankAccountsProvider({ config, children }: Readonly<BankAccountsProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedBankAccountsConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'BankAccountsProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      client,
-    };
-  }, [config, contextClient]);
-  return <BankAccountsConfigContext value={value}>{children}</BankAccountsConfigContext>;
-}
+export const BankAccountsProvider = Provider;
 
 /** Returns the bank accounts configuration from the nearest `BankAccountsProvider`. */
-export function useBankAccountsConfig(): ResolvedBankAccountsConfig {
-  const ctx = useContext(BankAccountsConfigContext);
-  if (!ctx) {
-    throw new Error('useBankAccountsConfig must be used within a BankAccountsProvider');
-  }
-  return ctx;
-}
+export const useBankAccountsConfig = useConfig;
 
 /** Builds a consistent React Query key for bank account operations. */
 export function buildBankAccountsQueryKey(

--- a/packages/@granit/react-blob-storage/src/providers/blob-storage-provider.tsx
+++ b/packages/@granit/react-blob-storage/src/providers/blob-storage-provider.tsx
@@ -1,52 +1,30 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
 /** Configuration for the blob-storage provider. */
-export interface BlobStorageConfig {
-  readonly client?: AxiosInstance;
-  /** Base path for blob-storage endpoints (default: `/api/v1/blob-storage`). */
-  readonly basePath?: string;
+export interface BlobStorageConfig extends GranitProviderConfig {
   readonly queryKeyPrefix?: readonly string[];
 }
 
 /** Resolved configuration where all optional fields have defaults applied. */
-export interface ResolvedBlobStorageConfig extends BlobStorageConfig {
-  readonly client: AxiosInstance;
-  readonly basePath: string;
-}
+export type ResolvedBlobStorageConfig = ResolvedGranitProviderConfig<BlobStorageConfig>;
 
-export interface BlobStorageProviderProps {
-  readonly config: BlobStorageConfig;
-  readonly children: ReactNode;
-}
+export type BlobStorageProviderProps = GranitProviderProps<BlobStorageConfig>;
 
-const BlobStorageConfigContext = createContext<ResolvedBlobStorageConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<BlobStorageConfig>({
+  name: 'BlobStorage',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
 /** Provides blob-storage configuration to child components and hooks. */
-export function BlobStorageProvider({ config, children }: Readonly<BlobStorageProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedBlobStorageConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'BlobStorageProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return { ...config, client, basePath: config.basePath ?? DEFAULT_BASE_PATH };
-  }, [config, contextClient]);
-  return <BlobStorageConfigContext value={value}>{children}</BlobStorageConfigContext>;
-}
+export const BlobStorageProvider = Provider;
 
 /** Returns the blob-storage configuration from the nearest `BlobStorageProvider`. */
-export function useBlobStorageConfig(): ResolvedBlobStorageConfig {
-  const ctx = useContext(BlobStorageConfigContext);
-  if (!ctx) {
-    throw new Error('useBlobStorageConfig must be used within a <BlobStorageProvider>');
-  }
-  return ctx;
-}
+export const useBlobStorageConfig = useConfig;

--- a/packages/@granit/react-cms-hostnames/src/providers/cms-hostnames-provider.tsx
+++ b/packages/@granit/react-cms-hostnames/src/providers/cms-hostnames-provider.tsx
@@ -1,14 +1,11 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX } from '../constants';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type { GranitProviderConfig, GranitProviderProps } from '@granit/react-api-client';
 
-export interface CmsHostnamesConfig {
-  readonly client?: AxiosInstance;
-  readonly basePath?: string;
+export interface CmsHostnamesConfig extends GranitProviderConfig {
   readonly queryKeyPrefix?: readonly string[];
 }
 
@@ -18,36 +15,20 @@ export interface ResolvedCmsHostnamesConfig extends CmsHostnamesConfig {
   readonly queryKeyPrefix: readonly string[];
 }
 
-export interface CmsHostnamesProviderProps {
-  readonly config: CmsHostnamesConfig;
-  readonly children: ReactNode;
-}
+export type CmsHostnamesProviderProps = GranitProviderProps<CmsHostnamesConfig>;
 
-const CmsHostnamesConfigContext = createContext<ResolvedCmsHostnamesConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<
+  CmsHostnamesConfig,
+  ResolvedCmsHostnamesConfig
+>({
+  name: 'CmsHostnames',
+  defaultBasePath: DEFAULT_BASE_PATH,
+  resolve: (base) => ({
+    ...base,
+    queryKeyPrefix: base.queryKeyPrefix ?? [...DEFAULT_QUERY_KEY_PREFIX],
+  }),
+});
 
-export function CmsHostnamesProvider({ config, children }: Readonly<CmsHostnamesProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedCmsHostnamesConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'CmsHostnamesProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      client,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      queryKeyPrefix: config.queryKeyPrefix ?? [...DEFAULT_QUERY_KEY_PREFIX],
-    };
-  }, [config, contextClient]);
-  return <CmsHostnamesConfigContext value={value}>{children}</CmsHostnamesConfigContext>;
-}
+export const CmsHostnamesProvider = Provider;
 
-export function useCmsHostnamesConfig(): ResolvedCmsHostnamesConfig {
-  const ctx = useContext(CmsHostnamesConfigContext);
-  if (!ctx) {
-    throw new Error('useCmsHostnamesConfig must be used within a CmsHostnamesProvider');
-  }
-  return ctx;
-}
+export const useCmsHostnamesConfig = useConfig;

--- a/packages/@granit/react-cms-redirects/src/providers/cms-redirects-provider.tsx
+++ b/packages/@granit/react-cms-redirects/src/providers/cms-redirects-provider.tsx
@@ -1,14 +1,11 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX } from '../constants';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type { GranitProviderConfig, GranitProviderProps } from '@granit/react-api-client';
 
-export interface CmsRedirectsConfig {
-  readonly client?: AxiosInstance;
-  readonly basePath?: string;
+export interface CmsRedirectsConfig extends GranitProviderConfig {
   readonly queryKeyPrefix?: readonly string[];
 }
 
@@ -18,36 +15,20 @@ export interface ResolvedCmsRedirectsConfig extends CmsRedirectsConfig {
   readonly queryKeyPrefix: readonly string[];
 }
 
-export interface CmsRedirectsProviderProps {
-  readonly config: CmsRedirectsConfig;
-  readonly children: ReactNode;
-}
+export type CmsRedirectsProviderProps = GranitProviderProps<CmsRedirectsConfig>;
 
-const CmsRedirectsConfigContext = createContext<ResolvedCmsRedirectsConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<
+  CmsRedirectsConfig,
+  ResolvedCmsRedirectsConfig
+>({
+  name: 'CmsRedirects',
+  defaultBasePath: DEFAULT_BASE_PATH,
+  resolve: (base) => ({
+    ...base,
+    queryKeyPrefix: base.queryKeyPrefix ?? [...DEFAULT_QUERY_KEY_PREFIX],
+  }),
+});
 
-export function CmsRedirectsProvider({ config, children }: Readonly<CmsRedirectsProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedCmsRedirectsConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'CmsRedirectsProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      client,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      queryKeyPrefix: config.queryKeyPrefix ?? [...DEFAULT_QUERY_KEY_PREFIX],
-    };
-  }, [config, contextClient]);
-  return <CmsRedirectsConfigContext value={value}>{children}</CmsRedirectsConfigContext>;
-}
+export const CmsRedirectsProvider = Provider;
 
-export function useCmsRedirectsConfig(): ResolvedCmsRedirectsConfig {
-  const ctx = useContext(CmsRedirectsConfigContext);
-  if (!ctx) {
-    throw new Error('useCmsRedirectsConfig must be used within a CmsRedirectsProvider');
-  }
-  return ctx;
-}
+export const useCmsRedirectsConfig = useConfig;

--- a/packages/@granit/react-cms-seo/src/providers/cms-seo-provider.tsx
+++ b/packages/@granit/react-cms-seo/src/providers/cms-seo-provider.tsx
@@ -1,14 +1,11 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX } from '../constants';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type { GranitProviderConfig, GranitProviderProps } from '@granit/react-api-client';
 
-export interface CmsSeoConfig {
-  readonly client?: AxiosInstance;
-  readonly basePath?: string;
+export interface CmsSeoConfig extends GranitProviderConfig {
   readonly queryKeyPrefix?: readonly string[];
 }
 
@@ -18,36 +15,17 @@ export interface ResolvedCmsSeoConfig extends CmsSeoConfig {
   readonly queryKeyPrefix: readonly string[];
 }
 
-export interface CmsSeoProviderProps {
-  readonly config: CmsSeoConfig;
-  readonly children: ReactNode;
-}
+export type CmsSeoProviderProps = GranitProviderProps<CmsSeoConfig>;
 
-const CmsSeoConfigContext = createContext<ResolvedCmsSeoConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<CmsSeoConfig, ResolvedCmsSeoConfig>({
+  name: 'CmsSeo',
+  defaultBasePath: DEFAULT_BASE_PATH,
+  resolve: (base) => ({
+    ...base,
+    queryKeyPrefix: base.queryKeyPrefix ?? [...DEFAULT_QUERY_KEY_PREFIX],
+  }),
+});
 
-export function CmsSeoProvider({ config, children }: Readonly<CmsSeoProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedCmsSeoConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'CmsSeoProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      client,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      queryKeyPrefix: config.queryKeyPrefix ?? [...DEFAULT_QUERY_KEY_PREFIX],
-    };
-  }, [config, contextClient]);
-  return <CmsSeoConfigContext value={value}>{children}</CmsSeoConfigContext>;
-}
+export const CmsSeoProvider = Provider;
 
-export function useCmsSeoConfig(): ResolvedCmsSeoConfig {
-  const ctx = useContext(CmsSeoConfigContext);
-  if (!ctx) {
-    throw new Error('useCmsSeoConfig must be used within a CmsSeoProvider');
-  }
-  return ctx;
-}
+export const useCmsSeoConfig = useConfig;

--- a/packages/@granit/react-cms/src/__tests__/cms-provider.test.tsx
+++ b/packages/@granit/react-cms/src/__tests__/cms-provider.test.tsx
@@ -25,7 +25,7 @@ function createWrapper(config: { client?: AxiosInstance; basePath?: string } = {
 describe('CmsProvider / useCmsConfig', () => {
   it('throws when used outside provider', () => {
     expect(() => renderHook(() => useCmsConfig())).toThrow(
-      'useCmsConfig must be used within a CmsProvider'
+      'useCmsConfig must be used within a <CmsProvider>'
     );
   });
 

--- a/packages/@granit/react-cms/src/providers/cms-provider.tsx
+++ b/packages/@granit/react-cms/src/providers/cms-provider.tsx
@@ -1,16 +1,13 @@
 'use client';
 
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX } from '../constants';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type { GranitProviderConfig, GranitProviderProps } from '@granit/react-api-client';
 
-export interface CmsConfig {
-  readonly client?: AxiosInstance;
-  readonly basePath?: string;
+export interface CmsConfig extends GranitProviderConfig {
   readonly queryKeyPrefix?: readonly string[];
 }
 
@@ -20,39 +17,20 @@ export interface ResolvedCmsConfig extends CmsConfig {
   readonly queryKeyPrefix: readonly string[];
 }
 
-export interface CmsProviderProps {
-  readonly config: CmsConfig;
-  readonly children: ReactNode;
-}
+export type CmsProviderProps = GranitProviderProps<CmsConfig>;
 
-const CmsConfigContext = createContext<ResolvedCmsConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<CmsConfig, ResolvedCmsConfig>({
+  name: 'Cms',
+  defaultBasePath: DEFAULT_BASE_PATH,
+  resolve: (base) => ({
+    ...base,
+    queryKeyPrefix: base.queryKeyPrefix ?? [...DEFAULT_QUERY_KEY_PREFIX],
+  }),
+});
 
-export function CmsProvider({ config, children }: Readonly<CmsProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedCmsConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'CmsProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      client,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      queryKeyPrefix: config.queryKeyPrefix ?? [...DEFAULT_QUERY_KEY_PREFIX],
-    };
-  }, [config, contextClient]);
-  return <CmsConfigContext value={value}>{children}</CmsConfigContext>;
-}
+export const CmsProvider = Provider;
 
-export function useCmsConfig(): ResolvedCmsConfig {
-  const ctx = useContext(CmsConfigContext);
-  if (!ctx) {
-    throw new Error('useCmsConfig must be used within a CmsProvider');
-  }
-  return ctx;
-}
+export const useCmsConfig = useConfig;
 
 export function buildCmsQueryKey(
   config: ResolvedCmsConfig,

--- a/packages/@granit/react-customer-balance/src/__tests__/customer-balance-provider.test.tsx
+++ b/packages/@granit/react-customer-balance/src/__tests__/customer-balance-provider.test.tsx
@@ -36,7 +36,7 @@ describe('CustomerBalanceProvider', () => {
   it('should throw when used outside provider', () => {
     expect(() => {
       renderHook(() => useCustomerBalanceConfig());
-    }).toThrow('useCustomerBalanceConfig must be used within a CustomerBalanceProvider');
+    }).toThrow('useCustomerBalanceConfig must be used within a <CustomerBalanceProvider>');
   });
 });
 

--- a/packages/@granit/react-customer-balance/src/providers/customer-balance-provider.tsx
+++ b/packages/@granit/react-customer-balance/src/providers/customer-balance-provider.tsx
@@ -1,16 +1,15 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
 /** Configuration for the customer-balance provider. */
-export interface CustomerBalanceConfig {
-  readonly client?: AxiosInstance;
-  /** Base path for customer-balance endpoints (default: `/api/v1/customer-balance`). */
-  readonly basePath?: string;
+export interface CustomerBalanceConfig extends GranitProviderConfig {
   readonly queryKeyPrefix?: readonly string[];
 }
 
@@ -18,47 +17,20 @@ export interface CustomerBalanceConfig {
  * CustomerBalanceConfig after the provider has resolved `client` from
  * `config.client` or the nearest `<GranitClientProvider>`.
  */
-export interface ResolvedCustomerBalanceConfig extends CustomerBalanceConfig {
-  readonly client: AxiosInstance;
-}
+export type ResolvedCustomerBalanceConfig = ResolvedGranitProviderConfig<CustomerBalanceConfig>;
 
-export interface CustomerBalanceProviderProps {
-  readonly config: CustomerBalanceConfig;
-  readonly children: ReactNode;
-}
+export type CustomerBalanceProviderProps = GranitProviderProps<CustomerBalanceConfig>;
 
-const CustomerBalanceConfigContext = createContext<ResolvedCustomerBalanceConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<CustomerBalanceConfig>({
+  name: 'CustomerBalance',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
 /** Provides customer-balance configuration to child components and hooks. */
-export function CustomerBalanceProvider({
-  config,
-  children,
-}: Readonly<CustomerBalanceProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedCustomerBalanceConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'CustomerBalanceProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      client,
-    };
-  }, [config, contextClient]);
-  return <CustomerBalanceConfigContext value={value}>{children}</CustomerBalanceConfigContext>;
-}
+export const CustomerBalanceProvider = Provider;
 
 /** Returns the customer-balance configuration from the nearest `CustomerBalanceProvider`. */
-export function useCustomerBalanceConfig(): ResolvedCustomerBalanceConfig {
-  const ctx = useContext(CustomerBalanceConfigContext);
-  if (!ctx) {
-    throw new Error('useCustomerBalanceConfig must be used within a CustomerBalanceProvider');
-  }
-  return ctx;
-}
+export const useCustomerBalanceConfig = useConfig;
 
 /** Builds a consistent React Query key for customer-balance operations. */
 export function buildCustomerBalanceQueryKey(

--- a/packages/@granit/react-dashboards/src/providers/dashboards-provider.tsx
+++ b/packages/@granit/react-dashboards/src/providers/dashboards-provider.tsx
@@ -1,52 +1,32 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
 /** Configuration for the dashboards provider. */
-export interface DashboardsConfig {
-  readonly client?: AxiosInstance;
+export interface DashboardsConfig extends GranitProviderConfig {
   /** Base path for dashboards endpoints (default: `/api/v1/dashboards`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
 }
 
 /** Resolved configuration where all optional fields have defaults applied. */
-export interface ResolvedDashboardsConfig extends DashboardsConfig {
-  readonly client: AxiosInstance;
-  readonly basePath: string;
-}
+export type ResolvedDashboardsConfig = ResolvedGranitProviderConfig<DashboardsConfig>;
 
-export interface DashboardsProviderProps {
-  readonly config: DashboardsConfig;
-  readonly children: ReactNode;
-}
+export type DashboardsProviderProps = GranitProviderProps<DashboardsConfig>;
 
-const DashboardsConfigContext = createContext<ResolvedDashboardsConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<DashboardsConfig>({
+  name: 'Dashboards',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
 /** Provides dashboards configuration to child components and hooks. */
-export function DashboardsProvider({ config, children }: Readonly<DashboardsProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedDashboardsConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'DashboardsProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return { ...config, client, basePath: config.basePath ?? DEFAULT_BASE_PATH };
-  }, [config, contextClient]);
-  return <DashboardsConfigContext value={value}>{children}</DashboardsConfigContext>;
-}
+export const DashboardsProvider = Provider;
 
 /** Returns the dashboards configuration from the nearest `DashboardsProvider`. */
-export function useDashboardsConfig(): ResolvedDashboardsConfig {
-  const ctx = useContext(DashboardsConfigContext);
-  if (!ctx) {
-    throw new Error('useDashboardsConfig must be used within a <DashboardsProvider>');
-  }
-  return ctx;
-}
+export const useDashboardsConfig = useConfig;

--- a/packages/@granit/react-documents/src/providers/documents-provider.tsx
+++ b/packages/@granit/react-documents/src/providers/documents-provider.tsx
@@ -1,16 +1,12 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX } from '../constants';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type { GranitProviderConfig, GranitProviderProps } from '@granit/react-api-client';
 
 /** Configuration for the documents provider. */
-export interface DocumentsConfig {
-  readonly client?: AxiosInstance;
-  /** Base path for documents endpoints (default: `/api/v1/documents`). */
-  readonly basePath?: string;
+export interface DocumentsConfig extends GranitProviderConfig {
   readonly queryKeyPrefix?: readonly string[];
 }
 
@@ -24,41 +20,22 @@ export interface ResolvedDocumentsConfig extends DocumentsConfig {
   readonly queryKeyPrefix: readonly string[];
 }
 
-export interface DocumentsProviderProps {
-  readonly config: DocumentsConfig;
-  readonly children: ReactNode;
-}
+export type DocumentsProviderProps = GranitProviderProps<DocumentsConfig>;
 
-const DocumentsConfigContext = createContext<ResolvedDocumentsConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<DocumentsConfig, ResolvedDocumentsConfig>({
+  name: 'Documents',
+  defaultBasePath: DEFAULT_BASE_PATH,
+  resolve: (base) => ({
+    ...base,
+    queryKeyPrefix: base.queryKeyPrefix ?? [...DEFAULT_QUERY_KEY_PREFIX],
+  }),
+});
 
 /** Provides documents configuration to child components and hooks. */
-export function DocumentsProvider({ config, children }: Readonly<DocumentsProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedDocumentsConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'DocumentsProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      client,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      queryKeyPrefix: config.queryKeyPrefix ?? [...DEFAULT_QUERY_KEY_PREFIX],
-    };
-  }, [config, contextClient]);
-  return <DocumentsConfigContext value={value}>{children}</DocumentsConfigContext>;
-}
+export const DocumentsProvider = Provider;
 
 /** Returns the documents configuration from the nearest `DocumentsProvider`. */
-export function useDocumentsConfig(): ResolvedDocumentsConfig {
-  const ctx = useContext(DocumentsConfigContext);
-  if (!ctx) {
-    throw new Error('useDocumentsConfig must be used within a DocumentsProvider');
-  }
-  return ctx;
-}
+export const useDocumentsConfig = useConfig;
 
 /** Builds a consistent React Query key for documents operations. */
 export function buildDocumentsQueryKey(

--- a/packages/@granit/react-features/src/__tests__/features-provider.test.tsx
+++ b/packages/@granit/react-features/src/__tests__/features-provider.test.tsx
@@ -36,7 +36,7 @@ describe('FeaturesProvider', () => {
   it('should throw when used outside provider', () => {
     expect(() => {
       renderHook(() => useFeaturesConfig());
-    }).toThrow('useFeaturesConfig must be used within a FeaturesProvider');
+    }).toThrow('useFeaturesConfig must be used within a <FeaturesProvider>');
   });
 });
 

--- a/packages/@granit/react-features/src/providers/features-provider.tsx
+++ b/packages/@granit/react-features/src/providers/features-provider.tsx
@@ -1,14 +1,15 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
 /** Configuration for the features provider. */
-export interface FeaturesConfig {
-  readonly client?: AxiosInstance;
+export interface FeaturesConfig extends GranitProviderConfig {
   /** Base path for features endpoints (default: `/api/v1/features`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
@@ -18,44 +19,20 @@ export interface FeaturesConfig {
  * FeaturesConfig after the provider has resolved `client` from
  * `config.client` or the nearest `<GranitClientProvider>`.
  */
-export interface ResolvedFeaturesConfig extends FeaturesConfig {
-  readonly client: AxiosInstance;
-}
+export type ResolvedFeaturesConfig = ResolvedGranitProviderConfig<FeaturesConfig>;
 
-export interface FeaturesProviderProps {
-  readonly config: FeaturesConfig;
-  readonly children: ReactNode;
-}
+export type FeaturesProviderProps = GranitProviderProps<FeaturesConfig>;
 
-const FeaturesConfigContext = createContext<ResolvedFeaturesConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<FeaturesConfig>({
+  name: 'Features',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
 /** Provides features configuration to child components and hooks. */
-export function FeaturesProvider({ config, children }: Readonly<FeaturesProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedFeaturesConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'FeaturesProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      client,
-    };
-  }, [config, contextClient]);
-  return <FeaturesConfigContext value={value}>{children}</FeaturesConfigContext>;
-}
+export const FeaturesProvider = Provider;
 
 /** Returns the features configuration from the nearest `FeaturesProvider`. */
-export function useFeaturesConfig(): ResolvedFeaturesConfig {
-  const ctx = useContext(FeaturesConfigContext);
-  if (!ctx) {
-    throw new Error('useFeaturesConfig must be used within a FeaturesProvider');
-  }
-  return ctx;
-}
+export const useFeaturesConfig = useConfig;
 
 /** Builds a consistent React Query key for features operations. */
 export function buildFeaturesQueryKey(

--- a/packages/@granit/react-hostnames/src/providers/hostnames-provider.tsx
+++ b/packages/@granit/react-hostnames/src/providers/hostnames-provider.tsx
@@ -1,51 +1,28 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
 /** Configuration for the hostnames provider. */
-export interface HostnamesConfig {
-  readonly client?: AxiosInstance;
-  /** Base path for hostnames endpoints (default: `/api/hostnames`). */
-  readonly basePath?: string;
-}
+export type HostnamesConfig = GranitProviderConfig;
 
-/** Resolved configuration where all optional fields have defaults applied. */
-export interface ResolvedHostnamesConfig extends HostnamesConfig {
-  readonly client: AxiosInstance;
-  readonly basePath: string;
-}
+/** Resolved configuration where `client` and `basePath` are guaranteed present. */
+export type ResolvedHostnamesConfig = ResolvedGranitProviderConfig<HostnamesConfig>;
 
-export interface HostnamesProviderProps {
-  readonly config: HostnamesConfig;
-  readonly children: ReactNode;
-}
+export type HostnamesProviderProps = GranitProviderProps<HostnamesConfig>;
 
-const HostnamesConfigContext = createContext<ResolvedHostnamesConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<HostnamesConfig>({
+  name: 'Hostnames',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
 /** Provides hostnames configuration to child components and hooks. */
-export function HostnamesProvider({ config, children }: Readonly<HostnamesProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedHostnamesConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'HostnamesProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return { ...config, client, basePath: config.basePath ?? DEFAULT_BASE_PATH };
-  }, [config, contextClient]);
-  return <HostnamesConfigContext value={value}>{children}</HostnamesConfigContext>;
-}
+export const HostnamesProvider = Provider;
 
 /** Returns the hostnames configuration from the nearest `HostnamesProvider`. */
-export function useHostnamesConfig(): ResolvedHostnamesConfig {
-  const ctx = useContext(HostnamesConfigContext);
-  if (!ctx) {
-    throw new Error('useHostnamesConfig must be used within a <HostnamesProvider>');
-  }
-  return ctx;
-}
+export const useHostnamesConfig = useConfig;

--- a/packages/@granit/react-multi-tenancy/src/__tests__/tenant-admin-provider.test.tsx
+++ b/packages/@granit/react-multi-tenancy/src/__tests__/tenant-admin-provider.test.tsx
@@ -53,7 +53,7 @@ describe('TenantAdminProvider', () => {
   it('should throw when used outside provider', () => {
     expect(() => {
       renderHook(() => useTenantAdminConfig());
-    }).toThrow('useTenantAdminConfig must be used within a TenantAdminProvider');
+    }).toThrow('useTenantAdminConfig must be used within a <TenantAdminProvider>');
   });
 });
 

--- a/packages/@granit/react-multi-tenancy/src/providers/tenant-admin-provider.tsx
+++ b/packages/@granit/react-multi-tenancy/src/providers/tenant-admin-provider.tsx
@@ -1,14 +1,14 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
-export interface TenantAdminConfig {
-  readonly client?: AxiosInstance;
-  readonly basePath?: string;
+export interface TenantAdminConfig extends GranitProviderConfig {
   readonly queryKeyPrefix?: readonly string[];
 }
 
@@ -16,48 +16,27 @@ export interface TenantAdminConfig {
  * TenantAdminConfig after the provider has resolved `client` from
  * `config.client` or the nearest `<GranitClientProvider>`.
  */
-export interface ResolvedTenantAdminConfig extends TenantAdminConfig {
-  readonly client: AxiosInstance;
-}
+export type ResolvedTenantAdminConfig = ResolvedGranitProviderConfig<TenantAdminConfig>;
 
-export interface TenantAdminProviderProps {
-  readonly config: TenantAdminConfig;
-  readonly children: ReactNode;
-}
+export type TenantAdminProviderProps = GranitProviderProps<TenantAdminConfig>;
 
 const DEFAULT_KEY_PREFIX = ['tenant-admin'] as const;
 
-const TenantAdminContext = createContext<ResolvedTenantAdminConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<TenantAdminConfig>({
+  name: 'TenantAdmin',
+  defaultBasePath: DEFAULT_BASE_PATH,
+  resolve: (base) => ({
+    ...base,
+    queryKeyPrefix: base.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
+  }),
+});
 
-export function useTenantAdminConfig(): ResolvedTenantAdminConfig {
-  const config = useContext(TenantAdminContext);
-  if (!config) throw new Error('useTenantAdminConfig must be used within a TenantAdminProvider');
-  return config;
-}
+export const TenantAdminProvider = Provider;
+export const useTenantAdminConfig = useConfig;
 
 export function buildTenantAdminQueryKey(
   config: TenantAdminConfig,
   ...segments: readonly string[]
 ): readonly unknown[] {
   return [...(config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX), ...segments];
-}
-
-export function TenantAdminProvider({ config, children }: TenantAdminProviderProps) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'TenantAdminProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
-      client,
-    };
-  }, [config, contextClient]);
-
-  return <TenantAdminContext value={value}>{children}</TenantAdminContext>;
 }

--- a/packages/@granit/react-notifications-mobile-push/src/providers/mobile-push-provider.tsx
+++ b/packages/@granit/react-notifications-mobile-push/src/providers/mobile-push-provider.tsx
@@ -1,9 +1,9 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
 import type { AxiosInstance } from '@granit/api-client';
+import type { GranitProviderConfig } from '@granit/react-api-client';
 import type { ReactNode } from 'react';
 
 /** Resolved configuration exposed by {@link useMobilePushConfig}. */
@@ -27,34 +27,17 @@ export interface MobilePushProviderProps {
   readonly children: ReactNode;
 }
 
-const MobilePushConfigContext = createContext<ResolvedMobilePushProviderConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<GranitProviderConfig>({
+  name: 'MobilePush',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
 /** Provides mobile push configuration to child components and hooks. */
-export function MobilePushProvider({ config, children }: Readonly<MobilePushProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'MobilePushProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      client,
-    };
-  }, [config, contextClient]);
-  return <MobilePushConfigContext value={value}>{children}</MobilePushConfigContext>;
-}
+export const MobilePushProvider = Provider as (
+  props: Readonly<MobilePushProviderProps>
+) => ReactNode;
 
 /** Returns the mobile push configuration from the nearest {@link MobilePushProvider}. */
-export function useMobilePushConfig(): ResolvedMobilePushProviderConfig {
-  const ctx = useContext(MobilePushConfigContext);
-  if (!ctx) {
-    throw new Error('useMobilePushConfig must be used within a MobilePushProvider');
-  }
-  return ctx;
-}
+export const useMobilePushConfig = useConfig as () => ResolvedMobilePushProviderConfig;
 
 export type { MobilePlatform } from '@granit/notifications-mobile-push';

--- a/packages/@granit/react-openiddict-admin/src/__tests__/openiddict-admin-provider.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/openiddict-admin-provider.test.tsx
@@ -53,7 +53,7 @@ describe('OpenIddictAdminProvider', () => {
   it('should throw when used outside provider', () => {
     expect(() => {
       renderHook(() => useAdminConfig());
-    }).toThrow('useAdminConfig must be used within an OpenIddictAdminProvider');
+    }).toThrow('useOpenIddictAdminConfig must be used within a <OpenIddictAdminProvider>');
   });
 });
 

--- a/packages/@granit/react-openiddict-admin/src/providers/openiddict-admin-provider.tsx
+++ b/packages/@granit/react-openiddict-admin/src/providers/openiddict-admin-provider.tsx
@@ -1,14 +1,14 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
-export interface OpenIddictAdminConfig {
-  readonly client?: AxiosInstance;
-  readonly basePath?: string;
+export interface OpenIddictAdminConfig extends GranitProviderConfig {
   /** Base path for authenticated (non-admin) OIDC endpoints, e.g. `/api/v1/oidc`. Used by the consent page. */
   readonly oidcBasePath?: string;
   readonly queryKeyPrefix?: readonly string[];
@@ -18,48 +18,27 @@ export interface OpenIddictAdminConfig {
  * OpenIddictAdminConfig after the provider has resolved `client` from
  * `config.client` or the nearest `<GranitClientProvider>`.
  */
-export interface ResolvedOpenIddictAdminConfig extends OpenIddictAdminConfig {
-  readonly client: AxiosInstance;
-}
+export type ResolvedOpenIddictAdminConfig = ResolvedGranitProviderConfig<OpenIddictAdminConfig>;
 
-export interface OpenIddictAdminProviderProps {
-  readonly config: OpenIddictAdminConfig;
-  readonly children: ReactNode;
-}
+export type OpenIddictAdminProviderProps = GranitProviderProps<OpenIddictAdminConfig>;
 
 const DEFAULT_KEY_PREFIX = ['openiddict-admin'] as const;
 
-const AdminContext = createContext<ResolvedOpenIddictAdminConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<OpenIddictAdminConfig>({
+  name: 'OpenIddictAdmin',
+  defaultBasePath: DEFAULT_BASE_PATH,
+  resolve: (base) => ({
+    ...base,
+    queryKeyPrefix: base.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
+  }),
+});
 
-export function useAdminConfig(): ResolvedOpenIddictAdminConfig {
-  const config = useContext(AdminContext);
-  if (!config) throw new Error('useAdminConfig must be used within an OpenIddictAdminProvider');
-  return config;
-}
+export const OpenIddictAdminProvider = Provider;
+export const useAdminConfig = useConfig;
 
 export function buildAdminQueryKey(
   config: OpenIddictAdminConfig,
   ...segments: readonly string[]
 ): readonly unknown[] {
   return [...(config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX), ...segments];
-}
-
-export function OpenIddictAdminProvider({ config, children }: OpenIddictAdminProviderProps) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'OpenIddictAdminProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
-      client,
-    };
-  }, [config, contextClient]);
-
-  return <AdminContext value={value}>{children}</AdminContext>;
 }

--- a/packages/@granit/react-parties/src/__tests__/parties-provider.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/parties-provider.test.tsx
@@ -43,7 +43,7 @@ describe('PartiesProvider', () => {
 
   it('throws when used outside provider', () => {
     expect(() => renderHook(() => usePartiesConfig())).toThrow(
-      'usePartiesConfig must be used within a PartiesProvider'
+      'usePartiesConfig must be used within a <PartiesProvider>'
     );
   });
 });

--- a/packages/@granit/react-parties/src/providers/parties-provider.tsx
+++ b/packages/@granit/react-parties/src/providers/parties-provider.tsx
@@ -1,14 +1,15 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
 /** Configuration for the parties provider. */
-export interface PartiesConfig {
-  readonly client?: AxiosInstance;
+export interface PartiesConfig extends GranitProviderConfig {
   /** Base path for parties endpoints (default: `/api/v1/parties`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
@@ -18,44 +19,20 @@ export interface PartiesConfig {
  * PartiesConfig after the provider has resolved `client` from
  * `config.client` or the nearest `<GranitClientProvider>`.
  */
-export interface ResolvedPartiesConfig extends PartiesConfig {
-  readonly client: AxiosInstance;
-}
+export type ResolvedPartiesConfig = ResolvedGranitProviderConfig<PartiesConfig>;
 
-export interface PartiesProviderProps {
-  readonly config: PartiesConfig;
-  readonly children: ReactNode;
-}
+export type PartiesProviderProps = GranitProviderProps<PartiesConfig>;
 
-const PartiesConfigContext = createContext<ResolvedPartiesConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<PartiesConfig>({
+  name: 'Parties',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
 /** Provides parties configuration to child components and hooks. */
-export function PartiesProvider({ config, children }: Readonly<PartiesProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedPartiesConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'PartiesProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      client,
-    };
-  }, [config, contextClient]);
-  return <PartiesConfigContext value={value}>{children}</PartiesConfigContext>;
-}
+export const PartiesProvider = Provider;
 
 /** Returns the parties configuration from the nearest `PartiesProvider`. */
-export function usePartiesConfig(): ResolvedPartiesConfig {
-  const ctx = useContext(PartiesConfigContext);
-  if (!ctx) {
-    throw new Error('usePartiesConfig must be used within a PartiesProvider');
-  }
-  return ctx;
-}
+export const usePartiesConfig = useConfig;
 
 /** Builds a consistent React Query key for parties operations. */
 export function buildPartiesQueryKey(

--- a/packages/@granit/react-payments-sepa-direct-debit/src/providers/sepa-direct-debit-provider.tsx
+++ b/packages/@granit/react-payments-sepa-direct-debit/src/providers/sepa-direct-debit-provider.tsx
@@ -1,14 +1,15 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
 /** Configuration for the SEPA Direct Debit provider. */
-export interface SepaDirectDebitConfig {
-  readonly client?: AxiosInstance;
+export interface SepaDirectDebitConfig extends GranitProviderConfig {
   /** Base path for SEPA Direct Debit endpoints (default: `/api/v1/sepa-direct-debit`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
@@ -20,48 +21,20 @@ export interface SepaDirectDebitConfig {
  * `basePath`. Both are guaranteed present, so hooks read them without a
  * non-null assertion.
  */
-export interface ResolvedSepaDirectDebitConfig extends SepaDirectDebitConfig {
-  readonly client: AxiosInstance;
-  readonly basePath: string;
-}
+export type ResolvedSepaDirectDebitConfig = ResolvedGranitProviderConfig<SepaDirectDebitConfig>;
 
-export interface SepaDirectDebitProviderProps {
-  readonly config: SepaDirectDebitConfig;
-  readonly children: ReactNode;
-}
+export type SepaDirectDebitProviderProps = GranitProviderProps<SepaDirectDebitConfig>;
 
-const SepaDirectDebitConfigContext = createContext<ResolvedSepaDirectDebitConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<SepaDirectDebitConfig>({
+  name: 'SepaDirectDebit',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
 /** Provides SEPA Direct Debit configuration to child components and hooks. */
-export function SepaDirectDebitProvider({
-  config,
-  children,
-}: Readonly<SepaDirectDebitProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedSepaDirectDebitConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'SepaDirectDebitProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      client,
-    };
-  }, [config, contextClient]);
-  return <SepaDirectDebitConfigContext value={value}>{children}</SepaDirectDebitConfigContext>;
-}
+export const SepaDirectDebitProvider = Provider;
 
 /** Returns the SEPA Direct Debit configuration from the nearest `SepaDirectDebitProvider`. */
-export function useSepaDirectDebitConfig(): ResolvedSepaDirectDebitConfig {
-  const ctx = useContext(SepaDirectDebitConfigContext);
-  if (!ctx) {
-    throw new Error('useSepaDirectDebitConfig must be used within a SepaDirectDebitProvider');
-  }
-  return ctx;
-}
+export const useSepaDirectDebitConfig = useConfig;
 
 /** Builds a consistent React Query key for SEPA Direct Debit operations. */
 export function buildSepaDirectDebitQueryKey(

--- a/packages/@granit/react-payments-sepa-transfer/src/providers/sepa-transfer-provider.tsx
+++ b/packages/@granit/react-payments-sepa-transfer/src/providers/sepa-transfer-provider.tsx
@@ -1,14 +1,15 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
 /** Configuration for the SEPA transfer provider. */
-export interface SepaTransferConfig {
-  readonly client?: AxiosInstance;
+export interface SepaTransferConfig extends GranitProviderConfig {
   /** Base path for SEPA transfer endpoints (default: `/api/v1/sepa-transfer`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
@@ -20,45 +21,20 @@ export interface SepaTransferConfig {
  * `basePath`. Both are guaranteed present, so hooks read them without a
  * non-null assertion.
  */
-export interface ResolvedSepaTransferConfig extends SepaTransferConfig {
-  readonly client: AxiosInstance;
-  readonly basePath: string;
-}
+export type ResolvedSepaTransferConfig = ResolvedGranitProviderConfig<SepaTransferConfig>;
 
-export interface SepaTransferProviderProps {
-  readonly config: SepaTransferConfig;
-  readonly children: ReactNode;
-}
+export type SepaTransferProviderProps = GranitProviderProps<SepaTransferConfig>;
 
-const SepaTransferConfigContext = createContext<ResolvedSepaTransferConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<SepaTransferConfig>({
+  name: 'SepaTransfer',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
 /** Provides SEPA transfer configuration to child components and hooks. */
-export function SepaTransferProvider({ config, children }: Readonly<SepaTransferProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedSepaTransferConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'SepaTransferProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      client,
-    };
-  }, [config, contextClient]);
-  return <SepaTransferConfigContext value={value}>{children}</SepaTransferConfigContext>;
-}
+export const SepaTransferProvider = Provider;
 
 /** Returns the SEPA transfer configuration from the nearest `SepaTransferProvider`. */
-export function useSepaTransferConfig(): ResolvedSepaTransferConfig {
-  const ctx = useContext(SepaTransferConfigContext);
-  if (!ctx) {
-    throw new Error('useSepaTransferConfig must be used within a SepaTransferProvider');
-  }
-  return ctx;
-}
+export const useSepaTransferConfig = useConfig;
 
 /** Builds a consistent React Query key for SEPA transfer operations. */
 export function buildSepaTransferQueryKey(

--- a/packages/@granit/react-payments/src/__tests__/payments-provider.test.tsx
+++ b/packages/@granit/react-payments/src/__tests__/payments-provider.test.tsx
@@ -36,7 +36,7 @@ describe('PaymentsProvider', () => {
   it('should throw when used outside provider', () => {
     expect(() => {
       renderHook(() => usePaymentsConfig());
-    }).toThrow('usePaymentsConfig must be used within a PaymentsProvider');
+    }).toThrow('usePaymentsConfig must be used within a <PaymentsProvider>');
   });
 });
 

--- a/packages/@granit/react-payments/src/providers/payments-provider.tsx
+++ b/packages/@granit/react-payments/src/providers/payments-provider.tsx
@@ -1,9 +1,12 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 import type { ReactNode } from 'react';
 
 /**
@@ -22,8 +25,7 @@ export interface PaymentBrandIconResolvers {
 }
 
 /** Configuration for the payments provider. */
-export interface PaymentsConfig {
-  readonly client?: AxiosInstance;
+export interface PaymentsConfig extends GranitProviderConfig {
   /** Base path for payment endpoints (default: `/api/v1/payments`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
@@ -38,53 +40,27 @@ export interface PaymentsConfig {
  * PaymentsConfig after the provider has resolved `client` from
  * `config.client` or the nearest `<GranitClientProvider>`.
  */
-export interface ResolvedPaymentsConfig extends PaymentsConfig {
-  readonly client: AxiosInstance;
-}
+export type ResolvedPaymentsConfig = ResolvedGranitProviderConfig<PaymentsConfig>;
 
-export interface PaymentsProviderProps {
-  readonly config: PaymentsConfig;
-  readonly children: ReactNode;
-}
+export type PaymentsProviderProps = GranitProviderProps<PaymentsConfig>;
 
-const PaymentsConfigContext = createContext<ResolvedPaymentsConfig | null>(null);
+const { Provider, useConfig, useOptionalConfig } = createConfigProvider<PaymentsConfig>({
+  name: 'Payments',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
 /** Provides payments configuration to child components and hooks. */
-export function PaymentsProvider({ config, children }: Readonly<PaymentsProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedPaymentsConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'PaymentsProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      client,
-    };
-  }, [config, contextClient]);
-  return <PaymentsConfigContext value={value}>{children}</PaymentsConfigContext>;
-}
+export const PaymentsProvider = Provider;
 
 /** Returns the payments configuration from the nearest `PaymentsProvider`. */
-export function usePaymentsConfig(): ResolvedPaymentsConfig {
-  const ctx = useContext(PaymentsConfigContext);
-  if (!ctx) {
-    throw new Error('usePaymentsConfig must be used within a PaymentsProvider');
-  }
-  return ctx;
-}
+export const usePaymentsConfig = useConfig;
 
 /**
  * Like `usePaymentsConfig`, but returns `null` instead of throwing when no
  * `PaymentsProvider` is mounted. Lets shared primitives (e.g. the icons) read
  * optional config — such as `brandIcons` — while staying usable standalone.
  */
-export function useOptionalPaymentsConfig(): ResolvedPaymentsConfig | null {
-  return useContext(PaymentsConfigContext);
-}
+export const useOptionalPaymentsConfig = useOptionalConfig;
 
 /** Builds a consistent React Query key for payments operations. */
 export function buildPaymentsQueryKey(

--- a/packages/@granit/react-privacy/src/__tests__/privacy-hooks.test.tsx
+++ b/packages/@granit/react-privacy/src/__tests__/privacy-hooks.test.tsx
@@ -82,7 +82,7 @@ describe('PrivacyProvider', () => {
       React.createElement(QueryClientProvider, { client: queryClient }, children);
 
     expect(() => renderHook(() => usePrivacyConfig(), { wrapper })).toThrow(
-      'usePrivacyConfig must be used within a PrivacyProvider'
+      'usePrivacyConfig must be used within a <PrivacyProvider>'
     );
   });
 });

--- a/packages/@granit/react-privacy/src/providers/privacy-provider.tsx
+++ b/packages/@granit/react-privacy/src/providers/privacy-provider.tsx
@@ -1,14 +1,14 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
-export interface PrivacyConfig {
-  readonly client?: AxiosInstance;
-  readonly basePath?: string;
+export interface PrivacyConfig extends GranitProviderConfig {
   readonly queryKeyPrefix?: readonly string[];
 }
 
@@ -16,48 +16,27 @@ export interface PrivacyConfig {
  * PrivacyConfig after the provider has resolved `client` from
  * `config.client` or the nearest `<GranitClientProvider>`.
  */
-export interface ResolvedPrivacyConfig extends PrivacyConfig {
-  readonly client: AxiosInstance;
-}
+export type ResolvedPrivacyConfig = ResolvedGranitProviderConfig<PrivacyConfig>;
 
-export interface PrivacyProviderProps {
-  readonly config: PrivacyConfig;
-  readonly children: ReactNode;
-}
+export type PrivacyProviderProps = GranitProviderProps<PrivacyConfig>;
 
 const DEFAULT_KEY_PREFIX = ['privacy'] as const;
 
-const PrivacyContext = createContext<ResolvedPrivacyConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<PrivacyConfig>({
+  name: 'Privacy',
+  defaultBasePath: DEFAULT_BASE_PATH,
+  resolve: (base) => ({
+    ...base,
+    queryKeyPrefix: base.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
+  }),
+});
 
-export function usePrivacyConfig(): ResolvedPrivacyConfig {
-  const config = useContext(PrivacyContext);
-  if (!config) throw new Error('usePrivacyConfig must be used within a PrivacyProvider');
-  return config;
-}
+export const PrivacyProvider = Provider;
+export const usePrivacyConfig = useConfig;
 
 export function buildPrivacyQueryKey(
   config: PrivacyConfig,
   ...segments: readonly string[]
 ): readonly unknown[] {
   return [...(config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX), ...segments];
-}
-
-export function PrivacyProvider({ config, children }: PrivacyProviderProps) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'PrivacyProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
-      client,
-    };
-  }, [config, contextClient]);
-
-  return <PrivacyContext value={value}>{children}</PrivacyContext>;
 }

--- a/packages/@granit/react-scheduling/src/__tests__/scheduling-provider.test.tsx
+++ b/packages/@granit/react-scheduling/src/__tests__/scheduling-provider.test.tsx
@@ -41,6 +41,6 @@ describe('SchedulingProvider', () => {
   it('should throw when used outside provider', () => {
     expect(() => {
       renderHook(() => useSchedulingConfig());
-    }).toThrow('useSchedulingConfig must be used within a SchedulingProvider');
+    }).toThrow('useSchedulingConfig must be used within a <SchedulingProvider>');
   });
 });

--- a/packages/@granit/react-scheduling/src/providers/scheduling-provider.tsx
+++ b/packages/@granit/react-scheduling/src/providers/scheduling-provider.tsx
@@ -1,14 +1,15 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
 /** Configuration for the scheduling provider. */
-export interface SchedulingConfig {
-  readonly client?: AxiosInstance;
+export interface SchedulingConfig extends GranitProviderConfig {
   /** Base path for scheduling endpoints (default: `/api/v1/scheduling`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
@@ -18,41 +19,17 @@ export interface SchedulingConfig {
  * SchedulingConfig after the provider has resolved `client` from
  * `config.client` or the nearest `<GranitClientProvider>`.
  */
-export interface ResolvedSchedulingConfig extends SchedulingConfig {
-  readonly client: AxiosInstance;
-}
+export type ResolvedSchedulingConfig = ResolvedGranitProviderConfig<SchedulingConfig>;
 
-export interface SchedulingProviderProps {
-  readonly config: SchedulingConfig;
-  readonly children: ReactNode;
-}
+export type SchedulingProviderProps = GranitProviderProps<SchedulingConfig>;
 
-const SchedulingConfigContext = createContext<ResolvedSchedulingConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<SchedulingConfig>({
+  name: 'Scheduling',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
 /** Provides scheduling configuration to child components and hooks. */
-export function SchedulingProvider({ config, children }: Readonly<SchedulingProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedSchedulingConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'SchedulingProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      client,
-    };
-  }, [config, contextClient]);
-  return <SchedulingConfigContext value={value}>{children}</SchedulingConfigContext>;
-}
+export const SchedulingProvider = Provider;
 
 /** Returns the scheduling configuration from the nearest `SchedulingProvider`. */
-export function useSchedulingConfig(): ResolvedSchedulingConfig {
-  const ctx = useContext(SchedulingConfigContext);
-  if (!ctx) {
-    throw new Error('useSchedulingConfig must be used within a SchedulingProvider');
-  }
-  return ctx;
-}
+export const useSchedulingConfig = useConfig;

--- a/packages/@granit/react-subscriptions/src/providers/subscriptions-provider.tsx
+++ b/packages/@granit/react-subscriptions/src/providers/subscriptions-provider.tsx
@@ -1,55 +1,35 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
 /** Configuration for the subscriptions provider. */
-export interface SubscriptionsConfig {
-  readonly client?: AxiosInstance;
+export interface SubscriptionsConfig extends GranitProviderConfig {
   /** Base path for subscriptions endpoints (default: `/api/v1/subscriptions`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
 }
 
 /** Resolved configuration where all optional fields have defaults applied. */
-export interface ResolvedSubscriptionsConfig extends SubscriptionsConfig {
-  readonly client: AxiosInstance;
-  readonly basePath: string;
-}
+export type ResolvedSubscriptionsConfig = ResolvedGranitProviderConfig<SubscriptionsConfig>;
 
-export interface SubscriptionsProviderProps {
-  readonly config: SubscriptionsConfig;
-  readonly children: ReactNode;
-}
+export type SubscriptionsProviderProps = GranitProviderProps<SubscriptionsConfig>;
 
-const SubscriptionsConfigContext = createContext<ResolvedSubscriptionsConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<SubscriptionsConfig>({
+  name: 'Subscriptions',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
 /** Provides subscriptions configuration to child components and hooks. */
-export function SubscriptionsProvider({ config, children }: Readonly<SubscriptionsProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedSubscriptionsConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'SubscriptionsProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return { ...config, client, basePath: config.basePath ?? DEFAULT_BASE_PATH };
-  }, [config, contextClient]);
-  return <SubscriptionsConfigContext value={value}>{children}</SubscriptionsConfigContext>;
-}
+export const SubscriptionsProvider = Provider;
 
 /** Returns the subscriptions configuration from the nearest `SubscriptionsProvider`. */
-export function useSubscriptionsConfig(): ResolvedSubscriptionsConfig {
-  const ctx = useContext(SubscriptionsConfigContext);
-  if (!ctx) {
-    throw new Error('useSubscriptionsConfig must be used within a SubscriptionsProvider');
-  }
-  return ctx;
-}
+export const useSubscriptionsConfig = useConfig;
 
 /** Builds a consistent React Query key for subscriptions operations. */
 export function buildSubscriptionsQueryKey(

--- a/packages/@granit/react-tax/src/__tests__/tax-provider.test.tsx
+++ b/packages/@granit/react-tax/src/__tests__/tax-provider.test.tsx
@@ -32,7 +32,7 @@ describe('TaxProvider', () => {
   it('should throw when used outside provider', () => {
     expect(() => {
       renderHook(() => useTaxConfig());
-    }).toThrow('useTaxConfig must be used within a TaxProvider');
+    }).toThrow('useTaxConfig must be used within a <TaxProvider>');
   });
 });
 

--- a/packages/@granit/react-tax/src/providers/tax-provider.tsx
+++ b/packages/@granit/react-tax/src/providers/tax-provider.tsx
@@ -1,14 +1,15 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
 /** Configuration for the tax provider. */
-export interface TaxConfig {
-  readonly client?: AxiosInstance;
+export interface TaxConfig extends GranitProviderConfig {
   /** Base path for tax endpoints (default: `/api/v1/tax`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
@@ -18,44 +19,20 @@ export interface TaxConfig {
  * TaxConfig after the provider has resolved `client` from
  * `config.client` or the nearest `<GranitClientProvider>`.
  */
-export interface ResolvedTaxConfig extends TaxConfig {
-  readonly client: AxiosInstance;
-}
+export type ResolvedTaxConfig = ResolvedGranitProviderConfig<TaxConfig>;
 
-export interface TaxProviderProps {
-  readonly config: TaxConfig;
-  readonly children: ReactNode;
-}
+export type TaxProviderProps = GranitProviderProps<TaxConfig>;
 
-const TaxConfigContext = createContext<ResolvedTaxConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<TaxConfig>({
+  name: 'Tax',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
 /** Provides tax configuration to child components and hooks. */
-export function TaxProvider({ config, children }: Readonly<TaxProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedTaxConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'TaxProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      client,
-    };
-  }, [config, contextClient]);
-  return <TaxConfigContext value={value}>{children}</TaxConfigContext>;
-}
+export const TaxProvider = Provider;
 
 /** Returns the tax configuration from the nearest `TaxProvider`. */
-export function useTaxConfig(): ResolvedTaxConfig {
-  const ctx = useContext(TaxConfigContext);
-  if (!ctx) {
-    throw new Error('useTaxConfig must be used within a TaxProvider');
-  }
-  return ctx;
-}
+export const useTaxConfig = useConfig;
 
 /** Builds a consistent React Query key for tax operations. */
 export function buildTaxQueryKey(

--- a/packages/@granit/react-templating/src/providers/templating-provider.tsx
+++ b/packages/@granit/react-templating/src/providers/templating-provider.tsx
@@ -1,51 +1,27 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
+import type { GranitProviderConfig, GranitProviderProps } from '@granit/react-api-client';
 import type { TemplatingConfig as ResolvedTemplatingConfig } from '@granit/templating';
-import type { ReactNode } from 'react';
 
-export interface TemplatingConfig {
-  readonly client?: AxiosInstance;
-  readonly basePath?: string;
+export interface TemplatingConfig extends GranitProviderConfig {
   readonly queryKeyPrefix?: readonly string[];
 }
 
-export interface TemplatingProviderProps {
-  readonly config: TemplatingConfig;
-  readonly children: ReactNode;
-}
+export type TemplatingProviderProps = GranitProviderProps<TemplatingConfig>;
 
 const DEFAULT_QUERY_KEY_PREFIX = ['templates'] as const;
 
-const TemplatingConfigContext = createContext<ResolvedTemplatingConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<TemplatingConfig, ResolvedTemplatingConfig>({
+  name: 'Templating',
+  defaultBasePath: DEFAULT_BASE_PATH,
+  resolve: (base) => ({
+    ...base,
+    queryKeyPrefix: base.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
+  }),
+});
 
-export function TemplatingProvider({ config, children }: TemplatingProviderProps) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedTemplatingConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'TemplatingProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      client,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
-    };
-  }, [config, contextClient]);
+export const TemplatingProvider = Provider;
 
-  return <TemplatingConfigContext value={value}>{children}</TemplatingConfigContext>;
-}
-
-export function useTemplatingConfig(): ResolvedTemplatingConfig {
-  const config = useContext(TemplatingConfigContext);
-  if (!config) {
-    throw new Error('useTemplatingConfig must be used within a <TemplatingProvider>');
-  }
-  return config;
-}
+export const useTemplatingConfig = useConfig;

--- a/packages/@granit/react-timeline/src/providers/timeline-provider.tsx
+++ b/packages/@granit/react-timeline/src/providers/timeline-provider.tsx
@@ -1,56 +1,33 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
+import type { GranitProviderConfig, GranitProviderProps } from '@granit/react-api-client';
 import type { TimelineConfig } from '@granit/timeline';
-import type { ReactNode } from 'react';
-
-const TimelineConfigContext = createContext<TimelineConfig | null>(null);
 
 /** Configuration for the timeline provider. */
-export interface TimelineProviderConfig {
-  readonly client?: AxiosInstance;
+export interface TimelineProviderConfig extends GranitProviderConfig {
   /** Base path for timeline endpoints (default: `/api/v1/timeline`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
 }
 
-export interface TimelineProviderProps {
-  readonly config: TimelineProviderConfig;
-  readonly children: ReactNode;
-}
+export type TimelineProviderProps = GranitProviderProps<TimelineProviderConfig>;
+
+const { Provider, useConfig } = createConfigProvider<TimelineProviderConfig, TimelineConfig>({
+  name: 'Timeline',
+  defaultBasePath: DEFAULT_BASE_PATH,
+  resolve: (base) => ({
+    ...base,
+    queryKeyPrefix: base.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
+  }),
+});
 
 /** Provides timeline configuration to child components and hooks. */
-export function TimelineProvider({ config, children }: Readonly<TimelineProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<TimelineConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'TimelineProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return {
-      ...config,
-      client,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
-    };
-  }, [config, contextClient]);
-
-  return <TimelineConfigContext value={value}>{children}</TimelineConfigContext>;
-}
+export const TimelineProvider = Provider;
 
 /** Returns the timeline configuration from the nearest `TimelineProvider`. */
-export function useTimelineConfig(): TimelineConfig {
-  const config = useContext(TimelineConfigContext);
-  if (!config) {
-    throw new Error('useTimelineConfig must be used within a <TimelineProvider>');
-  }
-  return config;
-}
+export const useTimelineConfig = useConfig;
 
 /** Builds a consistent React Query key for timeline operations. */
 export function buildTimelineQueryKey(

--- a/packages/@granit/react-webhooks/src/providers/webhooks-provider.tsx
+++ b/packages/@granit/react-webhooks/src/providers/webhooks-provider.tsx
@@ -1,14 +1,15 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_WEBHOOKS_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
 /** Configuration for the webhooks provider. */
-export interface WebhooksConfig {
-  readonly client?: AxiosInstance;
+export interface WebhooksConfig extends GranitProviderConfig {
   /**
    * Base path for webhooks endpoints (default: `/api/v1/webhooks`).
    *
@@ -20,38 +21,17 @@ export interface WebhooksConfig {
 }
 
 /** Resolved configuration where all optional fields have defaults applied. */
-export interface ResolvedWebhooksConfig extends WebhooksConfig {
-  readonly client: AxiosInstance;
-  readonly basePath: string;
-}
+export type ResolvedWebhooksConfig = ResolvedGranitProviderConfig<WebhooksConfig>;
 
-export interface WebhooksProviderProps {
-  readonly config: WebhooksConfig;
-  readonly children: ReactNode;
-}
+export type WebhooksProviderProps = GranitProviderProps<WebhooksConfig>;
 
-const WebhooksConfigContext = createContext<ResolvedWebhooksConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<WebhooksConfig>({
+  name: 'Webhooks',
+  defaultBasePath: DEFAULT_WEBHOOKS_BASE_PATH,
+});
 
 /** Provides webhooks configuration to child components and hooks. */
-export function WebhooksProvider({ config, children }: Readonly<WebhooksProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedWebhooksConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'WebhooksProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return { ...config, client, basePath: config.basePath ?? DEFAULT_WEBHOOKS_BASE_PATH };
-  }, [config, contextClient]);
-  return <WebhooksConfigContext value={value}>{children}</WebhooksConfigContext>;
-}
+export const WebhooksProvider = Provider;
 
 /** Returns the webhooks configuration from the nearest `WebhooksProvider`. */
-export function useWebhooksConfig(): ResolvedWebhooksConfig {
-  const ctx = useContext(WebhooksConfigContext);
-  if (!ctx) {
-    throw new Error('useWebhooksConfig must be used within a <WebhooksProvider>');
-  }
-  return ctx;
-}
+export const useWebhooksConfig = useConfig;

--- a/packages/@granit/react-workflow/src/providers/workflow-provider.tsx
+++ b/packages/@granit/react-workflow/src/providers/workflow-provider.tsx
@@ -1,52 +1,32 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
 
 /** Configuration for the workflow provider. */
-export interface WorkflowConfig {
-  readonly client?: AxiosInstance;
+export interface WorkflowConfig extends GranitProviderConfig {
   /** Base path for workflow endpoints (default: `/api/v1/workflow`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
 }
 
 /** Resolved configuration where all optional fields have defaults applied. */
-export interface ResolvedWorkflowConfig extends WorkflowConfig {
-  readonly client: AxiosInstance;
-  readonly basePath: string;
-}
+export type ResolvedWorkflowConfig = ResolvedGranitProviderConfig<WorkflowConfig>;
 
-export interface WorkflowProviderProps {
-  readonly config: WorkflowConfig;
-  readonly children: ReactNode;
-}
+export type WorkflowProviderProps = GranitProviderProps<WorkflowConfig>;
 
-const WorkflowConfigContext = createContext<ResolvedWorkflowConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<WorkflowConfig>({
+  name: 'Workflow',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
 
 /** Provides workflow configuration to child components and hooks. */
-export function WorkflowProvider({ config, children }: Readonly<WorkflowProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedWorkflowConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'WorkflowProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return { ...config, client, basePath: config.basePath ?? DEFAULT_BASE_PATH };
-  }, [config, contextClient]);
-  return <WorkflowConfigContext value={value}>{children}</WorkflowConfigContext>;
-}
+export const WorkflowProvider = Provider;
 
 /** Returns the workflow configuration from the nearest `WorkflowProvider`. */
-export function useWorkflowConfig(): ResolvedWorkflowConfig {
-  const ctx = useContext(WorkflowConfigContext);
-  if (!ctx) {
-    throw new Error('useWorkflowConfig must be used within a <WorkflowProvider>');
-  }
-  return ctx;
-}
+export const useWorkflowConfig = useConfig;


### PR DESCRIPTION
## What

Introduces a shared `createConfigProvider` factory and adopts it across **33** `@granit/react-*` domain packages, removing the hand-written config-provider triplet (~25 LOC each).

~53 packages each hand-wrote the same boilerplate: an `XConfig`/`ResolvedXConfig` pair, a context, an `<XProvider>` resolving the Axios client from `config.client` or the nearest `<GranitClientProvider>` (throwing when absent) and defaulting `basePath`, and a `useXConfig` hook that throws when used outside its provider. Only the name, default base path and error wording varied.

## Factory API (`@granit/react-api-client`)

```ts
createConfigProvider<TConfig, TResolved>({ name, defaultBasePath, resolve? })
  => { Provider, useConfig, useOptionalConfig }
```
- `resolve?(base, raw) => TResolved` — default extra fields (e.g. `queryKeyPrefix`) and expose the richer resolved type.
- `useOptionalConfig()` — for packages publishing a `useOptional<Name>Config` accessor (returns the context value or `null`).

Each package re-exports the factory output under its **public names**, so consumers (showcase-admin-react) see no API change. The front-index export count is unchanged (1709), confirming the migration is non-breaking.

## Commits

1. Factory + `react-hostnames` pilot.
2. basePath-only rollout — 16 packages.
3. Extend factory (`resolve` + `useOptionalConfig`) + 16 more packages.

## Migrated (33)

hostnames, authentication-local, background-jobs, bank-accounts, blob-storage, customer-balance, dashboards, features, notifications-mobile-push, parties, payments-sepa-direct-debit, payments-sepa-transfer, scheduling, subscriptions, tax, webhooks, workflow, documents, cms, cms-hostnames, cms-redirects, cms-seo, account, ai, ai-chat, ai-prompts, templating, authorization, payments, privacy, timeline, multi-tenancy (tenant-admin), openiddict-admin.

## Intentionally left bespoke (~9)

Providers that don't fit the factory: wrap `<QueryProvider>` (invoicing, metering, auditing); require `basePath` or use `Omit+Partial` props (entity-merge, identity, catalog); take an optional `config?` (data-exchange, data-lookup, presence); or resolve client/basePath from differently-named fields (`apiBase`, `apiClient`).

## Notes

- The factory standardizes the throw message to `use<Name>Config must be used within a <<Name>Provider>`; a few stale provider-test assertions were updated to match.
- Any package-local `buildXQueryKey` helper is preserved.

## Tests

Factory covered by 9 tests (client resolution, basePath default, passthrough, `resolve` defaulting, both throw paths, `useOptionalConfig`). Full `tsc -r` (226 packages) + migrated-package suites green (986 tests across the second batch).