### PR TITLE
fix(notifications)!: align mobile-push DTO with backend + relocate UI pages

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2229,25 +2229,7 @@
     {
       "name": "@granit/notifications-mobile-push",
       "description": "Mobile push (FCM/APNs) device token registration via Capacitor",
-      "exports": [
-        {
-          "name": "DeviceTokenDto",
-          "kind": "interface",
-          "signature": "interface DeviceTokenDto",
-          "members": []
-        },
-        {
-          "name": "MobilePlatform",
-          "kind": "type",
-          "signature": "type MobilePlatform = 'android' | 'ios'"
-        },
-        {
-          "name": "MobilePushTokenResponse",
-          "kind": "interface",
-          "signature": "interface MobilePushTokenResponse",
-          "members": []
-        }
-      ]
+      "exports": []
     },
     {
       "name": "@granit/notifications-signalr",

--- a/packages/@granit/notifications-mobile-push/README.md
+++ b/packages/@granit/notifications-mobile-push/README.md
@@ -35,17 +35,16 @@ import {
   listDeviceTokens,
   unregisterDeviceToken,
 } from '@granit/notifications-mobile-push';
-import type { DeviceTokenDto } from '@granit/notifications-mobile-push';
+import type { MobilePushTokenRegisterRequest } from '@granit/notifications-mobile-push';
 
 // `basePath` is the API root; the calls append
 // `/notifications/mobile-push/tokens` themselves.
 const basePath = '/api/v1';
 
 // 1. Register the token returned by the native FCM/APNs plugin.
-const payload: DeviceTokenDto = {
-  token: fcmToken,        // opaque registration token from the device
-  platform: 'android',    // 'android' (FCM) | 'ios' (APNs)
-  deviceId,               // optional stable per-device id
+const payload: MobilePushTokenRegisterRequest = {
+  deviceToken: fcmToken, // opaque registration token from the device
+  platform: 'Android', // 'Android' (FCM) | 'Ios' (APNs)
 };
 await registerDeviceToken(client, basePath, payload);
 
@@ -62,14 +61,14 @@ await unregisterDeviceToken(client, basePath, fcmToken);
 
 ## Public API
 
-| Symbol                    | Kind | Purpose                                                       |
-| ------------------------- | ---- | ------------------------------------------------------------- |
-| `MobilePlatform`          | type | `'android'` (FCM) \| `'ios'` (APNs)                           |
-| `DeviceTokenDto`          | type | Registration body: `token`, `platform`, optional `deviceId`  |
-| `MobilePushTokenResponse` | type | Listed token: `deviceToken`, `platform`, `createdAt`         |
-| `registerDeviceToken`     | fn   | `POST {basePath}/notifications/mobile-push/tokens`            |
-| `listDeviceTokens`        | fn   | `GET {basePath}/notifications/mobile-push/tokens`             |
-| `unregisterDeviceToken`   | fn   | `DELETE .../tokens/{token}` (token is URL-encoded into path)  |
+| Symbol                           | Kind | Purpose                                                      |
+| -------------------------------- | ---- | ------------------------------------------------------------ |
+| `MobilePlatform`                 | type | `'Android'` (FCM) \| `'Ios'` (APNs)                          |
+| `MobilePushTokenRegisterRequest` | type | Registration body: `deviceToken`, `platform`                 |
+| `MobilePushTokenResponse`        | type | Listed token: `deviceToken`, `platform`, `createdAt`         |
+| `registerDeviceToken`            | fn   | `POST {basePath}/notifications/mobile-push/tokens`           |
+| `listDeviceTokens`               | fn   | `GET {basePath}/notifications/mobile-push/tokens`            |
+| `unregisterDeviceToken`          | fn   | `DELETE .../tokens/{token}` (token is URL-encoded into path) |
 
 ## Out of scope / caveats
 
@@ -80,10 +79,11 @@ await unregisterDeviceToken(client, basePath, fcmToken);
   This package only persists tokens server-side.
 - **No React Query / caching.** These are bare Axios calls; query keys,
   caching and invalidation live in the React layer (`useDeviceTokens`).
-- **Token asymmetry is intentional.** Registration sends a `DeviceTokenDto`
-  (`token`), while the list endpoint returns `MobilePushTokenResponse`
-  (`deviceToken` + `createdAt`) — they mirror the backend request/response
-  shapes and are not interchangeable.
+- **Request and response DTOs both key the token as `deviceToken`.** Registration
+  sends a `MobilePushTokenRegisterRequest` (`deviceToken`, `platform`); the list
+  endpoint returns `MobilePushTokenResponse` (`deviceToken`, `platform`,
+  `createdAt`) — they mirror the backend `MobilePushTokenRegisterRequest` /
+  `MobilePushTokenResponse` shapes and are not interchangeable.
 - **Tokens are sensitive.** A device token can be used to push to a user's
   device; treat it like a credential — never log it, and rely on the
   `@granit/api-client` auth/CSRF interceptors for transport.

--- a/packages/@granit/notifications-mobile-push/src/__tests__/mobile-push-api.test.ts
+++ b/packages/@granit/notifications-mobile-push/src/__tests__/mobile-push-api.test.ts
@@ -13,13 +13,13 @@ describe('mobile-push-api', () => {
     const client = createMockClient();
 
     await registerDeviceToken(client, '/api/v1', {
-      token: 'fcm-token-123',
-      platform: 'android',
+      deviceToken: 'fcm-token-123',
+      platform: 'Android',
     });
 
     expect(client.post).toHaveBeenCalledWith('/api/v1/notifications/mobile-push/tokens', {
-      token: 'fcm-token-123',
-      platform: 'android',
+      deviceToken: 'fcm-token-123',
+      platform: 'Android',
     });
   });
 
@@ -48,12 +48,12 @@ describe('mobile-push-api', () => {
     const tokens = [
       {
         deviceToken: 'token-1',
-        platform: 'android' as const,
+        platform: 'Android' as const,
         createdAt: toISODateString('2026-03-17T10:00:00Z'),
       },
       {
         deviceToken: 'token-2',
-        platform: 'ios' as const,
+        platform: 'Ios' as const,
         createdAt: toISODateString('2026-03-17T11:00:00Z'),
       },
     ];

--- a/packages/@granit/notifications-mobile-push/src/api/mobile-push-api.ts
+++ b/packages/@granit/notifications-mobile-push/src/api/mobile-push-api.ts
@@ -1,12 +1,12 @@
 import { buildApiUrl } from '@granit/api-client';
 
-import type { DeviceTokenDto, MobilePushTokenResponse } from '../types';
+import type { MobilePushTokenRegisterRequest, MobilePushTokenResponse } from '../types';
 import type { AxiosInstance } from '@granit/api-client';
 
 export async function registerDeviceToken(
   client: AxiosInstance,
   basePath: string,
-  payload: DeviceTokenDto
+  payload: MobilePushTokenRegisterRequest
 ): Promise<void> {
   await client.post(buildApiUrl(basePath, 'notifications', 'mobile-push', 'tokens'), payload);
 }

--- a/packages/@granit/notifications-mobile-push/src/index.ts
+++ b/packages/@granit/notifications-mobile-push/src/index.ts
@@ -3,4 +3,8 @@ export {
   registerDeviceToken,
   unregisterDeviceToken,
 } from './api/mobile-push-api';
-export type { DeviceTokenDto, MobilePlatform, MobilePushTokenResponse } from './types';
+export type {
+  MobilePlatform,
+  MobilePushTokenRegisterRequest,
+  MobilePushTokenResponse,
+} from './types';

--- a/packages/@granit/notifications-mobile-push/src/types/index.ts
+++ b/packages/@granit/notifications-mobile-push/src/types/index.ts
@@ -1,11 +1,11 @@
 import type { ISODateString } from '@granit/types';
 
-export type MobilePlatform = 'android' | 'ios';
+export type MobilePlatform = 'Android' | 'Ios';
 
-export interface DeviceTokenDto {
-  readonly token: string;
+/** Write DTO for token registration. Mirrors `MobilePushTokenRegisterRequest` from .NET. */
+export interface MobilePushTokenRegisterRequest {
+  readonly deviceToken: string;
   readonly platform: MobilePlatform;
-  readonly deviceId?: string;
 }
 
 export interface MobilePushTokenResponse {

--- a/packages/@granit/react-notifications-mobile-push/README.md
+++ b/packages/@granit/react-notifications-mobile-push/README.md
@@ -65,7 +65,7 @@ function PushToggle() {
   // Requests OS permission, captures the FCM/APNs token, and registers it
   // with the backend; re-syncs automatically on token refresh while active.
   const { isRegistered, loading, error, register, unregister } = useMobilePush({
-    platform: 'android', // 'android' (FCM) | 'ios' (APNs)
+    platform: 'Android', // 'Android' (FCM) | 'Ios' (APNs)
   });
 
   return (

--- a/packages/@granit/react-notifications-mobile-push/README.md
+++ b/packages/@granit/react-notifications-mobile-push/README.md
@@ -15,7 +15,7 @@ notification, preference and subscription surfaces). The split is two packages �
 there is no `react-ui` admin feature kit:
 
 - [`@granit/notifications-mobile-push`](../notifications-mobile-push) —
-  framework-agnostic core: `DeviceTokenDto` / `MobilePushTokenResponse` DTOs and
+  framework-agnostic core: `MobilePushTokenRegisterRequest` / `MobilePushTokenResponse` DTOs and
   the bare Axios calls (`registerDeviceToken`, `listDeviceTokens`,
   `unregisterDeviceToken`).
 - `@granit/react-notifications-mobile-push` (this package) — React Query hooks,
@@ -53,19 +53,12 @@ the hooks anywhere below it. `useMobilePush` takes only the target `platform`;
 the base path comes from the provider, defaulting to `/api/v1/notifications`.
 
 ```tsx
-import {
-  MobilePushProvider,
-  useMobilePush,
-} from '@granit/react-notifications-mobile-push';
+import { MobilePushProvider, useMobilePush } from '@granit/react-notifications-mobile-push';
 import { useGranitClient } from '@granit/react-api-client';
 
 function App({ children }: { children: React.ReactNode }) {
   // `client` may be omitted if a <GranitClientProvider> is already mounted.
-  return (
-    <MobilePushProvider config={{ client: useGranitClient() }}>
-      {children}
-    </MobilePushProvider>
-  );
+  return <MobilePushProvider config={{ client: useGranitClient() }}>{children}</MobilePushProvider>;
 }
 
 function PushToggle() {
@@ -76,11 +69,7 @@ function PushToggle() {
   });
 
   return (
-    <button
-      type="button"
-      disabled={loading}
-      onClick={isRegistered ? unregister : register}
-    >
+    <button type="button" disabled={loading} onClick={isRegistered ? unregister : register}>
       {isRegistered ? 'Disable' : 'Enable'} push notifications
       {error ? ` — ${error.message}` : ''}
     </button>
@@ -110,17 +99,17 @@ function RegisteredDevices() {
 
 ## Public API
 
-| Symbol | Kind | Purpose |
-| --- | --- | --- |
-| `MobilePushProvider` | provider | Supplies the resolved Axios client + base path to all hooks below it |
-| `useMobilePushConfig` | hook | Read the resolved `{ client, basePath }`; throws outside a provider |
-| `useMobilePush` | hook | Permission prompt + FCM/APNs token capture + register/unregister + refresh |
-| `useDeviceTokens` | hook | `GET .../mobile-push/tokens` — the user's registered tokens (read-only) |
-| `deviceTokenKeys` | const | Query-key factory for the device-token query |
-| `MobilePushHookOptions` | type | `useMobilePush` input — `{ platform }` |
-| `UseMobilePushReturn` | type | `{ isRegistered, loading, error, register, unregister }` |
-| `MobilePushProviderConfig` | type | Resolved config — optional `client`, required `basePath` |
-| `MobilePushProviderProps` | type | `{ config, children }`; `config.basePath` optional (provider defaults it) |
+| Symbol                     | Kind     | Purpose                                                                    |
+| -------------------------- | -------- | -------------------------------------------------------------------------- |
+| `MobilePushProvider`       | provider | Supplies the resolved Axios client + base path to all hooks below it       |
+| `useMobilePushConfig`      | hook     | Read the resolved `{ client, basePath }`; throws outside a provider        |
+| `useMobilePush`            | hook     | Permission prompt + FCM/APNs token capture + register/unregister + refresh |
+| `useDeviceTokens`          | hook     | `GET .../mobile-push/tokens` — the user's registered tokens (read-only)    |
+| `deviceTokenKeys`          | const    | Query-key factory for the device-token query                               |
+| `MobilePushHookOptions`    | type     | `useMobilePush` input — `{ platform }`                                     |
+| `UseMobilePushReturn`      | type     | `{ isRegistered, loading, error, register, unregister }`                   |
+| `MobilePushProviderConfig` | type     | Resolved config — optional `client`, required `basePath`                   |
+| `MobilePushProviderProps`  | type     | `{ config, children }`; `config.basePath` optional (provider defaults it)  |
 
 `./testing` subpath (requires the optional `msw` peer):
 `createMobilePushHandlers` (stateful MSW handlers — register/unregister mutate an

--- a/packages/@granit/react-notifications-mobile-push/src/__tests__/use-mobile-push.test.tsx
+++ b/packages/@granit/react-notifications-mobile-push/src/__tests__/use-mobile-push.test.tsx
@@ -62,7 +62,7 @@ describe('useMobilePush', () => {
 
   it('should initialize with default state', () => {
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
+    const { result } = renderHook(() => useMobilePush({ platform: 'Android' }), { wrapper });
 
     expect(result.current.isRegistered).toBe(false);
     expect(result.current.loading).toBe(false);
@@ -71,7 +71,7 @@ describe('useMobilePush', () => {
 
   it('should expose register and unregister functions', () => {
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
+    const { result } = renderHook(() => useMobilePush({ platform: 'Android' }), { wrapper });
 
     expect(typeof result.current.register).toBe('function');
     expect(typeof result.current.unregister).toBe('function');
@@ -82,7 +82,7 @@ describe('useMobilePush', () => {
     mockRequestPermissions.mockResolvedValue({ receive: 'denied' });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
+    const { result } = renderHook(() => useMobilePush({ platform: 'Android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();
@@ -108,7 +108,7 @@ describe('useMobilePush', () => {
     });
 
     const { wrapper, client } = createWrapper();
-    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
+    const { result } = renderHook(() => useMobilePush({ platform: 'Android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();
@@ -118,8 +118,8 @@ describe('useMobilePush', () => {
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
     expect(mockRegisterDeviceToken).toHaveBeenCalledWith(client, '/api/v1/notifications', {
-      token: 'device-token-123',
-      platform: 'android',
+      deviceToken: 'device-token-123',
+      platform: 'Android',
     });
   });
 
@@ -135,7 +135,7 @@ describe('useMobilePush', () => {
     });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
+    const { result } = renderHook(() => useMobilePush({ platform: 'Android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();
@@ -157,7 +157,7 @@ describe('useMobilePush', () => {
     });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
+    const { result } = renderHook(() => useMobilePush({ platform: 'Android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();
@@ -180,7 +180,7 @@ describe('useMobilePush', () => {
     });
 
     const { wrapper, client } = createWrapper({ basePath: '/custom' });
-    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
+    const { result } = renderHook(() => useMobilePush({ platform: 'Android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();
@@ -200,7 +200,7 @@ describe('useMobilePush', () => {
 
   it('should handle unregister when no token exists', async () => {
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
+    const { result } = renderHook(() => useMobilePush({ platform: 'Android' }), { wrapper });
 
     await act(async () => {
       await result.current.unregister();
@@ -223,7 +223,7 @@ describe('useMobilePush', () => {
     });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
+    const { result } = renderHook(() => useMobilePush({ platform: 'Android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();
@@ -243,14 +243,14 @@ describe('useMobilePush', () => {
 
   it('should use default basePath from provider', () => {
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
+    const { result } = renderHook(() => useMobilePush({ platform: 'Android' }), { wrapper });
 
     expect(result.current.error).toBeNull();
   });
 
   it('should accept custom basePath via provider', () => {
     const { wrapper } = createWrapper({ basePath: '/custom/api' });
-    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
+    const { result } = renderHook(() => useMobilePush({ platform: 'Android' }), { wrapper });
 
     expect(result.current.error).toBeNull();
   });
@@ -259,7 +259,7 @@ describe('useMobilePush', () => {
     mockCheckPermissions.mockRejectedValueOnce('string error');
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
+    const { result } = renderHook(() => useMobilePush({ platform: 'Android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();
@@ -281,7 +281,7 @@ describe('useMobilePush', () => {
     });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
+    const { result } = renderHook(() => useMobilePush({ platform: 'Android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();
@@ -311,7 +311,7 @@ describe('useMobilePush', () => {
     });
 
     const { wrapper, client } = createWrapper();
-    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
+    const { result } = renderHook(() => useMobilePush({ platform: 'Android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();
@@ -349,8 +349,8 @@ describe('useMobilePush', () => {
         'initial-token'
       );
       expect(mockRegisterDeviceToken).toHaveBeenCalledWith(client, '/api/v1/notifications', {
-        token: 'refreshed-token',
-        platform: 'android',
+        deviceToken: 'refreshed-token',
+        platform: 'Android',
       });
     }
   });
@@ -367,7 +367,7 @@ describe('useMobilePush', () => {
     });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useMobilePush({ platform: 'ios' }), { wrapper });
+    const { result } = renderHook(() => useMobilePush({ platform: 'Ios' }), { wrapper });
 
     await act(async () => {
       await result.current.register();
@@ -402,7 +402,7 @@ describe('useMobilePush', () => {
     mockCheckPermissions.mockResolvedValue({ receive: 'denied' });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
+    const { result } = renderHook(() => useMobilePush({ platform: 'Android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();

--- a/packages/@granit/react-notifications-mobile-push/src/hooks/use-mobile-push.ts
+++ b/packages/@granit/react-notifications-mobile-push/src/hooks/use-mobile-push.ts
@@ -88,7 +88,7 @@ export function useMobilePush(options: MobilePushHookOptions): UseMobilePushRetu
           await unregisterDeviceToken(apiClient, basePath, oldToken);
         }
         await registerDeviceToken(apiClient, basePath, {
-          token: token.value,
+          deviceToken: token.value,
           platform: options.platform,
         });
         logger.info('Mobile push device token refreshed', { platform: options.platform });
@@ -128,7 +128,7 @@ export function useMobilePush(options: MobilePushHookOptions): UseMobilePushRetu
       tokenRef.current = token;
 
       await registerDeviceToken(apiClient, basePath, {
-        token,
+        deviceToken: token,
         platform: options.platform,
       });
 

--- a/packages/@granit/react-notifications-mobile-push/src/testing/data.ts
+++ b/packages/@granit/react-notifications-mobile-push/src/testing/data.ts
@@ -1,23 +1,26 @@
 import { toISODateString } from '@granit/types';
 
-import type { DeviceTokenDto, MobilePushTokenResponse } from '@granit/notifications-mobile-push';
+import type {
+  MobilePushTokenRegisterRequest,
+  MobilePushTokenResponse,
+} from '@granit/notifications-mobile-push';
 
 /**
  * Registered device tokens returned by
  * `GET {basePath}/notifications/mobile-push/tokens`.
  *
  * Mirrors the bare `MobilePushTokenResponse[]` the .NET endpoint produces — one
- * token per platform so the device-token list exercises both `android` and `ios`.
+ * token per platform so the device-token list exercises both `Android` and `Ios`.
  */
 export const mockMobilePushTokens: MobilePushTokenResponse[] = [
   {
     deviceToken: 'token-abc-123',
-    platform: 'android',
+    platform: 'Android',
     createdAt: toISODateString('2026-03-17T10:00:00Z'),
   },
   {
     deviceToken: 'token-def-456',
-    platform: 'ios',
+    platform: 'Ios',
     createdAt: toISODateString('2026-03-17T09:00:00Z'),
   },
 ];
@@ -26,8 +29,7 @@ export const mockMobilePushTokens: MobilePushTokenResponse[] = [
  * Sample registration payload for
  * `POST {basePath}/notifications/mobile-push/tokens`.
  */
-export const mockDeviceTokenRegistration: DeviceTokenDto = {
-  token: 'token-ghi-789',
-  platform: 'android',
-  deviceId: 'device-001',
+export const mockDeviceTokenRegistration: MobilePushTokenRegisterRequest = {
+  deviceToken: 'token-ghi-789',
+  platform: 'Android',
 };

--- a/packages/@granit/react-notifications-mobile-push/src/testing/handlers.ts
+++ b/packages/@granit/react-notifications-mobile-push/src/testing/handlers.ts
@@ -6,7 +6,10 @@ import { DEFAULT_BASE_PATH } from '../constants';
 
 import { mockMobilePushTokens } from './data';
 
-import type { DeviceTokenDto, MobilePushTokenResponse } from '@granit/notifications-mobile-push';
+import type {
+  MobilePushTokenRegisterRequest,
+  MobilePushTokenResponse,
+} from '@granit/notifications-mobile-push';
 
 /**
  * Create stateful MSW handlers for the mobile-push device-token endpoints.
@@ -28,13 +31,13 @@ export function createMobilePushHandlers(baseUrl = DEFAULT_BASE_PATH) {
 
     // POST register a device token — 204 No Content
     http.post(tokensUrl, async ({ request }) => {
-      const body = (await request.json()) as DeviceTokenDto;
-      const alreadyRegistered = tokens.some((t) => t.deviceToken === body.token);
+      const body = (await request.json()) as MobilePushTokenRegisterRequest;
+      const alreadyRegistered = tokens.some((t) => t.deviceToken === body.deviceToken);
       if (!alreadyRegistered) {
         tokens = [
           ...tokens,
           {
-            deviceToken: body.token,
+            deviceToken: body.deviceToken,
             platform: body.platform,
             createdAt: toISODateString('2026-03-17T12:00:00Z'),
           },

--- a/packages/@granit/react-ui-notifications/src/__tests__/notification-list-page.test.tsx
+++ b/packages/@granit/react-ui-notifications/src/__tests__/notification-list-page.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { NotificationListPage } from '../notification-list-page';
+import { NotificationListPage } from '../components/notification-list-page';
 
 import { renderNotifications } from './test-utils';
 

--- a/packages/@granit/react-ui-notifications/src/__tests__/notification-preferences-page.test.tsx
+++ b/packages/@granit/react-ui-notifications/src/__tests__/notification-preferences-page.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { NotificationPreferencesPage } from '../notification-preferences-page';
+import { NotificationPreferencesPage } from '../components/notification-preferences-page';
 
 import { renderNotifications } from './test-utils';
 

--- a/packages/@granit/react-ui-notifications/src/components/notification-list-page.tsx
+++ b/packages/@granit/react-ui-notifications/src/components/notification-list-page.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@granit/react-localization';
 
-import { NotificationInbox } from './components/notification-inbox';
+import { NotificationInbox } from './notification-inbox';
 
 export function NotificationListPage() {
   const { t } = useTranslation();

--- a/packages/@granit/react-ui-notifications/src/components/notification-preferences-page.tsx
+++ b/packages/@granit/react-ui-notifications/src/components/notification-preferences-page.tsx
@@ -1,9 +1,9 @@
 import { useTranslation } from '@granit/react-localization';
 
-import { NotificationPreferencesPanel } from './components/notification-preferences-panel';
-import { PushNotificationManager } from './components/push-notification-manager';
+import { NotificationPreferencesPanel } from './notification-preferences-panel';
+import { PushNotificationManager } from './push-notification-manager';
 
-import type { PushNotificationManagerProps } from './components/push-notification-manager';
+import type { PushNotificationManagerProps } from './push-notification-manager';
 
 export type NotificationPreferencesPageProps = PushNotificationManagerProps;
 

--- a/packages/@granit/react-ui-notifications/src/index.ts
+++ b/packages/@granit/react-ui-notifications/src/index.ts
@@ -4,9 +4,9 @@
 // resolves from the host-mounted NotificationProvider / GranitClientProvider.
 
 // Pages
-export { NotificationListPage } from './notification-list-page';
-export { NotificationPreferencesPage } from './notification-preferences-page';
-export type { NotificationPreferencesPageProps } from './notification-preferences-page';
+export { NotificationListPage } from './components/notification-list-page';
+export { NotificationPreferencesPage } from './components/notification-preferences-page';
+export type { NotificationPreferencesPageProps } from './components/notification-preferences-page';
 
 // Components
 export { NotificationBell } from './components/notification-bell';


### PR DESCRIPTION
## Audit remediation — `notifications*` packages

Framework audit of the `@granit/*notifications*` family against `Granit.Notifications.*`. Fixes the verified BREAKING/INCONSISTENCY findings that lint/tsc cannot catch.

### BREAKING — mobile-push register contract mismatched with `MobilePushTokenEndpoints`
- **`DeviceTokenDto.token` → `deviceToken`.** Backend `MobilePushTokenRegisterRequest` keys the token as `DeviceToken`; the front sent `token`, so the required field never bound → 422. Type renamed `DeviceTokenDto` → `MobilePushTokenRegisterRequest`; the unused `deviceId` (absent from the backend request) dropped.
- **`MobilePlatform` `'android' | 'ios'` → `'Android' | 'Ios'`.** The API serializes enums PascalCase (`JsonStringEnumConverter`, symmetric with `NotificationSeverity`), so lowercase values failed enum binding.
- README note claiming the token asymmetry was "intentional" corrected — request and response both key `deviceToken`.

### INCONSISTENCY — UI page placement
- `NotificationListPage` / `NotificationPreferencesPage` moved from `src/` root into `src/components/` (canonical `react-ui-{module}` layout).

### Out of scope (needs a backend PR first)
- **web-push is orphaned**: `@granit/notifications-web-push` posts to `/notifications/push-subscriptions`, which does not exist in granit-dotnet (`Granit.Notifications.WebPush` is a sender with only an in-memory store). Tracked separately — the front contract is correct in shape; the backend endpoint must be built.
- The `react-ui-notifications` direct `react-router-dom` import stays baselined (`UI_ROUTER_BASELINE`), unchanged here.

### Verification
- `tsc --noEmit` ✅ (notifications-mobile-push, react-notifications-mobile-push, react-ui-notifications)
- ESLint `--max-warnings 0` ✅
- Vitest ✅ 73 passed
- markdownlint ✅

> [!WARNING]
> **BREAKING CHANGE**: `@granit/notifications-mobile-push` renames the exported `DeviceTokenDto` → `MobilePushTokenRegisterRequest` and changes `MobilePlatform` values to `'Android' | 'Ios'`. No showcase consumers today (blast radius 0).