### PR TITLE
feat(dashboards): editable widget title in the config drawer

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4740,6 +4740,11 @@
           "signature": "function useDashboardWidget( dashboardId: string, widgetId: string ): UseQueryResult<DashboardRenderedWidget>"
         },
         {
+          "name": "resolveWidgetTitle",
+          "kind": "function",
+          "signature": "function resolveWidgetTitle(t: TFunction, key: string | undefined): string"
+        },
+        {
           "name": "useWidgetRender",
           "kind": "function",
           "signature": "function useWidgetRender<TDefinition extends WidgetDefinitionBase>( kind: WidgetRenderKind, definition: TDefinition, context: WidgetRenderContext ="

--- a/packages/@granit/react-dashboard-editor/src/__tests__/widget-config-drawer.test.tsx
+++ b/packages/@granit/react-dashboard-editor/src/__tests__/widget-config-drawer.test.tsx
@@ -101,6 +101,36 @@ describe('WidgetConfigDrawer', () => {
     });
   });
 
+  it('edits the widget title (titleLocalizationKey) common to every kind', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(
+      <WidgetConfigDrawer
+        widget={markdownWidget}
+        onChange={onChange}
+        registry={defaultWidgetConfigFormRegistry}
+      />
+    );
+    const input = container.querySelector('[data-slot="widget-title"]');
+    if (!(input instanceof HTMLInputElement)) throw new Error('title input not found');
+    fireEvent.change(input, { target: { value: 'Cancellations over time' } });
+    expect(onChange.mock.calls[0]?.[0]?.titleLocalizationKey).toBe('Cancellations over time');
+  });
+
+  it('clears the title to undefined when emptied', () => {
+    const onChange = vi.fn();
+    const titled = { ...markdownWidget, titleLocalizationKey: 'My title' };
+    const { container } = wrap(
+      <WidgetConfigDrawer
+        widget={titled}
+        onChange={onChange}
+        registry={defaultWidgetConfigFormRegistry}
+      />
+    );
+    const input = container.querySelector('[data-slot="widget-title"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '' } });
+    expect(onChange.mock.calls[0]?.[0]?.titleLocalizationKey).toBeUndefined();
+  });
+
   it('routes a text widget through the text form and edits the style enum', () => {
     const onChange = vi.fn();
     const { container } = wrap(

--- a/packages/@granit/react-dashboard-editor/src/components/widget-config-drawer.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/widget-config-drawer.tsx
@@ -52,6 +52,24 @@ export function WidgetConfigDrawer({
         <h2 className="text-base font-semibold">{widget.slug}</h2>
         {header}
       </div>
+      <label className="mb-3 block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Title.Label', { defaultValue: 'Title' })}
+        </span>
+        <input
+          type="text"
+          data-slot="widget-title"
+          value={widget.titleLocalizationKey ?? ''}
+          onChange={(event) =>
+            onChange({
+              ...widget,
+              titleLocalizationKey: event.target.value === '' ? undefined : event.target.value,
+            })
+          }
+          placeholder={t('Dashboard:Widget.Title.Placeholder', { defaultValue: 'Widget title' })}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
       {Form ? (
         <Form widget={widget} onChange={onChange} />
       ) : (

--- a/packages/@granit/react-dashboards/src/components/rendered-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/rendered-widget.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
 import { useWidgetTriggerHandler } from '../hooks/use-widget-trigger-handler';
+import { resolveWidgetTitle } from '../lib/resolve-widget-title';
 import { useSnapshotWidgetRegistry } from '../registry/snapshot-widget-registry-context';
 
 import { WidgetCard } from './widget-card';
@@ -83,10 +84,9 @@ export function RenderedWidget({ widget, framed = true }: RenderedWidgetProps) {
 
   if (!framed) return body;
 
-  // Empty translation = no header (i18n returns the key by default
-  // when a `defaultValue` is supplied; we explicitly request '' so a
-  // missing key collapses cleanly).
-  const title = t(widget.titleLocalizationKey, { defaultValue: '' });
+  // Translate the title key; a free-text title typed in the editor renders
+  // verbatim, while an unresolved `Namespace:…` key collapses to no header.
+  const title = resolveWidgetTitle(t, widget.titleLocalizationKey);
   return <WidgetCard title={title || undefined}>{body}</WidgetCard>;
 }
 

--- a/packages/@granit/react-dashboards/src/components/widget-renderer.tsx
+++ b/packages/@granit/react-dashboards/src/components/widget-renderer.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
+import { resolveWidgetTitle } from '../lib/resolve-widget-title';
 import { useWidgetRegistry } from '../registry/widget-registry-context';
 
 import { useDashboardContext } from './dashboard-context';
@@ -48,12 +49,13 @@ export function WidgetRenderer({ widget, framed = true }: WidgetRendererProps) {
   // definition bridge from a stored dashboard); fall back to the composed
   // `Widget:{Dashboard}.{Slug}.Title` convention for hand-authored
   // definitions (catalog previews / fixtures) that don't carry one.
+  // A free-text title typed in the editor renders verbatim (resolveWidgetTitle).
   const titleKey =
     widget.titleLocalizationKey ??
     (dashboardCtx
       ? `Widget:${dashboardCtx.dashboardName}.${widget.slug}.Title`
       : `Widget:${widget.slug}.Title`);
-  const title = t(titleKey, { defaultValue: '' });
+  const title = resolveWidgetTitle(t, titleKey);
 
   return <WidgetCard title={title || undefined}>{body}</WidgetCard>;
 }

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -18,6 +18,7 @@ export {
 } from './hooks/use-dashboard-render';
 export type { UseDashboardRenderOptions } from './hooks/use-dashboard-render';
 export { useDashboardWidget } from './hooks/use-dashboard-widget';
+export { resolveWidgetTitle } from './lib/resolve-widget-title';
 export { useWidgetRender, widgetRenderQueryKey } from './hooks/use-widget-render';
 export type {
   UseWidgetRenderOptions,

--- a/packages/@granit/react-dashboards/src/lib/__tests__/resolve-widget-title.test.ts
+++ b/packages/@granit/react-dashboards/src/lib/__tests__/resolve-widget-title.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveWidgetTitle } from '../resolve-widget-title';
+
+import type { TFunction } from 'i18next';
+
+const bundle: Record<string, string> = { 'Widget:Dash.RevenueChart.Title': 'Revenue' };
+
+// Minimal i18next stub: returns the bundle entry, else the supplied defaultValue.
+const t = ((key: string, opts: { defaultValue: string }) =>
+  bundle[key] ?? opts.defaultValue) as unknown as TFunction;
+
+describe('resolveWidgetTitle', () => {
+  it('returns the translation for a known key', () => {
+    expect(resolveWidgetTitle(t, 'Widget:Dash.RevenueChart.Title')).toBe('Revenue');
+  });
+
+  it('shows a free-text title verbatim when it is not a known key', () => {
+    expect(resolveWidgetTitle(t, 'Cancellations over time')).toBe('Cancellations over time');
+  });
+
+  it('collapses an unresolved Namespace:… key to empty (no header)', () => {
+    expect(resolveWidgetTitle(t, 'Widget:Dash.chart-1.Title')).toBe('');
+  });
+
+  it('returns empty for an absent title', () => {
+    expect(resolveWidgetTitle(t, undefined)).toBe('');
+    expect(resolveWidgetTitle(t, '')).toBe('');
+  });
+});

--- a/packages/@granit/react-dashboards/src/lib/resolve-widget-title.ts
+++ b/packages/@granit/react-dashboards/src/lib/resolve-widget-title.ts
@@ -1,0 +1,18 @@
+import type { TFunction } from 'i18next';
+
+/**
+ * Resolves a widget's display title from its `titleLocalizationKey`.
+ *
+ * The key is first translated against the merged i18n bundle (the host-shipped
+ * `Widget:*` / `Entity:*` keys). When it has no translation it is treated as a
+ * **free-text literal** title — so a title typed in the editor shows verbatim —
+ * UNLESS it looks like an unresolved `Namespace:…` localization key (e.g. the
+ * composed `Widget:{Dashboard}.{Slug}.Title` default), which collapses to an
+ * empty string so the widget renders without a header rather than a raw key.
+ */
+export function resolveWidgetTitle(t: TFunction, key: string | undefined): string {
+  if (!key) return '';
+  const resolved = t(key, { defaultValue: '' });
+  if (resolved) return resolved;
+  return /^[A-Za-z][\w.-]*:/.test(key) ? '' : key;
+}


### PR DESCRIPTION
## Why

Widgets couldn't be titled from the editor. The title is a localization key (`Widget:{Dashboard}.{Slug}.Title`) resolved from the i18n bundle, and a freshly added widget's composed key isn't in the bundle → blank title. None of the config forms exposed a title field.

## What

- **`WidgetConfigDrawer`** — a common **"Title"** text field above the kind-specific form (so every widget kind gets it), bound to `titleLocalizationKey`; emptying it clears to `undefined`.
- **`resolveWidgetTitle`** (`@granit/react-dashboards`) — translate the title key, else render the value as a **free-text literal** (so a title typed in the editor shows verbatim), UNLESS it looks like an unresolved `Namespace:…` key (e.g. the composed `Widget:…Title` default), which collapses to no header — preserving the current blank-on-missing-key behaviour.
- Both renderers (`widget-renderer`, `rendered-widget`) use it.

A typed title like "Cancellations over time" now shows verbatim; host-keyed titles (`Widget:*` / `Entity:*`) still translate.

## Tests

`resolveWidgetTitle` (key / literal / unresolved-key / empty) + the drawer title field (edit + clear). Existing drawer + renderer suites green (60 tests). `tsc`, `eslint --max-warnings 0` clean.

## Note

Front-only (option A): the title is stored in `titleLocalizationKey` and treated as key-or-literal. A cleaner model would add a separate free-text `title` field (backend change) — deferred.