### PR TITLE
feat(query-engine): group the query catalogue by owning module

### DIFF
--- a/contracts/openapi/query-engine.json
+++ b/contracts/openapi/query-engine.json
@@ -9,7 +9,7 @@
       "get": {
         "tags": ["Query Engine"],
         "summary": "Lists every registered QueryDefinition.",
-        "description": "Returns the full query catalogue surfaced by IQueryDefinitionRegistry so a dashboard editor can offer a dropdown of queries instead of a free-text queryName. Each entry carries the wire identifier and, when a MapGranitQuery route exposes it, the resolved base path of its list endpoint. Registration and routing are decoupled: a query registered without a mapped route is returned with a null base path rather than a forged URL.",
+        "description": "Returns the full query catalogue surfaced by IQueryDefinitionRegistry so a dashboard editor can offer a dropdown of queries instead of a free-text queryName. Each entry carries the owning module, the wire identifier and, when a MapGranitQuery route exposes it, the resolved base path of its list endpoint. Registration and routing are decoupled: a query registered without a mapped route is returned with a null base path rather than a forged URL. The array is ordered by moduleName then name (ascending, ordinal).",
         "operationId": "ListQueryCatalog",
         "responses": {
           "200": {
@@ -87,9 +87,12 @@
         }
       },
       "QueryCatalogEntryResponse": {
-        "required": ["name", "basePath", "labelKey"],
+        "required": ["moduleName", "name", "basePath", "labelKey"],
         "type": "object",
         "properties": {
+          "moduleName": {
+            "type": "string"
+          },
           "name": {
             "type": "string"
           },

--- a/packages/@granit/query-engine/src/__tests__/api.test.ts
+++ b/packages/@granit/query-engine/src/__tests__/api.test.ts
@@ -88,7 +88,12 @@ describe('query-api', () => {
   it('getQueryCatalog calls GET /catalog', async () => {
     const client = createMockClient();
     const catalog = [
-      { name: 'Granit.Test.Query', basePath: '/api/v1/patients', labelKey: 'Entity:Patient' },
+      {
+        moduleName: 'Test',
+        name: 'Granit.Test.Query',
+        basePath: '/api/v1/patients',
+        labelKey: 'Entity:Patient',
+      },
     ];
     vi.mocked(client.get).mockResolvedValueOnce({ data: catalog });
     const result = await getQueryCatalog(client, '/api/v1');

--- a/packages/@granit/query-engine/src/types/query-catalog.ts
+++ b/packages/@granit/query-engine/src/types/query-catalog.ts
@@ -9,6 +9,17 @@
  * `queryName`.
  */
 export interface QueryCatalogEntryResponse {
+  /**
+   * Owning module of the query (e.g. `Auditing`, `Identity.Local`) — derived
+   * backend-side from the query's namespace. A localization KEY for the module
+   * group heading (NOT a pre-resolved string): resolve it client-side against the
+   * merged i18n bundle (like `labelKey` / `Entity:*`), falling back to the raw
+   * value when the key is absent. Sibling queries share it (e.g.
+   * `Granit.Auditing.AuditEntryQuery` and `Granit.Auditing.AuditEntityChangeQuery`
+   * both yield `Auditing`); the catalogue is returned ordered by `moduleName` then
+   * {@link QueryCatalogEntryResponse.name}.
+   */
+  readonly moduleName: string;
   /** Wire identifier of the query (e.g. `Granit.Invoicing.InvoiceQuery`). */
   readonly name: string;
   /**

--- a/packages/@granit/react-analytics/src/__tests__/chart-config-form.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/chart-config-form.test.tsx
@@ -20,7 +20,8 @@ void testI18n.use(initReactI18next).init({
   fallbackLng: 'en',
   nsSeparator: false,
   keySeparator: false,
-  resources: { en: { translation: { 'Entity:Patient': 'Patients' } } },
+  // `Sales` is a module-name i18n key (→ `Ventes`); `Test` is absent → raw fallback.
+  resources: { en: { translation: { 'Entity:Patient': 'Patients', Sales: 'Ventes' } } },
   interpolation: { escapeValue: false },
 });
 
@@ -44,15 +45,26 @@ function mockCatalogClient() {
       return Promise.resolve({
         data: [
           // labelKey resolved via the i18n bundle.
-          { name: 'Granit.Test.Query', basePath: '/api/v1/patients', labelKey: 'Entity:Patient' },
+          {
+            moduleName: 'Test',
+            name: 'Granit.Test.Query',
+            basePath: '/api/v1/patients',
+            labelKey: 'Entity:Patient',
+          },
           // labelKey absent from the bundle → humanised last segment of the name.
           {
+            moduleName: 'Sales',
             name: 'Granit.Sales.RevenueByRegionQuery',
             basePath: '/api/v1/revenue',
             labelKey: 'Query:Granit.Sales.RevenueByRegionQuery',
           },
           // Unrouted (basePath null) → hidden from the dropdown.
-          { name: 'Granit.Test.UnroutedQuery', basePath: null, labelKey: 'Query:x' },
+          {
+            moduleName: 'Test',
+            name: 'Granit.Test.UnroutedQuery',
+            basePath: null,
+            labelKey: 'Query:x',
+          },
         ],
       });
     }
@@ -128,7 +140,7 @@ describe('ChartConfigForm', () => {
     expect(onChange.mock.calls.at(-1)?.[0]?.queryName).toBe('Granit.Test.Query');
   });
 
-  it('sorts queries by their displayed label (ascending)', async () => {
+  it('groups queries under their module heading, resolving moduleName via i18n', async () => {
     const user = userEvent.setup();
     const emptyChart: ChartWidgetDefinition = { ...baseChart, queryName: '' };
     const { container } = wrap(
@@ -138,10 +150,13 @@ describe('ChartConfigForm', () => {
 
     await user.click(container.querySelector('[data-slot="chart-query-name"]')!);
     await screen.findByRole('option', { name: 'Patients' });
+    // moduleName is an i18n key: 'Sales' → 'Ventes'; 'Test' is absent → raw fallback.
+    expect(screen.getByText('Ventes')).toBeInTheDocument();
+    expect(screen.getByText('Test')).toBeInTheDocument();
     const labels = screen.getAllByRole('option').map((o) => o.textContent ?? '');
-    const patients = labels.findIndex((l) => l.includes('Patients'));
-    const revenue = labels.findIndex((l) => l.includes('Revenue By Region Query'));
-    // Sorted by label asc: "Patients" before "Revenue By Region Query".
+    const patients = labels.findIndex((l) => l.includes('Patients')); // module 'Test'
+    const revenue = labels.findIndex((l) => l.includes('Revenue By Region Query')); // 'Ventes'
+    // Groups ordered by the RESOLVED heading asc: 'Test' before 'Ventes'.
     expect(patients).toBeGreaterThanOrEqual(0);
     expect(patients).toBeLessThan(revenue);
   });

--- a/packages/@granit/react-analytics/src/__tests__/pivot-config-form.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/pivot-config-form.test.tsx
@@ -42,7 +42,12 @@ function mockCatalogClient() {
     if (url.endsWith('/catalog')) {
       return Promise.resolve({
         data: [
-          { name: 'Granit.Test.Query', basePath: '/api/v1/patients', labelKey: 'Entity:Patient' },
+          {
+            moduleName: 'Test',
+            name: 'Granit.Test.Query',
+            basePath: '/api/v1/patients',
+            labelKey: 'Entity:Patient',
+          },
         ],
       });
     }

--- a/packages/@granit/react-analytics/src/__tests__/table-config-form.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/table-config-form.test.tsx
@@ -40,7 +40,12 @@ function mockCatalogClient() {
     if (url.endsWith('/catalog')) {
       return Promise.resolve({
         data: [
-          { name: 'Granit.Test.Query', basePath: '/api/v1/patients', labelKey: 'Entity:Patient' },
+          {
+            moduleName: 'Test',
+            name: 'Granit.Test.Query',
+            basePath: '/api/v1/patients',
+            labelKey: 'Entity:Patient',
+          },
         ],
       });
     }

--- a/packages/@granit/react-analytics/src/editor/query-field-controls.tsx
+++ b/packages/@granit/react-analytics/src/editor/query-field-controls.tsx
@@ -122,9 +122,13 @@ export function RequiredMark() {
  * Entry semantics (per the `/catalog` contract): the option VALUE is the stable
  * `name` (what we persist), the option LABEL is `t(labelKey)` resolved against the
  * merged i18n bundle — falling back to a humanised last segment of `name` when the
- * key is not in the bundle (`Query:*` keys are opt-in backend-side). Entries with
- * `basePath === null` are not routed (no endpoint to load data from), so they are
- * hidden — flip `HIDE_UNROUTED_QUERIES` to surface them disabled instead.
+ * key is not in the bundle (`Query:*` keys are opt-in backend-side). Options are
+ * grouped under their module heading — `moduleName` is itself an i18n key, resolved
+ * via the merged bundle (falling back to the raw value when absent) — with groups
+ * ordered alphabetically by that resolved heading and queries sorted by their
+ * resolved label within each. Entries with `basePath === null` are not routed (no
+ * endpoint to load data from), so they are hidden — flip `HIDE_UNROUTED_QUERIES`
+ * to surface them disabled instead.
  */
 const HIDE_UNROUTED_QUERIES = true;
 
@@ -143,6 +147,16 @@ export function resolveQueryLabel(t: TFunction, entry: QueryCatalogEntryResponse
   return translated === entry.labelKey ? humanizeQueryName(entry.name) : translated;
 }
 
+/**
+ * Resolves a module group heading: `moduleName` is itself an i18n key, so
+ * `t(moduleName)` against the merged bundle, falling back to the raw module name
+ * when the key is absent (`t` returns the key unchanged under the framework's
+ * `keySeparator: false`).
+ */
+export function resolveModuleLabel(t: TFunction, moduleName: string): string {
+  return t(moduleName) || moduleName;
+}
+
 export function QueryNameCombobox({
   slot,
   value,
@@ -159,9 +173,18 @@ export function QueryNameCombobox({
   const { t } = useTranslation();
   const options: ComboboxOption[] = (entries ?? [])
     .filter((entry) => !HIDE_UNROUTED_QUERIES || entry.basePath !== null)
-    .map((entry) => ({ value: entry.name, label: resolveQueryLabel(t, entry) }))
-    // Sorted by the DISPLAYED label (ascending), not the wire name.
-    .sort((a, b) => (a.label ?? '').localeCompare(b.label ?? ''));
+    .map((entry) => ({
+      value: entry.name,
+      label: resolveQueryLabel(t, entry),
+      group: resolveModuleLabel(t, entry.moduleName),
+    }))
+    // Grouped by the RESOLVED module heading; within each, by the DISPLAYED label
+    // (not the wire name). Sorting by group first makes the headings appear
+    // alphabetically by their resolved (localised) text.
+    .sort(
+      (a, b) =>
+        (a.group ?? '').localeCompare(b.group ?? '') || (a.label ?? '').localeCompare(b.label ?? '')
+    );
 
   return (
     <Combobox

--- a/packages/@granit/react-query-engine/src/__tests__/use-query-catalog.test.tsx
+++ b/packages/@granit/react-query-engine/src/__tests__/use-query-catalog.test.tsx
@@ -35,7 +35,12 @@ describe('useQueryCatalog', () => {
   it('fetches the catalogue from the provider root', async () => {
     const client = axios.create();
     const catalog = [
-      { name: 'Granit.Test.Query', basePath: '/api/v1/patients', labelKey: 'Entity:Patient' },
+      {
+        moduleName: 'Test',
+        name: 'Granit.Test.Query',
+        basePath: '/api/v1/patients',
+        labelKey: 'Entity:Patient',
+      },
     ];
     vi.spyOn(client, 'get').mockResolvedValue({ data: catalog });
 

--- a/packages/@granit/react-ui/src/combobox.tsx
+++ b/packages/@granit/react-ui/src/combobox.tsx
@@ -18,6 +18,48 @@ import { Popover, PopoverContent, PopoverTrigger } from './popover.js';
 export interface ComboboxOption {
   readonly value: string;
   readonly label?: string;
+  /**
+   * Optional heading the option is filed under. When any option carries a
+   * `group`, the single-select {@link Combobox} renders one headed section per
+   * distinct group (in first-seen order — sort `options` to control it). Options
+   * without a `group` fall under an unheaded leading section. Ignored by
+   * {@link ComboboxMulti}, which always renders a flat list.
+   */
+  readonly group?: string;
+}
+
+interface ComboboxGroup {
+  readonly key: string;
+  readonly heading?: string;
+  readonly options: readonly ComboboxOption[];
+}
+
+/**
+ * Partitions options into ordered headed sections. With no `group` on any
+ * option, returns a single unheaded section (the historical flat layout);
+ * otherwise one section per distinct `group`, in first-seen order.
+ */
+function groupOptions(options: readonly ComboboxOption[]): readonly ComboboxGroup[] {
+  if (!options.some((option) => option.group != null)) {
+    return [{ key: '', options }];
+  }
+  const order: string[] = [];
+  const byGroup = new Map<string, ComboboxOption[]>();
+  for (const option of options) {
+    const heading = option.group ?? '';
+    let bucket = byGroup.get(heading);
+    if (!bucket) {
+      bucket = [];
+      byGroup.set(heading, bucket);
+      order.push(heading);
+    }
+    bucket.push(option);
+  }
+  return order.map((heading) => ({
+    key: heading,
+    heading: heading || undefined,
+    options: byGroup.get(heading)!,
+  }));
 }
 
 interface ComboboxBaseProps {
@@ -85,6 +127,7 @@ export function Combobox({
   const trimmed = search.trim();
   const showCustom =
     allowCustomValue && trimmed.length > 0 && !options.some((option) => option.value === trimmed);
+  const groups = groupOptions(options);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -114,37 +157,43 @@ export function Combobox({
           <CommandInput placeholder={searchPlaceholder} value={search} onValueChange={setSearch} />
           <CommandList>
             <CommandEmpty>{emptyText}</CommandEmpty>
-            <CommandGroup>
-              {allowEmpty && (
+            {allowEmpty && (
+              <CommandGroup>
                 <CommandItem value="__none__" onSelect={() => commit('')}>
                   <CheckIcon
                     className={cn('mr-2 size-4', value === '' ? 'opacity-100' : 'opacity-0')}
                   />
                   <span className="text-muted-foreground">— none —</span>
                 </CommandItem>
-              )}
-              {options.map((option) => (
-                <CommandItem
-                  key={option.value}
-                  value={option.label ?? option.value}
-                  onSelect={() => commit(option.value)}
-                >
-                  <CheckIcon
-                    className={cn(
-                      'mr-2 size-4',
-                      value === option.value ? 'opacity-100' : 'opacity-0'
-                    )}
-                  />
-                  {option.label ?? option.value}
-                </CommandItem>
-              ))}
-              {showCustom && (
+              </CommandGroup>
+            )}
+            {groups.map((group) => (
+              <CommandGroup key={group.key} heading={group.heading}>
+                {group.options.map((option) => (
+                  <CommandItem
+                    key={option.value}
+                    value={option.label ?? option.value}
+                    onSelect={() => commit(option.value)}
+                  >
+                    <CheckIcon
+                      className={cn(
+                        'mr-2 size-4',
+                        value === option.value ? 'opacity-100' : 'opacity-0'
+                      )}
+                    />
+                    {option.label ?? option.value}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ))}
+            {showCustom && (
+              <CommandGroup>
                 <CommandItem value={trimmed} onSelect={() => commit(trimmed)}>
                   <CheckIcon className="mr-2 size-4 opacity-0" />
                   Use “{trimmed}”
                 </CommandItem>
-              )}
-            </CommandGroup>
+              </CommandGroup>
+            )}
           </CommandList>
         </Command>
       </PopoverContent>


### PR DESCRIPTION
## What

The query catalogue (`/catalog`) now carries an owning **module** per entry, and the dashboard query picker groups its dropdown by module heading.

- **`@granit/query-engine`**: `QueryCatalogEntryResponse.moduleName` — a localization **key** for the module group heading (derived backend-side from the query namespace, e.g. `Auditing`, `Identity.Local`). Catalogue returned ordered by module, then name. OpenAPI snapshot updated.
- **`@granit/react-ui` `Combobox`**: grouped option rendering — `ComboboxOption.group` partitions the list into ordered headed sections.
- **`@granit/react-analytics` `QueryNameCombobox`**: groups queries under their `moduleName` heading; groups ordered by module, queries sorted by resolved label within each.
- Tests updated (query-engine api, react-query-engine catalog, chart/pivot/table config-form pickers). `pnpm tsc` + lint clean; affected suites green.

## Stacking

Branched off the #833 HEAD (it touches `Combobox` + `QueryNameCombobox`, which #833 also edits). Rebase onto `develop` once #833 merges. Independent of the map-address work (#834) — they share no files.