### PR TITLE
feat(dashboards): polish editor — Lumoz-style resize handles, tighter cards, shrinkable KPI

### DIFF
--- a/packages/@granit/react-analytics/src/editor/analytics-widget-catalog.ts
+++ b/packages/@granit/react-analytics/src/editor/analytics-widget-catalog.ts
@@ -33,7 +33,8 @@ export const analyticsWidgetCatalog: readonly WidgetCatalogEntry[] = Object.free
     iconKey: 'kpi',
     // Two rows so the framed tile fits its header + value without clipping.
     defaultSize: { width: 3, height: 2 },
-    minSize: { width: 2, height: 2 },
+    // A single cell is enough for the header + value once it can shrink.
+    minSize: { width: 1, height: 1 },
     createDefaultWidget: (slug): KpiWidgetDefinition => ({
       slug,
       type: 'kpi',

--- a/packages/@granit/react-dashboard-editor/README.md
+++ b/packages/@granit/react-dashboard-editor/README.md
@@ -45,6 +45,19 @@ declare these peers:
   behind `<EditableDashboard>`. Its stylesheet is **not** imported (a CSS
   side-effect import breaks workspace `tsc -r`); the editor inlines the
   essential rules itself.
+
+  > **Vite consumers:** `react-grid-layout` bundles `react-draggable`, whose
+  > drag handlers read `process.env.DRAGGABLE_DEBUG` at runtime. Vite's dep
+  > optimizer only auto-replaces `process.env.NODE_ENV`, so this reference reaches
+  > the browser and throws `process is not defined` on the first drag. Add a
+  > static replacement to your Vite config:
+  >
+  > ```ts
+  > export default defineConfig({
+  >   define: { 'process.env.DRAGGABLE_DEBUG': 'false' },
+  > });
+  > ```
+
 - `react-i18next` (`^17`) — `<WidgetPalette>`, `<WidgetConfigDrawer>`, and the
   built-in config forms resolve labels via `useTranslation()`.
 - `react` (`^19`).

--- a/packages/@granit/react-dashboard-editor/src/components/grid-styles.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/grid-styles.tsx
@@ -25,6 +25,19 @@ const GRID_CSS = `
   z-index: 2;
   user-select: none;
 }
+[data-slot="editable-dashboard"] .react-grid-item::before {
+  content: "";
+  position: absolute;
+  inset: -3px;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 0.75rem;
+  opacity: 0;
+  transition: opacity 120ms ease;
+  pointer-events: none;
+  z-index: 4;
+}
+[data-slot="editable-dashboard"] .react-grid-item:hover::before,
+[data-slot="editable-dashboard"] .react-grid-item.resizing::before { opacity: 1; }
 [data-slot="editable-dashboard"] .react-resizable-handle {
   position: absolute;
   width: 16px;
@@ -40,12 +53,24 @@ const GRID_CSS = `
   content: "";
   position: absolute;
   inset: 50% auto auto 50%;
-  width: 7px;
-  height: 7px;
+  width: 8px;
+  height: 8px;
   transform: translate(-50%, -50%);
-  border-radius: 9999px;
-  background: var(--color-primary, #6366f1);
+  border-radius: 3px;
+  background: var(--color-muted-foreground, #9ca3af);
   box-shadow: 0 0 0 2px var(--color-card, #fff);
+}
+[data-slot="editable-dashboard"] .react-resizable-handle-n::after,
+[data-slot="editable-dashboard"] .react-resizable-handle-s::after {
+  width: 18px;
+  height: 5px;
+  border-radius: 9999px;
+}
+[data-slot="editable-dashboard"] .react-resizable-handle-e::after,
+[data-slot="editable-dashboard"] .react-resizable-handle-w::after {
+  width: 5px;
+  height: 18px;
+  border-radius: 9999px;
 }
 [data-slot="editable-dashboard"] .react-resizable-handle-se { bottom: 0; right: 0; cursor: se-resize; }
 [data-slot="editable-dashboard"] .react-resizable-handle-sw { bottom: 0; left: 0; cursor: sw-resize; }
@@ -55,6 +80,15 @@ const GRID_CSS = `
 [data-slot="editable-dashboard"] .react-resizable-handle-s { bottom: 0; left: 50%; margin-left: -8px; cursor: s-resize; }
 [data-slot="editable-dashboard"] .react-resizable-handle-e { right: 0; top: 50%; margin-top: -8px; cursor: e-resize; }
 [data-slot="editable-dashboard"] .react-resizable-handle-w { left: 0; top: 50%; margin-top: -8px; cursor: w-resize; }
+/* Anchor each grip onto the widget edge/corner so it sits on the frame line. */
+[data-slot="editable-dashboard"] .react-resizable-handle-se::after { inset: auto 0 0 auto; transform: translate(50%, 50%); }
+[data-slot="editable-dashboard"] .react-resizable-handle-sw::after { inset: auto auto 0 0; transform: translate(-50%, 50%); }
+[data-slot="editable-dashboard"] .react-resizable-handle-ne::after { inset: 0 0 auto auto; transform: translate(50%, -50%); }
+[data-slot="editable-dashboard"] .react-resizable-handle-nw::after { inset: 0 auto auto 0; transform: translate(-50%, -50%); }
+[data-slot="editable-dashboard"] .react-resizable-handle-n::after { inset: 0 auto auto 50%; transform: translate(-50%, -50%); }
+[data-slot="editable-dashboard"] .react-resizable-handle-s::after { inset: auto auto 0 50%; transform: translate(-50%, 50%); }
+[data-slot="editable-dashboard"] .react-resizable-handle-e::after { inset: 50% 0 auto auto; transform: translate(50%, -50%); }
+[data-slot="editable-dashboard"] .react-resizable-handle-w::after { inset: 50% auto auto 0; transform: translate(-50%, -50%); }
 `;
 
 export function GridStyles() {

--- a/packages/@granit/react-dashboards/src/components/widget-card.tsx
+++ b/packages/@granit/react-dashboards/src/components/widget-card.tsx
@@ -15,7 +15,7 @@ export interface WidgetCardProps {
 }
 
 export function WidgetCard({ title, children, className }: WidgetCardProps) {
-  const root = ['flex h-full flex-col gap-3 rounded-xl border bg-card p-4 shadow-sm', className]
+  const root = ['flex h-full flex-col gap-2 rounded-xl border bg-card p-3 shadow-sm', className]
     .filter(Boolean)
     .join(' ');
 


### PR DESCRIPTION
## Summary

Visual polish pass on the dashboard editor surface (Epic #835 follow-up):

- **Resize handles** — replace the blue primary-coloured dots with a Lumoz-style grey **frame revealed on hover/resize** plus grey **grips** anchored on the widget edges (rounded squares at the corners, pills at the side midpoints). Grips use `--color-muted-foreground`, the frame `--color-border`. Still injected via the scoped `<style>` (no CSS side-effect import).
- **Widget card** — tighten padding around the title: `p-4`→`p-3`, header/body `gap-3`→`gap-2`.
- **KPI widget** — lower the catalog `minSize` from `2x2` to `1x1` so it can shrink to a single grid cell (default size unchanged at `3x2`).
- **Docs** — note the Vite `process.env.DRAGGABLE_DEBUG` define consumers need (react-draggable reads it at runtime; Vite only replaces `NODE_ENV`).

## Verification

- `pnpm tsc` (workspace): ✅
- ESLint on changed files (`--max-warnings 0`): ✅
- Tests: react-dashboard-editor 8/8, react-analytics 74/74 ✅