### PR TITLE
fix(auth)!: register page honors 202 anti-enumeration contract

### DIFF
--- a/packages/@granit/react-ui-authentication-local/src/__tests__/register-page.test.tsx
+++ b/packages/@granit/react-ui-authentication-local/src/__tests__/register-page.test.tsx
@@ -65,11 +65,11 @@ describe('RegisterPage', () => {
     });
   });
 
-  it('should show error on duplicate email (409)', async () => {
-    mockMutateAsync.mockRejectedValueOnce({
-      isAxiosError: true,
-      response: { status: 409 },
-    });
+  it('should not leak account existence on a duplicate email (anti-enumeration)', async () => {
+    // The backend returns 202 Accepted for an already-registered email, so the
+    // response is indistinguishable from a fresh signup. The UI must show the
+    // same "check your email" confirmation and never reveal the account exists.
+    mockMutateAsync.mockResolvedValueOnce(undefined);
     const { user } = renderPage();
 
     await user.type(screen.getByLabelText(/email address/i), 'existing@test.com');
@@ -78,8 +78,9 @@ describe('RegisterPage', () => {
     await user.click(screen.getByRole('button', { name: /create account/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/already exists/i)).toBeInTheDocument();
+      expect(screen.getByText(/check your email/i)).toBeInTheDocument();
     });
+    expect(screen.queryByText(/already exists/i)).not.toBeInTheDocument();
   });
 
   it('should show disabled message when registration returns 403', async () => {
@@ -99,10 +100,10 @@ describe('RegisterPage', () => {
     });
   });
 
-  it('should show a validation error on a 400 response', async () => {
+  it('should show a validation error on a 422 response', async () => {
     mockMutateAsync.mockRejectedValueOnce({
       isAxiosError: true,
-      response: { status: 400 },
+      response: { status: 422 },
     });
     const { user } = renderPage();
 

--- a/packages/@granit/react-ui-authentication-local/src/locales/en.ts
+++ b/packages/@granit/react-ui-authentication-local/src/locales/en.ts
@@ -122,7 +122,6 @@ export const authLocalTranslationsEn = {
   'Auth.Register.ConfirmPasswordPlaceholder': 'Re-enter your password',
   'Auth.Register.Disabled': 'Registration disabled',
   'Auth.Register.DisabledMessage': 'Registration is currently disabled.',
-  'Auth.Register.EmailAlreadyExists': 'An account with this email already exists.',
   'Auth.Register.EmailLabel': 'Email address',
   'Auth.Register.EmailPlaceholder': 'admin@example.com',
   'Auth.Register.FirstNameLabel': 'First name',

--- a/packages/@granit/react-ui-authentication-local/src/locales/fr.ts
+++ b/packages/@granit/react-ui-authentication-local/src/locales/fr.ts
@@ -128,7 +128,6 @@ export const authLocalTranslationsFr: Record<keyof AuthLocalTranslations, string
   'Auth.Register.ConfirmPasswordPlaceholder': 'Saisissez à nouveau votre mot de passe',
   'Auth.Register.Disabled': 'Inscription désactivée',
   'Auth.Register.DisabledMessage': "L'inscription est actuellement désactivée.",
-  'Auth.Register.EmailAlreadyExists': 'Un compte avec cette adresse email existe déjà.',
   'Auth.Register.EmailLabel': 'Adresse email',
   'Auth.Register.EmailPlaceholder': 'admin@exemple.com',
   'Auth.Register.FirstNameLabel': 'Prénom',

--- a/packages/@granit/react-ui-authentication-local/src/register-page.tsx
+++ b/packages/@granit/react-ui-authentication-local/src/register-page.tsx
@@ -112,9 +112,10 @@ function RegisterForm() {
     } catch (err: unknown) {
       if (isAxiosError(err) && err.response?.status === 403) {
         setServerError(t('Auth.Register.Disabled'));
-      } else if (isAxiosError(err) && err.response?.status === 409) {
-        setServerError(t('Auth.Register.EmailAlreadyExists'));
-      } else if (isAxiosError(err) && err.response?.status === 400) {
+      } else if (isAxiosError(err) && err.response?.status === 422) {
+        // FluentValidation failures (invalid email, weak password) surface as 422.
+        // A duplicate email is NOT an error here: the backend returns 202 by design
+        // (anti-enumeration), which the success path already handles.
         setServerError(t('Auth.Register.ValidationError'));
       } else {
         setServerError(t('Auth.Register.UnexpectedError'));


### PR DESCRIPTION
## What

Aligns the local-auth register page with the backend's anti-enumeration contract.

- The backend returns **202 Accepted** for an already-registered email so the response is indistinguishable from a fresh signup. The UI now shows the same "check your email" confirmation and no longer surfaces a 409 "email already exists" message — closing an **account-enumeration leak**.
- FluentValidation failures now map to **422** (was 400).
- Removes the now-unused `Auth.Register.EmailAlreadyExists` translation key (en + fr).

## Why

A distinct "this email already exists" error lets an attacker enumerate registered accounts. The success and duplicate paths must be indistinguishable.

## Tests

`register-page.test.tsx` updated: duplicate email now asserts the confirmation is shown and the "already exists" copy is absent; the validation-error case asserts on 422.

> [!NOTE]
> Marked `!` (breaking) because the `Auth.Register.EmailAlreadyExists` key is removed from the published `@granit/react-ui-authentication-local` locale surface.