### PR TITLE
feat(geocoding): address typeahead + reverse-geocoding packages

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1765,6 +1765,27 @@
       ]
     },
     {
+      "name": "@granit/geocoding",
+      "description": "Framework-agnostic types and HTTP client for Granit geocoding (address autocomplete + reverse)",
+      "exports": [
+        {
+          "name": "GeocodeMatchPrecision",
+          "kind": "type",
+          "signature": "type GeocodeMatchPrecision = 'Rooftop' | 'Street' | 'Locality'"
+        },
+        {
+          "name": "getAddressSuggestions",
+          "kind": "function",
+          "signature": "async function getAddressSuggestions( client: AxiosInstance, basePath: string, params: GeocodingAutocompleteParams, signal?: AbortSignal ): Promise<GeocodingAutocompleteResponse>"
+        },
+        {
+          "name": "getReverseGeocode",
+          "kind": "function",
+          "signature": "async function getReverseGeocode( client: AxiosInstance, basePath: string, params: GeocodingReverseParams, signal?: AbortSignal ): Promise<GeocodingReverseResponse>"
+        }
+      ]
+    },
+    {
       "name": "@granit/hostnames",
       "description": "Managed hostname types and API functions — mirrors Granit.Hostnames .NET contract",
       "exports": [
@@ -6013,6 +6034,61 @@
           "name": "SetFeatureOverrideVariables",
           "kind": "type",
           "signature": "type SetFeatureOverrideVariables = { readonly name: string; readonly request: SetFeatureOverrideRequest; }"
+        }
+      ]
+    },
+    {
+      "name": "@granit/react-geocoding",
+      "description": "React bindings for @granit/geocoding — GeocodingProvider, hooks and AddressAutocompleteInput",
+      "exports": [
+        {
+          "name": "useAddressSuggestions",
+          "kind": "function",
+          "signature": "function useAddressSuggestions( search: string, options: UseAddressSuggestionsOptions ="
+        },
+        {
+          "name": "useReverseGeocode",
+          "kind": "function",
+          "signature": "function useReverseGeocode( coordinate: Coordinate | null, options:"
+        },
+        {
+          "name": "Coordinate",
+          "kind": "interface",
+          "signature": "interface Coordinate",
+          "members": []
+        },
+        {
+          "name": "UseReverseGeocodeResult",
+          "kind": "interface",
+          "signature": "interface UseReverseGeocodeResult",
+          "members": []
+        },
+        {
+          "name": "useDebouncedValue",
+          "kind": "function",
+          "signature": "function useDebouncedValue<T>(value: T, delayMs: number): T"
+        },
+        {
+          "name": "AddressAutocompleteInput",
+          "kind": "function",
+          "signature": "function AddressAutocompleteInput(props: AddressAutocompleteInputProps): ReactElement"
+        },
+        {
+          "name": "AddressAutocompleteInputProps",
+          "kind": "interface",
+          "signature": "interface AddressAutocompleteInputProps extends Pick<",
+          "members": []
+        },
+        {
+          "name": "AddressPrecisionBadge",
+          "kind": "function",
+          "signature": "function AddressPrecisionBadge("
+        },
+        {
+          "name": "AddressPrecisionBadgeProps",
+          "kind": "interface",
+          "signature": "interface AddressPrecisionBadgeProps",
+          "members": []
         }
       ]
     },

--- a/contracts/openapi/geocoding.json
+++ b/contracts/openapi/geocoding.json
@@ -1,0 +1,310 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "geocoding",
+    "version": "1"
+  },
+  "paths": {
+    "/geocoding/autocomplete": {
+      "get": {
+        "tags": ["Geocoding"],
+        "summary": "Suggests addresses for a partial query (typeahead).",
+        "description": "Returns ranked address suggestions for the partial text. Mapped only when an autocomplete-capable provider is registered. High-volume (per-keystroke): the host should apply a per-principal rate-limit policy.",
+        "operationId": "GeocodeAutocomplete",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 5
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodingAutocompleteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/geocoding/reverse": {
+      "get": {
+        "tags": ["Geocoding"],
+        "summary": "Reverse-geocodes a coordinate to the nearest address.",
+        "description": "Returns the postal address nearest the given latitude/longitude. Mapped only when a reverse-capable provider is registered.",
+        "operationId": "GeocodeReverse",
+        "parameters": [
+          {
+            "name": "Lat",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+              "type": ["number", "string"],
+              "format": "double"
+            }
+          },
+          {
+            "name": "Lon",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+              "type": ["number", "string"],
+              "format": "double"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodingReverseResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeocodeMatchPrecision": {
+        "enum": ["Rooftop", "Street", "Locality"],
+        "description": "Granularity of a geocoding match, derived from the provider response (e.g. Nominatim\n`addresstype`/`place_rank`, Photon feature `type`). Drives whether a result is treated\nas AddressGeocodingStatus.Resolved or AddressGeocodingStatus.Approximate."
+      },
+      "GeocodingAutocompleteResponse": {
+        "required": ["suggestions"],
+        "type": "object",
+        "properties": {
+          "suggestions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeocodingSuggestionResponse"
+            }
+          }
+        }
+      },
+      "GeocodingReverseResponse": {
+        "required": ["street", "postalCode", "locality", "country", "precision"],
+        "type": "object",
+        "properties": {
+          "street": {
+            "type": ["null", "string"]
+          },
+          "postalCode": {
+            "type": ["null", "string"]
+          },
+          "locality": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          },
+          "precision": {
+            "$ref": "#/components/schemas/GeocodeMatchPrecision"
+          }
+        }
+      },
+      "GeocodingSuggestionResponse": {
+        "required": [
+          "label",
+          "street",
+          "postalCode",
+          "locality",
+          "country",
+          "latitude",
+          "longitude"
+        ],
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "street": {
+            "type": ["null", "string"]
+          },
+          "postalCode": {
+            "type": ["null", "string"]
+          },
+          "locality": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          },
+          "latitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "longitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Geocoding"
+    }
+  ]
+}

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -529,6 +529,19 @@ export const CONTRACTS: readonly ModuleContract[] = [
     types: ['MonitoringHealthResponse', 'ServiceHealthResponse'],
   },
   {
+    // Capability-gated endpoints — both routes (`/autocomplete`, `/reverse`) are
+    // served by `api/` functions. `GeocodeMatchPrecision` is a standalone string
+    // enum, verified indirectly via the `precision` field it backs.
+    slug: 'geocoding',
+    package: 'geocoding',
+    types: [
+      'GeocodingSuggestionResponse',
+      'GeocodingAutocompleteResponse',
+      'GeocodingReverseResponse',
+    ],
+    checkEndpoints: true,
+  },
+  {
     slug: 'hostnames',
     package: 'hostnames',
     types: [

--- a/packages/@granit/geocoding/README.md
+++ b/packages/@granit/geocoding/README.md
@@ -1,0 +1,65 @@
+# @granit/geocoding
+
+Framework-agnostic **geocoding** SDK — the TypeScript counterpart of the .NET
+`Granit.Geocoding` module (`granit-dotnet/src/Granit.Geocoding.Endpoints`).
+
+It exposes the wire types and HTTP client functions for the two
+**capability-gated** geocoding endpoints:
+
+- `getAddressSuggestions` → `GET {basePath}/autocomplete` — ranked address
+  suggestions for a partial query (typeahead).
+- `getReverseGeocode` → `GET {basePath}/reverse` — the postal address nearest a
+  latitude/longitude (the data half of a map pin-drop).
+
+It holds **no** React, DOM or Node-only dependency. The React layer (provider,
+hooks, `AddressAutocompleteInput`) lives in
+[`@granit/react-geocoding`](../react-geocoding).
+
+## Capability gating
+
+Both endpoints are mapped on the backend **only when a capable provider is
+installed**. When absent, the route 404s — callers should treat that as
+"feature unavailable, fall back to manual entry", never a hard error. The
+autocomplete endpoint is **high-volume** (per-keystroke) and the upstream
+provider quota is shared and billable: always debounce before calling it (the
+React hook does this for you) and let the backend rate-limit per principal.
+
+## Install
+
+Workspace-internal — consumed via the `@granit/*` Vite/Vitest aliases. Declare
+the peer:
+
+- `@granit/api-client` — the centralized Axios client (`AxiosInstance`) every
+  call takes as its first argument (interceptors: CSRF, auth, tenant).
+
+## Quick start
+
+```ts
+import { getAddressSuggestions, getReverseGeocode } from '@granit/geocoding';
+import type { AxiosInstance } from '@granit/api-client';
+
+const basePath = '/api/v1/geocoding';
+
+// Typeahead — pass an AbortSignal to cancel an in-flight request.
+const { suggestions } = await getAddressSuggestions(
+  client,
+  basePath,
+  { q: 'rue de la loi', limit: 5 },
+  controller.signal
+);
+
+// Reverse — handle 404 (no match / not mapped) and 422 (out of range) quietly.
+const address = await getReverseGeocode(client, basePath, { lat: 50.8467, lon: 4.3676 });
+```
+
+## Types
+
+Hand-written to mirror the backend DTOs field-for-field; conformance against
+`contracts/openapi/geocoding.json` is enforced by `@granit/contract-tests`.
+
+- `GeocodingSuggestionResponse` — `label`, structured components
+  (`street`/`postalCode`/`locality`/`country`, nullable where the provider gave
+  none) and optional `latitude`/`longitude`.
+- `GeocodingAutocompleteResponse` — `{ suggestions }`.
+- `GeocodingReverseResponse` — structured components + `precision`
+  (`GeocodeMatchPrecision`: `Rooftop` | `Street` | `Locality`).

--- a/packages/@granit/geocoding/package.json
+++ b/packages/@granit/geocoding/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@granit/geocoding",
+  "description": "Framework-agnostic types and HTTP client for Granit geocoding (address autocomplete + reverse)",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/testing": "workspace:*"
+  }
+}

--- a/packages/@granit/geocoding/src/__tests__/geocoding-api.test.ts
+++ b/packages/@granit/geocoding/src/__tests__/geocoding-api.test.ts
@@ -1,0 +1,75 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { getAddressSuggestions, getReverseGeocode } from '../api/geocoding-api';
+
+import type { GeocodingAutocompleteResponse, GeocodingReverseResponse } from '../types/index';
+
+const basePath = '/api/v1/geocoding';
+
+const sampleAutocomplete: GeocodingAutocompleteResponse = {
+  suggestions: [
+    {
+      label: 'Rue de la Loi 16, 1000 Brussels, BE',
+      street: 'Rue de la Loi 16',
+      postalCode: '1000',
+      locality: 'Brussels',
+      country: 'BE',
+      latitude: 50.8467,
+      longitude: 4.3676,
+    },
+  ],
+};
+
+const sampleReverse: GeocodingReverseResponse = {
+  street: 'Rue de la Loi 16',
+  postalCode: '1000',
+  locality: 'Brussels',
+  country: 'BE',
+  precision: 'Rooftop',
+};
+
+describe('geocoding-api', () => {
+  describe('getAddressSuggestions', () => {
+    it('should GET {basePath}/autocomplete with q + limit query params', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleAutocomplete });
+
+      const result = await getAddressSuggestions(client, basePath, { q: 'rue de la', limit: 8 });
+
+      expect(client.get).toHaveBeenCalledWith('/api/v1/geocoding/autocomplete', {
+        params: { q: 'rue de la', limit: 8 },
+        signal: undefined,
+      });
+      expect(result).toEqual(sampleAutocomplete);
+    });
+
+    it('should forward the abort signal so callers can cancel in-flight requests', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleAutocomplete });
+      const controller = new AbortController();
+
+      await getAddressSuggestions(client, basePath, { q: 'rue' }, controller.signal);
+
+      expect(client.get).toHaveBeenCalledWith('/api/v1/geocoding/autocomplete', {
+        params: { q: 'rue', limit: undefined },
+        signal: controller.signal,
+      });
+    });
+  });
+
+  describe('getReverseGeocode', () => {
+    it('should GET {basePath}/reverse with lat + lon query params', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleReverse });
+
+      const result = await getReverseGeocode(client, basePath, { lat: 50.8467, lon: 4.3676 });
+
+      expect(client.get).toHaveBeenCalledWith('/api/v1/geocoding/reverse', {
+        params: { lat: 50.8467, lon: 4.3676 },
+        signal: undefined,
+      });
+      expect(result).toEqual(sampleReverse);
+    });
+  });
+});

--- a/packages/@granit/geocoding/src/api/geocoding-api.ts
+++ b/packages/@granit/geocoding/src/api/geocoding-api.ts
@@ -1,0 +1,57 @@
+import type {
+  GeocodingAutocompleteParams,
+  GeocodingAutocompleteResponse,
+  GeocodingReverseParams,
+  GeocodingReverseResponse,
+} from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Suggest addresses for a partial query (typeahead).
+ *
+ * High-volume endpoint — the upstream provider quota is a shared resource, so
+ * callers MUST debounce input before invoking this (see
+ * `@granit/react-geocoding`). Pass an `AbortSignal` to cancel an in-flight
+ * request when the input changes.
+ *
+ * The endpoint is **capability-gated**: when no autocomplete-capable provider
+ * is installed it is not mapped and the request 404s — treat that as "feature
+ * unavailable, fall back to manual entry" rather than a hard error.
+ *
+ * `GET {basePath}/autocomplete?q={q}&limit={limit}`
+ */
+export async function getAddressSuggestions(
+  client: AxiosInstance,
+  basePath: string,
+  params: GeocodingAutocompleteParams,
+  signal?: AbortSignal
+): Promise<GeocodingAutocompleteResponse> {
+  const response = await client.get<GeocodingAutocompleteResponse>(`${basePath}/autocomplete`, {
+    params: { q: params.q, limit: params.limit },
+    signal,
+  });
+  return response.data;
+}
+
+/**
+ * Reverse-geocode a coordinate to the nearest postal address.
+ *
+ * The endpoint is **capability-gated**: when no reverse-capable provider is
+ * installed it is not mapped (404). When mapped, an out-of-range coordinate is
+ * rejected with `422` and a coordinate that resolves to nothing returns `404` —
+ * callers should handle both quietly.
+ *
+ * `GET {basePath}/reverse?lat={lat}&lon={lon}`
+ */
+export async function getReverseGeocode(
+  client: AxiosInstance,
+  basePath: string,
+  params: GeocodingReverseParams,
+  signal?: AbortSignal
+): Promise<GeocodingReverseResponse> {
+  const response = await client.get<GeocodingReverseResponse>(`${basePath}/reverse`, {
+    params: { lat: params.lat, lon: params.lon },
+    signal,
+  });
+  return response.data;
+}

--- a/packages/@granit/geocoding/src/index.ts
+++ b/packages/@granit/geocoding/src/index.ts
@@ -1,0 +1,12 @@
+// Types
+export type {
+  GeocodingAutocompleteParams,
+  GeocodingAutocompleteResponse,
+  GeocodingReverseParams,
+  GeocodingReverseResponse,
+  GeocodingSuggestionResponse,
+} from './types/index';
+export { GeocodeMatchPrecision } from './types/index';
+
+// API
+export { getAddressSuggestions, getReverseGeocode } from './api/geocoding-api';

--- a/packages/@granit/geocoding/src/types/index.ts
+++ b/packages/@granit/geocoding/src/types/index.ts
@@ -1,0 +1,82 @@
+/**
+ * Granularity of a reverse-geocoding match. Mirrors the .NET
+ * `Granit.Domain.ValueObjects.GeocodeMatchPrecision` enum (string-serialized).
+ *
+ * - `Rooftop` — matched to an exact building / house number.
+ * - `Street` — matched to a street (interpolated along the road).
+ * - `Locality` — matched only to a locality / postcode centroid (coarse).
+ */
+export type GeocodeMatchPrecision = 'Rooftop' | 'Street' | 'Locality';
+
+/** Convenience map mirroring the .NET enum names. */
+export const GeocodeMatchPrecision = {
+  Rooftop: 'Rooftop',
+  Street: 'Street',
+  Locality: 'Locality',
+} as const satisfies Record<string, GeocodeMatchPrecision>;
+
+/**
+ * A single address-autocomplete suggestion, flattened for the wire. Mirrors the
+ * .NET `GeocodingSuggestionResponse`.
+ *
+ * `latitude`/`longitude` are `null` when the provider returned no coordinate;
+ * `street`/`postalCode` are `null` when the provider matched only to a locality.
+ */
+export interface GeocodingSuggestionResponse {
+  /** Human-readable one-line label for the typeahead list. */
+  readonly label: string;
+  /** Street line, or `null`. */
+  readonly street: string | null;
+  /** Postal code, or `null`. */
+  readonly postalCode: string | null;
+  /** Locality (city/town). */
+  readonly locality: string;
+  /** Country (ISO 3166-1 alpha-2 where known). */
+  readonly country: string;
+  /** Latitude, or `null` when the provider returned no coordinate. */
+  readonly latitude: number | null;
+  /** Longitude, or `null` when the provider returned no coordinate. */
+  readonly longitude: number | null;
+}
+
+/**
+ * The address-autocomplete suggestions for a partial query. Mirrors the .NET
+ * `GeocodingAutocompleteResponse`.
+ */
+export interface GeocodingAutocompleteResponse {
+  /** The suggestions, best match first (possibly empty). */
+  readonly suggestions: readonly GeocodingSuggestionResponse[];
+}
+
+/**
+ * The postal address nearest a reverse-geocoded coordinate. Mirrors the .NET
+ * `GeocodingReverseResponse`.
+ */
+export interface GeocodingReverseResponse {
+  /** Street line, or `null`. */
+  readonly street: string | null;
+  /** Postal code, or `null`. */
+  readonly postalCode: string | null;
+  /** Locality (city/town). */
+  readonly locality: string;
+  /** Country (ISO 3166-1 alpha-2). */
+  readonly country: string;
+  /** Match granularity (rooftop / street / locality). */
+  readonly precision: GeocodeMatchPrecision;
+}
+
+/** Query parameters for the address-autocomplete endpoint. */
+export interface GeocodingAutocompleteParams {
+  /** Partial address text to suggest for. */
+  readonly q: string;
+  /** Maximum number of suggestions. Backend default: `5`. */
+  readonly limit?: number;
+}
+
+/** Query parameters for the reverse-geocoding endpoint. */
+export interface GeocodingReverseParams {
+  /** Latitude in decimal degrees, in the range [-90, 90]. */
+  readonly lat: number;
+  /** Longitude in decimal degrees, in the range [-180, 180]. */
+  readonly lon: number;
+}

--- a/packages/@granit/geocoding/tsconfig.json
+++ b/packages/@granit/geocoding/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/geocoding/tsup.config.ts
+++ b/packages/@granit/geocoding/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-geocoding/README.md
+++ b/packages/@granit/react-geocoding/README.md
@@ -1,0 +1,96 @@
+# @granit/react-geocoding
+
+React bindings for [`@granit/geocoding`](../geocoding) — a provider, React Query
+hooks and a ready-to-use **address autocomplete** input.
+
+## What's inside
+
+- **`GeocodingProvider`** — supplies the Axios `client` + `basePath` (defaults to
+  `/api/v1/geocoding`) to the hooks. Built on the shared `createConfigProvider`
+  factory; `useGeocodingConfig` / `useOptionalGeocodingConfig` read it.
+- **`useAddressSuggestions(search, options)`** — debounced typeahead hook.
+  Returns ranked `suggestions` plus `isLoading` / `isError` / `isUnavailable`.
+- **`useReverseGeocode(coordinate, options)`** — headless reverse-geocoding for a
+  map pin-drop. Returns the nearest `address` (or `null` for a soft 404/422 miss).
+- **`AddressAutocompleteInput`** — an accessible (WAI-ARIA combobox) text input
+  that suggests addresses as you type and hands the structured components to the
+  caller on select.
+- **`AddressPrecisionBadge`** — a read-only badge for a reverse result's
+  `precision` ("Exact location" / "Approximate location").
+
+## Progressive enhancement
+
+Geocoding is **never a hard dependency**. When no `GeocodingProvider` is in
+scope, or the endpoint is not mapped (provider not installed → 404), the hooks
+report `isUnavailable` and `AddressAutocompleteInput` silently behaves as a plain
+text input — so a form keeps working with manual entry. Input is debounced
+(~275 ms) before it reaches the shared, rate-limited provider, and in-flight
+requests are cancelled when the text changes.
+
+## Quick start
+
+```tsx
+import { GeocodingProvider, AddressAutocompleteInput } from '@granit/react-geocoding';
+
+function BillingAddressField() {
+  const [text, setText] = useState('');
+  return (
+    <AddressAutocompleteInput
+      aria-label="Billing address"
+      value={text}
+      onValueChange={setText}
+      onSelect={(s) => {
+        // Fill the bound form fields from the structured components.
+        form.setValue('line1', s.street ?? '');
+        form.setValue('postalCode', s.postalCode ?? '');
+        form.setValue('city', s.locality);
+        form.setValue('country', s.country);
+        if (s.latitude != null && s.longitude != null) {
+          form.setValue('coordinate', { lat: s.latitude, lon: s.longitude });
+        }
+      }}
+    />
+  );
+}
+
+// Mount once, high in the tree (client comes from <GranitClientProvider>):
+<GeocodingProvider config={{}}>
+  <BillingAddressField />
+</GeocodingProvider>;
+```
+
+### Reverse pin-drop
+
+`@granit/react-map` is presentation-only (no interactive click callback), so the
+reverse flow is intentionally headless — wire `useReverseGeocode` to whichever
+map your app uses:
+
+```tsx
+const { address } = useReverseGeocode(pin); // pin: { lat, lon } | null
+useEffect(() => {
+  if (address) prefillForm(address);
+}, [address]);
+```
+
+## i18n
+
+User-facing copy lives in the `geocoding` namespace (brand-neutral). Register the
+bundles with your i18n instance:
+
+```ts
+import { geocodingTranslationsEn, geocodingTranslationsFr } from '@granit/react-geocoding';
+
+i18n.addResourceBundle('en', 'geocoding', geocodingTranslationsEn);
+i18n.addResourceBundle('fr', 'geocoding', geocodingTranslationsFr);
+```
+
+## Testing
+
+`@granit/react-geocoding/testing` ships MSW handlers and fixtures:
+
+```ts
+import {
+  createGeocodingHandlers,
+  createUnavailableGeocodingHandlers,
+} from '@granit/react-geocoding/testing';
+```

--- a/packages/@granit/react-geocoding/package.json
+++ b/packages/@granit/react-geocoding/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@granit/react-geocoding",
+  "description": "React bindings for @granit/geocoding — GeocodingProvider, hooks and AddressAutocompleteInput",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/geocoding": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/utils": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "msw": "^2.12.0",
+    "react": "^19.0.0",
+    "react-i18next": "^17.0.0"
+  },
+  "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "import": "./dist/testing/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/geocoding": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/react-ui": "workspace:*",
+    "@granit/testing": "workspace:*",
+    "@granit/utils": "workspace:*"
+  }
+}

--- a/packages/@granit/react-geocoding/src/__tests__/address-autocomplete-input.test.tsx
+++ b/packages/@granit/react-geocoding/src/__tests__/address-autocomplete-input.test.tsx
@@ -1,0 +1,132 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient, axiosResponse } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import i18next from 'i18next';
+import * as React from 'react';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { AddressAutocompleteInput } from '../components/address-autocomplete-input';
+import { geocodingTranslationsEn } from '../locales/en';
+import { GeocodingProvider } from '../providers/geocoding-provider';
+import { sampleSuggestions } from '../testing/data';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { GeocodingSuggestionResponse } from '@granit/geocoding';
+
+beforeAll(async () => {
+  if (!i18next.isInitialized) {
+    await i18next.use(initReactI18next).init({
+      lng: 'en',
+      fallbackLng: 'en',
+      ns: ['geocoding'],
+      defaultNS: 'geocoding',
+      resources: { en: { geocoding: geocodingTranslationsEn } },
+      interpolation: { escapeValue: false },
+      returnNull: false,
+    });
+  }
+});
+
+function httpError(status: number): unknown {
+  return { response: { status } };
+}
+
+function renderInput(client: AxiosInstance, onSelect = vi.fn()) {
+  const queryClient = createTestQueryClient();
+
+  function Harness() {
+    const [value, setValue] = React.useState('');
+    return (
+      <AddressAutocompleteInput
+        aria-label="Address"
+        value={value}
+        onValueChange={setValue}
+        onSelect={onSelect}
+        debounceMs={0}
+      />
+    );
+  }
+
+  render(
+    <I18nextProvider i18n={i18next}>
+      <QueryClientProvider client={queryClient}>
+        <GeocodingProvider config={{ client, basePath: '/api/v1/geocoding' }}>
+          <Harness />
+        </GeocodingProvider>
+      </QueryClientProvider>
+    </I18nextProvider>
+  );
+
+  return { onSelect };
+}
+
+function typeAddress(text: string): void {
+  const input = screen.getByRole('combobox');
+  fireEvent.focus(input);
+  fireEvent.change(input, { target: { value: text } });
+}
+
+describe('AddressAutocompleteInput', () => {
+  it('shows suggestions as the user types', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ suggestions: sampleSuggestions }));
+
+    renderInput(client);
+    typeAddress('rue de la');
+
+    expect(await screen.findByText(sampleSuggestions[0]!.label)).toBeInTheDocument();
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getAllByRole('option')).toHaveLength(sampleSuggestions.length);
+  });
+
+  it('fills the form from the structured components on select', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ suggestions: sampleSuggestions }));
+    const onSelect = vi.fn<(s: GeocodingSuggestionResponse) => void>();
+
+    renderInput(client, onSelect);
+    typeAddress('rue de la');
+
+    const option = await screen.findByText(sampleSuggestions[0]!.label);
+    fireEvent.mouseDown(option);
+
+    expect(onSelect).toHaveBeenCalledWith(sampleSuggestions[0]);
+    expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe(
+      sampleSuggestions[0]!.label
+    );
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('shows a no-results message when the query returns nothing', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ suggestions: [] }));
+
+    renderInput(client);
+    typeAddress('zzzzzz');
+
+    expect(await screen.findByText(geocodingTranslationsEn.NoResults)).toBeInTheDocument();
+  });
+
+  it('shows an error message when the request fails', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(httpError(500));
+
+    renderInput(client);
+    typeAddress('rue de la');
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(geocodingTranslationsEn.Error);
+  });
+
+  it('falls back to a plain input (no listbox) when the endpoint is absent (404)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(httpError(404));
+
+    renderInput(client);
+    typeAddress('rue de la');
+
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+  });
+});

--- a/packages/@granit/react-geocoding/src/__tests__/address-precision-badge.test.tsx
+++ b/packages/@granit/react-geocoding/src/__tests__/address-precision-badge.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import i18next from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { AddressPrecisionBadge } from '../components/address-precision-badge';
+import { geocodingTranslationsEn } from '../locales/en';
+
+beforeAll(async () => {
+  if (!i18next.isInitialized) {
+    await i18next.use(initReactI18next).init({
+      lng: 'en',
+      fallbackLng: 'en',
+      ns: ['geocoding'],
+      defaultNS: 'geocoding',
+      resources: { en: { geocoding: geocodingTranslationsEn } },
+      interpolation: { escapeValue: false },
+      returnNull: false,
+    });
+  }
+});
+
+function renderBadge(precision: 'Rooftop' | 'Street' | 'Locality') {
+  return render(
+    <I18nextProvider i18n={i18next}>
+      <AddressPrecisionBadge precision={precision} />
+    </I18nextProvider>
+  );
+}
+
+describe('AddressPrecisionBadge', () => {
+  it('renders the rooftop label as an exact location', () => {
+    renderBadge('Rooftop');
+    expect(screen.getByText(geocodingTranslationsEn.Precision.Rooftop)).toBeInTheDocument();
+  });
+
+  it('renders the locality label as an approximate location', () => {
+    renderBadge('Locality');
+    expect(screen.getByText(geocodingTranslationsEn.Precision.Locality)).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-geocoding/src/__tests__/geocoding-provider.test.tsx
+++ b/packages/@granit/react-geocoding/src/__tests__/geocoding-provider.test.tsx
@@ -1,0 +1,67 @@
+import { renderHook } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_BASE_PATH } from '../constants';
+import {
+  GeocodingProvider,
+  buildGeocodingQueryKey,
+  useGeocodingConfig,
+  useOptionalGeocodingConfig,
+} from '../providers/geocoding-provider';
+
+import type { GeocodingConfig } from '../providers/geocoding-provider';
+import type { AxiosInstance } from '@granit/api-client';
+
+const mockConfig: GeocodingConfig = {
+  client: {} as AxiosInstance,
+  basePath: DEFAULT_BASE_PATH,
+};
+
+function createWrapper(config: GeocodingConfig) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <GeocodingProvider config={config}>{children}</GeocodingProvider>;
+  };
+}
+
+describe('GeocodingProvider', () => {
+  it('provides config via useGeocodingConfig', () => {
+    const { result } = renderHook(() => useGeocodingConfig(), {
+      wrapper: createWrapper(mockConfig),
+    });
+
+    expect(result.current.client).toBe(mockConfig.client);
+    expect(result.current.basePath).toBe(DEFAULT_BASE_PATH);
+  });
+
+  it('defaults the basePath when omitted', () => {
+    const { result } = renderHook(() => useGeocodingConfig(), {
+      wrapper: createWrapper({ client: {} as AxiosInstance }),
+    });
+
+    expect(result.current.basePath).toBe(DEFAULT_BASE_PATH);
+  });
+
+  it('returns null from useOptionalGeocodingConfig outside a provider', () => {
+    const { result } = renderHook(() => useOptionalGeocodingConfig());
+    expect(result.current).toBeNull();
+  });
+});
+
+describe('buildGeocodingQueryKey', () => {
+  it('uses the default prefix', () => {
+    expect(buildGeocodingQueryKey({}, 'autocomplete', 'rue')).toEqual([
+      'geocoding',
+      'autocomplete',
+      'rue',
+    ]);
+  });
+
+  it('honours a custom prefix', () => {
+    expect(buildGeocodingQueryKey({ queryKeyPrefix: ['x', 'geo'] }, 'reverse')).toEqual([
+      'x',
+      'geo',
+      'reverse',
+    ]);
+  });
+});

--- a/packages/@granit/react-geocoding/src/__tests__/use-address-suggestions.test.tsx
+++ b/packages/@granit/react-geocoding/src/__tests__/use-address-suggestions.test.tsx
@@ -1,0 +1,76 @@
+import { composeWrappers, createQueryWrapper } from '@granit/react-testing';
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useAddressSuggestions } from '../hooks/use-address-suggestions';
+import { GeocodingProvider } from '../providers/geocoding-provider';
+import { sampleSuggestions } from '../testing/data';
+
+import type { GeocodingConfig } from '../providers/geocoding-provider';
+import type { AxiosInstance } from '@granit/api-client';
+
+function wrapperFor(client: AxiosInstance) {
+  const config: GeocodingConfig = { client, basePath: '/api/v1/geocoding' };
+  return composeWrappers(createQueryWrapper(), ({ children }) => (
+    <GeocodingProvider config={config}>{children}</GeocodingProvider>
+  ));
+}
+
+/** An Axios-style rejection carrying an HTTP status. */
+function httpError(status: number): unknown {
+  return { response: { status } };
+}
+
+describe('useAddressSuggestions', () => {
+  it('stays disabled below the minimum query length', () => {
+    const client = createMockClient();
+
+    const { result } = renderHook(() => useAddressSuggestions('ru', { debounceMs: 0 }), {
+      wrapper: wrapperFor(client),
+    });
+
+    expect(client.get).not.toHaveBeenCalled();
+    expect(result.current.suggestions).toEqual([]);
+  });
+
+  it('queries and exposes suggestions once the term is long enough', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ suggestions: sampleSuggestions }));
+
+    const { result } = renderHook(() => useAddressSuggestions('rue de la', { debounceMs: 0 }), {
+      wrapper: wrapperFor(client),
+    });
+
+    await waitFor(() => expect(result.current.suggestions.length).toBe(sampleSuggestions.length));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/geocoding/autocomplete', {
+      params: { q: 'rue de la', limit: 5 },
+      signal: expect.any(AbortSignal),
+    });
+    expect(result.current.isUnavailable).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('reports isUnavailable (not isError) on a 404 — the capability is absent', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(httpError(404));
+
+    const { result } = renderHook(() => useAddressSuggestions('rue de la', { debounceMs: 0 }), {
+      wrapper: wrapperFor(client),
+    });
+
+    await waitFor(() => expect(result.current.isUnavailable).toBe(true));
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('reports isUnavailable and never queries when no provider is in scope', () => {
+    const client = createMockClient();
+
+    const { result } = renderHook(() => useAddressSuggestions('rue de la', { debounceMs: 0 }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    expect(client.get).not.toHaveBeenCalled();
+    expect(result.current.isUnavailable).toBe(true);
+  });
+});

--- a/packages/@granit/react-geocoding/src/__tests__/use-reverse-geocode.test.tsx
+++ b/packages/@granit/react-geocoding/src/__tests__/use-reverse-geocode.test.tsx
@@ -1,0 +1,74 @@
+import { composeWrappers, createQueryWrapper } from '@granit/react-testing';
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useReverseGeocode } from '../hooks/use-reverse-geocode';
+import { GeocodingProvider } from '../providers/geocoding-provider';
+import { sampleReverseAddress } from '../testing/data';
+
+import type { GeocodingConfig } from '../providers/geocoding-provider';
+import type { AxiosInstance } from '@granit/api-client';
+
+function wrapperFor(client: AxiosInstance) {
+  const config: GeocodingConfig = { client, basePath: '/api/v1/geocoding' };
+  return composeWrappers(createQueryWrapper(), ({ children }) => (
+    <GeocodingProvider config={config}>{children}</GeocodingProvider>
+  ));
+}
+
+function httpError(status: number): unknown {
+  return { response: { status } };
+}
+
+describe('useReverseGeocode', () => {
+  it('stays disabled when no coordinate is given', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => useReverseGeocode(null), { wrapper: wrapperFor(client) });
+
+    expect(client.get).not.toHaveBeenCalled();
+    expect(result.current.address).toBeNull();
+  });
+
+  it('resolves the nearest address for a coordinate', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleReverseAddress));
+
+    const { result } = renderHook(() => useReverseGeocode({ lat: 50.8467, lon: 4.3676 }), {
+      wrapper: wrapperFor(client),
+    });
+
+    await waitFor(() => expect(result.current.address).toEqual(sampleReverseAddress));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/geocoding/reverse', {
+      params: { lat: 50.8467, lon: 4.3676 },
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it('treats a 422 (out of range) as a quiet no-result, not an error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(httpError(422));
+
+    const { result } = renderHook(() => useReverseGeocode({ lat: 999, lon: 0 }), {
+      wrapper: wrapperFor(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.address).toBeNull();
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isUnavailable).toBe(false);
+  });
+
+  it('treats a 404 as unavailable', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(httpError(404));
+
+    const { result } = renderHook(() => useReverseGeocode({ lat: 0, lon: 0 }), {
+      wrapper: wrapperFor(client),
+    });
+
+    await waitFor(() => expect(result.current.isUnavailable).toBe(true));
+    expect(result.current.address).toBeNull();
+    expect(result.current.isError).toBe(false);
+  });
+});

--- a/packages/@granit/react-geocoding/src/components/address-autocomplete-input.tsx
+++ b/packages/@granit/react-geocoding/src/components/address-autocomplete-input.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import { Input, Spinner } from '@granit/react-ui';
+import { cn } from '@granit/utils';
+import { useCallback, useId, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { I18N_NAMESPACE } from '../constants';
+import { useAddressSuggestions } from '../hooks/use-address-suggestions';
+
+import type { UseAddressSuggestionsOptions } from '../hooks/use-address-suggestions';
+import type { GeocodingSuggestionResponse } from '@granit/geocoding';
+import type { KeyboardEvent, ReactElement } from 'react';
+
+export interface AddressAutocompleteInputProps extends Pick<
+  UseAddressSuggestionsOptions,
+  'limit' | 'debounceMs' | 'minQueryLength'
+> {
+  /** Current input text (controlled). */
+  readonly value: string;
+  /** Called as the user types (the raw text). */
+  readonly onValueChange: (next: string) => void;
+  /**
+   * Called when the user picks a suggestion. Fill the bound address form fields
+   * from the structured components (`street`/`postalCode`/`locality`/`country`)
+   * and keep `latitude`/`longitude` if present.
+   */
+  readonly onSelect: (suggestion: GeocodingSuggestionResponse) => void;
+  readonly id?: string;
+  readonly name?: string;
+  readonly placeholder?: string;
+  readonly disabled?: boolean;
+  readonly required?: boolean;
+  readonly className?: string;
+  readonly 'aria-label'?: string;
+  readonly 'aria-labelledby'?: string;
+}
+
+/**
+ * Address typeahead: an accessible (WAI-ARIA combobox) input that suggests
+ * addresses as the user types and, on selection, hands the caller the
+ * structured components to fill a form.
+ *
+ * **Progressive enhancement.** When no `GeocodingProvider` is in scope, or the
+ * endpoint is not mapped (provider not installed → 404), the dropdown never
+ * opens and the field behaves as a plain text input — geocoding is never a hard
+ * dependency. Input is debounced before it reaches the (shared, rate-limited)
+ * provider, and in-flight requests are cancelled when the text changes.
+ */
+export function AddressAutocompleteInput(props: AddressAutocompleteInputProps): ReactElement {
+  const {
+    value,
+    onValueChange,
+    onSelect,
+    id,
+    name,
+    placeholder,
+    disabled = false,
+    required = false,
+    className,
+    limit,
+    debounceMs,
+    minQueryLength,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
+  } = props;
+
+  const { t } = useTranslation(I18N_NAMESPACE);
+  const reactId = useId();
+  const listboxId = `${id ?? reactId}-listbox`;
+  const getOptionId = useCallback((index: number) => `${listboxId}-option-${index}`, [listboxId]);
+
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  // A selection writes the label back into `value`; suppress the re-query that
+  // the resulting text change would otherwise trigger.
+  const suppressQueryRef = useRef(false);
+
+  const { suggestions, isLoading, isFetching, isSuccess, isError, isUnavailable } =
+    useAddressSuggestions(value, {
+      limit,
+      debounceMs,
+      minQueryLength,
+      enabled: open && !suppressQueryRef.current,
+    });
+
+  // When the capability is absent we degrade to a plain text input.
+  const enhanced = !isUnavailable;
+  const showList =
+    enhanced && open && (suggestions.length > 0 || isLoading || isFetching || isError || isSuccess);
+
+  const pick = useCallback(
+    (suggestion: GeocodingSuggestionResponse | undefined) => {
+      if (!suggestion) return;
+      suppressQueryRef.current = true;
+      onValueChange(suggestion.label);
+      onSelect(suggestion);
+      setOpen(false);
+      setActiveIndex(-1);
+    },
+    [onSelect, onValueChange]
+  );
+
+  const onInputChange = useCallback(
+    (next: string) => {
+      suppressQueryRef.current = false;
+      onValueChange(next);
+      setOpen(true);
+      setActiveIndex(-1);
+    },
+    [onValueChange]
+  );
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (!enhanced) return;
+      switch (event.key) {
+        case 'ArrowDown':
+          if (suggestions.length === 0) return;
+          event.preventDefault();
+          setOpen(true);
+          setActiveIndex((i) => (i + 1) % suggestions.length);
+          break;
+        case 'ArrowUp':
+          if (suggestions.length === 0) return;
+          event.preventDefault();
+          setOpen(true);
+          setActiveIndex((i) => (i <= 0 ? suggestions.length - 1 : i - 1));
+          break;
+        case 'Enter':
+          if (open && activeIndex >= 0) {
+            event.preventDefault();
+            pick(suggestions[activeIndex]);
+          }
+          break;
+        case 'Escape':
+          setOpen(false);
+          setActiveIndex(-1);
+          break;
+        default:
+          break;
+      }
+    },
+    [enhanced, suggestions, open, activeIndex, pick]
+  );
+
+  const activeDescendant = open && activeIndex >= 0 ? getOptionId(activeIndex) : undefined;
+
+  return (
+    <div className={cn('relative', className)}>
+      <Input
+        id={id}
+        name={name}
+        type="text"
+        autoComplete="off"
+        role="combobox"
+        aria-expanded={showList}
+        aria-controls={listboxId}
+        aria-autocomplete="list"
+        aria-activedescendant={activeDescendant}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        value={value}
+        placeholder={placeholder ?? t('SearchPlaceholder')}
+        disabled={disabled}
+        required={required}
+        onChange={(event) => onInputChange(event.target.value)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => {
+          // Defer so a pointer-down on an option still registers as a pick.
+          window.setTimeout(() => setOpen(false), 120);
+        }}
+        onKeyDown={onKeyDown}
+      />
+
+      {(isLoading || isFetching) && enhanced ? (
+        <Spinner
+          size="sm"
+          aria-hidden
+          className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+        />
+      ) : null}
+
+      {showList ? (
+        <ul
+          id={listboxId}
+          role="listbox"
+          className="absolute z-50 mt-1 max-h-72 w-full overflow-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
+        >
+          {isError ? (
+            <li role="alert" className="px-3 py-2 text-sm text-destructive">
+              {t('Error')}
+            </li>
+          ) : null}
+
+          {!isError && suggestions.length === 0 && !isLoading && !isFetching ? (
+            <li className="px-3 py-2 text-sm text-muted-foreground">{t('NoResults')}</li>
+          ) : null}
+
+          {suggestions.map((suggestion, index) => (
+            <li
+              key={`${suggestion.label}-${index}`}
+              id={getOptionId(index)}
+              role="option"
+              aria-selected={index === activeIndex}
+              className={cn(
+                'cursor-pointer rounded-sm px-3 py-2 text-sm',
+                index === activeIndex ? 'bg-accent text-accent-foreground' : 'text-foreground'
+              )}
+              onMouseEnter={() => setActiveIndex(index)}
+              // `onMouseDown` (not `onClick`) so the pick beats the input's blur.
+              onMouseDown={(event) => {
+                event.preventDefault();
+                pick(suggestion);
+              }}
+            >
+              {suggestion.label}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/@granit/react-geocoding/src/components/address-precision-badge.tsx
+++ b/packages/@granit/react-geocoding/src/components/address-precision-badge.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Badge } from '@granit/react-ui';
+import { useTranslation } from 'react-i18next';
+
+import { I18N_NAMESPACE } from '../constants';
+
+import type { GeocodeMatchPrecision } from '@granit/geocoding';
+import type { ComponentProps, ReactElement } from 'react';
+
+type BadgeVariant = ComponentProps<typeof Badge>['variant'];
+
+const VARIANT_BY_PRECISION: Record<GeocodeMatchPrecision, BadgeVariant> = {
+  Rooftop: 'default',
+  Street: 'secondary',
+  Locality: 'outline',
+};
+
+export interface AddressPrecisionBadgeProps {
+  /** The match granularity returned by the reverse-geocoding endpoint. */
+  readonly precision: GeocodeMatchPrecision;
+  readonly className?: string;
+}
+
+/**
+ * Read-only badge surfacing how precisely an address was geocoded — e.g.
+ * "Exact location" (rooftop) vs "Approximate location" (locality centroid).
+ * Fed by the `precision` of a {@link useReverseGeocode} result; the label comes
+ * from the `geocoding` i18n namespace, so user-facing copy stays brand-neutral.
+ */
+export function AddressPrecisionBadge({
+  precision,
+  className,
+}: AddressPrecisionBadgeProps): ReactElement {
+  const { t } = useTranslation(I18N_NAMESPACE);
+
+  return (
+    <Badge variant={VARIANT_BY_PRECISION[precision]} className={className}>
+      {t(`Precision.${precision}`)}
+    </Badge>
+  );
+}

--- a/packages/@granit/react-geocoding/src/constants.ts
+++ b/packages/@granit/react-geocoding/src/constants.ts
@@ -1,0 +1,15 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'geocoding';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;
+
+/** i18next namespace the in-package UI reads from. */
+export const I18N_NAMESPACE = 'geocoding';
+
+/** Debounce applied to the typeahead input before it hits the network (ms). */
+export const DEFAULT_DEBOUNCE_MS = 275;
+
+/** Minimum query length before the autocomplete request fires. */
+export const DEFAULT_MIN_QUERY_LENGTH = 3;
+
+/** Default maximum number of suggestions requested. */
+export const DEFAULT_SUGGESTION_LIMIT = 5;

--- a/packages/@granit/react-geocoding/src/hooks/use-address-suggestions.ts
+++ b/packages/@granit/react-geocoding/src/hooks/use-address-suggestions.ts
@@ -1,0 +1,108 @@
+'use client';
+
+import { getAddressSuggestions } from '@granit/geocoding';
+import { useQuery } from '@tanstack/react-query';
+
+import {
+  DEFAULT_DEBOUNCE_MS,
+  DEFAULT_MIN_QUERY_LENGTH,
+  DEFAULT_SUGGESTION_LIMIT,
+} from '../constants';
+import {
+  buildGeocodingQueryKey,
+  useOptionalGeocodingConfig,
+} from '../providers/geocoding-provider';
+
+import { useDebouncedValue } from './use-debounced-value';
+
+import type { GeocodingSuggestionResponse } from '@granit/geocoding';
+
+/** Whether an error is an HTTP 404 (endpoint not mapped / provider not installed). */
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { response?: { status?: number } }).response?.status === 404
+  );
+}
+
+export interface UseAddressSuggestionsOptions {
+  /** Maximum number of suggestions to request. Default: {@link DEFAULT_SUGGESTION_LIMIT}. */
+  readonly limit?: number;
+  /** Debounce applied before the request fires. Default: {@link DEFAULT_DEBOUNCE_MS} ms. */
+  readonly debounceMs?: number;
+  /** Minimum (trimmed) length before querying. Default: {@link DEFAULT_MIN_QUERY_LENGTH}. */
+  readonly minQueryLength?: number;
+  /** Set `false` to suspend querying (e.g. while the field is unfocused). */
+  readonly enabled?: boolean;
+}
+
+export interface UseAddressSuggestionsResult {
+  /** Suggestions for the current (debounced) query — best match first. */
+  readonly suggestions: readonly GeocodingSuggestionResponse[];
+  /** The debounced query the suggestions correspond to. */
+  readonly query: string;
+  /** First page is loading (no data yet). */
+  readonly isLoading: boolean;
+  /** A request is in flight. */
+  readonly isFetching: boolean;
+  /** A request settled successfully (the suggestions reflect the current query). */
+  readonly isSuccess: boolean;
+  /** A genuine error occurred (excludes the "endpoint unavailable" 404 case). */
+  readonly isError: boolean;
+  /**
+   * The endpoint is unavailable — no provider configured (`null` config) or the
+   * route is not mapped (HTTP 404). The UI should fall back to manual entry
+   * rather than treat this as an error.
+   */
+  readonly isUnavailable: boolean;
+}
+
+/**
+ * Debounced address-autocomplete hook. Calls `GET {basePath}/autocomplete` for
+ * the (trimmed, debounced) `search` term and returns ranked suggestions.
+ *
+ * Designed as **progressive enhancement**: when no `GeocodingProvider` is in
+ * scope, or the endpoint 404s (provider not installed), it stays quiet and
+ * reports `isUnavailable` so the caller can fall back to plain manual entry.
+ * React Query aborts the in-flight request automatically when `search` changes.
+ */
+export function useAddressSuggestions(
+  search: string,
+  options: UseAddressSuggestionsOptions = {}
+): UseAddressSuggestionsResult {
+  const {
+    limit = DEFAULT_SUGGESTION_LIMIT,
+    debounceMs = DEFAULT_DEBOUNCE_MS,
+    minQueryLength = DEFAULT_MIN_QUERY_LENGTH,
+    enabled = true,
+  } = options;
+
+  const config = useOptionalGeocodingConfig();
+  const debounced = useDebouncedValue(search.trim(), debounceMs);
+  const isEnabled = enabled && config !== null && debounced.length >= minQueryLength;
+
+  const result = useQuery({
+    queryKey: buildGeocodingQueryKey(config, 'autocomplete', debounced, limit),
+    queryFn: ({ signal }) =>
+      // `config` is non-null whenever the query is enabled.
+      getAddressSuggestions(config!.client, config!.basePath, { q: debounced, limit }, signal),
+    enabled: isEnabled,
+    // Per-keystroke endpoint — a failed suggestion request is not worth retrying
+    // (the next keystroke supersedes it); a 404 means the capability is absent.
+    retry: false,
+    staleTime: 60_000,
+  });
+
+  const unavailable = config === null || isNotFound(result.error);
+
+  return {
+    suggestions: result.data?.suggestions ?? [],
+    query: debounced,
+    isLoading: result.isLoading && isEnabled,
+    isFetching: result.isFetching,
+    isSuccess: result.isSuccess,
+    isError: result.isError && !unavailable,
+    isUnavailable: unavailable,
+  };
+}

--- a/packages/@granit/react-geocoding/src/hooks/use-debounced-value.ts
+++ b/packages/@granit/react-geocoding/src/hooks/use-debounced-value.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns a debounced copy of `value` that only updates after `delayMs` have
+ * elapsed without a change. The initial value is returned synchronously (no
+ * artificial delay on mount), so only subsequent updates are coalesced.
+ *
+ * Used by {@link useAddressSuggestions} to throttle the typeahead term before it
+ * reaches the (shared, rate-limited) geocoding provider.
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState<T>(value);
+
+  useEffect(() => {
+    if (delayMs <= 0) {
+      setDebounced(value);
+      return;
+    }
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/packages/@granit/react-geocoding/src/hooks/use-reverse-geocode.ts
+++ b/packages/@granit/react-geocoding/src/hooks/use-reverse-geocode.ts
@@ -1,0 +1,87 @@
+'use client';
+
+import { getReverseGeocode } from '@granit/geocoding';
+import { useQuery } from '@tanstack/react-query';
+
+import {
+  buildGeocodingQueryKey,
+  useOptionalGeocodingConfig,
+} from '../providers/geocoding-provider';
+
+import type { GeocodingReverseResponse } from '@granit/geocoding';
+
+/** A latitude/longitude pair to reverse-geocode. */
+export interface Coordinate {
+  readonly lat: number;
+  readonly lon: number;
+}
+
+/** An HTTP status from an Axios-style error, or `undefined`. */
+function statusOf(error: unknown): number | undefined {
+  return (error as { response?: { status?: number } } | null)?.response?.status;
+}
+
+/**
+ * "Soft" statuses that mean "no address" rather than a failure: endpoint not
+ * mapped (404), no match (404), or an out-of-range coordinate (422). The UI
+ * should swallow these — a pin-drop on the ocean is not an error.
+ */
+function isSoftMiss(error: unknown): boolean {
+  const status = statusOf(error);
+  return status === 404 || status === 422;
+}
+
+export interface UseReverseGeocodeResult {
+  /** The resolved address, or `null` when nothing resolved / no coordinate given. */
+  readonly address: GeocodingReverseResponse | null;
+  /** A lookup is in flight. */
+  readonly isLoading: boolean;
+  /** A genuine error occurred (excludes the soft 404/422 misses). */
+  readonly isError: boolean;
+  /** The endpoint is unavailable — no provider configured or the route is not mapped. */
+  readonly isUnavailable: boolean;
+}
+
+/**
+ * Reverse-geocode a coordinate to the nearest postal address — the data half of
+ * a map pin-drop. Pass the clicked coordinate (or `null` to disable); on a hit,
+ * `address` carries the structured fields to pre-fill a form.
+ *
+ * `@granit/react-map` is presentation-only (no interactive click callback), so
+ * this hook is intentionally headless: wire it to whichever map a consuming app
+ * uses. Out-of-range (422) and no-match / not-mapped (404) responses resolve to
+ * `address: null` without surfacing an error.
+ */
+export function useReverseGeocode(
+  coordinate: Coordinate | null,
+  options: { readonly enabled?: boolean } = {}
+): UseReverseGeocodeResult {
+  const { enabled = true } = options;
+  const config = useOptionalGeocodingConfig();
+  const isEnabled = enabled && config !== null && coordinate !== null;
+
+  const result = useQuery({
+    queryKey: buildGeocodingQueryKey(
+      config,
+      'reverse',
+      coordinate?.lat ?? null,
+      coordinate?.lon ?? null
+    ),
+    queryFn: ({ signal }) =>
+      getReverseGeocode(config!.client, config!.basePath, coordinate!, signal),
+    enabled: isEnabled,
+    // A pin-drop is user-initiated and cheap to repeat; soft 404/422 misses are
+    // expected, so don't retry — surface the result (or its absence) at once.
+    retry: false,
+    staleTime: 5 * 60_000,
+  });
+
+  const unavailable = config === null || statusOf(result.error) === 404;
+
+  return {
+    address: result.data ?? null,
+    isLoading: result.isLoading && isEnabled,
+    isError: result.isError && !isSoftMiss(result.error),
+    isUnavailable: unavailable,
+  };
+}

--- a/packages/@granit/react-geocoding/src/index.ts
+++ b/packages/@granit/react-geocoding/src/index.ts
@@ -1,0 +1,40 @@
+// Provider
+export {
+  GeocodingProvider,
+  buildGeocodingQueryKey,
+  useGeocodingConfig,
+  useOptionalGeocodingConfig,
+} from './providers/geocoding-provider';
+export type {
+  GeocodingConfig,
+  GeocodingProviderProps,
+  ResolvedGeocodingConfig,
+} from './providers/geocoding-provider';
+
+// Hooks
+export { useAddressSuggestions } from './hooks/use-address-suggestions';
+export type {
+  UseAddressSuggestionsOptions,
+  UseAddressSuggestionsResult,
+} from './hooks/use-address-suggestions';
+export { useReverseGeocode } from './hooks/use-reverse-geocode';
+export type { Coordinate, UseReverseGeocodeResult } from './hooks/use-reverse-geocode';
+export { useDebouncedValue } from './hooks/use-debounced-value';
+
+// Components
+export { AddressAutocompleteInput } from './components/address-autocomplete-input';
+export type { AddressAutocompleteInputProps } from './components/address-autocomplete-input';
+export { AddressPrecisionBadge } from './components/address-precision-badge';
+export type { AddressPrecisionBadgeProps } from './components/address-precision-badge';
+
+// Locales
+export { geocodingTranslationsEn, geocodingTranslationsFr } from './locales/index';
+
+// Constants
+export {
+  DEFAULT_BASE_PATH,
+  DEFAULT_DEBOUNCE_MS,
+  DEFAULT_MIN_QUERY_LENGTH,
+  DEFAULT_SUGGESTION_LIMIT,
+  I18N_NAMESPACE,
+} from './constants';

--- a/packages/@granit/react-geocoding/src/locales/en.ts
+++ b/packages/@granit/react-geocoding/src/locales/en.ts
@@ -1,0 +1,17 @@
+/**
+ * English translation bundle for the geocoding feature. Consumers register it
+ * via `i18n.addResourceBundle('en', 'geocoding', geocodingTranslationsEn)` (or
+ * via the `react-i18next` configuration).
+ */
+export const geocodingTranslationsEn = {
+  /** Address typeahead. */
+  SearchPlaceholder: 'Start typing an address…',
+  NoResults: 'No matching address',
+  Error: 'Could not load suggestions',
+  /** Match-precision badge labels. */
+  Precision: {
+    Rooftop: 'Exact location',
+    Street: 'Street-level',
+    Locality: 'Approximate location',
+  },
+};

--- a/packages/@granit/react-geocoding/src/locales/fr.ts
+++ b/packages/@granit/react-geocoding/src/locales/fr.ts
@@ -1,0 +1,17 @@
+/**
+ * French translation bundle for the geocoding feature. Consumers register it
+ * via `i18n.addResourceBundle('fr', 'geocoding', geocodingTranslationsFr)` (or
+ * via the `react-i18next` configuration).
+ */
+export const geocodingTranslationsFr = {
+  /** Address typeahead. */
+  SearchPlaceholder: 'Commencez à saisir une adresse…',
+  NoResults: 'Aucune adresse correspondante',
+  Error: 'Impossible de charger les suggestions',
+  /** Match-precision badge labels. */
+  Precision: {
+    Rooftop: 'Emplacement exact',
+    Street: 'Au niveau de la rue',
+    Locality: 'Emplacement approximatif',
+  },
+};

--- a/packages/@granit/react-geocoding/src/locales/index.ts
+++ b/packages/@granit/react-geocoding/src/locales/index.ts
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------------------
+// @granit/react-geocoding — i18next resource bundles (namespace: "geocoding")
+// ---------------------------------------------------------------------------
+//
+// Consumers register the bundles with their i18n instance:
+//
+//   i18n.addResourceBundle('en', 'geocoding', geocodingTranslationsEn);
+//   i18n.addResourceBundle('fr', 'geocoding', geocodingTranslationsFr);
+//
+// The AddressAutocompleteInput and AddressPrecisionBadge read keys from this
+// namespace via `useTranslation('geocoding')`.
+// ---------------------------------------------------------------------------
+
+export { geocodingTranslationsEn } from './en';
+export { geocodingTranslationsFr } from './fr';

--- a/packages/@granit/react-geocoding/src/providers/geocoding-provider.tsx
+++ b/packages/@granit/react-geocoding/src/providers/geocoding-provider.tsx
@@ -1,0 +1,55 @@
+import { createConfigProvider } from '@granit/react-api-client';
+
+import { DEFAULT_BASE_PATH } from '../constants';
+
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
+
+/** Configuration for the geocoding provider. */
+export interface GeocodingConfig extends GranitProviderConfig {
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * {@link GeocodingConfig} after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>` and defaulted
+ * `basePath`. Both are guaranteed present, so hooks read them without a
+ * non-null assertion.
+ */
+export type ResolvedGeocodingConfig = ResolvedGranitProviderConfig<GeocodingConfig>;
+
+export type GeocodingProviderProps = GranitProviderProps<GeocodingConfig>;
+
+const { Provider, useConfig, useOptionalConfig } = createConfigProvider<GeocodingConfig>({
+  name: 'Geocoding',
+  defaultBasePath: DEFAULT_BASE_PATH,
+});
+
+/** Provides geocoding configuration to child components and hooks. */
+export const GeocodingProvider = Provider;
+
+/** Returns the geocoding configuration from the nearest `GeocodingProvider`. */
+export const useGeocodingConfig = useConfig;
+
+/**
+ * Returns the geocoding configuration from the nearest `GeocodingProvider`, or
+ * `null` when there is none — lets a component degrade gracefully (manual entry)
+ * when geocoding is not wired up.
+ */
+export const useOptionalGeocodingConfig = useOptionalConfig;
+
+/**
+ * Builds a consistent React Query key for geocoding operations. Accepts a `null`
+ * config (no provider in scope) so callers can build a stable key for a disabled
+ * query without duplicating the default prefix.
+ */
+export function buildGeocodingQueryKey(
+  config: GeocodingConfig | null,
+  ...segments: readonly unknown[]
+): readonly unknown[] {
+  const prefix = config?.queryKeyPrefix ?? ['geocoding'];
+  return [...prefix, ...segments];
+}

--- a/packages/@granit/react-geocoding/src/testing/data.ts
+++ b/packages/@granit/react-geocoding/src/testing/data.ts
@@ -1,0 +1,41 @@
+import type { GeocodingReverseResponse, GeocodingSuggestionResponse } from '@granit/geocoding';
+
+/** A handful of Brussels-area suggestions for tests and stories. */
+export const sampleSuggestions: readonly GeocodingSuggestionResponse[] = [
+  {
+    label: 'Rue de la Loi 16, 1000 Brussels, BE',
+    street: 'Rue de la Loi 16',
+    postalCode: '1000',
+    locality: 'Brussels',
+    country: 'BE',
+    latitude: 50.8467,
+    longitude: 4.3676,
+  },
+  {
+    label: 'Avenue Louise 143, 1050 Ixelles, BE',
+    street: 'Avenue Louise 143',
+    postalCode: '1050',
+    locality: 'Ixelles',
+    country: 'BE',
+    latitude: 50.8275,
+    longitude: 4.3625,
+  },
+  {
+    label: 'Grote Markt, 1000 Brussels, BE',
+    street: null,
+    postalCode: '1000',
+    locality: 'Brussels',
+    country: 'BE',
+    latitude: null,
+    longitude: null,
+  },
+];
+
+/** A sample reverse-geocoding result. */
+export const sampleReverseAddress: GeocodingReverseResponse = {
+  street: 'Rue de la Loi 16',
+  postalCode: '1000',
+  locality: 'Brussels',
+  country: 'BE',
+  precision: 'Rooftop',
+};

--- a/packages/@granit/react-geocoding/src/testing/handlers.ts
+++ b/packages/@granit/react-geocoding/src/testing/handlers.ts
@@ -1,0 +1,81 @@
+import { http, HttpResponse } from 'msw';
+
+import { DEFAULT_BASE_PATH } from '../constants';
+
+import { sampleReverseAddress, sampleSuggestions } from './data';
+
+import type {
+  GeocodingAutocompleteResponse,
+  GeocodingReverseResponse,
+  GeocodingSuggestionResponse,
+} from '@granit/geocoding';
+import type { RequestHandler } from 'msw';
+
+export interface CreateGeocodingHandlersOptions {
+  /** Suggestions returned by the autocomplete handler (filtered by `q`, sliced by `limit`). */
+  readonly suggestions?: readonly GeocodingSuggestionResponse[];
+  /** Address returned by the reverse handler, or `null` to respond `404`. */
+  readonly reverseAddress?: GeocodingReverseResponse | null;
+}
+
+/**
+ * MSW handlers for the geocoding endpoints. The autocomplete handler filters the
+ * sample suggestions by the `q` term (case-insensitive substring on the label)
+ * and honours `limit`; the reverse handler returns a fixed address, validates
+ * the coordinate bounds (`422`), and `404`s when `reverseAddress` is `null`.
+ */
+export function createGeocodingHandlers(
+  baseUrl: string = DEFAULT_BASE_PATH,
+  options: CreateGeocodingHandlersOptions = {}
+): RequestHandler[] {
+  const suggestions = options.suggestions ?? sampleSuggestions;
+  const reverseAddress =
+    options.reverseAddress === undefined ? sampleReverseAddress : options.reverseAddress;
+
+  return [
+    http.get(`${baseUrl}/autocomplete`, ({ request }) => {
+      const url = new URL(request.url);
+      const q = (url.searchParams.get('q') ?? '').trim().toLowerCase();
+      const limit = Number(url.searchParams.get('limit') ?? '5');
+      const matched = suggestions.filter((s) => s.label.toLowerCase().includes(q));
+      const body: GeocodingAutocompleteResponse = { suggestions: matched.slice(0, limit) };
+      return HttpResponse.json(body);
+    }),
+
+    http.get(`${baseUrl}/reverse`, ({ request }) => {
+      const url = new URL(request.url);
+      const lat = Number(url.searchParams.get('lat'));
+      const lon = Number(url.searchParams.get('lon'));
+      if (
+        !Number.isFinite(lat) ||
+        !Number.isFinite(lon) ||
+        Math.abs(lat) > 90 ||
+        Math.abs(lon) > 180
+      ) {
+        return HttpResponse.json(
+          { type: 'about:blank', title: 'Validation failed', status: 422 },
+          { status: 422 }
+        );
+      }
+      if (reverseAddress === null) {
+        return HttpResponse.json(
+          { type: 'about:blank', title: 'Not found', status: 404 },
+          { status: 404 }
+        );
+      }
+      return HttpResponse.json(reverseAddress);
+    }),
+  ];
+}
+
+/** Handlers simulating an absent capability — both routes respond `404` (not mapped). */
+export function createUnavailableGeocodingHandlers(
+  baseUrl: string = DEFAULT_BASE_PATH
+): RequestHandler[] {
+  const notMapped = () =>
+    HttpResponse.json({ type: 'about:blank', title: 'Not found', status: 404 }, { status: 404 });
+  return [
+    http.get(`${baseUrl}/autocomplete`, notMapped),
+    http.get(`${baseUrl}/reverse`, notMapped),
+  ];
+}

--- a/packages/@granit/react-geocoding/src/testing/index.ts
+++ b/packages/@granit/react-geocoding/src/testing/index.ts
@@ -1,0 +1,3 @@
+export { sampleReverseAddress, sampleSuggestions } from './data';
+export { createGeocodingHandlers, createUnavailableGeocodingHandlers } from './handlers';
+export type { CreateGeocodingHandlersOptions } from './handlers';

--- a/packages/@granit/react-geocoding/tsconfig.json
+++ b/packages/@granit/react-geocoding/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["@testing-library/jest-dom"],
+    "paths": {
+      "@granit/geocoding": ["../geocoding/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-geocoding/tsup.config.ts
+++ b/packages/@granit/react-geocoding/tsup.config.ts
@@ -1,0 +1,6 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig({
+  entry: ['src/index.ts', 'src/testing/index.ts'],
+  external: [/^@granit\//, 'msw'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -771,6 +771,15 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/geocoding:
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/hostnames:
     devDependencies:
       '@granit/api-client':
@@ -2485,6 +2494,43 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+
+  packages/@granit/react-geocoding:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: 5.101.2
+        version: 5.101.2(react@19.2.7)
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@26.0.1)(typescript@6.0.3)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-i18next:
+        specifier: ^17.0.0
+        version: 17.0.8(i18next@26.3.3(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/geocoding':
+        specifier: workspace:*
+        version: link:../geocoding
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/react-ui':
+        specifier: workspace:*
+        version: link:../react-ui
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@granit/utils':
+        specifier: workspace:*
+        version: link:../utils
 
   packages/@granit/react-hostnames:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -76,6 +76,10 @@ export default defineConfig({
         __dirname,
         'packages/@granit/react-features/src/testing/index.ts'
       ),
+      '@granit/react-geocoding/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-geocoding/src/testing/index.ts'
+      ),
       '@granit/react-identity/testing': path.resolve(
         __dirname,
         'packages/@granit/react-identity/src/testing/index.ts'


### PR DESCRIPTION
## Summary

Front-side of the address platform (Phase 5) — backend: `Granit.Geocoding` (granit-dotnet #2870).

- **`@granit/geocoding`** (core) — hand-written DTOs + Axios client for the two **capability-gated** endpoints: `getAddressSuggestions` (`GET /geocoding/autocomplete`) and `getReverseGeocode` (`GET /geocoding/reverse`).
- **`@granit/react-geocoding`** (react) — `GeocodingProvider`, `useAddressSuggestions` / `useReverseGeocode` hooks, the accessible **`AddressAutocompleteInput`** (WAI-ARIA combobox), `AddressPrecisionBadge`, i18n bundles (en/fr) and MSW testing fixtures.

## Behaviour

- Typeahead **debounces** (~275 ms) before hitting the shared, rate-limited provider, and **cancels in-flight requests** on input change.
- **Progressive enhancement**: when no provider is configured or the endpoint 404s (capability absent), the field degrades to plain manual entry — geocoding is never a hard dependency.
- Loading / no-results / error states; reverse 404/422 misses resolve quietly.
- Contract conformance: `contracts/openapi/geocoding.json` vendored and registered in `@granit/contract-tests` (DTOs + endpoint routes verified).

## Deviations from the handoff (deliberate)

- **No codegen** — granit-front hand-writes DTOs (verified against the regenerated spec, field-for-field).
- **Reverse out-of-range is `422`, not `400`** (FluentValidation) — handled alongside `404`.
- **Party address-quality badge dropped** — `PartyAddressResponse` carries no `geocodingStatus`/`verificationStatus`; the badge instead surfaces the `precision` the reverse endpoint returns.
- **Reverse pin-drop is headless** — `@granit/react-map` has no interactive click callback, so `useReverseGeocode` is wired for any consumer map rather than shipping a map picker.
- **No Storybook story** — stories are a `react-ui-*` tier convention (all 265 live there); this data-tier package is covered by Vitest. A Storybook demo belongs in a future `react-ui-geocoding`/showcase.

## Tests

`@granit/geocoding` + `@granit/react-geocoding` (23) and the geocoding conformance checks all green; workspace `tsc`, lint, arch-tests, `check:csp` clean.

## Follow-up

Showcase wiring (showcase-admin-react) to land as a separate Draft MR once this merges (cross-repo ordering).