### PR TITLE
fix(api-client): remove dangling test-utils references after #797

### DIFF
--- a/packages/@granit/api-client/README.md
+++ b/packages/@granit/api-client/README.md
@@ -26,9 +26,7 @@ dependencies a consumer must declare:
 - `axios` (`^1.6.0`) — required.
 - `@granit/logger` — optional; wire a redacting logger so interceptor warnings
   (e.g. missing CSRF token) stay out of `console` and route to OTLP. Falls back
-  to `console.warn` when absent.
-- `@granit/testing` — optional; only the `./test-utils` subpath re-exports from
-  it.
+  to the package logger (`createLogger('api-client')`) when absent.
 
 ## Quick start
 
@@ -107,12 +105,6 @@ const api = createApiClient({
 | `isIdempotentReplay`                       | fn   | `true` when the backend served a cached replay (`Idempotent-Replayed`)                                             |
 | `IdempotencyTombstoneInfo`                 | type | Machine-readable tombstone reason                                                                                  |
 | Axios façade                               | type | `AxiosError`, `AxiosInstance`, `AxiosRequestConfig`, `AxiosResponse`, `InternalAxiosRequestConfig`, `isAxiosError` |
-
-### `./test-utils` subpath
-
-Backward-compatible re-exports from [`@granit/testing`](../testing):
-`createMockClient` (a mock `AxiosInstance`) and `axiosResponse` (wrap a value as
-an `AxiosResponse`).
 
 ## Out of scope / caveats
 

--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -69,9 +69,10 @@ export interface ApiClientConfig {
   /**
    * Optional logger from `@granit/logger`. Used to report interceptor-level
    * warnings (e.g. missing CSRF token on a BFF mutation). When omitted, the
-   * client falls back to `console.warn` so framework-level diagnostics are
-   * never lost — but production apps should always wire a redacting logger
-   * to keep PII out of `console` and route diagnostics to OTLP.
+   * client falls back to the package logger (`createLogger('api-client')`) so
+   * framework-level diagnostics are never lost — but production apps should
+   * always wire a redacting logger to keep PII out of logs and route
+   * diagnostics to OTLP.
    */
   logger?: Logger;
 }

--- a/packages/@granit/api-client/tsup.config.ts
+++ b/packages/@granit/api-client/tsup.config.ts
@@ -1,7 +1,7 @@
 import { createTsupConfig } from '../../../tsup.preset';
 
 export default createTsupConfig({
-  entry: ['src/index.ts', 'src/test-utils.ts'],
+  entry: ['src/index.ts'],
   splitting: false,
   external: [/^@granit\//, 'vitest'],
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,10 +5,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   resolve: {
     alias: {
-      '@granit/api-client/test-utils': path.resolve(
-        __dirname,
-        'packages/@granit/api-client/src/test-utils.ts'
-      ),
       '@granit/api-client': path.resolve(__dirname, 'packages/@granit/api-client/src/index.ts'),
       '@granit/arch-tests-kit': path.resolve(
         __dirname,


### PR DESCRIPTION
## Context

`/audit api-client et react-api-client` surfaced leftover references to `src/test-utils.ts`, which **#797** deleted (along with its `./test-utils` package export) to break a workspace dependency cycle. The deletion left three dangling references plus a stale `console.warn` doc claim.

## Changes

| File | Fix |
| --- | --- |
| `tsup.config.ts` | Drop `src/test-utils.ts` from the build `entry` (tsup silently skipped the missing file) |
| `vitest.config.ts` | Remove the `@granit/api-client/test-utils` alias pointing at the deleted file |
| `README.md` | Remove the `./test-utils` subpath section documenting an export that no longer exists |
| `README.md` + `src/index.ts` | Correct the `ApiClientConfig.logger` fallback docs: it falls back to the package logger (`createLogger('api-client')`), **not** `console.warn` |

No exported runtime API changes — cleanup + doc accuracy only.

## Verification

- `pnpm --filter @granit/api-client build` ✅ (tsup ESM + DTS)
- `vitest run` api-client + react-api-client ✅ 91 passed
- `markdownlint-cli2 README.md` ✅ 0 errors
- tsc / eslint source ✅ clean