### PR TITLE
fix(analytics): make chart Group By clearable via the "— none —" option

### DIFF
--- a/packages/@granit/react-analytics/src/__tests__/chart-config-form.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/chart-config-form.test.tsx
@@ -145,6 +145,15 @@ describe('ChartConfigForm', () => {
     expect(screen.queryByRole('option', { name: 'Unrouted Query' })).toBeNull();
   });
 
+  it('clears Group By via the "— none —" option', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { container } = wrap(<ChartConfigForm widget={baseChart} onChange={onChange} />);
+    await user.click(container.querySelector('[data-slot="chart-group-by"]')!);
+    await user.click(await screen.findByRole('option', { name: '— none —' }));
+    expect(onChange.mock.calls.at(-1)?.[0]?.groupBy).toBe('');
+  });
+
   it('sources Group By from group-by fields and Field from numeric columns only', async () => {
     const user = userEvent.setup();
     const { container } = wrap(

--- a/packages/@granit/react-analytics/src/editor/chart-config-form.tsx
+++ b/packages/@granit/react-analytics/src/editor/chart-config-form.tsx
@@ -56,6 +56,7 @@ export function ChartConfigForm({
           slot="chart-group-by"
           value={widget.groupBy}
           options={groupByOptions}
+          allowEmpty
           onChange={(value) => onChange({ ...widget, groupBy: value })}
         />
       </label>


### PR DESCRIPTION
The chart Group By combobox had no way to remove an existing value (showed e.g. `CancelledAt` with no clear path). Pass `allowEmpty` so the dropdown offers a "— none —" item that commits the empty string — same mechanism as the Field control. No clear (×) button on the trigger (it fights the Radix popover open handler — clicking it reopened the list instead of clearing); the list item is the single reliable clear affordance. Test added.