### PR TITLE
fix(dashboards): read queryName from the denormalized column for query-backed widgets

### DIFF
--- a/packages/@granit/dashboards/src/types/__tests__/widget-bridge.test.ts
+++ b/packages/@granit/dashboards/src/types/__tests__/widget-bridge.test.ts
@@ -44,6 +44,15 @@ interface MapWidgetStub extends WidgetDefinitionBase {
   };
 }
 
+interface ChartWidgetStub extends WidgetDefinitionBase {
+  readonly type: 'chart';
+  readonly queryName: string;
+  readonly groupBy: string;
+  readonly aggregation: string;
+  readonly field: string | null;
+  readonly chartType: string;
+}
+
 const DASHBOARD_NAME = 'Granit.Showcase.Demo';
 const ID = '8c6b1e10-0000-4000-8000-000000000001';
 const WIDGET_ID = '8c6b1e10-0000-0000-0000-000000000010';
@@ -123,6 +132,54 @@ describe('widgetInstanceToDefinition', () => {
     const widget = widgetInstanceToDefinition(instance, DASHBOARD_NAME);
     expect(widget.slug).toBe('Broken');
     expect(widget.type).toBe('markdown');
+  });
+
+  it('reads queryName from configJson for a query-backed widget (backend-corrected path)', () => {
+    const instance: WidgetInstanceResponse = {
+      id: WIDGET_ID,
+      widgetType: 'Chart',
+      x: 0,
+      y: 0,
+      width: 6,
+      height: 3,
+      titleLocalizationKey: `Widget:${DASHBOARD_NAME}.Cancellations`,
+      metricName: null,
+      queryName: 'Granit.Subscriptions.SubscriptionsQuery',
+      configJson: JSON.stringify({
+        queryName: 'Granit.Subscriptions.SubscriptionsQuery',
+        groupBy: 'Week',
+        aggregation: 'Count',
+        field: null,
+        chartType: 'Line',
+      }),
+      requiredPermission: null,
+    };
+    const widget = widgetInstanceToDefinition(instance, DASHBOARD_NAME) as ChartWidgetStub;
+    expect(widget.queryName).toBe('Granit.Subscriptions.SubscriptionsQuery');
+  });
+
+  it('falls back to the denormalized queryName column when configJson omits it (legacy dashboard)', () => {
+    const instance: WidgetInstanceResponse = {
+      id: WIDGET_ID,
+      widgetType: 'Chart',
+      x: 0,
+      y: 0,
+      width: 6,
+      height: 3,
+      titleLocalizationKey: `Widget:${DASHBOARD_NAME}.Cancellations`,
+      metricName: null,
+      // The denormalized column carries the query; the legacy configJson does not.
+      queryName: 'Granit.Subscriptions.SubscriptionsQuery',
+      configJson: JSON.stringify({
+        groupBy: 'Week',
+        aggregation: 'Count',
+        field: null,
+        chartType: 'Line',
+      }),
+      requiredPermission: null,
+    };
+    const widget = widgetInstanceToDefinition(instance, DASHBOARD_NAME) as ChartWidgetStub;
+    expect(widget.queryName).toBe('Granit.Subscriptions.SubscriptionsQuery');
   });
 });
 

--- a/packages/@granit/dashboards/src/types/widget-bridge.ts
+++ b/packages/@granit/dashboards/src/types/widget-bridge.ts
@@ -180,7 +180,21 @@ export function widgetInstanceToDefinition(
   // `widget.datasource` undefined and crashes `<KpiTile>`. KPI `actions` are
   // not part of `configJson` (no server-side Actions column for KPI), so they
   // don't round-trip through detail/edit — consistent with the backend.
-  const fields = instance.widgetType === 'Kpi' ? { datasource: parsed } : parsed;
+  // Chart / Table / Pivot / Map carry `queryName` as a denormalized column.
+  // Treat that column as the source of truth and overlay it onto the parsed
+  // config so the editor's Query field stays populated even for dashboards
+  // persisted before the backend started writing `queryName` into `configJson`.
+  // Side-effect, by design: for such a legacy dashboard the local widget now
+  // carries `queryName` while the server `configJson` does not, so the next
+  // `diffDashboardWidgets` marks it `updated` (recomputed `configJson` differs).
+  // This only persists on an explicit save and heals the stored record — not a
+  // bug. KPI is unchanged: its query lives inside the serialized `datasource`.
+  const fields =
+    instance.widgetType === 'Kpi'
+      ? { datasource: parsed }
+      : instance.queryName !== null
+        ? { ...parsed, queryName: instance.queryName }
+        : parsed;
   const widget: WidgetDefinitionBase & Readonly<Record<string, unknown>> = {
     ...fields,
     slug,


### PR DESCRIPTION
## Problème

`widgetInstanceToDefinition` (`@granit/dashboards`, `src/types/widget-bridge.ts`) reconstruisait les widgets query-backed (Chart / Table / Pivot / Map) **uniquement depuis `configJson`**. Les dashboards persistés **avant** le fix backend (granit-business) n'ont pas de `queryName` dans leur `configJson` — seule la colonne dénormalisée `WidgetInstanceResponse.queryName` le porte. Résultat : `queryName` arrivait `undefined` → **champ Query vide dans l'éditeur** pour ces dashboards importés/legacy.

## Fix

Pour les kinds query-backed (tout sauf KPI), la colonne dénormalisée `instance.queryName` devient la **source de vérité** et est superposée au config parsé. KPI inchangé (sa query vit dans le `datasource` sérialisé).

Le write-path n'est **pas** touché et reste symétrique avec le backend : `widgetFieldsToConfigJson` écrit déjà `queryName` dans `configJson` et `denormalizeReferences` le remonte dans la colonne.

### Effet de bord (voulu, documenté)
Pour un dashboard legacy, le read produit désormais un widget local portant `queryName` alors que le `configJson` serveur ne l'a pas → `diffDashboardWidgets` le marque `updated`. Persisté **uniquement à une sauvegarde explicite**, ce qui soigne l'enregistrement stocké. Ce n'est pas un bug.

## Tests

Ajoutés dans `widget-bridge.test.ts` :
- read d'un Chart dont le `configJson` contient `queryName` (backend corrigé) → `definition.queryName` correct ;
- read d'un Chart legacy (`configJson` sans `queryName`, colonne renseignée) → repris de la colonne ;
- round-trip KPI existant inchangé.

Fixtures (`react-dashboards/src/testing/data.ts`) et manifest (`contract-tests`) : **aucun changement requis** — les mocks dérivent `configJson`/`queryName` via le write-bridge (déjà alignés sur le contrat corrigé) et le manifest ne fige que `configJson: string` (opaque).

## Vérification (DoD)

- `widget-bridge.test.ts` : 24/24 ✅
- `@granit/react-dashboards` : 171/171 ✅
- ESLint (`--max-warnings 0`) : ✅
- `tsc` (`@granit/dashboards`) : ✅