### PR TITLE
fix(blob-storage): audit remediation on react-ui-blob-storage

### DIFF
--- a/packages/@granit/react-ui-blob-storage/package.json
+++ b/packages/@granit/react-ui-blob-storage/package.json
@@ -44,6 +44,7 @@
     "@granit/blob-storage": "workspace:*",
     "@granit/logger": "workspace:*",
     "@granit/query-engine": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-authorization": "workspace:*",
     "@granit/react-blob-storage": "workspace:*",
     "@granit/react-localization": "workspace:*",

--- a/packages/@granit/react-ui-blob-storage/src/__tests__/blob-list-page.test.tsx
+++ b/packages/@granit/react-ui-blob-storage/src/__tests__/blob-list-page.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import * as React from 'react';
 
-import { BlobListPage } from '../blob-list-page';
+import { BlobListPage } from '../components/blob-list-page';
 
 import { renderWithProviders } from './test-utils';
 
@@ -10,6 +10,7 @@ vi.mock('@granit/react-authorization', () => ({
 }));
 
 vi.mock('@granit/react-blob-storage', () => ({
+  useBlobStorageConfig: () => ({ basePath: '/api/v1/blob-storage', client: {} }),
   useDownloadUrl: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useDeleteBlob: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useCleanupOrphans: () => ({ mutateAsync: vi.fn(), isPending: false }),

--- a/packages/@granit/react-ui-blob-storage/src/components/blob-list-page.stories.tsx
+++ b/packages/@granit/react-ui-blob-storage/src/components/blob-list-page.stories.tsx
@@ -1,0 +1,67 @@
+import { createApiClient } from '@granit/api-client';
+import { GranitClientProvider } from '@granit/react-api-client';
+import { BlobStorageProvider } from '@granit/react-blob-storage';
+import { blobQueryMetadata, createBlobStorageHandlers } from '@granit/react-blob-storage/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+
+import { BlobListPage } from './blob-list-page';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const client = createApiClient({ baseURL: '' });
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const BASE = '/api/v1/blob-storage';
+
+/** Grants the full admin permission set so the row actions + cleanup button render. */
+const grantManage = http.get('/api/v1/authorization/permissions', () =>
+  HttpResponse.json({
+    permissions: ['BlobStorage.Administration.Read', 'BlobStorage.Administration.Manage'],
+  })
+);
+
+/** Read-only: only the Read permission, so the manage actions stay hidden. */
+const grantReadOnly = http.get('/api/v1/authorization/permissions', () =>
+  HttpResponse.json({ permissions: ['BlobStorage.Administration.Read'] })
+);
+
+const metaHandler = http.get(`${BASE}/blobs/meta`, () => HttpResponse.json(blobQueryMetadata));
+
+const meta: Meta<typeof BlobListPage> = {
+  title: 'Features/BlobStorage/BlobListPage',
+  component: BlobListPage,
+  tags: ['autodocs', '!test'],
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers: [grantManage, metaHandler, ...createBlobStorageHandlers()] },
+  },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <GranitClientProvider client={client}>
+          <BlobStorageProvider config={{ client }}>
+            <div className="p-6">
+              <Story />
+            </div>
+          </BlobStorageProvider>
+        </GranitClientProvider>
+      </QueryClientProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Full admin view: the query grid backed by the mock blobs, with per-row download/delete and orphan-cleanup. */
+export const Default: Story = {};
+
+/** Read-only view (no `Manage` permission): the actions column and cleanup button are hidden. */
+export const ReadOnly: Story = {
+  parameters: {
+    msw: { handlers: [grantReadOnly, metaHandler, ...createBlobStorageHandlers()] },
+  },
+};

--- a/packages/@granit/react-ui-blob-storage/src/components/blob-list-page.tsx
+++ b/packages/@granit/react-ui-blob-storage/src/components/blob-list-page.tsx
@@ -1,6 +1,6 @@
 import { BlobStoragePermissions } from '@granit/blob-storage';
 import { usePermissions } from '@granit/react-authorization';
-import { useDeleteBlob, useDownloadUrl } from '@granit/react-blob-storage';
+import { useBlobStorageConfig, useDeleteBlob, useDownloadUrl } from '@granit/react-blob-storage';
 import { useDateFormatter, useTranslation } from '@granit/react-localization';
 import { QueryProvider, useQueryEndpoint, useQueryMeta } from '@granit/react-query-engine';
 import {
@@ -25,9 +25,10 @@ import { formatBytes } from '@granit/utils';
 import { Download, MoreHorizontal, Trash2 } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
-import { BlobCleanupOrphansButton } from './components/blob-cleanup-orphans-button';
-import { BlobDeleteDialog } from './components/blob-delete-dialog';
-import { logger } from './logger';
+import { logger } from '../logger';
+
+import { BlobCleanupOrphansButton } from './blob-cleanup-orphans-button';
+import { BlobDeleteDialog } from './blob-delete-dialog';
 
 import type { BlobDescriptorListItem, BlobStatus } from '@granit/blob-storage';
 import type { QueryConfig } from '@granit/query-engine';
@@ -35,10 +36,8 @@ import type { CellContext, ColumnDef } from '@tanstack/react-table';
 
 type TranslateFn = ReturnType<typeof useTranslation>['t'];
 
-const QUERY_CONFIG: QueryConfig = {
-  basePath: '/api/v1/blob-storage/blobs',
-};
-
+/** Scoped logger for the blob list page. */
+const log = logger.child('BlobList');
 
 const STATUS_INTENT: Record<BlobStatus, StatusBadgeIntent> = {
   Pending: 'warning',
@@ -212,7 +211,7 @@ function BlobStorageContent() {
         globalThis.open(downloadUrl, '_blank', 'noopener,noreferrer');
       } catch (err) {
         // API errors are surfaced by the global MutationCache.onError toast.
-        logger.error('[BlobList] Download failed', err);
+        log.error('Download failed', err);
       }
     },
     [downloadMutation]
@@ -234,7 +233,7 @@ function BlobStorageContent() {
       setDeleteTarget(null);
     } catch (err) {
       // API errors are surfaced by the global MutationCache.onError toast.
-      logger.error('[BlobList] Delete failed', err);
+      log.error('Delete failed', err);
     }
   };
 
@@ -344,8 +343,13 @@ function BlobStorageContent() {
 }
 
 export function BlobListPage() {
+  // Single-source the grid base path from the ambient BlobStorageProvider so it
+  // can never drift from the base path the mutation hooks (download/delete) use.
+  const { basePath } = useBlobStorageConfig();
+  const queryConfig = useMemo<QueryConfig>(() => ({ basePath: `${basePath}/blobs` }), [basePath]);
+
   return (
-    <QueryProvider config={QUERY_CONFIG}>
+    <QueryProvider config={queryConfig}>
       <BlobStorageContent />
     </QueryProvider>
   );

--- a/packages/@granit/react-ui-blob-storage/src/index.ts
+++ b/packages/@granit/react-ui-blob-storage/src/index.ts
@@ -1,4 +1,4 @@
-export { BlobListPage } from './blob-list-page';
+export { BlobListPage } from './components/blob-list-page';
 export { BlobCleanupOrphansButton } from './components/blob-cleanup-orphans-button';
 export { BlobDeleteDialog } from './components/blob-delete-dialog';
 export { FileUploadField } from './components/file-upload-field';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4502,6 +4502,9 @@ importers:
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-authorization':
         specifier: workspace:*
         version: link:../react-authorization


### PR DESCRIPTION
## Context

`/audit` on the upload subsystem (`@granit/blob-storage` trio) surfaced structural
findings on `@granit/react-ui-blob-storage`. This PR remediates the frontend-fixable ones.

## Changes

- **Placement (7f)** — `blob-list-page.tsx` moved from `src/` root to `src/components/`
  (canonical `react-ui-{module}` structure); barrel + test import updated.
- **Base-path drift (IMPROVEMENT)** — `BlobListPage` now sources the query grid `basePath`
  from the ambient `BlobStorageProvider` (`useBlobStorageConfig`) instead of a hardcoded
  literal, so it can never diverge from the base path the download/delete mutation hooks use.
- **Logging (5d)** — replaced the manual `[BlobList]` string prefix with
  `logger.child('BlobList')`.
- **Storybook (GAP)** — added `BlobListPage` stories (`Default` + `ReadOnly`), reusing the
  shared `@granit/react-blob-storage/testing` fixtures (`createBlobStorageHandlers`).
- `@granit/react-api-client` added to **devDependencies** (story wiring only — not a runtime
  peer, conforms to the UI-tier data-access rule); lockfile regenerated in the same commit.

## Verification

- `tsc --noEmit` ✅
- `vitest run` (react-ui-blob-storage) — 28/28 ✅
- `eslint` — clean ✅

## Deferred / out of scope

- **`BlobImage` default download URL** — the default `<img src>` targets
  `GET /blobs/{id}/download`, a route no Granit backend serves. This is backend-side and is
  being handled in `granit-dotnet` (add the endpoint), followed by an OpenAPI resync here.
- **UI upload-field factorization** — composing `FileUploadField`/`ImageUploadField` on the
  headless `BlobUploadField` (IMPROVEMENT) is deferred: the render slots don't cleanly express
  the file-row / aspect-ratio UX, and both components are tested as-is.