### PR TITLE
feat(analytics): resolve query-catalogue labelKey (i18n) in the widget editor

### DIFF
--- a/contracts/openapi/query-engine.json
+++ b/contracts/openapi/query-engine.json
@@ -87,7 +87,7 @@
         }
       },
       "QueryCatalogEntryResponse": {
-        "required": ["name", "basePath", "label"],
+        "required": ["name", "basePath", "labelKey"],
         "type": "object",
         "properties": {
           "name": {
@@ -96,7 +96,7 @@
           "basePath": {
             "type": ["null", "string"]
           },
-          "label": {
+          "labelKey": {
             "type": "string"
           }
         }

--- a/packages/@granit/query-engine/src/__tests__/api.test.ts
+++ b/packages/@granit/query-engine/src/__tests__/api.test.ts
@@ -88,7 +88,7 @@ describe('query-api', () => {
   it('getQueryCatalog calls GET /catalog', async () => {
     const client = createMockClient();
     const catalog = [
-      { name: 'Granit.Test.Query', basePath: '/api/v1/patients', label: 'Patients' },
+      { name: 'Granit.Test.Query', basePath: '/api/v1/patients', labelKey: 'Entity:Patient' },
     ];
     vi.mocked(client.get).mockResolvedValueOnce({ data: catalog });
     const result = await getQueryCatalog(client, '/api/v1');

--- a/packages/@granit/query-engine/src/types/query-catalog.ts
+++ b/packages/@granit/query-engine/src/types/query-catalog.ts
@@ -17,6 +17,12 @@ export interface QueryCatalogEntryResponse {
    * `/meta` to fetch its {@link QueryMetadata}.
    */
   readonly basePath: string | null;
-  /** Human-readable label (falls back to {@link QueryCatalogEntryResponse.name} backend-side). */
-  readonly label: string;
+  /**
+   * Localization KEY for the dropdown label (NOT a resolved string) — the target
+   * entity's display key (e.g. `Entity:Party`, already translated) when the query
+   * targets a registered entity, else `Query:{name}`. Resolve it client-side via
+   * the merged i18n bundle (like `Entity:*` / `Permission:*`); fall back to a
+   * humanised last segment of {@link QueryCatalogEntryResponse.name} when unresolved.
+   */
+  readonly labelKey: string;
 }

--- a/packages/@granit/react-analytics/src/__tests__/chart-config-form.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/chart-config-form.test.tsx
@@ -20,7 +20,7 @@ void testI18n.use(initReactI18next).init({
   fallbackLng: 'en',
   nsSeparator: false,
   keySeparator: false,
-  resources: { en: { translation: {} } },
+  resources: { en: { translation: { 'Entity:Patient': 'Patients' } } },
   interpolation: { escapeValue: false },
 });
 
@@ -42,7 +42,18 @@ function mockCatalogClient() {
   vi.spyOn(client, 'get').mockImplementation((url: string) => {
     if (url.endsWith('/catalog')) {
       return Promise.resolve({
-        data: [{ name: 'Granit.Test.Query', basePath: '/api/v1/patients', label: 'Patients' }],
+        data: [
+          // labelKey resolved via the i18n bundle.
+          { name: 'Granit.Test.Query', basePath: '/api/v1/patients', labelKey: 'Entity:Patient' },
+          // labelKey absent from the bundle → humanised last segment of the name.
+          {
+            name: 'Granit.Sales.RevenueByRegionQuery',
+            basePath: '/api/v1/revenue',
+            labelKey: 'Query:Granit.Sales.RevenueByRegionQuery',
+          },
+          // Unrouted (basePath null) → hidden from the dropdown.
+          { name: 'Granit.Test.UnroutedQuery', basePath: null, labelKey: 'Query:x' },
+        ],
       });
     }
     if (url.endsWith('/meta')) {
@@ -115,6 +126,23 @@ describe('ChartConfigForm', () => {
     await user.click(container.querySelector('[data-slot="chart-query-name"]')!);
     await user.click(await screen.findByRole('option', { name: 'Patients' }));
     expect(onChange.mock.calls.at(-1)?.[0]?.queryName).toBe('Granit.Test.Query');
+  });
+
+  it('resolves labelKey via i18n / humanises the fallback and hides unrouted queries', async () => {
+    const user = userEvent.setup();
+    const emptyChart: ChartWidgetDefinition = { ...baseChart, queryName: '' };
+    const { container } = wrap(
+      <ChartConfigForm widget={emptyChart} onChange={vi.fn()} />,
+      mockCatalogClient()
+    );
+
+    await user.click(container.querySelector('[data-slot="chart-query-name"]')!);
+    // labelKey present in the bundle → translated.
+    expect(await screen.findByRole('option', { name: 'Patients' })).toBeInTheDocument();
+    // labelKey absent → humanised last segment of the name.
+    expect(screen.getByRole('option', { name: 'Revenue By Region Query' })).toBeInTheDocument();
+    // basePath === null → hidden (its humanised label would be "Unrouted Query").
+    expect(screen.queryByRole('option', { name: 'Unrouted Query' })).toBeNull();
   });
 
   it('sources Group By from group-by fields and Field from numeric columns only', async () => {

--- a/packages/@granit/react-analytics/src/__tests__/pivot-config-form.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/pivot-config-form.test.tsx
@@ -41,7 +41,9 @@ function mockCatalogClient() {
   vi.spyOn(client, 'get').mockImplementation((url: string) => {
     if (url.endsWith('/catalog')) {
       return Promise.resolve({
-        data: [{ name: 'Granit.Test.Query', basePath: '/api/v1/patients', label: 'Patients' }],
+        data: [
+          { name: 'Granit.Test.Query', basePath: '/api/v1/patients', labelKey: 'Entity:Patient' },
+        ],
       });
     }
     if (url.endsWith('/meta')) {

--- a/packages/@granit/react-analytics/src/__tests__/table-config-form.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/table-config-form.test.tsx
@@ -39,7 +39,9 @@ function mockCatalogClient() {
   vi.spyOn(client, 'get').mockImplementation((url: string) => {
     if (url.endsWith('/catalog')) {
       return Promise.resolve({
-        data: [{ name: 'Granit.Test.Query', basePath: '/api/v1/patients', label: 'Patients' }],
+        data: [
+          { name: 'Granit.Test.Query', basePath: '/api/v1/patients', labelKey: 'Entity:Patient' },
+        ],
       });
     }
     if (url.endsWith('/meta')) {

--- a/packages/@granit/react-analytics/src/editor/query-field-controls.tsx
+++ b/packages/@granit/react-analytics/src/editor/query-field-controls.tsx
@@ -20,8 +20,10 @@ import {
   SelectValue,
   type ComboboxOption,
 } from '@granit/react-ui';
+import { useTranslation } from 'react-i18next';
 
 import type { QueryCatalogEntryResponse } from '@granit/query-engine';
+import type { TFunction } from 'i18next';
 
 /** CLR type names eligible for numeric aggregation (Sum/Avg/Min/Max). */
 const NUMERIC_CLR_TYPES = new Set([
@@ -107,7 +109,31 @@ const toComboboxOptions = (options: readonly FieldOption[]): ComboboxOption[] =>
 /**
  * Query name picker: a catalogue-backed combobox that also accepts an arbitrary
  * typed value, so it works with or without a `<QueryCatalogProvider>`.
+ *
+ * Entry semantics (per the `/catalog` contract): the option VALUE is the stable
+ * `name` (what we persist), the option LABEL is `t(labelKey)` resolved against the
+ * merged i18n bundle — falling back to a humanised last segment of `name` when the
+ * key is not in the bundle (`Query:*` keys are opt-in backend-side). Entries with
+ * `basePath === null` are not routed (no endpoint to load data from), so they are
+ * hidden — flip `HIDE_UNROUTED_QUERIES` to surface them disabled instead.
  */
+const HIDE_UNROUTED_QUERIES = true;
+
+/** Humanises the last dot-segment of a query name, e.g. `…CategoriesQuery` → `Categories Query`. */
+export function humanizeQueryName(name: string): string {
+  const last = name.split('.').pop() ?? name;
+  return last
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .trim();
+}
+
+/** Resolves a catalogue entry's display label: `t(labelKey)`, else a humanised name. */
+export function resolveQueryLabel(t: TFunction, entry: QueryCatalogEntryResponse): string {
+  const translated = t(entry.labelKey);
+  return translated === entry.labelKey ? humanizeQueryName(entry.name) : translated;
+}
+
 export function QueryNameCombobox({
   slot,
   value,
@@ -119,12 +145,17 @@ export function QueryNameCombobox({
   readonly onChange: (value: string) => void;
   readonly entries: readonly QueryCatalogEntryResponse[] | undefined;
 }) {
+  const { t } = useTranslation();
+  const options: ComboboxOption[] = (entries ?? [])
+    .filter((entry) => !HIDE_UNROUTED_QUERIES || entry.basePath !== null)
+    .map((entry) => ({ value: entry.name, label: resolveQueryLabel(t, entry) }));
+
   return (
     <Combobox
       slot={slot}
       value={value}
       onValueChange={onChange}
-      options={(entries ?? []).map((entry) => ({ value: entry.name, label: entry.label }))}
+      options={options}
       allowCustomValue
       placeholder="Select a query…"
       searchPlaceholder="Search or type a query name…"

--- a/packages/@granit/react-query-engine/src/__tests__/use-query-catalog.test.tsx
+++ b/packages/@granit/react-query-engine/src/__tests__/use-query-catalog.test.tsx
@@ -35,7 +35,7 @@ describe('useQueryCatalog', () => {
   it('fetches the catalogue from the provider root', async () => {
     const client = axios.create();
     const catalog = [
-      { name: 'Granit.Test.Query', basePath: '/api/v1/patients', label: 'Patients' },
+      { name: 'Granit.Test.Query', basePath: '/api/v1/patients', labelKey: 'Entity:Patient' },
     ];
     vi.spyOn(client, 'get').mockResolvedValue({ data: catalog });
 


### PR DESCRIPTION
## Why

The final `/catalog` contract (granit-dotnet #2853/#2854, DTO commit `baf02a24c`) renames the entry field `label` → **`labelKey`**: it's now a **localization key** (the target entity's display key, e.g. `Entity:Party` — already translated — or `Query:{name}`), **not** a pre-resolved string. The front was still typed/displaying `label`, so against the deployed backend the query dropdown showed raw keys / `undefined`.

## What

- **`@granit/query-engine`** — `QueryCatalogEntryResponse.label` → `labelKey`; vendored `query-engine` OpenAPI snapshot updated to match (contract oracle green).
- **`QueryNameCombobox`** — resolves `t(labelKey)` against the merged i18n bundle (same mechanism as `Entity:*` / `Permission:*`), and **never shows a raw key**: when the key isn't in the bundle (`Query:*` are opt-in backend-side) it falls back to a **humanised last segment** of `name` (`…CategoriesQuery` → "Categories Query").
- **Unrouted entries** (`basePath === null`, registered but no endpoint to load from) are **hidden** by default; `HIDE_UNROUTED_QUERIES` flips them to surfaced-disabled.
- Semantics respected: the **`name`** is what's persisted; **`basePath`** (never `name`) is used to fetch (`{basePath}` + params, `{basePath}/meta` for config).

## Tests

All 4 config-form suites + the api/hook catalogue tests updated to the `labelKey` shape (34 tests). New coverage in the chart form: i18n-resolved label, humanised fallback, and unrouted-entry hiding. `tsc`, `eslint --max-warnings 0`, contract conformance (`query-engine`) green.

## Follow-up (separate repo)

The showcase MSW handler (`granit-showcase-react` `query-catalog-handlers.ts`) still emits `label` — needs the same `label` → `labelKey` rename to mock the final contract.