### PR TITLE
fix(react-analytics): declare i18next dependency

### DIFF
--- a/packages/@granit/react-analytics/package.json
+++ b/packages/@granit/react-analytics/package.json
@@ -27,6 +27,7 @@
     "@granit/query-engine": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
+    "i18next": "^26.0.0",
     "lucide-react": "^1.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0",
@@ -70,6 +71,7 @@
     "@granit/query-engine": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*",
+    "i18next": "^26.0.0",
     "msw": "^2.14.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1387,6 +1387,9 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
+      i18next:
+        specifier: ^26.0.0
+        version: 26.3.2(typescript@6.0.3)
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@26.0.0)(typescript@6.0.3)


### PR DESCRIPTION
## Problem

CI on `develop` is red on the arch-test `no-undeclared-dep` rule:

```
packages/@granit/react-analytics/src/editor/query-field-controls.tsx
  imports "i18next" but it is not declared in package.json
```

The labelKey i18n work (#827) added `import type { TFunction } from 'i18next'` to `query-field-controls.tsx`, and the config-form tests already `import i18n from 'i18next'` directly — but the package only declared `react-i18next`, never `i18next` itself (it had been resolving via workspace hoisting).

## Fix

Declare `i18next` `^26.0.0` (the repo-wide pin used by ~38 sibling packages):
- **peerDependencies** — runtime peer alongside `react-i18next` (provided by the consuming app)
- **devDependencies** — the package's own tests import it directly

Lockfile regenerated (`pnpm install --lockfile-only`, 3-line diff). No new third-party entry — `i18next` is already in THIRD-PARTY-NOTICES.

## Verification

`pnpm exec vitest run packages/@granit/arch-tests/src/__tests__/deps.test.ts` → **73 passed**.