### PR TITLE
refactor(cms): centralize /api/cms prefix in DEFAULT_BASE_PATH

### DIFF
--- a/packages/@granit/cms-hostnames/src/__tests__/hostnames.test.ts
+++ b/packages/@granit/cms-hostnames/src/__tests__/hostnames.test.ts
@@ -14,7 +14,7 @@ import type { SiteHostnameAvailabilityResponse, SiteHostnameResponse } from '../
 
 const BASE = 'https://cms.example.com';
 const SITE_ID = 'site-1';
-const HOSTNAMES_BASE = `${BASE}/api/cms/sites/site-1/hostnames`;
+const HOSTNAMES_BASE = `${BASE}/sites/site-1/hostnames`;
 
 const hostname: SiteHostnameResponse = {
   id: 'h-1',

--- a/packages/@granit/cms-hostnames/src/api/hostnames.ts
+++ b/packages/@granit/cms-hostnames/src/api/hostnames.ts
@@ -7,7 +7,7 @@ import type { AxiosInstance } from '@granit/api-client';
 
 /** Builds the base URL for a site's hostname collection. */
 function siteHostnamesBase(basePath: string, siteId: string): string {
-  return `${basePath}/api/cms/sites/${encodeURIComponent(siteId)}/hostnames`;
+  return `${basePath}/sites/${encodeURIComponent(siteId)}/hostnames`;
 }
 
 /**

--- a/packages/@granit/cms-redirects/src/__tests__/redirects-admin.test.ts
+++ b/packages/@granit/cms-redirects/src/__tests__/redirects-admin.test.ts
@@ -50,7 +50,7 @@ describe('listRedirects', () => {
 
     const result = await listRedirects(client, BASE, SITE);
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/redirects/sites/${SITE}/redirects`);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/sites/${SITE}/redirects`);
     expect(result).toEqual([redirect]);
   });
 
@@ -60,7 +60,7 @@ describe('listRedirects', () => {
 
     await listRedirects(client, BASE, 'a/b');
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/redirects/sites/a%2Fb/redirects`);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/sites/a%2Fb/redirects`);
   });
 });
 
@@ -71,7 +71,7 @@ describe('getRedirect', () => {
 
     const result = await getRedirect(client, BASE, 'redir-1');
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/redirects/redir-1`);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/redir-1`);
     expect(result).toEqual(redirect);
   });
 });
@@ -84,10 +84,7 @@ describe('createRedirect', () => {
     const request: RedirectCreateRequest = { source: '/old', target: '/new' };
     const result = await createRedirect(client, BASE, SITE, request);
 
-    expect(client.post).toHaveBeenCalledWith(
-      `${BASE}/api/cms/redirects/sites/${SITE}/redirects`,
-      request
-    );
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/sites/${SITE}/redirects`, request);
     expect(result).toEqual(mutationResult);
   });
 });
@@ -104,7 +101,7 @@ describe('updateRedirect', () => {
     const request: RedirectUpdateRequest = { target: '/newer' };
     const result = await updateRedirect(client, BASE, 'redir-1', request);
 
-    expect(client.put).toHaveBeenCalledWith(`${BASE}/api/cms/redirects/redir-1`, request);
+    expect(client.put).toHaveBeenCalledWith(`${BASE}/redir-1`, request);
     expect(result).toEqual(updated);
   });
 });
@@ -116,7 +113,7 @@ describe('deleteRedirect', () => {
 
     await deleteRedirect(client, BASE, 'redir-1');
 
-    expect(client.delete).toHaveBeenCalledWith(`${BASE}/api/cms/redirects/redir-1`);
+    expect(client.delete).toHaveBeenCalledWith(`${BASE}/redir-1`);
   });
 });
 
@@ -128,7 +125,7 @@ describe('getRedirectSettings', () => {
 
     const result = await getRedirectSettings(client, BASE, SITE);
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/redirects/sites/${SITE}/settings`);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/sites/${SITE}/settings`);
     expect(result).toEqual(settings);
   });
 });
@@ -141,7 +138,7 @@ describe('updateRedirectSettings', () => {
 
     const result = await updateRedirectSettings(client, BASE, SITE, { autoRedirectOnMove: false });
 
-    expect(client.put).toHaveBeenCalledWith(`${BASE}/api/cms/redirects/sites/${SITE}/settings`, {
+    expect(client.put).toHaveBeenCalledWith(`${BASE}/sites/${SITE}/settings`, {
       autoRedirectOnMove: false,
     });
     expect(result).toEqual(settings);
@@ -160,7 +157,7 @@ describe('previewRedirect', () => {
 
     const result = await previewRedirect(client, BASE, SITE, { path: '/old', culture: 'fr' });
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/redirects/sites/${SITE}/preview`, {
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/sites/${SITE}/preview`, {
       params: { path: '/old', culture: 'fr' },
     });
     expect(result).toEqual(preview);
@@ -178,10 +175,7 @@ describe('getRedirectsGrid', () => {
 
     const result = await getRedirectsGrid(client, BASE, { page: 1, pageSize: 25 });
 
-    expect(client.get).toHaveBeenCalledWith(
-      `${BASE}/api/cms/redirects/grid?page=1&pageSize=25`,
-      undefined
-    );
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/grid?page=1&pageSize=25`, undefined);
     expect(result).toEqual(page);
   });
 });

--- a/packages/@granit/cms-redirects/src/__tests__/redirects.test.ts
+++ b/packages/@granit/cms-redirects/src/__tests__/redirects.test.ts
@@ -20,7 +20,7 @@ describe('resolveRedirect', () => {
     });
 
     expect(client.get).toHaveBeenCalledWith(
-      `${basePath}/api/cms/redirects/resolve`,
+      `${basePath}/resolve`,
       expect.objectContaining({
         params: { path: '/old-path', culture: 'fr' },
         headers: { 'X-Granit-Site': 'site-1' },
@@ -53,7 +53,7 @@ describe('resolveRedirect', () => {
     );
 
     expect(client.get).toHaveBeenCalledWith(
-      `${basePath}/api/cms/redirects/resolve`,
+      `${basePath}/resolve`,
       expect.objectContaining({ fetchOptions: { cache: 'force-cache' } })
     );
   });

--- a/packages/@granit/cms-redirects/src/api/redirects-admin.ts
+++ b/packages/@granit/cms-redirects/src/api/redirects-admin.ts
@@ -13,7 +13,7 @@ import type {
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
-const ROOT = '/api/cms/redirects';
+const ROOT = '';
 
 /**
  * `GET {basePath}/api/cms/redirects/sites/{siteId}/redirects` — flat list of a site's

--- a/packages/@granit/cms-redirects/src/api/redirects.ts
+++ b/packages/@granit/cms-redirects/src/api/redirects.ts
@@ -3,7 +3,7 @@ import type { AxiosInstance, RequestFetchOptions } from '@granit/api-client';
 
 /**
  * Resolves a request path to its redirect target (public, anonymous).
- * `GET {basePath}/api/cms/redirects/resolve?path={path}&culture={culture}`
+ * `GET {basePath}/resolve?path={path}&culture={culture}`
  * + `X-Granit-Site: {siteId}` header — the backend scopes by site via `ICurrentSite`,
  * NOT a query parameter.
  *
@@ -18,14 +18,11 @@ export async function resolveRedirect(
   params: { siteId: string; path: string; culture?: string },
   fetchOptions?: RequestFetchOptions
 ): Promise<ResolveResponse | null> {
-  const response = await client.get<ResolveResponse | null>(
-    `${basePath}/api/cms/redirects/resolve`,
-    {
-      params: { path: params.path, culture: params.culture },
-      headers: { 'X-Granit-Site': params.siteId },
-      validateStatus: (s) => s === 200 || s === 204,
-      ...(fetchOptions ? { fetchOptions } : {}),
-    }
-  );
+  const response = await client.get<ResolveResponse | null>(`${basePath}/resolve`, {
+    params: { path: params.path, culture: params.culture },
+    headers: { 'X-Granit-Site': params.siteId },
+    validateStatus: (s) => s === 200 || s === 204,
+    ...(fetchOptions ? { fetchOptions } : {}),
+  });
   return response.status === 204 ? null : (response.data ?? null);
 }

--- a/packages/@granit/cms-seo/src/__tests__/seo-admin.test.ts
+++ b/packages/@granit/cms-seo/src/__tests__/seo-admin.test.ts
@@ -26,7 +26,7 @@ import type {
 
 const BASE = 'https://cms.example.com';
 const PARAMS = { siteId: 'site-1', contentType: 'page', contentId: 'page-1', culture: 'fr' };
-const META_URL = `${BASE}/api/cms/seo/sites/site-1/metadata/page/page-1/fr`;
+const META_URL = `${BASE}/sites/site-1/metadata/page/page-1/fr`;
 
 const robots: RobotsDirective = {
   index: true,
@@ -138,7 +138,7 @@ describe('getSeoDefaults', () => {
 
     const result = await getSeoDefaults(client, BASE, 'site-1');
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/seo/sites/site-1/defaults`, {
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/sites/site-1/defaults`, {
       validateStatus: expect.any(Function),
     });
     expect(result).toEqual(defaults);
@@ -161,7 +161,7 @@ describe('updateSeoDefaults', () => {
 
     await updateSeoDefaults(client, BASE, 'site-1', { siteName: 'Updated' });
 
-    expect(client.put).toHaveBeenCalledWith(`${BASE}/api/cms/seo/sites/site-1/defaults`, {
+    expect(client.put).toHaveBeenCalledWith(`${BASE}/sites/site-1/defaults`, {
       siteName: 'Updated',
     });
   });
@@ -192,7 +192,7 @@ describe('listSeoMetadata', () => {
     const result = await listSeoMetadata(client, BASE, { quickFilters: ['MissingDescription'] });
 
     expect(client.get).toHaveBeenCalledWith(
-      `${BASE}/api/cms/seo/metadata?quickFilters=MissingDescription`,
+      `${BASE}/metadata?quickFilters=MissingDescription`,
       undefined
     );
     expect(result).toEqual(response);
@@ -206,7 +206,7 @@ describe('listSeoMetadata', () => {
 
     await listSeoMetadata(client, BASE);
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/seo/metadata`, undefined);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/metadata`, undefined);
   });
 });
 
@@ -217,7 +217,7 @@ describe('invalidateSitemap', () => {
 
     await invalidateSitemap(client, BASE, 'site-1');
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/seo/sites/site-1/sitemap/invalidate`);
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/sites/site-1/sitemap/invalidate`);
   });
 });
 

--- a/packages/@granit/cms-seo/src/__tests__/seo-ai.test.ts
+++ b/packages/@granit/cms-seo/src/__tests__/seo-ai.test.ts
@@ -61,7 +61,7 @@ describe('suggestSeo', () => {
     };
     const result = await suggestSeo(client, BASE, request);
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/seo/ai/suggest`, request);
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/ai/suggest`, request);
     expect(result).toEqual(response);
   });
 });
@@ -74,7 +74,7 @@ describe('listSeoSuggestions', () => {
 
     const result = await listSeoSuggestions(client, BASE, { status: 'Pending', skip: 0, take: 25 });
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/seo/ai/suggestions`, {
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/ai/suggestions`, {
       params: { status: 'Pending', skip: 0, take: 25 },
     });
     expect(result).toEqual(response);
@@ -96,7 +96,7 @@ describe('getSeoSuggestionDiff', () => {
 
     const result = await getSeoSuggestionDiff(client, BASE, 'sug-1');
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/seo/ai/suggestions/sug-1/diff`);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/ai/suggestions/sug-1/diff`);
     expect(result).toEqual(diff);
   });
 });
@@ -111,7 +111,7 @@ describe('applySeoSuggestion', () => {
       fields: 'Title, Description',
     });
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/seo/ai/suggestions/sug-1/apply`, {
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/ai/suggestions/sug-1/apply`, {
       fields: 'Title, Description',
     });
     expect(result).toEqual(applied);
@@ -126,7 +126,7 @@ describe('rejectSeoSuggestion', () => {
 
     await rejectSeoSuggestion(client, BASE, 'sug-1', { reason: 'Not relevant' });
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/seo/ai/suggestions/sug-1/reject`, {
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/ai/suggestions/sug-1/reject`, {
       reason: 'Not relevant',
     });
   });
@@ -137,7 +137,7 @@ describe('rejectSeoSuggestion', () => {
 
     await rejectSeoSuggestion(client, BASE, 'sug-1');
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/seo/ai/suggestions/sug-1/reject`, {});
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/ai/suggestions/sug-1/reject`, {});
   });
 });
 
@@ -149,7 +149,7 @@ describe('triggerBulkSeoAudit', () => {
     await triggerBulkSeoAudit(client, BASE, 'site-1');
 
     expect(client.post).toHaveBeenCalledWith(
-      `${BASE}/api/cms/seo/ai/sites/site-1/audit`,
+      `${BASE}/ai/sites/site-1/audit`,
       null,
       expect.objectContaining({})
     );

--- a/packages/@granit/cms-seo/src/__tests__/seo.test.ts
+++ b/packages/@granit/cms-seo/src/__tests__/seo.test.ts
@@ -59,7 +59,7 @@ describe('getEffectiveSeo', () => {
     });
 
     expect(client.get).toHaveBeenCalledWith(
-      `${basePath}/api/cms/seo/sites/site-1/metadata/CmsPage/page-1/fr/effective`,
+      `${basePath}/sites/site-1/metadata/CmsPage/page-1/fr/effective`,
       { params: { contentTitle: 'À propos', contentDescription: undefined } }
     );
     expect(result).toEqual(sampleSeo);
@@ -82,7 +82,7 @@ describe('getSitemap', () => {
     const result = await getSitemap(client, basePath, 'site-1');
 
     expect(client.get).toHaveBeenCalledWith(
-      `${basePath}/api/cms/seo/sites/site-1/sitemap.xml`,
+      `${basePath}/sites/site-1/sitemap.xml`,
       expect.objectContaining({ responseType: 'text' })
     );
     expect(result).toEqual({
@@ -105,7 +105,7 @@ describe('getSitemap', () => {
     const result = await getSitemap(client, basePath, 'site-1', { ifNoneMatch: '"v1"' });
 
     expect(client.get).toHaveBeenCalledWith(
-      `${basePath}/api/cms/seo/sites/site-1/sitemap.xml`,
+      `${basePath}/sites/site-1/sitemap.xml`,
       expect.objectContaining({ headers: { 'If-None-Match': '"v1"' } })
     );
     expect(result.status).toBe(304);
@@ -120,7 +120,7 @@ describe('getSitemap', () => {
     await getSitemap(client, basePath, 'site-1', { fetchOptions: { cache: 'force-cache' } });
 
     expect(client.get).toHaveBeenCalledWith(
-      `${basePath}/api/cms/seo/sites/site-1/sitemap.xml`,
+      `${basePath}/sites/site-1/sitemap.xml`,
       expect.objectContaining({ fetchOptions: { cache: 'force-cache' } })
     );
   });
@@ -134,7 +134,7 @@ describe('getSitemapFile', () => {
     const result = await getSitemapFile(client, basePath, 'site-1', 'sitemap-1.xml');
 
     expect(client.get).toHaveBeenCalledWith(
-      `${basePath}/api/cms/seo/sites/site-1/sitemap/sitemap-1.xml`,
+      `${basePath}/sites/site-1/sitemap/sitemap-1.xml`,
       expect.objectContaining({ responseType: 'text' })
     );
     expect(result.status).toBe(200);
@@ -164,7 +164,7 @@ describe('getRobotsTxt', () => {
     const result = await getRobotsTxt(client, basePath, 'site-1');
 
     expect(client.get).toHaveBeenCalledWith(
-      `${basePath}/api/cms/seo/sites/site-1/robots.txt`,
+      `${basePath}/sites/site-1/robots.txt`,
       expect.objectContaining({ responseType: 'text' })
     );
     expect(result.body).toContain('User-agent');
@@ -178,7 +178,7 @@ describe('getRobotsTxt', () => {
     await getRobotsTxt(client, basePath, 'site-1', { fetchOptions: { cache: 'force-cache' } });
 
     expect(client.get).toHaveBeenCalledWith(
-      `${basePath}/api/cms/seo/sites/site-1/robots.txt`,
+      `${basePath}/sites/site-1/robots.txt`,
       expect.objectContaining({ fetchOptions: { cache: 'force-cache' } })
     );
   });

--- a/packages/@granit/cms-seo/src/api/seo-admin.ts
+++ b/packages/@granit/cms-seo/src/api/seo-admin.ts
@@ -30,7 +30,7 @@ export async function getSeoMetadata(
 ): Promise<SeoMetadataResponse | null> {
   const { siteId, contentType, contentId, culture } = params;
   const res = await client.get<SeoMetadataResponse>(
-    `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/metadata/${encodeURIComponent(contentType)}/${encodeURIComponent(contentId)}/${encodeURIComponent(culture)}`,
+    `${basePath}/sites/${encodeURIComponent(siteId)}/metadata/${encodeURIComponent(contentType)}/${encodeURIComponent(contentId)}/${encodeURIComponent(culture)}`,
     { validateStatus: (s) => s === 200 || s === 404 }
   );
   return res.status === 404 ? null : res.data;
@@ -53,7 +53,7 @@ export async function upsertSeoMetadata(
 ): Promise<SeoMetadataResponse> {
   const { siteId, contentType, contentId, culture } = params;
   const res = await client.put<SeoMetadataResponse>(
-    `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/metadata/${encodeURIComponent(contentType)}/${encodeURIComponent(contentId)}/${encodeURIComponent(culture)}`,
+    `${basePath}/sites/${encodeURIComponent(siteId)}/metadata/${encodeURIComponent(contentType)}/${encodeURIComponent(contentId)}/${encodeURIComponent(culture)}`,
     request
   );
   return res.data;
@@ -75,7 +75,7 @@ export async function deleteSeoMetadata(
 ): Promise<void> {
   const { siteId, contentType, contentId, culture } = params;
   await client.delete(
-    `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/metadata/${encodeURIComponent(contentType)}/${encodeURIComponent(contentId)}/${encodeURIComponent(culture)}`
+    `${basePath}/sites/${encodeURIComponent(siteId)}/metadata/${encodeURIComponent(contentType)}/${encodeURIComponent(contentId)}/${encodeURIComponent(culture)}`
   );
 }
 
@@ -89,7 +89,7 @@ export async function getSeoDefaults(
   siteId: string
 ): Promise<SiteSeoDefaultsResponse | null> {
   const res = await client.get<SiteSeoDefaultsResponse>(
-    `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/defaults`,
+    `${basePath}/sites/${encodeURIComponent(siteId)}/defaults`,
     { validateStatus: (s) => s === 200 || s === 404 }
   );
   return res.status === 404 ? null : res.data;
@@ -103,7 +103,7 @@ export async function updateSeoDefaults(
   request: SiteSeoDefaultsRequest
 ): Promise<SiteSeoDefaultsResponse> {
   const res = await client.put<SiteSeoDefaultsResponse>(
-    `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/defaults`,
+    `${basePath}/sites/${encodeURIComponent(siteId)}/defaults`,
     request
   );
   return res.data;
@@ -122,7 +122,7 @@ export async function listSeoMetadata(
 ): Promise<PagedResult<SeoMetadataListItem>> {
   const qs = params ? serializeQueryRequest(params) : '';
   const suffix = qs ? `?${qs}` : '';
-  const url = `${basePath}/api/cms/seo/metadata${suffix}`;
+  const url = `${basePath}/metadata${suffix}`;
   const res = await client.get<PagedResult<SeoMetadataListItem>>(url, options);
   return res.data;
 }
@@ -133,9 +133,7 @@ export async function invalidateSitemap(
   basePath: string,
   siteId: string
 ): Promise<void> {
-  await client.post(
-    `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/sitemap/invalidate`
-  );
+  await client.post(`${basePath}/sites/${encodeURIComponent(siteId)}/sitemap/invalidate`);
 }
 
 /** `GET .../metadata/{contentType}/{contentId}/{culture}/preview/serp`. Requires `Cms.Seo.Read`. */
@@ -151,7 +149,7 @@ export async function getSerpPreview(
 ): Promise<SerpPreviewResponse | null> {
   const { siteId, contentType, contentId, culture } = params;
   const res = await client.get<SerpPreviewResponse>(
-    `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/metadata/${encodeURIComponent(contentType)}/${encodeURIComponent(contentId)}/${encodeURIComponent(culture)}/preview/serp`,
+    `${basePath}/sites/${encodeURIComponent(siteId)}/metadata/${encodeURIComponent(contentType)}/${encodeURIComponent(contentId)}/${encodeURIComponent(culture)}/preview/serp`,
     { validateStatus: (s) => s === 200 || s === 204 }
   );
   return res.status === 204 ? null : res.data;
@@ -170,7 +168,7 @@ export async function getOgCardPreview(
 ): Promise<OgPreviewResponse | null> {
   const { siteId, contentType, contentId, culture } = params;
   const res = await client.get<OgPreviewResponse>(
-    `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/metadata/${encodeURIComponent(contentType)}/${encodeURIComponent(contentId)}/${encodeURIComponent(culture)}/preview/og`,
+    `${basePath}/sites/${encodeURIComponent(siteId)}/metadata/${encodeURIComponent(contentType)}/${encodeURIComponent(contentId)}/${encodeURIComponent(culture)}/preview/og`,
     { validateStatus: (s) => s === 200 || s === 204 }
   );
   return res.status === 204 ? null : res.data;
@@ -193,7 +191,7 @@ export async function getJsonLdPreview(
 ): Promise<string | null> {
   const { siteId, contentType, contentId, culture } = params;
   const res = await client.get<string>(
-    `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/metadata/${encodeURIComponent(contentType)}/${encodeURIComponent(contentId)}/${encodeURIComponent(culture)}/preview/jsonld`,
+    `${basePath}/sites/${encodeURIComponent(siteId)}/metadata/${encodeURIComponent(contentType)}/${encodeURIComponent(contentId)}/${encodeURIComponent(culture)}/preview/jsonld`,
     { responseType: 'text', validateStatus: (s) => s === 200 || s === 204 }
   );
   return res.status === 204 ? null : res.data;

--- a/packages/@granit/cms-seo/src/api/seo-ai.ts
+++ b/packages/@granit/cms-seo/src/api/seo-ai.ts
@@ -20,7 +20,7 @@ export async function suggestSeo(
   basePath: string,
   request: SeoSuggestRequest
 ): Promise<SeoSuggestResponse> {
-  const res = await client.post<SeoSuggestResponse>(`${basePath}/api/cms/seo/ai/suggest`, request);
+  const res = await client.post<SeoSuggestResponse>(`${basePath}/ai/suggest`, request);
   return res.data;
 }
 
@@ -30,10 +30,7 @@ export async function listSeoSuggestions(
   basePath: string,
   params?: ListSeoSuggestionsParams
 ): Promise<SeoSuggestionListResponse> {
-  const res = await client.get<SeoSuggestionListResponse>(
-    `${basePath}/api/cms/seo/ai/suggestions`,
-    { params }
-  );
+  const res = await client.get<SeoSuggestionListResponse>(`${basePath}/ai/suggestions`, { params });
   return res.data;
 }
 
@@ -44,7 +41,7 @@ export async function getSeoSuggestionDiff(
   id: string
 ): Promise<SeoSuggestionDiff> {
   const res = await client.get<SeoSuggestionDiff>(
-    `${basePath}/api/cms/seo/ai/suggestions/${encodeURIComponent(id)}/diff`
+    `${basePath}/ai/suggestions/${encodeURIComponent(id)}/diff`
   );
   return res.data;
 }
@@ -61,7 +58,7 @@ export async function applySeoSuggestion(
   request: SeoSuggestionApplyRequest
 ): Promise<SeoSuggestionResponse> {
   const res = await client.post<SeoSuggestionResponse>(
-    `${basePath}/api/cms/seo/ai/suggestions/${encodeURIComponent(id)}/apply`,
+    `${basePath}/ai/suggestions/${encodeURIComponent(id)}/apply`,
     request
   );
   return res.data;
@@ -75,7 +72,7 @@ export async function rejectSeoSuggestion(
   request?: RejectSeoAiRequest
 ): Promise<SeoSuggestionResponse> {
   const res = await client.post<SeoSuggestionResponse>(
-    `${basePath}/api/cms/seo/ai/suggestions/${encodeURIComponent(id)}/reject`,
+    `${basePath}/ai/suggestions/${encodeURIComponent(id)}/reject`,
     request ?? {}
   );
   return res.data;
@@ -90,7 +87,7 @@ export async function triggerBulkSeoAudit(
   basePath: string,
   siteId: string
 ): Promise<void> {
-  await client.post(`${basePath}/api/cms/seo/ai/sites/${encodeURIComponent(siteId)}/audit`, null, {
+  await client.post(`${basePath}/ai/sites/${encodeURIComponent(siteId)}/audit`, null, {
     validateStatus: (s) => s === 202,
   });
 }

--- a/packages/@granit/cms-seo/src/api/seo.ts
+++ b/packages/@granit/cms-seo/src/api/seo.ts
@@ -3,7 +3,7 @@ import type { AxiosInstance, RequestFetchOptions } from '@granit/api-client';
 
 /**
  * Fetches the cascade-resolved, render-ready SEO for a content item.
- * `GET {basePath}/api/cms/seo/sites/{siteId}/metadata/{contentType}/{contentId}/{culture}/effective`
+ * `GET {basePath}/sites/{siteId}/metadata/{contentType}/{contentId}/{culture}/effective`
  *
  * `contentTitle` and `contentDescription` seed the cascade when no explicit
  * title/description row exists for the content item.
@@ -25,7 +25,7 @@ export async function getEffectiveSeo(
 ): Promise<EffectiveSeoResponse> {
   const { siteId, contentType, contentId, culture, contentTitle, contentDescription } = params;
   const response = await client.get<EffectiveSeoResponse>(
-    `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/metadata/${encodeURIComponent(contentType)}/${encodeURIComponent(contentId)}/${encodeURIComponent(culture)}/effective`,
+    `${basePath}/sites/${encodeURIComponent(siteId)}/metadata/${encodeURIComponent(contentType)}/${encodeURIComponent(contentId)}/${encodeURIComponent(culture)}/effective`,
     { params: { contentTitle, contentDescription }, ...(fetchOptions ? { fetchOptions } : {}) }
   );
   return response.data;
@@ -85,7 +85,7 @@ function rawDocumentConfig(opts: RawDocumentOptions | undefined, allow404: boole
 
 /**
  * Public, anonymous sitemap document for a site (index or single urlset).
- * `GET {basePath}/api/cms/seo/sites/{siteId}/sitemap.xml` — returns raw XML.
+ * `GET {basePath}/sites/{siteId}/sitemap.xml` — returns raw XML.
  *
  * Supports conditional GET: pass `opts.ifNoneMatch` to relay the upstream `ETag`
  * and short-circuit on `304`. See {@link RawDocumentResult}.
@@ -97,7 +97,7 @@ export async function getSitemap(
   opts?: RawDocumentOptions
 ): Promise<RawDocumentResult> {
   const res = await client.get<string>(
-    `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/sitemap.xml`,
+    `${basePath}/sites/${encodeURIComponent(siteId)}/sitemap.xml`,
     rawDocumentConfig(opts, false)
   );
   return toRawDocumentResult(res);
@@ -105,7 +105,7 @@ export async function getSitemap(
 
 /**
  * A named child sitemap file referenced by the sitemap index.
- * `GET {basePath}/api/cms/seo/sites/{siteId}/sitemap/{file}` — returns raw XML,
+ * `GET {basePath}/sites/{siteId}/sitemap/{file}` — returns raw XML,
  * `status: 404` (with `body: null`) when the file does not exist.
  *
  * Supports conditional GET via `opts.ifNoneMatch`. See {@link RawDocumentResult}.
@@ -118,7 +118,7 @@ export async function getSitemapFile(
   opts?: RawDocumentOptions
 ): Promise<RawDocumentResult> {
   const res = await client.get<string>(
-    `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/sitemap/${encodeURIComponent(file)}`,
+    `${basePath}/sites/${encodeURIComponent(siteId)}/sitemap/${encodeURIComponent(file)}`,
     rawDocumentConfig(opts, true)
   );
   return toRawDocumentResult(res);
@@ -126,7 +126,7 @@ export async function getSitemapFile(
 
 /**
  * Public, anonymous `robots.txt` for a site.
- * `GET {basePath}/api/cms/seo/sites/{siteId}/robots.txt` — returns raw text.
+ * `GET {basePath}/sites/{siteId}/robots.txt` — returns raw text.
  *
  * Supports conditional GET via `opts.ifNoneMatch`. See {@link RawDocumentResult}.
  */
@@ -137,7 +137,7 @@ export async function getRobotsTxt(
   opts?: RawDocumentOptions
 ): Promise<RawDocumentResult> {
   const res = await client.get<string>(
-    `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/robots.txt`,
+    `${basePath}/sites/${encodeURIComponent(siteId)}/robots.txt`,
     rawDocumentConfig(opts, false)
   );
   return toRawDocumentResult(res);
@@ -145,7 +145,7 @@ export async function getRobotsTxt(
 
 /**
  * Public, anonymous PWA web app manifest for a site.
- * `GET {basePath}/api/cms/seo/sites/{siteId}/manifest.webmanifest` — returns the
+ * `GET {basePath}/sites/{siteId}/manifest.webmanifest` — returns the
  * raw `application/manifest+json` text, `status: 404` (with `body: null`) when no
  * manifest is set.
  *
@@ -158,7 +158,7 @@ export async function getManifest(
   opts?: RawDocumentOptions
 ): Promise<RawDocumentResult> {
   const res = await client.get<string>(
-    `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/manifest.webmanifest`,
+    `${basePath}/sites/${encodeURIComponent(siteId)}/manifest.webmanifest`,
     rawDocumentConfig(opts, true)
   );
   return toRawDocumentResult(res);

--- a/packages/@granit/cms/src/__tests__/blocks.test.ts
+++ b/packages/@granit/cms/src/__tests__/blocks.test.ts
@@ -40,7 +40,7 @@ describe('getBlockCatalog', () => {
 
     const result = await getBlockCatalog(client, basePath);
 
-    expect(client.get).toHaveBeenCalledWith(`${basePath}/api/cms/blocks`);
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/blocks`);
     expect(result).toEqual(catalog);
   });
 });
@@ -52,7 +52,7 @@ describe('getPublicBlockCatalog', () => {
 
     const result = await getPublicBlockCatalog(client, basePath);
 
-    expect(client.get).toHaveBeenCalledWith(`${basePath}/api/cms/blocks/public`, undefined);
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/blocks/public`, undefined);
     expect(result).toEqual(catalog);
   });
 
@@ -64,7 +64,7 @@ describe('getPublicBlockCatalog', () => {
     // by the renderer (which augments RequestInit). The forwarding mechanism is identical.
     await getPublicBlockCatalog(client, basePath, { cache: 'force-cache' });
 
-    expect(client.get).toHaveBeenCalledWith(`${basePath}/api/cms/blocks/public`, {
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/blocks/public`, {
       fetchOptions: { cache: 'force-cache' },
     });
   });
@@ -88,7 +88,7 @@ describe('resolveBlockData', () => {
 
     const result = await resolveBlockData(client, basePath, req);
 
-    expect(client.post).toHaveBeenCalledWith(`${basePath}/api/cms/blocks/data`, req, undefined);
+    expect(client.post).toHaveBeenCalledWith(`${basePath}/blocks/data`, req, undefined);
     expect(result).toEqual(resp);
   });
 
@@ -98,7 +98,7 @@ describe('resolveBlockData', () => {
 
     await resolveBlockData(client, basePath, req, { cache: 'no-store' });
 
-    expect(client.post).toHaveBeenCalledWith(`${basePath}/api/cms/blocks/data`, req, {
+    expect(client.post).toHaveBeenCalledWith(`${basePath}/blocks/data`, req, {
       fetchOptions: { cache: 'no-store' },
     });
   });

--- a/packages/@granit/cms/src/__tests__/menus-admin.test.ts
+++ b/packages/@granit/cms/src/__tests__/menus-admin.test.ts
@@ -32,7 +32,7 @@ describe('listMenus', () => {
 
     const result = await listMenus(client, BASE);
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/menus`, undefined);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/menus`, undefined);
     expect(result).toEqual(response);
   });
 
@@ -44,7 +44,7 @@ describe('listMenus', () => {
 
     await listMenus(client, BASE, { page: 1, pageSize: 20 });
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/menus?page=1&pageSize=20`, undefined);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/menus?page=1&pageSize=20`, undefined);
   });
 });
 
@@ -55,7 +55,7 @@ describe('getMenu', () => {
 
     const result = await getMenu(client, BASE, 'menu-1');
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/menus/menu-1`);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/menus/menu-1`);
     expect(result).toEqual(menu);
   });
 });
@@ -68,7 +68,7 @@ describe('createMenu', () => {
     const request = { siteId: 'site-1', key: 'main', title: 'Main navigation' };
     const result = await createMenu(client, BASE, request);
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/menus`, request);
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/menus`, request);
     expect(result).toEqual(menu);
   });
 });
@@ -82,7 +82,7 @@ describe('updateMenu', () => {
     const request = { title: 'Primary nav', items: [] };
     const result = await updateMenu(client, BASE, 'menu-1', request);
 
-    expect(client.put).toHaveBeenCalledWith(`${BASE}/api/cms/menus/menu-1`, request);
+    expect(client.put).toHaveBeenCalledWith(`${BASE}/menus/menu-1`, request);
     expect(result).toEqual(updated);
   });
 });
@@ -94,6 +94,6 @@ describe('deleteMenu', () => {
 
     await deleteMenu(client, BASE, 'menu-1');
 
-    expect(client.delete).toHaveBeenCalledWith(`${BASE}/api/cms/menus/menu-1`);
+    expect(client.delete).toHaveBeenCalledWith(`${BASE}/menus/menu-1`);
   });
 });

--- a/packages/@granit/cms/src/__tests__/menus.test.ts
+++ b/packages/@granit/cms/src/__tests__/menus.test.ts
@@ -38,7 +38,7 @@ describe('resolveMenu', () => {
       culture: 'fr',
     });
 
-    expect(client.get).toHaveBeenCalledWith(`${basePath}/api/cms/menus/resolve`, {
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/menus/resolve`, {
       params: { key: 'main', culture: 'fr' },
       headers: { 'X-Granit-Site': 'site-1' },
     });

--- a/packages/@granit/cms/src/__tests__/pages-admin.test.ts
+++ b/packages/@granit/cms/src/__tests__/pages-admin.test.ts
@@ -67,7 +67,7 @@ describe('getPageTree', () => {
 
     const result = await getPageTree(client, BASE, 'site-1');
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/pages/tree`, {
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/pages/tree`, {
       headers: { 'X-Granit-Site': 'site-1' },
     });
     expect(result).toEqual([treeNode]);
@@ -83,7 +83,7 @@ describe('listPages', () => {
 
     await listPages(client, BASE, { page: 1, pageSize: 20 });
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/pages?page=1&pageSize=20`, undefined);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/pages?page=1&pageSize=20`, undefined);
   });
 });
 
@@ -94,7 +94,7 @@ describe('getPage', () => {
 
     const result = await getPage(client, BASE, 'page-1');
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/pages/page-1`);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/pages/page-1`);
     expect(result).toEqual(page);
   });
 });
@@ -107,7 +107,7 @@ describe('createPage', () => {
     const request = { parentId: 'parent-1', slugSegment: 'home', layoutKey: null };
     const result = await createPage(client, BASE, request);
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/pages`, request);
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/pages`, request);
     expect(result).toEqual(page);
   });
 });
@@ -122,7 +122,7 @@ describe('updatePage', () => {
       concurrencyStamp: 'stamp-1',
     });
 
-    expect(client.put).toHaveBeenCalledWith(`${BASE}/api/cms/pages/page-1`, {
+    expect(client.put).toHaveBeenCalledWith(`${BASE}/pages/page-1`, {
       slugSegment: 'new-home',
       concurrencyStamp: 'stamp-1',
     });
@@ -139,7 +139,7 @@ describe('updatePageTranslation', () => {
       title: 'Accueil',
     });
 
-    expect(client.put).toHaveBeenCalledWith(`${BASE}/api/cms/pages/page-1/translations/fr`, {
+    expect(client.put).toHaveBeenCalledWith(`${BASE}/pages/page-1/translations/fr`, {
       urlSlug: 'accueil',
       title: 'Accueil',
     });
@@ -156,7 +156,7 @@ describe('movePage', () => {
       concurrencyStamp: 'stamp-1',
     });
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/pages/page-1/move`, {
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/pages/page-1/move`, {
       newParentId: 'parent-1',
       concurrencyStamp: 'stamp-1',
     });
@@ -170,7 +170,7 @@ describe('deletePage', () => {
 
     await deletePage(client, BASE, 'page-1');
 
-    expect(client.delete).toHaveBeenCalledWith(`${BASE}/api/cms/pages/page-1`);
+    expect(client.delete).toHaveBeenCalledWith(`${BASE}/pages/page-1`);
   });
 });
 
@@ -202,7 +202,7 @@ describe('listPageVersions', () => {
 
     const result = await listPageVersions(client, BASE, 'page-1');
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/pages/page-1/versions`);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/pages/page-1/versions`);
     expect(result).toEqual([version]);
   });
 });
@@ -214,7 +214,7 @@ describe('publishPage', () => {
 
     await publishPage(client, BASE, 'page-1');
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/pages/page-1/publish`);
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/pages/page-1/publish`);
   });
 });
 
@@ -225,7 +225,7 @@ describe('unpublishPage', () => {
 
     await unpublishPage(client, BASE, 'page-1');
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/pages/page-1/unpublish`);
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/pages/page-1/unpublish`);
   });
 });
 
@@ -236,6 +236,6 @@ describe('rollbackPage', () => {
 
     await rollbackPage(client, BASE, 'page-1', 'v-1');
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/pages/page-1/rollback/v-1`);
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/pages/page-1/rollback/v-1`);
   });
 });

--- a/packages/@granit/cms/src/__tests__/pages.test.ts
+++ b/packages/@granit/cms/src/__tests__/pages.test.ts
@@ -44,7 +44,7 @@ describe('getPageByPath', () => {
     });
 
     expect(client.get).toHaveBeenCalledWith(
-      `${basePath}/api/cms/pages/by-path`,
+      `${basePath}/pages/by-path`,
       expect.objectContaining({
         params: { culture: 'fr', path: '/a-propos' },
         headers: { 'X-Granit-Site': 'site-1' },
@@ -88,7 +88,7 @@ describe('mintPreviewToken', () => {
 
     const result = await mintPreviewToken(client, basePath, 'page-1', req);
 
-    expect(client.post).toHaveBeenCalledWith(`${basePath}/api/cms/pages/page-1/preview-token`, req);
+    expect(client.post).toHaveBeenCalledWith(`${basePath}/pages/page-1/preview-token`, req);
     expect(result).toEqual(resp);
   });
 });
@@ -100,7 +100,7 @@ describe('resolvePreview', () => {
 
     const result = await resolvePreview(client, basePath, 'tok_abc');
 
-    expect(client.get).toHaveBeenCalledWith(`${basePath}/api/cms/preview/resolve`, {
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/preview/resolve`, {
       params: { token: 'tok_abc' },
     });
     expect(result).toEqual(sampleDraft);

--- a/packages/@granit/cms/src/__tests__/releases.test.ts
+++ b/packages/@granit/cms/src/__tests__/releases.test.ts
@@ -45,7 +45,7 @@ describe('listReleases', () => {
 
     const result = await listReleases(client, BASE);
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/releases`, undefined);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/releases`, undefined);
     expect(result).toEqual(response);
   });
 
@@ -57,10 +57,7 @@ describe('listReleases', () => {
 
     await listReleases(client, BASE, { page: 1, pageSize: 20 });
 
-    expect(client.get).toHaveBeenCalledWith(
-      `${BASE}/api/cms/releases?page=1&pageSize=20`,
-      undefined
-    );
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/releases?page=1&pageSize=20`, undefined);
   });
 });
 
@@ -71,7 +68,7 @@ describe('getRelease', () => {
 
     const result = await getRelease(client, BASE, 'rel-1');
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/releases/rel-1`);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/releases/rel-1`);
     expect(result).toEqual(release);
   });
 });
@@ -84,7 +81,7 @@ describe('createRelease', () => {
     const request = { siteId: 'site-1', name: 'Sprint 42' };
     const result = await createRelease(client, BASE, request);
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/releases`, request);
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/releases`, request);
     expect(result).toEqual(release);
   });
 });
@@ -100,7 +97,7 @@ describe('updateRelease', () => {
       concurrencyStamp: 'stamp-1',
     });
 
-    expect(client.put).toHaveBeenCalledWith(`${BASE}/api/cms/releases/rel-1`, {
+    expect(client.put).toHaveBeenCalledWith(`${BASE}/releases/rel-1`, {
       name: 'Sprint 42 rev2',
       concurrencyStamp: 'stamp-1',
     });
@@ -121,7 +118,7 @@ describe('addReleaseAction', () => {
     };
     const result = await addReleaseAction(client, BASE, 'rel-1', request);
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/releases/rel-1/actions`, request);
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/releases/rel-1/actions`, request);
     expect(result).toEqual(release);
   });
 });
@@ -133,7 +130,7 @@ describe('removeReleaseAction', () => {
 
     const result = await removeReleaseAction(client, BASE, 'rel-1', 'action-1');
 
-    expect(client.delete).toHaveBeenCalledWith(`${BASE}/api/cms/releases/rel-1/actions/action-1`);
+    expect(client.delete).toHaveBeenCalledWith(`${BASE}/releases/rel-1/actions/action-1`);
     expect(result).toEqual(release);
   });
 });
@@ -151,7 +148,7 @@ describe('scheduleRelease', () => {
     };
     const result = await scheduleRelease(client, BASE, 'rel-1', request);
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/releases/rel-1/schedule`, request);
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/releases/rel-1/schedule`, request);
     expect(result).toEqual(scheduled);
   });
 });
@@ -164,7 +161,7 @@ describe('cancelRelease', () => {
 
     const result = await cancelRelease(client, BASE, 'rel-1');
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/releases/rel-1/cancel`);
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/releases/rel-1/cancel`);
     expect(result).toEqual(cancelled);
   });
 });
@@ -177,7 +174,7 @@ describe('publishRelease', () => {
 
     const result = await publishRelease(client, BASE, 'rel-1');
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/releases/rel-1/publish`);
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/releases/rel-1/publish`);
     expect(result).toEqual(executed);
   });
 });

--- a/packages/@granit/cms/src/__tests__/sites.test.ts
+++ b/packages/@granit/cms/src/__tests__/sites.test.ts
@@ -37,7 +37,7 @@ describe('listSites', () => {
 
     const result = await listSites(client, BASE);
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/sites`, undefined);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/sites`, undefined);
     expect(result).toEqual(response);
   });
 
@@ -49,7 +49,7 @@ describe('listSites', () => {
 
     await listSites(client, BASE, { page: 1, pageSize: 10 });
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/sites?page=1&pageSize=10`, undefined);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/sites?page=1&pageSize=10`, undefined);
   });
 });
 
@@ -60,7 +60,7 @@ describe('getSite', () => {
 
     const result = await getSite(client, BASE, 'site-1');
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/sites/site-1`);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/sites/site-1`);
     expect(result).toEqual(site);
   });
 });
@@ -73,7 +73,7 @@ describe('createSite', () => {
     const request = { slug: 'acme', defaultCulture: 'fr', allowedCultures: ['fr', 'en'] };
     const result = await createSite(client, BASE, request);
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/sites`, request);
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/sites`, request);
     expect(result).toEqual(site);
   });
 });
@@ -93,7 +93,7 @@ describe('updateSite', () => {
     };
     const result = await updateSite(client, BASE, 'site-1', request);
 
-    expect(client.put).toHaveBeenCalledWith(`${BASE}/api/cms/sites/site-1`, request);
+    expect(client.put).toHaveBeenCalledWith(`${BASE}/sites/site-1`, request);
     expect(result).toEqual(updated);
   });
 });
@@ -105,6 +105,6 @@ describe('deleteSite', () => {
 
     await deleteSite(client, BASE, 'site-1');
 
-    expect(client.delete).toHaveBeenCalledWith(`${BASE}/api/cms/sites/site-1`);
+    expect(client.delete).toHaveBeenCalledWith(`${BASE}/sites/site-1`);
   });
 });

--- a/packages/@granit/cms/src/api/blocks.ts
+++ b/packages/@granit/cms/src/api/blocks.ts
@@ -7,19 +7,19 @@ import type { AxiosInstance, RequestFetchOptions } from '@granit/api-client';
 
 /**
  * Fetches the editor-agnostic block catalog.
- * `GET {basePath}/api/cms/blocks`
+ * `GET {basePath}/blocks`
  */
 export async function getBlockCatalog(
   client: AxiosInstance,
   basePath: string
 ): Promise<BlockCatalogResponse> {
-  const response = await client.get<BlockCatalogResponse>(`${basePath}/api/cms/blocks`);
+  const response = await client.get<BlockCatalogResponse>(`${basePath}/blocks`);
   return response.data;
 }
 
 /**
  * Fetches the anonymous, read-only block catalog for the public SSR renderer.
- * `GET {basePath}/api/cms/blocks/public`
+ * `GET {basePath}/blocks/public`
  *
  * Same `BlockCatalogResponse` shape as {@link getBlockCatalog}, but served by an
  * `AllowAnonymous` route so the public renderer can build its render config
@@ -34,7 +34,7 @@ export async function getPublicBlockCatalog(
   fetchOptions?: RequestFetchOptions
 ): Promise<BlockCatalogResponse> {
   const response = await client.get<BlockCatalogResponse>(
-    `${basePath}/api/cms/blocks/public`,
+    `${basePath}/blocks/public`,
     fetchOptions ? { fetchOptions } : undefined
   );
   return response.data;
@@ -42,7 +42,7 @@ export async function getPublicBlockCatalog(
 
 /**
  * Resolves live data for a data-bound block at SSR time.
- * `POST {basePath}/api/cms/blocks/data`
+ * `POST {basePath}/blocks/data`
  *
  * The `consumedContentKeys` in the response should be added as ISR cache tags
  * so a backend publish of any consumed content invalidates the page.
@@ -57,7 +57,7 @@ export async function resolveBlockData(
   fetchOptions?: RequestFetchOptions
 ): Promise<BlockDataResponse> {
   const response = await client.post<BlockDataResponse>(
-    `${basePath}/api/cms/blocks/data`,
+    `${basePath}/blocks/data`,
     request,
     fetchOptions ? { fetchOptions } : undefined
   );

--- a/packages/@granit/cms/src/api/menus-admin.ts
+++ b/packages/@granit/cms/src/api/menus-admin.ts
@@ -16,7 +16,7 @@ export async function listMenus(
   params?: ListMenusParams,
   options?: { readonly signal?: AbortSignal }
 ): Promise<PagedResult<MenuResponse>> {
-  return getPage<MenuResponse>(client, `${basePath}/api/cms/menus`, params ?? {}, options);
+  return getPage<MenuResponse>(client, `${basePath}/menus`, params ?? {}, options);
 }
 
 /** `GET /api/cms/menus/{id}`. Requires `Cms.Menus.Read`. */
@@ -25,7 +25,7 @@ export async function getMenu(
   basePath: string,
   id: string
 ): Promise<MenuResponse> {
-  const res = await client.get<MenuResponse>(`${basePath}/api/cms/menus/${encodeURIComponent(id)}`);
+  const res = await client.get<MenuResponse>(`${basePath}/menus/${encodeURIComponent(id)}`);
   return res.data;
 }
 
@@ -35,7 +35,7 @@ export async function createMenu(
   basePath: string,
   request: CreateMenuRequest
 ): Promise<MenuResponse> {
-  const res = await client.post<MenuResponse>(`${basePath}/api/cms/menus`, request);
+  const res = await client.post<MenuResponse>(`${basePath}/menus`, request);
   return res.data;
 }
 
@@ -47,7 +47,7 @@ export async function updateMenu(
   request: UpdateMenuRequest
 ): Promise<MenuResponse> {
   const res = await client.put<MenuResponse>(
-    `${basePath}/api/cms/menus/${encodeURIComponent(id)}`,
+    `${basePath}/menus/${encodeURIComponent(id)}`,
     request
   );
   return res.data;
@@ -59,5 +59,5 @@ export async function deleteMenu(
   basePath: string,
   id: string
 ): Promise<void> {
-  await client.delete(`${basePath}/api/cms/menus/${encodeURIComponent(id)}`);
+  await client.delete(`${basePath}/menus/${encodeURIComponent(id)}`);
 }

--- a/packages/@granit/cms/src/api/menus.ts
+++ b/packages/@granit/cms/src/api/menus.ts
@@ -3,7 +3,7 @@ import type { AxiosInstance, RequestFetchOptions } from '@granit/api-client';
 
 /**
  * Resolves a menu into a render-ready tree (anonymous).
- * `GET {basePath}/api/cms/menus/resolve?key={key}&culture={culture}`
+ * `GET {basePath}/menus/resolve?key={key}&culture={culture}`
  * + `X-Granit-Site: {siteId}` header (the backend scopes by site via the header).
  *
  * Returns `null` when no menu with the given key exists.
@@ -17,7 +17,7 @@ export async function resolveMenu(
   fetchOptions?: RequestFetchOptions
 ): Promise<ResolvedMenu | null> {
   try {
-    const response = await client.get<ResolvedMenu>(`${basePath}/api/cms/menus/resolve`, {
+    const response = await client.get<ResolvedMenu>(`${basePath}/menus/resolve`, {
       params: { key: params.key, culture: params.culture },
       headers: { 'X-Granit-Site': params.siteId },
       ...(fetchOptions ? { fetchOptions } : {}),

--- a/packages/@granit/cms/src/api/page-presence.ts
+++ b/packages/@granit/cms/src/api/page-presence.ts
@@ -3,7 +3,7 @@ import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Records or refreshes the caller's presence in the page-editing room.
- * `POST {basePath}/api/cms/pages/{id}/editing/heartbeat` + `X-Granit-Site: {siteId}`.
+ * `POST {basePath}/pages/{id}/editing/heartbeat` + `X-Granit-Site: {siteId}`.
  * Idempotent. Requires `Cms.Pages.Manage`. Returns the active editors.
  */
 export async function sendPageEditingHeartbeat(
@@ -13,7 +13,7 @@ export async function sendPageEditingHeartbeat(
   id: string
 ): Promise<PageEditingPresenceResponse> {
   const res = await client.post<PageEditingPresenceResponse>(
-    `${basePath}/api/cms/pages/${encodeURIComponent(id)}/editing/heartbeat`,
+    `${basePath}/pages/${encodeURIComponent(id)}/editing/heartbeat`,
     undefined,
     { headers: { 'X-Granit-Site': siteId } }
   );
@@ -22,7 +22,7 @@ export async function sendPageEditingHeartbeat(
 
 /**
  * Lists the editors currently in the page-editing room (freshest first).
- * `GET {basePath}/api/cms/pages/{id}/editing` + `X-Granit-Site: {siteId}`.
+ * `GET {basePath}/pages/{id}/editing` + `X-Granit-Site: {siteId}`.
  * Requires `Cms.Pages.Read`.
  */
 export async function getPageEditingPresence(
@@ -32,7 +32,7 @@ export async function getPageEditingPresence(
   id: string
 ): Promise<PageEditingPresenceResponse> {
   const res = await client.get<PageEditingPresenceResponse>(
-    `${basePath}/api/cms/pages/${encodeURIComponent(id)}/editing`,
+    `${basePath}/pages/${encodeURIComponent(id)}/editing`,
     { headers: { 'X-Granit-Site': siteId } }
   );
   return res.data;
@@ -40,7 +40,7 @@ export async function getPageEditingPresence(
 
 /**
  * Removes the caller from the page-editing room (e.g. on tab close).
- * `DELETE {basePath}/api/cms/pages/{id}/editing` + `X-Granit-Site: {siteId}`.
+ * `DELETE {basePath}/pages/{id}/editing` + `X-Granit-Site: {siteId}`.
  * Requires `Cms.Pages.Manage`. Returns `204 NoContent`.
  */
 export async function leavePageEditing(
@@ -49,7 +49,7 @@ export async function leavePageEditing(
   siteId: string,
   id: string
 ): Promise<void> {
-  await client.delete(`${basePath}/api/cms/pages/${encodeURIComponent(id)}/editing`, {
+  await client.delete(`${basePath}/pages/${encodeURIComponent(id)}/editing`, {
     headers: { 'X-Granit-Site': siteId },
   });
 }

--- a/packages/@granit/cms/src/api/page-search.ts
+++ b/packages/@granit/cms/src/api/page-search.ts
@@ -3,7 +3,7 @@ import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Public, site-scoped page search (anonymous).
- * `GET {basePath}/api/cms/search?q={q}&culture={culture}&page=&pageSize=`
+ * `GET {basePath}/search?q={q}&culture={culture}&page=&pageSize=`
  * + `X-Granit-Site: {siteId}` header — only the current site's pages are returned.
  */
 export async function searchPages(
@@ -12,7 +12,7 @@ export async function searchPages(
   siteId: string,
   params: PageSearchParams
 ): Promise<PageSearchPageResponse> {
-  const res = await client.get<PageSearchPageResponse>(`${basePath}/api/cms/search`, {
+  const res = await client.get<PageSearchPageResponse>(`${basePath}/search`, {
     params: {
       q: params.q,
       culture: params.culture,
@@ -26,7 +26,7 @@ export async function searchPages(
 
 /**
  * Admin page search across every site the caller's tenant owns.
- * `GET {basePath}/api/cms/pages/search?q={q}&culture={culture}&page=&pageSize=`
+ * `GET {basePath}/pages/search?q={q}&culture={culture}&page=&pageSize=`
  * Requires `Cms.Pages.Read`. No site filter — admin search spans the whole CMS.
  */
 export async function searchPagesAdmin(
@@ -34,7 +34,7 @@ export async function searchPagesAdmin(
   basePath: string,
   params: PageSearchParams
 ): Promise<PageSearchPageResponse> {
-  const res = await client.get<PageSearchPageResponse>(`${basePath}/api/cms/pages/search`, {
+  const res = await client.get<PageSearchPageResponse>(`${basePath}/pages/search`, {
     params: {
       q: params.q,
       culture: params.culture,

--- a/packages/@granit/cms/src/api/pages-admin.ts
+++ b/packages/@granit/cms/src/api/pages-admin.ts
@@ -22,7 +22,7 @@ export async function getPageTree(
   basePath: string,
   siteId: string
 ): Promise<readonly PageTreeNodeResponse[]> {
-  const res = await client.get<readonly PageTreeNodeResponse[]>(`${basePath}/api/cms/pages/tree`, {
+  const res = await client.get<readonly PageTreeNodeResponse[]>(`${basePath}/pages/tree`, {
     headers: { 'X-Granit-Site': siteId },
   });
   return res.data;
@@ -35,7 +35,7 @@ export async function listPages(
   params?: ListPagesParams,
   options?: { readonly signal?: AbortSignal }
 ): Promise<PagedResult<PageResponse>> {
-  return getResultsPage<PageResponse>(client, `${basePath}/api/cms/pages`, params ?? {}, options);
+  return getResultsPage<PageResponse>(client, `${basePath}/pages`, params ?? {}, options);
 }
 
 /** `GET /api/cms/pages/{id}`. Requires `Cms.Pages.Read`. */
@@ -44,7 +44,7 @@ export async function getPage(
   basePath: string,
   id: string
 ): Promise<PageResponse> {
-  const res = await client.get<PageResponse>(`${basePath}/api/cms/pages/${encodeURIComponent(id)}`);
+  const res = await client.get<PageResponse>(`${basePath}/pages/${encodeURIComponent(id)}`);
   return res.data;
 }
 
@@ -54,7 +54,7 @@ export async function createPage(
   basePath: string,
   request: CreatePageRequest
 ): Promise<PageResponse> {
-  const res = await client.post<PageResponse>(`${basePath}/api/cms/pages`, request);
+  const res = await client.post<PageResponse>(`${basePath}/pages`, request);
   return res.data;
 }
 
@@ -66,7 +66,7 @@ export async function updatePage(
   request: UpdatePageRequest
 ): Promise<PageResponse> {
   const res = await client.put<PageResponse>(
-    `${basePath}/api/cms/pages/${encodeURIComponent(id)}`,
+    `${basePath}/pages/${encodeURIComponent(id)}`,
     request
   );
   return res.data;
@@ -81,7 +81,7 @@ export async function updatePageTranslation(
   request: UpdatePageTranslationRequest
 ): Promise<PageResponse> {
   const res = await client.put<PageResponse>(
-    `${basePath}/api/cms/pages/${encodeURIComponent(id)}/translations/${encodeURIComponent(culture)}`,
+    `${basePath}/pages/${encodeURIComponent(id)}/translations/${encodeURIComponent(culture)}`,
     request
   );
   return res.data;
@@ -94,7 +94,7 @@ export async function movePage(
   id: string,
   request: MovePageRequest
 ): Promise<void> {
-  await client.post(`${basePath}/api/cms/pages/${encodeURIComponent(id)}/move`, request);
+  await client.post(`${basePath}/pages/${encodeURIComponent(id)}/move`, request);
 }
 
 /** `DELETE /api/cms/pages/{id}`. Requires `Cms.Pages.Manage`. Returns `204`. */
@@ -103,7 +103,7 @@ export async function deletePage(
   basePath: string,
   id: string
 ): Promise<void> {
-  await client.delete(`${basePath}/api/cms/pages/${encodeURIComponent(id)}`);
+  await client.delete(`${basePath}/pages/${encodeURIComponent(id)}`);
 }
 
 /**
@@ -119,7 +119,7 @@ export async function saveDraft(
   request: SaveDraftRequest
 ): Promise<SaveDraftResult> {
   const res = await client.put<PageVersionSummaryResponse | PageDraftConflictResponse>(
-    `${basePath}/api/cms/pages/${encodeURIComponent(id)}/draft/${encodeURIComponent(culture)}`,
+    `${basePath}/pages/${encodeURIComponent(id)}/draft/${encodeURIComponent(culture)}`,
     request,
     { validateStatus: (s) => s === 200 || s === 409 }
   );
@@ -136,7 +136,7 @@ export async function listPageVersions(
   id: string
 ): Promise<readonly PageVersionSummaryResponse[]> {
   const res = await client.get<readonly PageVersionSummaryResponse[]>(
-    `${basePath}/api/cms/pages/${encodeURIComponent(id)}/versions`
+    `${basePath}/pages/${encodeURIComponent(id)}/versions`
   );
   return res.data;
 }
@@ -147,7 +147,7 @@ export async function publishPage(
   basePath: string,
   id: string
 ): Promise<void> {
-  await client.post(`${basePath}/api/cms/pages/${encodeURIComponent(id)}/publish`);
+  await client.post(`${basePath}/pages/${encodeURIComponent(id)}/publish`);
 }
 
 /** `POST /api/cms/pages/{id}/unpublish`. Requires `Cms.Pages.Publish`. */
@@ -156,7 +156,7 @@ export async function unpublishPage(
   basePath: string,
   id: string
 ): Promise<void> {
-  await client.post(`${basePath}/api/cms/pages/${encodeURIComponent(id)}/unpublish`);
+  await client.post(`${basePath}/pages/${encodeURIComponent(id)}/unpublish`);
 }
 
 /**
@@ -170,6 +170,6 @@ export async function rollbackPage(
   versionId: string
 ): Promise<void> {
   await client.post(
-    `${basePath}/api/cms/pages/${encodeURIComponent(id)}/rollback/${encodeURIComponent(versionId)}`
+    `${basePath}/pages/${encodeURIComponent(id)}/rollback/${encodeURIComponent(versionId)}`
   );
 }

--- a/packages/@granit/cms/src/api/pages.ts
+++ b/packages/@granit/cms/src/api/pages.ts
@@ -8,7 +8,7 @@ import type { AxiosInstance, RequestFetchOptions } from '@granit/api-client';
 
 /**
  * Resolves a published page by per-culture path.
- * `GET {basePath}/api/cms/pages/by-path?culture={culture}&path={path}`
+ * `GET {basePath}/pages/by-path?culture={culture}&path={path}`
  * + `X-Granit-Site: {siteId}` header.
  *
  * Returns `null` on 404 (draft, archived, or unknown path).
@@ -22,7 +22,7 @@ export async function getPageByPath(
   fetchOptions?: RequestFetchOptions
 ): Promise<PublishedPageResponse | null> {
   try {
-    const response = await client.get<PublishedPageResponse>(`${basePath}/api/cms/pages/by-path`, {
+    const response = await client.get<PublishedPageResponse>(`${basePath}/pages/by-path`, {
       params: { culture: params.culture, path: params.path },
       headers: { 'X-Granit-Site': params.siteId },
       ...(fetchOptions ? { fetchOptions } : {}),
@@ -36,7 +36,7 @@ export async function getPageByPath(
 
 /**
  * Mints a signed preview token for a page draft (admin-gated).
- * `POST {basePath}/api/cms/pages/{pageId}/preview-token`
+ * `POST {basePath}/pages/{pageId}/preview-token`
  */
 export async function mintPreviewToken(
   client: AxiosInstance,
@@ -45,7 +45,7 @@ export async function mintPreviewToken(
   request: MintPreviewTokenRequest
 ): Promise<MintPreviewTokenResponse> {
   const response = await client.post<MintPreviewTokenResponse>(
-    `${basePath}/api/cms/pages/${encodeURIComponent(pageId)}/preview-token`,
+    `${basePath}/pages/${encodeURIComponent(pageId)}/preview-token`,
     request
   );
   return response.data;
@@ -53,7 +53,7 @@ export async function mintPreviewToken(
 
 /**
  * Resolves a preview token into the corresponding draft content (anonymous, token-gated).
- * `GET {basePath}/api/cms/preview/resolve?token={token}`
+ * `GET {basePath}/preview/resolve?token={token}`
  *
  * Returns `null` on 401 (invalid/expired token) or 404.
  *
@@ -67,10 +67,10 @@ export async function resolvePreview(
   fetchOptions?: RequestFetchOptions
 ): Promise<DraftPagePreviewResponse | null> {
   try {
-    const response = await client.get<DraftPagePreviewResponse>(
-      `${basePath}/api/cms/preview/resolve`,
-      { params: { token }, ...(fetchOptions ? { fetchOptions } : {}) }
-    );
+    const response = await client.get<DraftPagePreviewResponse>(`${basePath}/preview/resolve`, {
+      params: { token },
+      ...(fetchOptions ? { fetchOptions } : {}),
+    });
     return response.data;
   } catch (err: unknown) {
     if (isAxios401Or404(err)) return null;

--- a/packages/@granit/cms/src/api/releases.ts
+++ b/packages/@granit/cms/src/api/releases.ts
@@ -18,7 +18,7 @@ export async function listReleases(
   params?: ListReleasesParams,
   options?: { readonly signal?: AbortSignal }
 ): Promise<PagedResult<ReleaseResponse>> {
-  return getPage<ReleaseResponse>(client, `${basePath}/api/cms/releases`, params ?? {}, options);
+  return getPage<ReleaseResponse>(client, `${basePath}/releases`, params ?? {}, options);
 }
 
 /** `GET /api/cms/releases/{id}`. Requires `Cms.Releases.Read`. */
@@ -27,9 +27,7 @@ export async function getRelease(
   basePath: string,
   id: string
 ): Promise<ReleaseResponse> {
-  const res = await client.get<ReleaseResponse>(
-    `${basePath}/api/cms/releases/${encodeURIComponent(id)}`
-  );
+  const res = await client.get<ReleaseResponse>(`${basePath}/releases/${encodeURIComponent(id)}`);
   return res.data;
 }
 
@@ -39,7 +37,7 @@ export async function createRelease(
   basePath: string,
   request: CreateReleaseRequest
 ): Promise<ReleaseResponse> {
-  const res = await client.post<ReleaseResponse>(`${basePath}/api/cms/releases`, request);
+  const res = await client.post<ReleaseResponse>(`${basePath}/releases`, request);
   return res.data;
 }
 
@@ -51,7 +49,7 @@ export async function updateRelease(
   request: UpdateReleaseRequest
 ): Promise<ReleaseResponse> {
   const res = await client.put<ReleaseResponse>(
-    `${basePath}/api/cms/releases/${encodeURIComponent(id)}`,
+    `${basePath}/releases/${encodeURIComponent(id)}`,
     request
   );
   return res.data;
@@ -65,7 +63,7 @@ export async function addReleaseAction(
   request: AddReleaseActionRequest
 ): Promise<ReleaseResponse> {
   const res = await client.post<ReleaseResponse>(
-    `${basePath}/api/cms/releases/${encodeURIComponent(id)}/actions`,
+    `${basePath}/releases/${encodeURIComponent(id)}/actions`,
     request
   );
   return res.data;
@@ -79,7 +77,7 @@ export async function removeReleaseAction(
   actionId: string
 ): Promise<ReleaseResponse> {
   const res = await client.delete<ReleaseResponse>(
-    `${basePath}/api/cms/releases/${encodeURIComponent(id)}/actions/${encodeURIComponent(actionId)}`
+    `${basePath}/releases/${encodeURIComponent(id)}/actions/${encodeURIComponent(actionId)}`
   );
   return res.data;
 }
@@ -92,7 +90,7 @@ export async function scheduleRelease(
   request: ScheduleReleaseRequest
 ): Promise<ReleaseResponse> {
   const res = await client.post<ReleaseResponse>(
-    `${basePath}/api/cms/releases/${encodeURIComponent(id)}/schedule`,
+    `${basePath}/releases/${encodeURIComponent(id)}/schedule`,
     request
   );
   return res.data;
@@ -105,7 +103,7 @@ export async function cancelRelease(
   id: string
 ): Promise<ReleaseResponse> {
   const res = await client.post<ReleaseResponse>(
-    `${basePath}/api/cms/releases/${encodeURIComponent(id)}/cancel`
+    `${basePath}/releases/${encodeURIComponent(id)}/cancel`
   );
   return res.data;
 }
@@ -117,7 +115,7 @@ export async function publishRelease(
   id: string
 ): Promise<ReleaseResponse> {
   const res = await client.post<ReleaseResponse>(
-    `${basePath}/api/cms/releases/${encodeURIComponent(id)}/publish`
+    `${basePath}/releases/${encodeURIComponent(id)}/publish`
   );
   return res.data;
 }

--- a/packages/@granit/cms/src/api/sites.ts
+++ b/packages/@granit/cms/src/api/sites.ts
@@ -16,7 +16,7 @@ export async function listSites(
   params?: ListSitesParams,
   options?: { readonly signal?: AbortSignal }
 ): Promise<PagedResult<SiteResponse>> {
-  return getPage<SiteResponse>(client, `${basePath}/api/cms/sites`, params ?? {}, options);
+  return getPage<SiteResponse>(client, `${basePath}/sites`, params ?? {}, options);
 }
 
 /** `GET /api/cms/sites/{id}`. Requires `Cms.Sites.Read`. */
@@ -25,7 +25,7 @@ export async function getSite(
   basePath: string,
   id: string
 ): Promise<SiteResponse> {
-  const res = await client.get<SiteResponse>(`${basePath}/api/cms/sites/${encodeURIComponent(id)}`);
+  const res = await client.get<SiteResponse>(`${basePath}/sites/${encodeURIComponent(id)}`);
   return res.data;
 }
 
@@ -35,7 +35,7 @@ export async function createSite(
   basePath: string,
   request: CreateSiteRequest
 ): Promise<SiteResponse> {
-  const res = await client.post<SiteResponse>(`${basePath}/api/cms/sites`, request);
+  const res = await client.post<SiteResponse>(`${basePath}/sites`, request);
   return res.data;
 }
 
@@ -47,7 +47,7 @@ export async function updateSite(
   request: UpdateSiteRequest
 ): Promise<SiteResponse> {
   const res = await client.put<SiteResponse>(
-    `${basePath}/api/cms/sites/${encodeURIComponent(id)}`,
+    `${basePath}/sites/${encodeURIComponent(id)}`,
     request
   );
   return res.data;
@@ -59,5 +59,5 @@ export async function deleteSite(
   basePath: string,
   id: string
 ): Promise<void> {
-  await client.delete(`${basePath}/api/cms/sites/${encodeURIComponent(id)}`);
+  await client.delete(`${basePath}/sites/${encodeURIComponent(id)}`);
 }

--- a/packages/@granit/react-cms-hostnames/src/__tests__/use-site-hostname-mutations.test.ts
+++ b/packages/@granit/react-cms-hostnames/src/__tests__/use-site-hostname-mutations.test.ts
@@ -52,7 +52,7 @@ describe('useAddSiteHostname', () => {
     result.current.mutate({ host: 'example.com', isPrimary: true });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(addSiteHostname).toHaveBeenCalledWith(client, '', 'site-1', {
+    expect(addSiteHostname).toHaveBeenCalledWith(client, '/api/cms', 'site-1', {
       host: 'example.com',
       isPrimary: true,
     });
@@ -74,7 +74,7 @@ describe('useRemoveSiteHostname', () => {
     result.current.mutate(hostname.id);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(removeSiteHostname).toHaveBeenCalledWith(client, '', 'site-1', hostname.id);
+    expect(removeSiteHostname).toHaveBeenCalledWith(client, '/api/cms', 'site-1', hostname.id);
   });
 });
 
@@ -93,7 +93,7 @@ describe('useVerifySiteHostname', () => {
     result.current.mutate(hostname.id);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(verifySiteHostname).toHaveBeenCalledWith(client, '', 'site-1', hostname.id);
+    expect(verifySiteHostname).toHaveBeenCalledWith(client, '/api/cms', 'site-1', hostname.id);
     expect(result.current.data).toEqual(hostname);
   });
 });

--- a/packages/@granit/react-cms-hostnames/src/__tests__/use-site-hostnames.test.ts
+++ b/packages/@granit/react-cms-hostnames/src/__tests__/use-site-hostnames.test.ts
@@ -47,7 +47,7 @@ describe('useSiteHostnames', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(listSiteHostnames).toHaveBeenCalledWith(client, '', 'site-1');
+    expect(listSiteHostnames).toHaveBeenCalledWith(client, '/api/cms', 'site-1');
     expect(result.current.data).toEqual([hostname]);
   });
 
@@ -74,7 +74,12 @@ describe('useSiteHostnameAvailability', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(checkSiteHostnameAvailability).toHaveBeenCalledWith(client, '', 'site-1', 'example.com');
+    expect(checkSiteHostnameAvailability).toHaveBeenCalledWith(
+      client,
+      '/api/cms',
+      'site-1',
+      'example.com'
+    );
     expect(result.current.data).toEqual(avail);
   });
 

--- a/packages/@granit/react-cms-hostnames/src/constants.ts
+++ b/packages/@granit/react-cms-hostnames/src/constants.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_BASE_PATH = '';
+export const DEFAULT_BASE_PATH = '/api/cms';
 export const DEFAULT_QUERY_KEY_PREFIX = ['cms-hostnames'] as const;

--- a/packages/@granit/react-cms-redirects/src/__tests__/use-redirect-mutations.test.ts
+++ b/packages/@granit/react-cms-redirects/src/__tests__/use-redirect-mutations.test.ts
@@ -59,7 +59,7 @@ describe('useCreateRedirect', () => {
     result.current.mutate({ siteId: 'site-1', request });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(createRedirect).toHaveBeenCalledWith(client, '', 'site-1', request);
+    expect(createRedirect).toHaveBeenCalledWith(client, '/api/cms/redirects', 'site-1', request);
     expect(result.current.data).toEqual(mutationResult);
   });
 
@@ -90,7 +90,7 @@ describe('useUpdateRedirect', () => {
     result.current.mutate({ id: redirect.id, request });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(updateRedirect).toHaveBeenCalledWith(client, '', redirect.id, request);
+    expect(updateRedirect).toHaveBeenCalledWith(client, '/api/cms/redirects', redirect.id, request);
   });
 });
 
@@ -105,7 +105,7 @@ describe('useDeleteRedirect', () => {
     result.current.mutate({ id: redirect.id, siteId: redirect.siteId });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(deleteRedirect).toHaveBeenCalledWith(client, '', redirect.id);
+    expect(deleteRedirect).toHaveBeenCalledWith(client, '/api/cms/redirects', redirect.id);
   });
 });
 
@@ -124,6 +124,11 @@ describe('useUpdateRedirectSettings', () => {
     result.current.mutate({ siteId: 'site-1', request });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(updateRedirectSettings).toHaveBeenCalledWith(client, '', 'site-1', request);
+    expect(updateRedirectSettings).toHaveBeenCalledWith(
+      client,
+      '/api/cms/redirects',
+      'site-1',
+      request
+    );
   });
 });

--- a/packages/@granit/react-cms-redirects/src/__tests__/use-redirects.test.ts
+++ b/packages/@granit/react-cms-redirects/src/__tests__/use-redirects.test.ts
@@ -67,7 +67,7 @@ describe('useRedirects', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(listRedirects).toHaveBeenCalledWith(client, '', 'site-1');
+    expect(listRedirects).toHaveBeenCalledWith(client, '/api/cms/redirects', 'site-1');
     expect(result.current.data).toEqual([redirect]);
   });
 
@@ -93,7 +93,7 @@ describe('useRedirect', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getRedirect).toHaveBeenCalledWith(client, '', redirect.id);
+    expect(getRedirect).toHaveBeenCalledWith(client, '/api/cms/redirects', redirect.id);
   });
 });
 
@@ -112,7 +112,7 @@ describe('useRedirectsGrid', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(getRedirectsGrid).toHaveBeenCalledWith(
       client,
-      '',
+      '/api/cms/redirects',
       { page: 1, pageSize: 25 },
       expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
@@ -133,7 +133,7 @@ describe('useRedirectSettings', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getRedirectSettings).toHaveBeenCalledWith(client, '', 'site-1');
+    expect(getRedirectSettings).toHaveBeenCalledWith(client, '/api/cms/redirects', 'site-1');
   });
 });
 
@@ -151,7 +151,7 @@ describe('useRedirectPreview', () => {
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(previewRedirect).toHaveBeenCalledWith(client, '', 'site-1', {
+    expect(previewRedirect).toHaveBeenCalledWith(client, '/api/cms/redirects', 'site-1', {
       path: '/old',
       culture: 'fr',
     });

--- a/packages/@granit/react-cms-redirects/src/constants.ts
+++ b/packages/@granit/react-cms-redirects/src/constants.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_BASE_PATH = '';
+export const DEFAULT_BASE_PATH = '/api/cms/redirects';
 export const DEFAULT_QUERY_KEY_PREFIX = ['cms-redirects'] as const;

--- a/packages/@granit/react-cms-seo/src/__tests__/use-seo-ai.test.ts
+++ b/packages/@granit/react-cms-seo/src/__tests__/use-seo-ai.test.ts
@@ -71,7 +71,7 @@ describe('useSeoSuggestions', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(listSeoSuggestions).toHaveBeenCalledWith(client, '', { status: 'Pending' });
+    expect(listSeoSuggestions).toHaveBeenCalledWith(client, '/api/cms/seo', { status: 'Pending' });
   });
 });
 
@@ -94,7 +94,7 @@ describe('useSeoSuggestionDiff', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getSeoSuggestionDiff).toHaveBeenCalledWith(client, '', suggestion.id);
+    expect(getSeoSuggestionDiff).toHaveBeenCalledWith(client, '/api/cms/seo', suggestion.id);
   });
 
   it('is disabled when id is empty', () => {
@@ -130,7 +130,7 @@ describe('useSuggestSeo', () => {
     result.current.mutate(req);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(suggestSeo).toHaveBeenCalledWith(client, '', req);
+    expect(suggestSeo).toHaveBeenCalledWith(client, '/api/cms/seo', req);
   });
 });
 
@@ -149,7 +149,9 @@ describe('useApplySeoSuggestion', () => {
     result.current.mutate({ id: suggestion.id, request: { fields: 'Title' } });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(applySeoSuggestion).toHaveBeenCalledWith(client, '', suggestion.id, { fields: 'Title' });
+    expect(applySeoSuggestion).toHaveBeenCalledWith(client, '/api/cms/seo', suggestion.id, {
+      fields: 'Title',
+    });
   });
 });
 
@@ -168,7 +170,7 @@ describe('useRejectSeoSuggestion', () => {
     result.current.mutate({ id: suggestion.id, request: { reason: 'Not relevant' } });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(rejectSeoSuggestion).toHaveBeenCalledWith(client, '', suggestion.id, {
+    expect(rejectSeoSuggestion).toHaveBeenCalledWith(client, '/api/cms/seo', suggestion.id, {
       reason: 'Not relevant',
     });
   });
@@ -189,6 +191,6 @@ describe('useTriggerBulkSeoAudit', () => {
     result.current.mutate('site-1');
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(triggerBulkSeoAudit).toHaveBeenCalledWith(client, '', 'site-1');
+    expect(triggerBulkSeoAudit).toHaveBeenCalledWith(client, '/api/cms/seo', 'site-1');
   });
 });

--- a/packages/@granit/react-cms-seo/src/__tests__/use-seo-metadata.test.ts
+++ b/packages/@granit/react-cms-seo/src/__tests__/use-seo-metadata.test.ts
@@ -109,7 +109,7 @@ describe('useSeoMetadata', () => {
     const { result } = renderHook(() => useSeoMetadata(KEY), { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getSeoMetadata).toHaveBeenCalledWith(client, '', KEY);
+    expect(getSeoMetadata).toHaveBeenCalledWith(client, '/api/cms/seo', KEY);
     expect(result.current.data).toEqual(metadata);
   });
 
@@ -165,7 +165,10 @@ describe('useEffectiveSeo', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getEffectiveSeo).toHaveBeenCalledWith(client, '', { ...KEY, contentTitle: 'Seed' });
+    expect(getEffectiveSeo).toHaveBeenCalledWith(client, '/api/cms/seo', {
+      ...KEY,
+      contentTitle: 'Seed',
+    });
   });
 });
 
@@ -183,7 +186,7 @@ describe('useSeoDefaults', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getSeoDefaults).toHaveBeenCalledWith(client, '', 'site-1');
+    expect(getSeoDefaults).toHaveBeenCalledWith(client, '/api/cms/seo', 'site-1');
   });
 
   it('is disabled when siteId is empty', () => {
@@ -215,7 +218,7 @@ describe('useSeoMetadataAudit', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(listSeoMetadata).toHaveBeenCalledWith(
       client,
-      '',
+      '/api/cms/seo',
       undefined,
       expect.objectContaining({})
     );
@@ -239,7 +242,7 @@ describe('useSerpPreview', () => {
     const { result } = renderHook(() => useSerpPreview(KEY), { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getSerpPreview).toHaveBeenCalledWith(client, '', KEY);
+    expect(getSerpPreview).toHaveBeenCalledWith(client, '/api/cms/seo', KEY);
   });
 });
 
@@ -262,7 +265,7 @@ describe('useOgCardPreview', () => {
     const { result } = renderHook(() => useOgCardPreview(KEY), { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getOgCardPreview).toHaveBeenCalledWith(client, '', KEY);
+    expect(getOgCardPreview).toHaveBeenCalledWith(client, '/api/cms/seo', KEY);
   });
 });
 
@@ -279,6 +282,6 @@ describe('useJsonLdPreview', () => {
     const { result } = renderHook(() => useJsonLdPreview(KEY), { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getJsonLdPreview).toHaveBeenCalledWith(client, '', KEY);
+    expect(getJsonLdPreview).toHaveBeenCalledWith(client, '/api/cms/seo', KEY);
   });
 });

--- a/packages/@granit/react-cms-seo/src/__tests__/use-seo-mutations.test.ts
+++ b/packages/@granit/react-cms-seo/src/__tests__/use-seo-mutations.test.ts
@@ -92,7 +92,7 @@ describe('useUpsertSeoMetadata', () => {
     result.current.mutate({ key: KEY, request: { title: 'Test' } });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(upsertSeoMetadata).toHaveBeenCalledWith(client, '', KEY, { title: 'Test' });
+    expect(upsertSeoMetadata).toHaveBeenCalledWith(client, '/api/cms/seo', KEY, { title: 'Test' });
   });
 });
 
@@ -109,7 +109,7 @@ describe('useDeleteSeoMetadata', () => {
     result.current.mutate(KEY);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(deleteSeoMetadata).toHaveBeenCalledWith(client, '', KEY);
+    expect(deleteSeoMetadata).toHaveBeenCalledWith(client, '/api/cms/seo', KEY);
   });
 });
 
@@ -127,7 +127,9 @@ describe('useUpdateSeoDefaults', () => {
     result.current.mutate({ siteId: 'site-1', request: { siteName: 'ACME' } });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(updateSeoDefaults).toHaveBeenCalledWith(client, '', 'site-1', { siteName: 'ACME' });
+    expect(updateSeoDefaults).toHaveBeenCalledWith(client, '/api/cms/seo', 'site-1', {
+      siteName: 'ACME',
+    });
   });
 });
 
@@ -144,6 +146,6 @@ describe('useInvalidateSitemap', () => {
     result.current.mutate('site-1');
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(invalidateSitemap).toHaveBeenCalledWith(client, '', 'site-1');
+    expect(invalidateSitemap).toHaveBeenCalledWith(client, '/api/cms/seo', 'site-1');
   });
 });

--- a/packages/@granit/react-cms-seo/src/constants.ts
+++ b/packages/@granit/react-cms-seo/src/constants.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_BASE_PATH = '';
+export const DEFAULT_BASE_PATH = '/api/cms/seo';
 export const DEFAULT_QUERY_KEY_PREFIX = ['cms-seo'] as const;

--- a/packages/@granit/react-cms/src/__tests__/cms-provider.test.tsx
+++ b/packages/@granit/react-cms/src/__tests__/cms-provider.test.tsx
@@ -32,7 +32,7 @@ describe('CmsProvider / useCmsConfig', () => {
   it('returns resolved config with injected client and default basePath', () => {
     const { result } = renderHook(() => useCmsConfig(), { wrapper: createWrapper() });
     expect(result.current.client).toBe(mockClient);
-    expect(result.current.basePath).toBe('');
+    expect(result.current.basePath).toBe('/api/cms');
     expect(result.current.queryKeyPrefix).toEqual(['cms']);
   });
 

--- a/packages/@granit/react-cms/src/__tests__/use-menu-mutations.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-menu-mutations.test.ts
@@ -46,7 +46,7 @@ describe('useCreateMenu', () => {
     result.current.mutate({ siteId: 'site-1', key: 'main', title: 'Main navigation' });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(createMenu).toHaveBeenCalledWith(client, '', {
+    expect(createMenu).toHaveBeenCalledWith(client, '/api/cms', {
       siteId: 'site-1',
       key: 'main',
       title: 'Main navigation',
@@ -67,7 +67,7 @@ describe('useUpdateMenu', () => {
     result.current.mutate({ id: menu.id, request: { title: 'Primary nav', items: [] } });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(updateMenu).toHaveBeenCalledWith(client, '', menu.id, {
+    expect(updateMenu).toHaveBeenCalledWith(client, '/api/cms', menu.id, {
       title: 'Primary nav',
       items: [],
     });
@@ -87,6 +87,6 @@ describe('useDeleteMenu', () => {
     result.current.mutate({ id: menu.id, siteId: menu.siteId });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(deleteMenu).toHaveBeenCalledWith(client, '', menu.id);
+    expect(deleteMenu).toHaveBeenCalledWith(client, '/api/cms', menu.id);
   });
 });

--- a/packages/@granit/react-cms/src/__tests__/use-menus-admin.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-menus-admin.test.ts
@@ -56,7 +56,7 @@ describe('useMenus', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(listMenus).toHaveBeenCalledWith(
       client,
-      '',
+      '/api/cms',
       { page: 1, pageSize: 20 },
       expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
@@ -75,7 +75,7 @@ describe('useMenu', () => {
     const { result } = renderHook(() => useMenu(menu.id), { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getMenu).toHaveBeenCalledWith(client, '', menu.id);
+    expect(getMenu).toHaveBeenCalledWith(client, '/api/cms', menu.id);
   });
 
   it('is disabled when id is empty', () => {

--- a/packages/@granit/react-cms/src/__tests__/use-page-mutations.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-page-mutations.test.ts
@@ -93,7 +93,7 @@ describe('useCreatePage', () => {
     result.current.mutate({ parentId: 'parent-1', slugSegment: 'home', layoutKey: null });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(createPage).toHaveBeenCalledWith(client, '', {
+    expect(createPage).toHaveBeenCalledWith(client, '/api/cms', {
       parentId: 'parent-1',
       slugSegment: 'home',
       layoutKey: null,
@@ -117,7 +117,7 @@ describe('useUpdatePage', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(updatePage).toHaveBeenCalledWith(client, '', 'page-1', {
+    expect(updatePage).toHaveBeenCalledWith(client, '/api/cms', 'page-1', {
       slugSegment: 'new-home',
       concurrencyStamp: 'stamp-1',
     });
@@ -143,7 +143,7 @@ describe('useUpdatePageTranslation', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(updatePageTranslation).toHaveBeenCalledWith(client, '', 'page-1', 'fr', {
+    expect(updatePageTranslation).toHaveBeenCalledWith(client, '/api/cms', 'page-1', 'fr', {
       urlSlug: 'accueil',
       title: 'Accueil',
     });
@@ -167,7 +167,7 @@ describe('useMovePage', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(movePage).toHaveBeenCalledWith(client, '', 'page-1', {
+    expect(movePage).toHaveBeenCalledWith(client, '/api/cms', 'page-1', {
       newParentId: 'parent-1',
       concurrencyStamp: 'stamp-1',
     });
@@ -187,7 +187,7 @@ describe('useDeletePage', () => {
     result.current.mutate({ id: 'page-1', siteId: 'site-1' });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(deletePage).toHaveBeenCalledWith(client, '', 'page-1');
+    expect(deletePage).toHaveBeenCalledWith(client, '/api/cms', 'page-1');
   });
 });
 
@@ -221,7 +221,7 @@ describe('usePublishPage', () => {
     result.current.mutate('page-1');
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(publishPage).toHaveBeenCalledWith(client, '', 'page-1');
+    expect(publishPage).toHaveBeenCalledWith(client, '/api/cms', 'page-1');
   });
 });
 
@@ -238,7 +238,7 @@ describe('useUnpublishPage', () => {
     result.current.mutate('page-1');
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(unpublishPage).toHaveBeenCalledWith(client, '', 'page-1');
+    expect(unpublishPage).toHaveBeenCalledWith(client, '/api/cms', 'page-1');
   });
 });
 
@@ -255,6 +255,6 @@ describe('useRollbackPage', () => {
     result.current.mutate({ id: 'page-1', versionId: 'v-1' });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(rollbackPage).toHaveBeenCalledWith(client, '', 'page-1', 'v-1');
+    expect(rollbackPage).toHaveBeenCalledWith(client, '/api/cms', 'page-1', 'v-1');
   });
 });

--- a/packages/@granit/react-cms/src/__tests__/use-pages.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-pages.test.ts
@@ -71,7 +71,7 @@ describe('usePageTree', () => {
     const { result } = renderHook(() => usePageTree('site-1'), { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getPageTree).toHaveBeenCalledWith(client, '', 'site-1');
+    expect(getPageTree).toHaveBeenCalledWith(client, '/api/cms', 'site-1');
   });
 
   it('is disabled when siteId is empty', () => {
@@ -104,7 +104,7 @@ describe('usePages', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(listPages).toHaveBeenCalledWith(
       client,
-      '',
+      '/api/cms',
       { page: 1, pageSize: 20 },
       expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
@@ -123,7 +123,7 @@ describe('usePage', () => {
     const { result } = renderHook(() => usePage('page-1'), { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getPage).toHaveBeenCalledWith(client, '', 'page-1');
+    expect(getPage).toHaveBeenCalledWith(client, '/api/cms', 'page-1');
   });
 
   it('is disabled when id is empty', () => {
@@ -148,6 +148,6 @@ describe('usePageVersions', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(listPageVersions).toHaveBeenCalledWith(client, '', 'page-1');
+    expect(listPageVersions).toHaveBeenCalledWith(client, '/api/cms', 'page-1');
   });
 });

--- a/packages/@granit/react-cms/src/__tests__/use-release-mutations.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-release-mutations.test.ts
@@ -67,7 +67,10 @@ describe('useCreateRelease', () => {
     result.current.mutate({ siteId: 'site-1', name: 'Sprint 1' });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(createRelease).toHaveBeenCalledWith(client, '', { siteId: 'site-1', name: 'Sprint 1' });
+    expect(createRelease).toHaveBeenCalledWith(client, '/api/cms', {
+      siteId: 'site-1',
+      name: 'Sprint 1',
+    });
   });
 });
 
@@ -87,7 +90,7 @@ describe('useUpdateRelease', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(updateRelease).toHaveBeenCalledWith(client, '', release.id, {
+    expect(updateRelease).toHaveBeenCalledWith(client, '/api/cms', release.id, {
       name: 'Sprint 1 v2',
       concurrencyStamp: stamp,
     });
@@ -114,7 +117,7 @@ describe('useAddReleaseAction', () => {
     result.current.mutate({ id: release.id, request: req });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(addReleaseAction).toHaveBeenCalledWith(client, '', release.id, req);
+    expect(addReleaseAction).toHaveBeenCalledWith(client, '/api/cms', release.id, req);
   });
 });
 
@@ -133,7 +136,7 @@ describe('useRemoveReleaseAction', () => {
     result.current.mutate({ id: release.id, actionId: 'action-1' });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(removeReleaseAction).toHaveBeenCalledWith(client, '', release.id, 'action-1');
+    expect(removeReleaseAction).toHaveBeenCalledWith(client, '/api/cms', release.id, 'action-1');
   });
 });
 
@@ -155,7 +158,7 @@ describe('useScheduleRelease', () => {
     result.current.mutate({ id: release.id, request: req });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(scheduleRelease).toHaveBeenCalledWith(client, '', release.id, req);
+    expect(scheduleRelease).toHaveBeenCalledWith(client, '/api/cms', release.id, req);
   });
 });
 
@@ -172,7 +175,7 @@ describe('useCancelRelease', () => {
     result.current.mutate(release.id);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(cancelRelease).toHaveBeenCalledWith(client, '', release.id);
+    expect(cancelRelease).toHaveBeenCalledWith(client, '/api/cms', release.id);
   });
 });
 
@@ -189,6 +192,6 @@ describe('usePublishRelease', () => {
     result.current.mutate(release.id);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(publishRelease).toHaveBeenCalledWith(client, '', release.id);
+    expect(publishRelease).toHaveBeenCalledWith(client, '/api/cms', release.id);
   });
 });

--- a/packages/@granit/react-cms/src/__tests__/use-releases.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-releases.test.ts
@@ -56,7 +56,7 @@ describe('useReleases', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(listReleases).toHaveBeenCalledWith(
       client,
-      '',
+      '/api/cms',
       { page: 1, pageSize: 20 },
       expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
@@ -75,7 +75,7 @@ describe('useRelease', () => {
     const { result } = renderHook(() => useRelease(release.id), { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getRelease).toHaveBeenCalledWith(client, '', release.id);
+    expect(getRelease).toHaveBeenCalledWith(client, '/api/cms', release.id);
   });
 
   it('is disabled when id is empty', () => {

--- a/packages/@granit/react-cms/src/__tests__/use-site-mutations.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-site-mutations.test.ts
@@ -46,7 +46,7 @@ describe('useCreateSite', () => {
     result.current.mutate({ slug: 'acme', defaultCulture: 'fr', allowedCultures: ['fr'] });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(createSite).toHaveBeenCalledWith(client, '', {
+    expect(createSite).toHaveBeenCalledWith(client, '/api/cms', {
       slug: 'acme',
       defaultCulture: 'fr',
       allowedCultures: ['fr'],
@@ -74,7 +74,7 @@ describe('useUpdateSite', () => {
     result.current.mutate({ id: site.id, request });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(updateSite).toHaveBeenCalledWith(client, '', site.id, request);
+    expect(updateSite).toHaveBeenCalledWith(client, '/api/cms', site.id, request);
   });
 });
 
@@ -91,6 +91,6 @@ describe('useDeleteSite', () => {
     result.current.mutate(site.id);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(deleteSite).toHaveBeenCalledWith(client, '', site.id);
+    expect(deleteSite).toHaveBeenCalledWith(client, '/api/cms', site.id);
   });
 });

--- a/packages/@granit/react-cms/src/__tests__/use-sites.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-sites.test.ts
@@ -54,7 +54,7 @@ describe('useSites', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(listSites).toHaveBeenCalledWith(
       client,
-      '',
+      '/api/cms',
       undefined,
       expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
@@ -77,7 +77,7 @@ describe('useSites', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(listSites).toHaveBeenCalledWith(
       client,
-      '',
+      '/api/cms',
       { page: 1, pageSize: 10 },
       expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
@@ -96,7 +96,7 @@ describe('useSite', () => {
     const { result } = renderHook(() => useSite(site.id), { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getSite).toHaveBeenCalledWith(client, '', site.id);
+    expect(getSite).toHaveBeenCalledWith(client, '/api/cms', site.id);
     expect(result.current.data).toEqual(site);
   });
 

--- a/packages/@granit/react-cms/src/constants.ts
+++ b/packages/@granit/react-cms/src/constants.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_BASE_PATH = '';
+export const DEFAULT_BASE_PATH = '/api/cms';
 export const DEFAULT_QUERY_KEY_PREFIX = ['cms'] as const;


### PR DESCRIPTION
## Context

Recovered from a dangling stash (`refactor/dedup-hooks-storage`, "cms-path-comment-changes"). The stashed work was **runtime-complete but test-incomplete** — the API path construction had been refactored but the ~150 test assertions were never updated, so the suite failed. This PR finishes the job.

## What

Move the service-root prefix (`/api/cms`, `/api/cms/seo`, `/api/cms/redirects`) out of each individual API path and into the `DEFAULT_BASE_PATH` constant of the `react-cms*` packages. API functions in `@granit/cms*` now build paths **relative to the injected `basePath`**.

| Package | `DEFAULT_BASE_PATH` (was `''`) |
|---------|--------------------------------|
| `react-cms` | `/api/cms` |
| `react-cms-hostnames` | `/api/cms` |
| `react-cms-redirects` | `/api/cms/redirects` |
| `react-cms-seo` | `/api/cms/seo` |

**The resolved runtime URL is unchanged** (`DEFAULT_BASE_PATH` + relative path = the same `/api/cms/...`). MSW handlers, hooks, and integration paths are untouched.

## Test changes

- `@granit/cms*` unit tests: assertions updated to the new `basePath`-relative paths (`it()` labels keep the real backend route for documentation).
- `react-cms*` hook tests: the `basePath` arg / default-config assertions updated from `''` to the new `DEFAULT_BASE_PATH`.

## Verification

- ✅ `vitest run` — 262 passed across the 8 affected packages
- ✅ `eslint --max-warnings 0` on changed files
- ✅ `pnpm tsc` (repo-wide `--noEmit`) — clean
- ✅ pre-commit hook (gitleaks + lint-staged + tsc + front-index) passed