### PR TITLE
feat(analytics): address (geocoded) map point-source [front scaffold]

### DIFF
--- a/packages/@granit/analytics/src/index.ts
+++ b/packages/@granit/analytics/src/index.ts
@@ -20,6 +20,7 @@ export type {
   Trend,
   ValueKind,
   // Widgets — catalog declarations + snapshot envelopes consumed by @granit/dashboards
+  AddressMapPointSource,
   AggregateFunction,
   AnalyticsWidgetDefinition,
   ChartBucket,
@@ -52,6 +53,7 @@ export type {
 
 // Widgets — runtime type guards
 export {
+  isAddressMapPointSource,
   isChartSnapshotEnvelope,
   isGeographyMapPointSource,
   isKpiSnapshotEnvelope,

--- a/packages/@granit/analytics/src/types/index.ts
+++ b/packages/@granit/analytics/src/types/index.ts
@@ -25,6 +25,7 @@ export type { AnalyticsWidgetDefinition } from './analytics-widget';
 export type { ChartType, ChartWidgetDefinition } from './chart-widget';
 export type { KpiWidgetDefinition } from './kpi-widget';
 export type {
+  AddressMapPointSource,
   GeographyMapPointSource,
   LatLngMapPointSource,
   MapCenter,

--- a/packages/@granit/analytics/src/types/map-widget.ts
+++ b/packages/@granit/analytics/src/types/map-widget.ts
@@ -26,14 +26,19 @@ export type MapTileLayerKind = 'Plan' | 'Satellite' | 'Hybrid' | 'Topo' | 'Custo
  * produced by its backing query. Mirrors
  * `Granit.Analytics.Dashboards.Widgets.MapPointSource`.
  *
- * Two flavours per B7. The default {@link LatLngMapPointSource} maps to plain
+ * Three flavours. The default {@link LatLngMapPointSource} maps to plain
  * decimal columns and works on any database. The opt-in
  * {@link GeographyMapPointSource} reads a single PostGIS `geography(Point)`
- * column — unlocks server-side spatial filters but is PostGIS-only.
+ * column — unlocks server-side spatial filters but is PostGIS-only. The
+ * {@link AddressMapPointSource} carries no coordinates: the backend geocodes
+ * the address columns into points at snapshot time (prefer the lat-lng /
+ * geography flavours when rows already hold coordinates — geocoding has a
+ * cost and a per-provider rate limit).
  *
  * Wire format uses the `kind` discriminator with kebab tags (`'lat-lng'` /
- * `'geography'`) — same convention as `Datasource`. Refine a value with the
- * `isLatLngMapPointSource` / `isGeographyMapPointSource` guards.
+ * `'geography'` / `'address'`) — same convention as `Datasource`. Refine a
+ * value with the `isLatLngMapPointSource` / `isGeographyMapPointSource` /
+ * `isAddressMapPointSource` guards.
  */
 export interface LatLngMapPointSource {
   readonly kind: 'lat-lng';
@@ -49,7 +54,30 @@ export interface GeographyMapPointSource {
   readonly geographyColumn: string;
 }
 
-export type MapPointSource = LatLngMapPointSource | GeographyMapPointSource;
+/**
+ * Address-based source: the rows carry a postal address (no coordinates) and
+ * the backend geocodes it into a point at snapshot time. `localityColumn` and
+ * `countryColumn` are the geocoding floor (required); `streetColumn` and
+ * `postalCodeColumn` are optional and sharpen the result (`''` when a row has
+ * no such column). Geocoding failures drop the row from the snapshot rather
+ * than failing the whole widget.
+ */
+export interface AddressMapPointSource {
+  readonly kind: 'address';
+  /** Column carrying the street line (number + street). Optional — `''` when unmapped. */
+  readonly streetColumn: string;
+  /** Column carrying the postal / ZIP code. Optional — `''` when unmapped. */
+  readonly postalCodeColumn: string;
+  /** Column carrying the city / locality. Required. */
+  readonly localityColumn: string;
+  /** Column carrying the country (name or ISO code). Required. */
+  readonly countryColumn: string;
+}
+
+export type MapPointSource =
+  | LatLngMapPointSource
+  | GeographyMapPointSource
+  | AddressMapPointSource;
 
 /**
  * Latitude / longitude pair seeding {@link MapWidgetDefinition.defaultCenter}.

--- a/packages/@granit/analytics/src/widgets/guards.ts
+++ b/packages/@granit/analytics/src/widgets/guards.ts
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------------------
 
 import type {
+  AddressMapPointSource,
   ChartSnapshotEnvelope,
   GeographyMapPointSource,
   KpiSnapshotEnvelope,
@@ -65,4 +66,9 @@ export function isGeographyMapPointSource(
   source: MapPointSource
 ): source is GeographyMapPointSource {
   return source.kind === 'geography';
+}
+
+/** Narrows a {@link MapPointSource} to the geocoded-address flavour. */
+export function isAddressMapPointSource(source: MapPointSource): source is AddressMapPointSource {
+  return source.kind === 'address';
 }

--- a/packages/@granit/analytics/src/widgets/index.ts
+++ b/packages/@granit/analytics/src/widgets/index.ts
@@ -1,4 +1,5 @@
 export {
+  isAddressMapPointSource,
   isChartSnapshotEnvelope,
   isGeographyMapPointSource,
   isKpiSnapshotEnvelope,

--- a/packages/@granit/react-analytics/src/__tests__/validate-widget.test.ts
+++ b/packages/@granit/react-analytics/src/__tests__/validate-widget.test.ts
@@ -103,4 +103,34 @@ describe('validateWidgetConfig', () => {
       []
     );
   });
+
+  it('requires locality + country for an address source; street + postal code are optional', () => {
+    expect(
+      fields(
+        map({
+          pointSource: {
+            kind: 'address',
+            streetColumn: '',
+            postalCodeColumn: '',
+            localityColumn: '',
+            countryColumn: '',
+          },
+        })
+      )
+    ).toEqual(['localityColumn', 'countryColumn']);
+    // Street + postal code empty is fine once locality + country are set.
+    expect(
+      fields(
+        map({
+          pointSource: {
+            kind: 'address',
+            streetColumn: '',
+            postalCodeColumn: '',
+            localityColumn: 'City',
+            countryColumn: 'Country',
+          },
+        })
+      )
+    ).toEqual([]);
+  });
 });

--- a/packages/@granit/react-analytics/src/editor/validate-widget.ts
+++ b/packages/@granit/react-analytics/src/editor/validate-widget.ts
@@ -13,7 +13,11 @@
 // validate as complete.
 // ---------------------------------------------------------------------------
 
-import { isGeographyMapPointSource, isLatLngMapPointSource } from '@granit/analytics';
+import {
+  isAddressMapPointSource,
+  isGeographyMapPointSource,
+  isLatLngMapPointSource,
+} from '@granit/analytics';
 import { isMetricDatasource, isQueryAggregateDatasource } from '@granit/dashboards';
 
 import type {
@@ -95,6 +99,12 @@ function validateMap(widget: MapWidgetDefinition): WidgetConfigError[] {
       field: 'geographyColumn',
       labelKey: 'Dashboard:Widget.Map.GeographyColumn.Label',
     });
+  } else if (isAddressMapPointSource(pointSource)) {
+    // Locality + country are the geocoding floor; street + postal code are optional.
+    if (blank(pointSource.localityColumn))
+      errors.push({ field: 'localityColumn', labelKey: 'Dashboard:Widget.Map.LocalityColumn.Label' });
+    if (blank(pointSource.countryColumn))
+      errors.push({ field: 'countryColumn', labelKey: 'Dashboard:Widget.Map.CountryColumn.Label' });
   }
   return errors;
 }

--- a/packages/@granit/react-map/src/editor/map-config-form.tsx
+++ b/packages/@granit/react-map/src/editor/map-config-form.tsx
@@ -1,4 +1,8 @@
-import { isGeographyMapPointSource, isLatLngMapPointSource } from '@granit/analytics';
+import {
+  isAddressMapPointSource,
+  isGeographyMapPointSource,
+  isLatLngMapPointSource,
+} from '@granit/analytics';
 import {
   EnumSelect,
   MetaFieldInput,
@@ -17,7 +21,10 @@ const LAYER_KINDS: readonly MapTileLayerKind[] = ['Plan', 'Satellite', 'Hybrid',
 const POINT_SOURCE_KINDS = [
   { value: 'lat-lng', label: 'Lat / lng pair' },
   { value: 'geography', label: 'PostGIS geography column' },
+  { value: 'address', label: 'Address (geocoded)' },
 ] as const;
+
+type PointSourceKind = (typeof POINT_SOURCE_KINDS)[number]['value'];
 
 /**
  * Built-in config form for {@link MapWidgetDefinition}. Edits the query
@@ -36,14 +43,25 @@ export function MapConfigForm({ widget, onChange }: WidgetConfigFormProps<MapWid
   const { pointSource } = widget;
   const { catalogEntries, columnOptions } = useQueryFieldMetadata(widget.queryName);
 
-  const handlePointSourceKindChange = (kind: 'lat-lng' | 'geography') => {
+  const handlePointSourceKindChange = (kind: PointSourceKind) => {
     if (kind === 'lat-lng') {
       onChange({
         ...widget,
         pointSource: { kind: 'lat-lng', latitudeColumn: '', longitudeColumn: '' },
       });
-    } else {
+    } else if (kind === 'geography') {
       onChange({ ...widget, pointSource: { kind: 'geography', geographyColumn: '' } });
+    } else {
+      onChange({
+        ...widget,
+        pointSource: {
+          kind: 'address',
+          streetColumn: '',
+          postalCodeColumn: '',
+          localityColumn: '',
+          countryColumn: '',
+        },
+      });
     }
   };
 
@@ -73,7 +91,7 @@ export function MapConfigForm({ widget, onChange }: WidgetConfigFormProps<MapWid
           slot="map-point-source-kind"
           value={pointSource.kind}
           options={POINT_SOURCE_KINDS}
-          onChange={(value) => handlePointSourceKindChange(value as 'lat-lng' | 'geography')}
+          onChange={(value) => handlePointSourceKindChange(value as PointSourceKind)}
         />
       </label>
 
@@ -128,6 +146,69 @@ export function MapConfigForm({ widget, onChange }: WidgetConfigFormProps<MapWid
             }
           />
         </label>
+      )}
+
+      {isAddressMapPointSource(pointSource) && (
+        <>
+          <label className="block text-sm">
+            <span className="mb-1 block text-muted-foreground">
+              {t('Dashboard:Widget.Map.StreetColumn.Label')}
+            </span>
+            <MetaFieldInput
+              slot="map-street-column"
+              value={pointSource.streetColumn}
+              options={columnOptions}
+              allowEmpty
+              onChange={(value) =>
+                onChange({ ...widget, pointSource: { ...pointSource, streetColumn: value } })
+              }
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="mb-1 block text-muted-foreground">
+              {t('Dashboard:Widget.Map.PostalCodeColumn.Label')}
+            </span>
+            <MetaFieldInput
+              slot="map-postal-code-column"
+              value={pointSource.postalCodeColumn}
+              options={columnOptions}
+              allowEmpty
+              onChange={(value) =>
+                onChange({ ...widget, pointSource: { ...pointSource, postalCodeColumn: value } })
+              }
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="mb-1 block text-muted-foreground">
+              {t('Dashboard:Widget.Map.LocalityColumn.Label')}
+              <RequiredMark />
+            </span>
+            <MetaFieldInput
+              slot="map-locality-column"
+              value={pointSource.localityColumn}
+              options={columnOptions}
+              required
+              onChange={(value) =>
+                onChange({ ...widget, pointSource: { ...pointSource, localityColumn: value } })
+              }
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="mb-1 block text-muted-foreground">
+              {t('Dashboard:Widget.Map.CountryColumn.Label')}
+              <RequiredMark />
+            </span>
+            <MetaFieldInput
+              slot="map-country-column"
+              value={pointSource.countryColumn}
+              options={columnOptions}
+              required
+              onChange={(value) =>
+                onChange({ ...widget, pointSource: { ...pointSource, countryColumn: value } })
+              }
+            />
+          </label>
+        </>
       )}
 
       <label className="block text-sm">


### PR DESCRIPTION
## What

Adds a third `MapPointSource` flavour — **`address`** — alongside `lat-lng` and `geography`. Rows carry a postal address (no coordinates); the **backend geocodes** the address columns into points at snapshot render time.

- **`@granit/analytics`**: `AddressMapPointSource { streetColumn, postalCodeColumn, localityColumn, countryColumn }` + `isAddressMapPointSource` guard (exported). Locality + country are the geocoding floor (required); street + postal code are optional refinements.
- **Map config form**: third *“Address (geocoded)”* option + four column pickers (locality + country required, with the #833 asterisk + destructive-border treatment).
- **`validateWidgetConfig`**: address branch requires locality + country.
- Tests: validator address coverage; map + analytics suites green; `pnpm tsc` + lint clean.

## ✅ Backend shipped — contract verified

The backend implemented this (granit-dotnet `Granit.Geocoding` + Nominatim/Photon providers, `GeoCoordinate`; granit-business `MapRunner`). The front contract here matches the backend **exactly**:

| | Backend `MapPointSource.Address` | Front |
|---|---|---|
| discriminator | `kind: "address"` | `kind: 'address'` |
| fields | Street/PostalCode/Locality/Country Column (`string`) | same (camelCase) |
| validation | Locality + Country required, Street/PostalCode optional | identical |

`MapPointSource` is a union excluded from the contract-conformance oracle, so no OpenAPI-snapshot bump is required.

## Stacking

Stacks on **#833** (required-field marking + validator) — branched off its HEAD. Rebase onto `develop` once #833 merges. Host-provided labels land via showcase MR !172.