### PR TITLE
fix(arch-tests): ignore createLogger mentions in comments

### DIFF
--- a/packages/@granit/arch-tests/src/__tests__/imports.test.ts
+++ b/packages/@granit/arch-tests/src/__tests__/imports.test.ts
@@ -9,6 +9,7 @@ import {
   scanAxiosImports,
   scanConsole,
   scanFetch,
+  stripComments,
   walkSourceFiles,
 } from '@granit/arch-tests-kit';
 import { describe, expect, it } from 'vitest';
@@ -188,7 +189,11 @@ describe('imports — granit-specific rules', () => {
       if (pkg.name === '@granit/logger') continue;
       let count = 0;
       for (const f of walkSourceFiles(pkg.srcDir, (file) => !isTestFile(file))) {
-        count += (fs.readFileSync(f, 'utf8').match(/\bcreateLogger\s*\(/g) ?? []).length;
+        // Strip comments first — a `createLogger('pkg')` mention inside a JSDoc
+        // block (e.g. @granit/api-client) is a doc reference, not a second
+        // instance. Mirrors the comment-aware scan every other rule uses.
+        count += (stripComments(fs.readFileSync(f, 'utf8')).match(/\bcreateLogger\s*\(/g) ?? [])
+          .length;
       }
       if (count > 1 && !LOGGER_MULTI_INSTANCE_BASELINE.includes(pkg.name)) {
         offenders.push(`${pkg.name} (${count} createLogger calls)`);


### PR DESCRIPTION
## Problem
The `packages create at most one logger instance` arch-test counted `createLogger(` on **raw file text**, so a mention inside a JSDoc block was miscounted as a real second instance. `@granit/api-client` tripped it: its `logger?` option doc block references `` `createLogger('api-client')` `` — a doc reference, not a call. This reddened `develop` CI for every branch.

## Fix
Strip comments before matching, reusing `stripComments` from `@granit/arch-tests-kit` — the same comment-aware helper every other scan (imports, console, fetch) already uses. The count now reflects real call sites only; the rule stays at **zero offenders** (no package legitimately hid a second real `createLogger` behind a comment).

## Verification
- `arch-tests/imports.test.ts` — **10 passed** (was 1 failing) ✅
- tsc ✅ · ESLint `--max-warnings 0` ✅