### PR TITLE
feat(dashboards): map widget query picker + query-field clear/sort consistency

### DIFF
--- a/packages/@granit/react-analytics/src/__tests__/chart-config-form.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/chart-config-form.test.tsx
@@ -128,6 +128,24 @@ describe('ChartConfigForm', () => {
     expect(onChange.mock.calls.at(-1)?.[0]?.queryName).toBe('Granit.Test.Query');
   });
 
+  it('offers a — none — option and sorts queries by their displayed label', async () => {
+    const user = userEvent.setup();
+    const emptyChart: ChartWidgetDefinition = { ...baseChart, queryName: '' };
+    const { container } = wrap(
+      <ChartConfigForm widget={emptyChart} onChange={vi.fn()} />,
+      mockCatalogClient()
+    );
+
+    await user.click(container.querySelector('[data-slot="chart-query-name"]')!);
+    expect(await screen.findByRole('option', { name: '— none —' })).toBeInTheDocument();
+    const labels = screen.getAllByRole('option').map((o) => o.textContent ?? '');
+    const patients = labels.findIndex((l) => l.includes('Patients'));
+    const revenue = labels.findIndex((l) => l.includes('Revenue By Region Query'));
+    // Sorted by label asc: "Patients" before "Revenue By Region Query".
+    expect(patients).toBeGreaterThanOrEqual(0);
+    expect(patients).toBeLessThan(revenue);
+  });
+
   it('resolves labelKey via i18n / humanises the fallback and hides unrouted queries', async () => {
     const user = userEvent.setup();
     const emptyChart: ChartWidgetDefinition = { ...baseChart, queryName: '' };

--- a/packages/@granit/react-analytics/src/editor/index.ts
+++ b/packages/@granit/react-analytics/src/editor/index.ts
@@ -12,6 +12,16 @@ import { TableConfigForm } from './table-config-form';
 import type { WidgetConfigForm, WidgetConfigFormRegistry } from '@granit/react-dashboard-editor';
 
 export { analyticsWidgetCatalog } from './analytics-widget-catalog';
+// Shared query-binding editor controls — reused by the map widget config form
+// (and any downstream widget that binds to a query-engine query).
+export {
+  EnumSelect,
+  MetaFieldInput,
+  MetaMultiFieldInput,
+  QueryNameCombobox,
+  useQueryFieldMetadata,
+} from './query-field-controls';
+export type { FieldOption, QueryFieldMetadata } from './query-field-controls';
 export { ChartConfigForm } from './chart-config-form';
 export { KpiConfigForm } from './kpi-config-form';
 export { PivotConfigForm } from './pivot-config-form';

--- a/packages/@granit/react-analytics/src/editor/query-field-controls.tsx
+++ b/packages/@granit/react-analytics/src/editor/query-field-controls.tsx
@@ -148,7 +148,9 @@ export function QueryNameCombobox({
   const { t } = useTranslation();
   const options: ComboboxOption[] = (entries ?? [])
     .filter((entry) => !HIDE_UNROUTED_QUERIES || entry.basePath !== null)
-    .map((entry) => ({ value: entry.name, label: resolveQueryLabel(t, entry) }));
+    .map((entry) => ({ value: entry.name, label: resolveQueryLabel(t, entry) }))
+    // Sorted by the DISPLAYED label (ascending), not the wire name.
+    .sort((a, b) => (a.label ?? '').localeCompare(b.label ?? ''));
 
   return (
     <Combobox
@@ -157,6 +159,7 @@ export function QueryNameCombobox({
       onValueChange={onChange}
       options={options}
       allowCustomValue
+      allowEmpty
       placeholder="Select a query…"
       searchPlaceholder="Search or type a query name…"
       emptyText="No matching query — type to use a custom name."

--- a/packages/@granit/react-map/package.json
+++ b/packages/@granit/react-map/package.json
@@ -19,9 +19,11 @@
     "@granit/analytics": "workspace:*",
     "@granit/csp": "workspace:*",
     "@granit/dashboards": "workspace:*",
+    "@granit/react-analytics": "workspace:*",
     "@granit/react-dashboard-editor": "workspace:*",
     "@granit/react-dashboards": "workspace:*",
     "@granit/utils": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
     "dompurify": "^3.0.0",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
@@ -29,6 +31,12 @@
     "react-i18next": "^17.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/react-analytics": {
+      "optional": true
+    },
+    "@tanstack/react-query": {
+      "optional": true
+    },
     "@granit/react-dashboard-editor": {
       "optional": true
     },
@@ -63,11 +71,13 @@
     "@granit/analytics": "workspace:*",
     "@granit/csp": "workspace:*",
     "@granit/dashboards": "workspace:*",
+    "@granit/react-analytics": "workspace:*",
     "@granit/react-dashboard-editor": "workspace:*",
     "@granit/react-dashboards": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/utils": "workspace:*",
+    "@tanstack/react-query": "^5.90.5",
     "@types/leaflet": "^1.9.21",
     "@types/leaflet.markercluster": "^1.5.6",
     "dompurify": "^3.4.11",

--- a/packages/@granit/react-map/src/__tests__/map-config-form.test.tsx
+++ b/packages/@granit/react-map/src/__tests__/map-config-form.test.tsx
@@ -1,4 +1,7 @@
-import { fireEvent, render } from '@testing-library/react';
+import { createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import i18n from 'i18next';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { describe, expect, it, vi } from 'vitest';
@@ -18,8 +21,16 @@ void testI18n.use(initReactI18next).init({
   interpolation: { escapeValue: false },
 });
 
+// The query / column controls use the shared metadata hook (React Query); the
+// map editor degrades to free-text when no <QueryCatalogProvider> is present, so
+// a bare QueryClientProvider is enough here.
 function wrap(node: ReactNode) {
-  return render(<I18nextProvider i18n={testI18n}>{node}</I18nextProvider>);
+  const queryClient = createTestQueryClient();
+  return render(
+    <I18nextProvider i18n={testI18n}>
+      <QueryClientProvider client={queryClient}>{node}</QueryClientProvider>
+    </I18nextProvider>
+  );
 }
 
 const baseMap: MapWidgetDefinition = {
@@ -39,53 +50,50 @@ const baseMap: MapWidgetDefinition = {
 };
 
 describe('MapConfigForm', () => {
-  it('shows the lat / lng column inputs when bound to a lat-lng point source', () => {
+  it('shows the lat / lng column controls when bound to a lat-lng point source', () => {
     const { container } = wrap(<MapConfigForm widget={baseMap} onChange={vi.fn()} />);
     expect(container.querySelector('[data-slot="map-latitude-column"]')).not.toBeNull();
     expect(container.querySelector('[data-slot="map-longitude-column"]')).not.toBeNull();
     expect(container.querySelector('[data-slot="map-geography-column"]')).toBeNull();
   });
 
-  it('emits an updated query-name on change', () => {
+  it('emits a typed query name via the catalogue combobox', async () => {
+    const user = userEvent.setup();
     const onChange = vi.fn();
     const { container } = wrap(<MapConfigForm widget={baseMap} onChange={onChange} />);
-    const input = container.querySelector('[data-slot="map-query-name"]');
-    if (!(input instanceof HTMLInputElement)) throw new Error('input not found');
-    fireEvent.change(input, { target: { value: 'Granit.Test.Branches' } });
-    expect(onChange.mock.calls[0]?.[0]?.queryName).toBe('Granit.Test.Branches');
+    await user.click(container.querySelector('[data-slot="map-query-name"]')!);
+    await user.type(
+      await screen.findByPlaceholderText('Search or type a query name…'),
+      'Granit.Test.Branches'
+    );
+    await user.click(await screen.findByRole('option', { name: /Granit\.Test\.Branches/ }));
+    expect(onChange.mock.calls.at(-1)?.[0]?.queryName).toBe('Granit.Test.Branches');
   });
 
-  it('switches to a geography column input when the point-source kind changes', () => {
+  it('switches to a geography column when the point-source kind changes', async () => {
+    const user = userEvent.setup();
     const onChange = vi.fn();
     const { container } = wrap(<MapConfigForm widget={baseMap} onChange={onChange} />);
-    const select = container.querySelector('[data-slot="map-point-source-kind"]');
-    if (!(select instanceof HTMLSelectElement)) throw new Error('select not found');
-    fireEvent.change(select, { target: { value: 'geography' } });
-    expect(onChange.mock.calls[0]?.[0]?.pointSource).toEqual({
+    await user.click(container.querySelector('[data-slot="map-point-source-kind"]')!);
+    await user.click(await screen.findByRole('option', { name: 'PostGIS geography column' }));
+    expect(onChange.mock.calls.at(-1)?.[0]?.pointSource).toEqual({
       kind: 'geography',
       geographyColumn: '',
     });
   });
 
-  it('parses comma-separated popup columns into the array shape the backend expects', () => {
+  it('adds a popup column through the multi-select (typed value)', async () => {
+    const user = userEvent.setup();
     const onChange = vi.fn();
     const { container } = wrap(<MapConfigForm widget={baseMap} onChange={onChange} />);
-    const input = container.querySelector('[data-slot="map-popup-columns"]');
-    if (!(input instanceof HTMLInputElement)) throw new Error('input not found');
-    fireEvent.change(input, { target: { value: ' name , employees ' } });
-    expect(onChange.mock.calls[0]?.[0]?.popupColumns).toEqual(['name', 'employees']);
+    await user.click(container.querySelector('[data-slot="map-popup-columns"]')!);
+    await user.type(await screen.findByPlaceholderText('Search or type a field…'), 'employees');
+    await user.click(await screen.findByRole('option', { name: /employees/ }));
+    // Toggled on, on top of the existing `name` column.
+    expect(onChange.mock.calls.at(-1)?.[0]?.popupColumns).toEqual(['name', 'employees']);
   });
 
-  it('collapses the empty popup-columns input to null (backend convention)', () => {
-    const onChange = vi.fn();
-    const { container } = wrap(<MapConfigForm widget={baseMap} onChange={onChange} />);
-    const input = container.querySelector('[data-slot="map-popup-columns"]');
-    if (!(input instanceof HTMLInputElement)) throw new Error('input not found');
-    fireEvent.change(input, { target: { value: '' } });
-    expect(onChange.mock.calls[0]?.[0]?.popupColumns).toBeNull();
-  });
-
-  it('keeps defaultCenter null when only one of lat / lng is provided (avoids backend rejection)', () => {
+  it('keeps defaultCenter null when only one of lat / lng is provided', () => {
     const onChange = vi.fn();
     const { container } = wrap(<MapConfigForm widget={baseMap} onChange={onChange} />);
     const lat = container.querySelector('[data-slot="map-default-center-latitude"]');
@@ -113,7 +121,6 @@ describe('MapConfigForm', () => {
   it('exposes the layer-kind select with a "(provider default)" no-op option', () => {
     const { container } = wrap(<MapConfigForm widget={baseMap} onChange={vi.fn()} />);
     const select = container.querySelector('[data-slot="map-default-layer-kind"]');
-    expect(select).not.toBeNull();
     if (!(select instanceof HTMLSelectElement)) throw new Error('select not found');
     expect(select.value).toBe('');
   });

--- a/packages/@granit/react-map/src/editor/map-config-form.tsx
+++ b/packages/@granit/react-map/src/editor/map-config-form.tsx
@@ -1,10 +1,22 @@
 import { isGeographyMapPointSource, isLatLngMapPointSource } from '@granit/analytics';
+import {
+  EnumSelect,
+  MetaFieldInput,
+  MetaMultiFieldInput,
+  QueryNameCombobox,
+  useQueryFieldMetadata,
+} from '@granit/react-analytics/editor';
 import { useTranslation } from 'react-i18next';
 
 import type { MapTileLayerKind, MapWidgetDefinition } from '@granit/analytics';
 import type { WidgetConfigFormProps } from '@granit/react-dashboard-editor';
 
 const LAYER_KINDS: readonly MapTileLayerKind[] = ['Plan', 'Satellite', 'Hybrid', 'Topo', 'Custom'];
+
+const POINT_SOURCE_KINDS = [
+  { value: 'lat-lng', label: 'Lat / lng pair' },
+  { value: 'geography', label: 'PostGIS geography column' },
+] as const;
 
 /**
  * Built-in config form for {@link MapWidgetDefinition}. Edits the query
@@ -21,6 +33,7 @@ const LAYER_KINDS: readonly MapTileLayerKind[] = ['Plan', 'Satellite', 'Hybrid',
 export function MapConfigForm({ widget, onChange }: WidgetConfigFormProps<MapWidgetDefinition>) {
   const { t } = useTranslation();
   const { pointSource } = widget;
+  const { catalogEntries, columnOptions } = useQueryFieldMetadata(widget.queryName);
 
   const handlePointSourceKindChange = (kind: 'lat-lng' | 'geography') => {
     if (kind === 'lat-lng') {
@@ -33,7 +46,6 @@ export function MapConfigForm({ widget, onChange }: WidgetConfigFormProps<MapWid
     }
   };
 
-  const popupColumnsValue = widget.popupColumns?.join(', ') ?? '';
   const center = widget.defaultCenter;
 
   return (
@@ -42,12 +54,11 @@ export function MapConfigForm({ widget, onChange }: WidgetConfigFormProps<MapWid
         <span className="mb-1 block text-muted-foreground">
           {t('Dashboard:Widget.Map.QueryName.Label')}
         </span>
-        <input
-          type="text"
-          data-slot="map-query-name"
+        <QueryNameCombobox
+          slot="map-query-name"
           value={widget.queryName}
-          onChange={(event) => onChange({ ...widget, queryName: event.target.value })}
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+          onChange={(value) => onChange({ ...widget, queryName: value })}
+          entries={catalogEntries}
         />
       </label>
 
@@ -55,17 +66,12 @@ export function MapConfigForm({ widget, onChange }: WidgetConfigFormProps<MapWid
         <span className="mb-1 block text-muted-foreground">
           {t('Dashboard:Widget.Map.PointSourceKind.Label')}
         </span>
-        <select
-          data-slot="map-point-source-kind"
+        <EnumSelect
+          slot="map-point-source-kind"
           value={pointSource.kind}
-          onChange={(event) =>
-            handlePointSourceKindChange(event.target.value as 'lat-lng' | 'geography')
-          }
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
-        >
-          <option value="lat-lng">Lat / lng pair</option>
-          <option value="geography">PostGIS geography column</option>
-        </select>
+          options={POINT_SOURCE_KINDS}
+          onChange={(value) => handlePointSourceKindChange(value as 'lat-lng' | 'geography')}
+        />
       </label>
 
       {isLatLngMapPointSource(pointSource) && (
@@ -74,34 +80,26 @@ export function MapConfigForm({ widget, onChange }: WidgetConfigFormProps<MapWid
             <span className="mb-1 block text-muted-foreground">
               {t('Dashboard:Widget.Map.LatitudeColumn.Label')}
             </span>
-            <input
-              type="text"
-              data-slot="map-latitude-column"
+            <MetaFieldInput
+              slot="map-latitude-column"
               value={pointSource.latitudeColumn}
-              onChange={(event) =>
-                onChange({
-                  ...widget,
-                  pointSource: { ...pointSource, latitudeColumn: event.target.value },
-                })
+              options={columnOptions}
+              onChange={(value) =>
+                onChange({ ...widget, pointSource: { ...pointSource, latitudeColumn: value } })
               }
-              className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
             />
           </label>
           <label className="block text-sm">
             <span className="mb-1 block text-muted-foreground">
               {t('Dashboard:Widget.Map.LongitudeColumn.Label')}
             </span>
-            <input
-              type="text"
-              data-slot="map-longitude-column"
+            <MetaFieldInput
+              slot="map-longitude-column"
               value={pointSource.longitudeColumn}
-              onChange={(event) =>
-                onChange({
-                  ...widget,
-                  pointSource: { ...pointSource, longitudeColumn: event.target.value },
-                })
+              options={columnOptions}
+              onChange={(value) =>
+                onChange({ ...widget, pointSource: { ...pointSource, longitudeColumn: value } })
               }
-              className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
             />
           </label>
         </>
@@ -112,17 +110,13 @@ export function MapConfigForm({ widget, onChange }: WidgetConfigFormProps<MapWid
           <span className="mb-1 block text-muted-foreground">
             {t('Dashboard:Widget.Map.GeographyColumn.Label')}
           </span>
-          <input
-            type="text"
-            data-slot="map-geography-column"
+          <MetaFieldInput
+            slot="map-geography-column"
             value={pointSource.geographyColumn}
-            onChange={(event) =>
-              onChange({
-                ...widget,
-                pointSource: { ...pointSource, geographyColumn: event.target.value },
-              })
+            options={columnOptions}
+            onChange={(value) =>
+              onChange({ ...widget, pointSource: { ...pointSource, geographyColumn: value } })
             }
-            className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
           />
         </label>
       )}
@@ -131,23 +125,14 @@ export function MapConfigForm({ widget, onChange }: WidgetConfigFormProps<MapWid
         <span className="mb-1 block text-muted-foreground">
           {t('Dashboard:Widget.Map.PopupColumns.Label')}
         </span>
-        <input
-          type="text"
-          data-slot="map-popup-columns"
-          value={popupColumnsValue}
+        <MetaMultiFieldInput
+          slot="map-popup-columns"
+          values={widget.popupColumns ?? []}
+          options={columnOptions}
           placeholder="leave empty for no popup body"
-          onChange={(event) => {
-            const raw = event.target.value.trim();
-            const next =
-              raw === ''
-                ? null
-                : raw
-                    .split(',')
-                    .map((s) => s.trim())
-                    .filter((s) => s.length > 0);
-            onChange({ ...widget, popupColumns: next });
-          }}
-          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+          onChange={(values) =>
+            onChange({ ...widget, popupColumns: values.length > 0 ? values : null })
+          }
         />
       </label>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2667,6 +2667,9 @@ importers:
       '@granit/dashboards':
         specifier: workspace:*
         version: link:../dashboards
+      '@granit/react-analytics':
+        specifier: workspace:*
+        version: link:../react-analytics
       '@granit/react-dashboard-editor':
         specifier: workspace:*
         version: link:../react-dashboard-editor
@@ -2682,6 +2685,9 @@ importers:
       '@granit/utils':
         specifier: workspace:*
         version: link:../utils
+      '@tanstack/react-query':
+        specifier: 5.101.1
+        version: 5.101.1(react@19.2.7)
       '@types/leaflet':
         specifier: ^1.9.21
         version: 1.9.21


### PR DESCRIPTION
## Why

The **Map** widget config form still bound its query (and columns) with free-text inputs — the only widget whose **Query** field wasn't the catalogue combobox. Plus the query dropdown wasn't sorted, and Query/Group By had no clear ("none") affordance.

## What

- **`@granit/react-analytics/editor`** — exports the shared query-binding controls (`QueryNameCombobox`, `MetaFieldInput`, `MetaMultiFieldInput`, `EnumSelect`, `useQueryFieldMetadata`) so other widget packages can reuse them instead of re-rolling free-text inputs.
- **`@granit/react-map`** — `MapConfigForm` now uses them: **Query** = catalogue combobox, lat/lng/geography = metadata field pickers, popup columns = metadata multi-select, point-source kind = shadcn `Select`. (Adds `@granit/react-analytics` + `@tanstack/react-query` as editor-only optional peers.)
- **`QueryNameCombobox`** — options **sorted by the displayed label** (ascending, problem 2), and a **"— none —"** clear item (`allowEmpty`), so Query is consistent with Group By / Field.

Map-render-only fields (zoom, center, cluster, detail route, tile URL, layer kind) stay native — they're not query-bound.

## Tests

Map config-form suite rewritten for the new controls (combobox/select via userEvent); chart suite gains a sort + "— none —" assertion. `tsc`, `eslint --max-warnings 0` green; rebased on develop before opening.

## Note

The chart **Group By** "— none —" clear already landed via #830 (merged) — this branch only adds the **Query** "none"/sort + the **Map** migration on top.