### PR TITLE
fix(notifications)!: audit remediation across notifications + webhooks

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -6356,17 +6356,22 @@
     },
     {
       "name": "@granit/react-notifications",
-      "description": "React bindings for @granit/notifications — NotificationProvider, hooks",
+      "description": "React bindings for @granit/notifications — NotificationsProvider, hooks",
       "exports": [
         {
-          "name": "NotificationProvider",
+          "name": "NotificationsProvider",
           "kind": "function",
-          "signature": "function NotificationProvider("
+          "signature": "function NotificationsProvider("
         },
         {
           "name": "useNotificationConfig",
           "kind": "function",
           "signature": "function useNotificationConfig(): NotificationContextValue"
+        },
+        {
+          "name": "buildNotificationsQueryKey",
+          "kind": "function",
+          "signature": "function buildNotificationsQueryKey( config: NotificationConfig &"
         },
         {
           "name": "registerNotificationView",
@@ -6522,11 +6527,6 @@
           "name": "useEntityActivityFeed",
           "kind": "function",
           "signature": "function useEntityActivityFeed( options: UseEntityActivityFeedOptions ): UseEntityActivityFeedReturn"
-        },
-        {
-          "name": "useNotificationPreferences",
-          "kind": "function",
-          "signature": "function useNotificationPreferences(): UseNotificationPreferencesReturn"
         },
         {
           "name": "UseNotificationPreferencesReturn",
@@ -11407,14 +11407,14 @@
           "signature": "function useTestPing(): UseMutationResult< WebhookSubscriptionTestPingResponse, Error, string >"
         },
         {
-          "name": "useRevokeSigningKey",
+          "name": "useCreateSigningKey",
           "kind": "function",
-          "signature": "function useRevokeSigningKey(): UseMutationResult< void, Error,"
+          "signature": "function useCreateSigningKey(): UseMutationResult< WebhookSigningKeyCreatedResponse, Error, string >"
         },
         {
-          "name": "useRotateSigningKey",
+          "name": "useDeleteSigningKey",
           "kind": "function",
-          "signature": "function useRotateSigningKey(): UseMutationResult< WebhookSigningKeyCreatedResponse, Error, string >"
+          "signature": "function useDeleteSigningKey(): UseMutationResult< void, Error,"
         },
         {
           "name": "useSigningKeys",

--- a/packages/@granit/notifications-signalr/README.md
+++ b/packages/@granit/notifications-signalr/README.md
@@ -12,7 +12,7 @@ connection lifecycle and delegates all listener bookkeeping to
 `createTransportListeners` from the core. It is the WebSocket/long-polling
 sibling of the EventSource adapter [`@granit/notifications-sse`](../notifications-sse);
 both produce the same `NotificationTransport` shape and are interchangeable at
-the `NotificationProvider` wiring point. React hooks, the provider, and the
+the `NotificationsProvider` wiring point. React hooks, the provider, and the
 admin feature kit live in [`@granit/react-notifications`](../react-notifications)
 and [`@granit/react-ui-notifications`](../react-ui-notifications) respectively —
 none of that lives here.
@@ -32,7 +32,7 @@ as a published dependency for app consumption. Declare the two peers:
 
 ```ts
 import { createSignalRTransport } from '@granit/notifications-signalr';
-import { NotificationProvider } from '@granit/react-notifications';
+import { NotificationsProvider } from '@granit/react-notifications';
 
 // Build the transport once and pass it to the provider. `hubUrl` points at the
 // .NET notifications hub; `tokenGetter` is called on every connection attempt
@@ -44,9 +44,9 @@ const transport = createSignalRTransport({
 
 function AppShell({ children }: { children: React.ReactNode }) {
   return (
-    <NotificationProvider config={{ apiClient }} transport={transport}>
+    <NotificationsProvider config={{ apiClient }} transport={transport}>
       {children}
-    </NotificationProvider>
+    </NotificationsProvider>
   );
 }
 ```

--- a/packages/@granit/notifications-signalr/src/transports/create-signalr-transport.ts
+++ b/packages/@granit/notifications-signalr/src/transports/create-signalr-transport.ts
@@ -21,7 +21,7 @@ export interface SignalRTransportConfig {
  *   tokenGetter: () => keycloak.token,
  * });
  *
- * <NotificationProvider config={{ apiClient }} transport={transport}>
+ * <NotificationsProvider config={{ apiClient }} transport={transport}>
  * ```
  */
 export function createSignalRTransport(config: SignalRTransportConfig): NotificationTransport {

--- a/packages/@granit/notifications-sse/README.md
+++ b/packages/@granit/notifications-sse/README.md
@@ -14,7 +14,7 @@ sibling [`@granit/notifications-signalr`](../notifications-signalr) implements
 the same `NotificationTransport` contract over a WebSocket/SignalR hub — pick
 one per app. The transport is consumed by the React layer
 [`@granit/react-notifications`](../react-notifications), whose
-`NotificationProvider` accepts an optional `transport` prop; the admin feature
+`NotificationsProvider` accepts an optional `transport` prop; the admin feature
 kit is [`@granit/react-ui-notifications`](../react-ui-notifications). The backend
 counterpart is the `Granit.Notifications` .NET module (wire contract:
 `contracts/openapi/notifications.json`).
@@ -33,13 +33,13 @@ installed from a public registry for app consumption. Declare the peers:
 ## Quick start
 
 `createSseTransport` returns a `NotificationTransport`. Hand it to the
-`NotificationProvider` from `@granit/react-notifications`; the provider drives
+`NotificationsProvider` from `@granit/react-notifications`; the provider drives
 `connect()` / `disconnect()` and subscribes to its callbacks. When omitted, the
 provider falls back to REST polling only.
 
 ```tsx
 import { createSseTransport } from '@granit/notifications-sse';
-import { NotificationProvider } from '@granit/react-notifications';
+import { NotificationsProvider } from '@granit/react-notifications';
 
 // Built once, outside render — same-origin streamUrl, Bearer token re-read on
 // every (re)connect via tokenGetter.
@@ -50,9 +50,9 @@ const transport = createSseTransport({
 
 export function App({ children }: { children: React.ReactNode }) {
   return (
-    <NotificationProvider config={{ apiClient }} transport={transport}>
+    <NotificationsProvider config={{ apiClient }} transport={transport}>
       {children}
-    </NotificationProvider>
+    </NotificationsProvider>
   );
 }
 ```
@@ -80,16 +80,16 @@ await transport.disconnect();
 
 ## Public API
 
-| Symbol               | Kind | Purpose                                                        |
-| -------------------- | ---- | -------------------------------------------------------------- |
-| `createSseTransport` | fn   | Builds a `NotificationTransport` backed by an SSE stream       |
-| `SseTransportConfig` | type | Factory options (`streamUrl`, `tokenGetter`, heartbeat, CORS)  |
+| Symbol               | Kind | Purpose                                                       |
+| -------------------- | ---- | ------------------------------------------------------------- |
+| `createSseTransport` | fn   | Builds a `NotificationTransport` backed by an SSE stream      |
+| `SseTransportConfig` | type | Factory options (`streamUrl`, `tokenGetter`, heartbeat, CORS) |
 
 ### `SseTransportConfig`
 
 | Field               | Type                            | Default           | Purpose                                                               |
 | ------------------- | ------------------------------- | ----------------- | --------------------------------------------------------------------- |
-| `streamUrl`         | `string`                        | — (required)      | SSE endpoint, e.g. `/api/v1/notifications/stream`.                     |
+| `streamUrl`         | `string`                        | — (required)      | SSE endpoint, e.g. `/api/v1/notifications/stream`.                    |
 | `tokenGetter`       | `() => Promise<string \| null>` | none              | Called on each connection attempt; result is sent as `Bearer` if set. |
 | `heartbeatTypeName` | `string`                        | `'__heartbeat__'` | Event name treated as a keep-alive and filtered from notifications.   |
 | `allowCrossOrigin`  | `boolean`                       | `false`           | Opt in to a cross-origin `streamUrl` (see caveats).                   |

--- a/packages/@granit/notifications-sse/src/transports/create-sse-transport.ts
+++ b/packages/@granit/notifications-sse/src/transports/create-sse-transport.ts
@@ -54,7 +54,7 @@ class FatalError extends Error {}
  *   tokenGetter: () => keycloak.token,
  * });
  *
- * <NotificationProvider config={{ apiClient }} transport={transport}>
+ * <NotificationsProvider config={{ apiClient }} transport={transport}>
  * ```
  */
 export function createSseTransport(config: SseTransportConfig): NotificationTransport {

--- a/packages/@granit/react-notifications/README.md
+++ b/packages/@granit/react-notifications/README.md
@@ -6,7 +6,7 @@ feed, preferences, type subscriptions, entity follows, and a pluggable per-type
 rendering registry. This is the **React hooks layer**: it wraps the
 framework-agnostic Axios calls and DTOs from
 [`@granit/notifications`](../notifications) in TanStack Query hooks and a shared
-`NotificationProvider`, and adds the headless rendering primitives that turn a
+`NotificationsProvider`, and adds the headless rendering primitives that turn a
 raw notification payload into a uniform presentation descriptor. It ships no
 chrome — bell, inbox page, preferences panel, and toasts live one layer up.
 
@@ -55,19 +55,19 @@ Wire the provider once (it resolves the Axios client / base path and, optionally
 a real-time transport), then call the hooks anywhere below it.
 
 ```tsx
-import { NotificationProvider } from '@granit/react-notifications';
+import { NotificationsProvider } from '@granit/react-notifications';
 import { useGranitClient } from '@granit/react-api-client';
 import { createSseTransport } from '@granit/notifications-sse';
 
 function App({ children }: { children: React.ReactNode }) {
   const apiClient = useGranitClient();
   return (
-    <NotificationProvider
+    <NotificationsProvider
       config={{ apiClient }}
       transport={createSseTransport({ streamUrl: '/api/v1/notifications/stream' })}
     >
       {children}
-    </NotificationProvider>
+    </NotificationsProvider>
   );
 }
 ```
@@ -99,7 +99,11 @@ function Inbox() {
           </li>
         ))}
       </ul>
-      {hasMore && <button type="button" onClick={loadMore}>Load more</button>}
+      {hasMore && (
+        <button type="button" onClick={loadMore}>
+          Load more
+        </button>
+      )}
     </>
   );
 }
@@ -136,7 +140,7 @@ const presentation = resolveNotificationPresentation(notification, { t });
 
 | Symbol                               | Kind     | Purpose                                                          |
 | ------------------------------------ | -------- | ---------------------------------------------------------------- |
-| `NotificationProvider`               | provider | Supplies config + optional transport; tracks connection / unread |
+| `NotificationsProvider`              | provider | Supplies config + optional transport; tracks connection / unread |
 | `useNotificationConfig`              | hook     | Read the context value (config, connection state, last message)  |
 | `useNotifications`                   | hook     | Paginated inbox, optimistic `markRead` / `markAllRead`           |
 | `useUnreadCount`                     | hook     | Live unread count (push + polling + manual `refresh`)            |

--- a/packages/@granit/react-notifications/package.json
+++ b/packages/@granit/react-notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@granit/react-notifications",
-  "description": "React bindings for @granit/notifications — NotificationProvider, hooks",
+  "description": "React bindings for @granit/notifications — NotificationsProvider, hooks",
   "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/@granit/react-notifications/src/__tests__/notification-provider.test.tsx
+++ b/packages/@granit/react-notifications/src/__tests__/notification-provider.test.tsx
@@ -2,7 +2,7 @@ import { toEntityId, toISODateString } from '@granit/types';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { NotificationProvider, useNotificationConfig } from '../providers/notification-provider';
+import { NotificationsProvider, useNotificationConfig } from '../providers/notifications-provider';
 
 import { createMockClient } from './test-utils';
 
@@ -38,14 +38,14 @@ function createProviderWrapper(
       ...configOverrides,
     };
     return (
-      <NotificationProvider config={config} transport={transport}>
+      <NotificationsProvider config={config} transport={transport}>
         {children}
-      </NotificationProvider>
+      </NotificationsProvider>
     );
   };
 }
 
-describe('NotificationProvider', () => {
+describe('NotificationsProvider', () => {
   let client: AxiosInstance;
 
   beforeEach(() => {
@@ -67,7 +67,7 @@ describe('NotificationProvider', () => {
   it('should throw when used outside provider', () => {
     expect(() => {
       renderHook(() => useNotificationConfig());
-    }).toThrow('useNotificationConfig must be used within a <NotificationProvider>');
+    }).toThrow('useNotificationConfig must be used within a <NotificationsProvider>');
   });
 
   it('should stay disconnected when no transport is provided', () => {

--- a/packages/@granit/react-notifications/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-notifications/src/__tests__/test-utils.tsx
@@ -1,6 +1,6 @@
 export { axiosResponse, createMockClient } from '@granit/testing';
 
-import { NotificationProvider } from '../providers/notification-provider';
+import { NotificationsProvider } from '../providers/notifications-provider';
 
 import type { NotificationConfig } from '@granit/notifications';
 import type { AxiosInstance } from 'axios';
@@ -11,7 +11,7 @@ export function createWrapper(client: AxiosInstance, basePath = '/api/v1') {
       apiClient: client,
       basePath,
     };
-    return <NotificationProvider config={config}>{children}</NotificationProvider>;
+    return <NotificationsProvider config={config}>{children}</NotificationsProvider>;
   };
 }
 
@@ -22,6 +22,6 @@ export function createWrapper(client: AxiosInstance, basePath = '/api/v1') {
 export function createWrapperWithoutBasePath(client: AxiosInstance) {
   return function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
     const config: NotificationConfig = { apiClient: client };
-    return <NotificationProvider config={config}>{children}</NotificationProvider>;
+    return <NotificationsProvider config={config}>{children}</NotificationsProvider>;
   };
 }

--- a/packages/@granit/react-notifications/src/__tests__/use-notification-preferences.test.tsx
+++ b/packages/@granit/react-notifications/src/__tests__/use-notification-preferences.test.tsx
@@ -4,8 +4,12 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { mockNotificationPreferences } from '@granit/react-notifications/testing';
 
-import { useNotificationPreferences } from '../hooks/use-notification-preferences';
-import { NotificationProvider } from '../providers/notification-provider';
+import { buildNotificationsQueryKey } from '../hooks/query-keys';
+import {
+  useNotificationPreferences,
+  useUpsertNotificationPreference,
+} from '../hooks/use-notification-preferences';
+import { NotificationsProvider } from '../providers/notifications-provider';
 
 import { axiosResponse, createMockClient } from './test-utils';
 
@@ -21,7 +25,7 @@ function createWrapper(client: AxiosInstance, basePath = '/api/v1') {
     const config: NotificationConfig = { apiClient: client, basePath };
     return (
       <QueryClientProvider client={queryClient}>
-        <NotificationProvider config={config}>{children}</NotificationProvider>
+        <NotificationsProvider config={config}>{children}</NotificationsProvider>
       </QueryClientProvider>
     );
   };
@@ -35,7 +39,7 @@ function createWrapperWithoutBasePath(client: AxiosInstance) {
     const config: NotificationConfig = { apiClient: client };
     return (
       <QueryClientProvider client={queryClient}>
-        <NotificationProvider config={config}>{children}</NotificationProvider>
+        <NotificationsProvider config={config}>{children}</NotificationsProvider>
       </QueryClientProvider>
     );
   };
@@ -206,5 +210,67 @@ describe('useNotificationPreferences', () => {
     expect(client.get).toHaveBeenCalledWith(
       expect.stringContaining('/api/v1/notifications/preferences')
     );
+  });
+});
+
+describe('useUpsertNotificationPreference', () => {
+  it('should PUT the preference and resolve on success', async () => {
+    const client = createMockClient();
+    vi.mocked(client.put).mockResolvedValue(axiosResponse(undefined));
+
+    const { result } = renderHook(() => useUpsertNotificationPreference(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        notificationTypeName: 'security.login',
+        channelName: 'Email',
+        isEnabled: true,
+      });
+    });
+
+    expect(client.put).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/notifications/preferences'),
+      { notificationTypeName: 'security.login', channelName: 'Email', isEnabled: true }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it('should surface the error on failure', async () => {
+    const client = createMockClient();
+    vi.mocked(client.put).mockRejectedValue(new Error('Upsert failed'));
+
+    const { result } = renderHook(() => useUpsertNotificationPreference(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current
+        .mutateAsync({ notificationTypeName: 't', channelName: 'InApp', isEnabled: false })
+        .catch(() => undefined);
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Upsert failed');
+  });
+});
+
+describe('buildNotificationsQueryKey', () => {
+  it('should default the prefix to ["notifications"]', () => {
+    const config = { apiClient: createMockClient() };
+    expect(buildNotificationsQueryKey(config, 'preferences')).toEqual([
+      'notifications',
+      'preferences',
+    ]);
+  });
+
+  it('should honour a custom queryKeyPrefix', () => {
+    const config = { apiClient: createMockClient(), queryKeyPrefix: ['scope', 'notifs'] as const };
+    expect(buildNotificationsQueryKey(config, 'subscriptions')).toEqual([
+      'scope',
+      'notifs',
+      'subscriptions',
+    ]);
   });
 });

--- a/packages/@granit/react-notifications/src/__tests__/use-notification-subscriptions.test.tsx
+++ b/packages/@granit/react-notifications/src/__tests__/use-notification-subscriptions.test.tsx
@@ -11,7 +11,7 @@ import {
   useUnfollowEntity,
   useUnsubscribeFromNotificationType,
 } from '../hooks/use-notification-subscriptions';
-import { NotificationProvider } from '../providers/notification-provider';
+import { NotificationsProvider } from '../providers/notifications-provider';
 
 import { axiosResponse, createMockClient } from './test-utils';
 
@@ -31,7 +31,7 @@ function createWrapper(client: AxiosInstance, basePath = '/api/v1') {
     const config: NotificationConfig = { apiClient: client, basePath };
     return (
       <QueryClientProvider client={queryClient}>
-        <NotificationProvider config={config}>{children}</NotificationProvider>
+        <NotificationsProvider config={config}>{children}</NotificationsProvider>
       </QueryClientProvider>
     );
   };

--- a/packages/@granit/react-notifications/src/hooks/query-keys.ts
+++ b/packages/@granit/react-notifications/src/hooks/query-keys.ts
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------------------
+// Query key builder
+// ---------------------------------------------------------------------------
+
+import type { NotificationConfig } from '@granit/notifications';
+
+const DEFAULT_QUERY_KEY_PREFIX = ['notifications'] as const;
+
+/**
+ * Builds a config-scoped query key for notifications queries. The module
+ * namespace (default `['notifications']`) is prepended, so a host mounting
+ * several isolated notification scopes can override it via the config's
+ * optional `queryKeyPrefix`.
+ *
+ * @param config - Notification config, optionally carrying a `queryKeyPrefix`.
+ * @param segments - Additional segments appended after the prefix.
+ */
+export function buildNotificationsQueryKey(
+  config: NotificationConfig & { queryKeyPrefix?: readonly string[] },
+  ...segments: readonly unknown[]
+): readonly unknown[] {
+  return [...(config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX), ...segments];
+}

--- a/packages/@granit/react-notifications/src/hooks/use-entity-activity-feed.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-entity-activity-feed.ts
@@ -3,7 +3,7 @@ import { useInfiniteScroll as usePaginatedFetch } from '@granit/react-query-engi
 import { useCallback } from 'react';
 
 import { API_BASE_PATH } from '../constants';
-import { useNotificationConfig } from '../providers/notification-provider';
+import { useNotificationConfig } from '../providers/notifications-provider';
 
 import type { UserNotification, UserNotificationPage } from '@granit/notifications';
 

--- a/packages/@granit/react-notifications/src/hooks/use-notification-preferences.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-notification-preferences.ts
@@ -1,14 +1,17 @@
 import { getPreferences, updatePreference } from '@granit/notifications';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { API_BASE_PATH } from '../constants';
-import { useNotificationConfig } from '../providers/notification-provider';
+import { useNotificationConfig } from '../providers/notifications-provider';
+
+import { buildNotificationsQueryKey } from './query-keys';
 
 import type {
   NotificationPreferenceResponse,
   NotificationPreferenceUpdateRequest,
 } from '@granit/notifications';
+import type { UseMutationResult } from '@tanstack/react-query';
 
 export interface UseNotificationPreferencesReturn {
   preferences: readonly NotificationPreferenceResponse[];
@@ -19,13 +22,39 @@ export interface UseNotificationPreferencesReturn {
   refresh: () => void;
 }
 
-const PREFERENCES_KEY = ['notifications', 'preferences'] as const;
-
 interface ToggleVars {
   preferenceId: string;
   notificationTypeName: string;
   channelName: string;
   enabled: boolean;
+}
+
+/**
+ * Mutation hook that upserts a single notification preference row (one per type ×
+ * channel). Use it to create a preference that does not exist yet, or to update
+ * an existing one. Invalidates the preferences query on success so the panel
+ * reflects the server-assigned row.
+ *
+ * `PUT {basePath}/notifications/preferences`
+ */
+export function useUpsertNotificationPreference(): UseMutationResult<
+  void,
+  Error,
+  NotificationPreferenceUpdateRequest
+> {
+  const { config } = useNotificationConfig();
+  const basePath = config.basePath ?? API_BASE_PATH;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: NotificationPreferenceUpdateRequest) =>
+      updatePreference(config.apiClient, basePath, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildNotificationsQueryKey(config, 'preferences'),
+      });
+    },
+  });
 }
 
 /**
@@ -38,6 +67,7 @@ export function useNotificationPreferences(): UseNotificationPreferencesReturn {
   const { config } = useNotificationConfig();
   const basePath = config.basePath ?? API_BASE_PATH;
   const queryClient = useQueryClient();
+  const preferencesKey = useMemo(() => buildNotificationsQueryKey(config, 'preferences'), [config]);
 
   const {
     data: preferences = [],
@@ -45,7 +75,7 @@ export function useNotificationPreferences(): UseNotificationPreferencesReturn {
     error: queryError,
     refetch,
   } = useQuery({
-    queryKey: PREFERENCES_KEY,
+    queryKey: preferencesKey,
     queryFn: () => getPreferences(config.apiClient, basePath),
   });
 
@@ -59,29 +89,29 @@ export function useNotificationPreferences(): UseNotificationPreferencesReturn {
       return updatePreference(config.apiClient, basePath, req);
     },
     onMutate: async ({ preferenceId, enabled }) => {
-      await queryClient.cancelQueries({ queryKey: PREFERENCES_KEY });
+      await queryClient.cancelQueries({ queryKey: preferencesKey });
       const previous =
-        queryClient.getQueryData<readonly NotificationPreferenceResponse[]>(PREFERENCES_KEY);
+        queryClient.getQueryData<readonly NotificationPreferenceResponse[]>(preferencesKey);
       queryClient.setQueryData<readonly NotificationPreferenceResponse[]>(
-        PREFERENCES_KEY,
+        preferencesKey,
         (old = []) => old.map((p) => (p.id === preferenceId ? { ...p, isEnabled: enabled } : p))
       );
       return { previous };
     },
     onError: (_err, _vars, context) => {
       if (context?.previous) {
-        queryClient.setQueryData(PREFERENCES_KEY, context.previous);
+        queryClient.setQueryData(preferencesKey, context.previous);
       }
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: PREFERENCES_KEY });
+      queryClient.invalidateQueries({ queryKey: preferencesKey });
     },
   });
 
   const togglePreference = useCallback(
     (preferenceId: string, enabled: boolean) => {
       const pref = (
-        queryClient.getQueryData<readonly NotificationPreferenceResponse[]>(PREFERENCES_KEY) ?? []
+        queryClient.getQueryData<readonly NotificationPreferenceResponse[]>(preferencesKey) ?? []
       ).find((p) => p.id === preferenceId);
       if (!pref) return;
       mutation.mutate({
@@ -91,7 +121,7 @@ export function useNotificationPreferences(): UseNotificationPreferencesReturn {
         enabled,
       });
     },
-    [mutation, queryClient]
+    [mutation, queryClient, preferencesKey]
   );
 
   const refresh = useCallback(() => {

--- a/packages/@granit/react-notifications/src/hooks/use-notification-subscriptions.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-notification-subscriptions.ts
@@ -11,22 +11,15 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { API_BASE_PATH } from '../constants';
 import { logger } from '../logger';
-import { useNotificationConfig } from '../providers/notification-provider';
+import { useNotificationConfig } from '../providers/notifications-provider';
+
+import { buildNotificationsQueryKey } from './query-keys';
 
 import type {
   NotificationDefinition,
   NotificationSubscriptionResponse,
 } from '@granit/notifications';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
-
-// ---------------------------------------------------------------------------
-// Query keys
-// ---------------------------------------------------------------------------
-
-const NOTIFICATION_TYPES_KEY = ['notifications', 'types'] as const;
-const SUBSCRIPTIONS_KEY = ['notifications', 'subscriptions'] as const;
-const ENTITY_FOLLOWERS_KEY = (entityType: string, entityId: string) =>
-  ['notifications', 'entity', entityType, entityId, 'followers'] as const;
 
 // ---------------------------------------------------------------------------
 // Notification types — the registry of available notifications
@@ -42,7 +35,7 @@ export function useNotificationTypes(): UseQueryResult<readonly NotificationDefi
   const { config } = useNotificationConfig();
   const basePath = config.basePath ?? API_BASE_PATH;
   return useQuery({
-    queryKey: NOTIFICATION_TYPES_KEY,
+    queryKey: buildNotificationsQueryKey(config, 'types'),
     queryFn: () => listNotificationTypes(config.apiClient, basePath),
     staleTime: 5 * 60_000,
   });
@@ -63,7 +56,7 @@ export function useNotificationSubscriptions(): UseQueryResult<
   const { config } = useNotificationConfig();
   const basePath = config.basePath ?? API_BASE_PATH;
   return useQuery({
-    queryKey: SUBSCRIPTIONS_KEY,
+    queryKey: buildNotificationsQueryKey(config, 'subscriptions'),
     queryFn: () => listSubscriptions(config.apiClient, basePath),
   });
 }
@@ -81,7 +74,9 @@ export function useSubscribeToNotificationType(): UseMutationResult<void, Error,
     mutationFn: (typeName) => subscribeToNotificationType(config.apiClient, basePath, typeName),
     onSuccess: (_data, typeName) => {
       logger.debug('Subscribed to notification type', { typeName });
-      queryClient.invalidateQueries({ queryKey: SUBSCRIPTIONS_KEY });
+      queryClient.invalidateQueries({
+        queryKey: buildNotificationsQueryKey(config, 'subscriptions'),
+      });
     },
   });
 }
@@ -99,7 +94,9 @@ export function useUnsubscribeFromNotificationType(): UseMutationResult<void, Er
     mutationFn: (typeName) => unsubscribeFromNotificationType(config.apiClient, basePath, typeName),
     onSuccess: (_data, typeName) => {
       logger.debug('Unsubscribed from notification type', { typeName });
-      queryClient.invalidateQueries({ queryKey: SUBSCRIPTIONS_KEY });
+      queryClient.invalidateQueries({
+        queryKey: buildNotificationsQueryKey(config, 'subscriptions'),
+      });
     },
   });
 }
@@ -128,7 +125,9 @@ export function useFollowEntity(): UseMutationResult<void, Error, EntityFollowVa
       followEntity(config.apiClient, basePath, entityType, entityId),
     onSuccess: (_data, { entityType, entityId }) => {
       logger.debug('Followed entity', { entityType, entityId });
-      queryClient.invalidateQueries({ queryKey: ENTITY_FOLLOWERS_KEY(entityType, entityId) });
+      queryClient.invalidateQueries({
+        queryKey: buildNotificationsQueryKey(config, 'entity', entityType, entityId, 'followers'),
+      });
     },
   });
 }
@@ -147,7 +146,9 @@ export function useUnfollowEntity(): UseMutationResult<void, Error, EntityFollow
       unfollowEntity(config.apiClient, basePath, entityType, entityId),
     onSuccess: (_data, { entityType, entityId }) => {
       logger.debug('Unfollowed entity', { entityType, entityId });
-      queryClient.invalidateQueries({ queryKey: ENTITY_FOLLOWERS_KEY(entityType, entityId) });
+      queryClient.invalidateQueries({
+        queryKey: buildNotificationsQueryKey(config, 'entity', entityType, entityId, 'followers'),
+      });
     },
   });
 }
@@ -164,7 +165,7 @@ export function useEntityFollowers(
   const { config } = useNotificationConfig();
   const basePath = config.basePath ?? API_BASE_PATH;
   return useQuery({
-    queryKey: ENTITY_FOLLOWERS_KEY(entityType, entityId),
+    queryKey: buildNotificationsQueryKey(config, 'entity', entityType, entityId, 'followers'),
     queryFn: () => listEntityFollowers(config.apiClient, basePath, entityType, entityId),
     enabled: Boolean(entityType) && Boolean(entityId),
   });

--- a/packages/@granit/react-notifications/src/hooks/use-notifications.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-notifications.ts
@@ -5,7 +5,7 @@ import { useCallback } from 'react';
 
 import { API_BASE_PATH } from '../constants';
 import { logger } from '../logger';
-import { useNotificationConfig } from '../providers/notification-provider';
+import { useNotificationConfig } from '../providers/notifications-provider';
 
 import type { UserNotification, UserNotificationPage } from '@granit/notifications';
 

--- a/packages/@granit/react-notifications/src/hooks/use-real-time-notifications.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-real-time-notifications.ts
@@ -1,4 +1,4 @@
-import { useNotificationConfig } from '../providers/notification-provider';
+import { useNotificationConfig } from '../providers/notifications-provider';
 
 import type { ConnectionState, NotificationTransportMessage } from '@granit/notifications';
 

--- a/packages/@granit/react-notifications/src/hooks/use-unread-count.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-unread-count.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import { API_BASE_PATH } from '../constants';
 import { logger } from '../logger';
-import { useNotificationConfig } from '../providers/notification-provider';
+import { useNotificationConfig } from '../providers/notifications-provider';
 
 export interface UseUnreadCountOptions {
   /** Polling interval in ms. Set to 0 to disable polling. Default: 60 000 */

--- a/packages/@granit/react-notifications/src/index.ts
+++ b/packages/@granit/react-notifications/src/index.ts
@@ -1,5 +1,8 @@
 // Provider
-export { NotificationProvider, useNotificationConfig } from './providers/notification-provider';
+export { NotificationsProvider, useNotificationConfig } from './providers/notifications-provider';
+
+// Query keys
+export { buildNotificationsQueryKey } from './hooks/query-keys';
 
 // Rendering — view registry, resolution, default view
 export { registerNotificationView, getNotificationView } from './rendering/registry';
@@ -30,7 +33,10 @@ export type {
   UseEntityActivityFeedReturn,
 } from './hooks/use-entity-activity-feed';
 
-export { useNotificationPreferences } from './hooks/use-notification-preferences';
+export {
+  useNotificationPreferences,
+  useUpsertNotificationPreference,
+} from './hooks/use-notification-preferences';
 export type { UseNotificationPreferencesReturn } from './hooks/use-notification-preferences';
 
 export {

--- a/packages/@granit/react-notifications/src/providers/notifications-provider.tsx
+++ b/packages/@granit/react-notifications/src/providers/notifications-provider.tsx
@@ -30,7 +30,7 @@ const NotificationContext = createContext<NotificationContextValue | null>(null)
 export function useNotificationConfig(): NotificationContextValue {
   const ctx = useContext(NotificationContext);
   if (!ctx) {
-    throw new Error('useNotificationConfig must be used within a <NotificationProvider>');
+    throw new Error('useNotificationConfig must be used within a <NotificationsProvider>');
   }
   return ctx;
 }
@@ -39,18 +39,18 @@ export function useNotificationConfig(): NotificationContextValue {
 // Provider
 // ---------------------------------------------------------------------------
 
-interface NotificationProviderProps {
+interface NotificationsProviderProps {
   children: React.ReactNode;
   config: NotificationConfig;
   /** Optional real-time transport. When omitted, only REST API polling is available. */
   transport?: NotificationTransport;
 }
 
-export function NotificationProvider({
+export function NotificationsProvider({
   children,
   config,
   transport,
-}: Readonly<NotificationProviderProps>) {
+}: Readonly<NotificationsProviderProps>) {
   const [connectionState, setConnectionState] = useState<ConnectionState>('disconnected');
   const [lastMessage, setLastMessage] = useState<NotificationTransportMessage | null>(null);
   const [unreadCount, setUnreadCount] = useState(0);

--- a/packages/@granit/react-ui-notifications/README.md
+++ b/packages/@granit/react-ui-notifications/README.md
@@ -17,7 +17,7 @@ is:
 - [`@granit/notifications`](../notifications) — framework-agnostic core: DTOs +
   Axios calls (`updatePreference`, severity/channel/state enums, `UserNotification`).
 - [`@granit/react-notifications`](../react-notifications) — React Query hooks,
-  `NotificationProvider`, and the headless rendering registry this kit re-exports.
+  `NotificationsProvider`, and the headless rendering registry this kit re-exports.
 - `@granit/react-ui-notifications` (this package) — the admin pages and components.
 
 Transports plug in below the headless layer:
@@ -35,7 +35,7 @@ Workspace-internal — consumed via the `@granit/*` Vite/Vitest aliases, not
 published for app consumption through a public registry. A consumer must declare
 these peers:
 
-- `@granit/react-notifications` — headless data hooks, `NotificationProvider`,
+- `@granit/react-notifications` — headless data hooks, `NotificationsProvider`,
   and the rendering registry this kit composes.
 - `@granit/notifications` — core DTOs (`NotificationSeverity`, `NotificationChannel`,
   `NotificationDefinition`, `UserNotification`) and the `updatePreference` call.
@@ -55,14 +55,14 @@ these peers:
 
 ## Quick start
 
-The host wraps the tree in the headless `NotificationProvider` (which resolves the
+The host wraps the tree in the headless `NotificationsProvider` (which resolves the
 Axios client from the surrounding `GranitClientProvider`), registers the i18n
 bundle, then mounts the bell, the toast handler, and the page routes. Importing any
 rendering symbol self-registers the built-in views (test notification + activity
 notifications) as a side effect.
 
 ```tsx
-import { NotificationProvider } from '@granit/react-notifications';
+import { NotificationsProvider } from '@granit/react-notifications';
 import {
   NotificationListPage,
   NotificationPreferencesPage,
@@ -76,7 +76,7 @@ i18n.addResourceBundle('en', 'translation', notificationsTranslationsEn, true, t
 
 function NotificationsArea() {
   return (
-    <NotificationProvider config={{ apiClient, basePath: '/api/v1' }}>
+    <NotificationsProvider config={{ apiClient, basePath: '/api/v1' }}>
       <NotificationBell />
       <NotificationToastHandler />
       <Routes>
@@ -89,7 +89,7 @@ function NotificationsArea() {
           }
         />
       </Routes>
-    </NotificationProvider>
+    </NotificationsProvider>
   );
 }
 ```
@@ -111,7 +111,10 @@ registerNotificationView<{ title: string; documentId: string }>({
   present: (data, _notification, ctx) => ({
     title: data.title,
     icon: FileText,
-    action: { label: ctx.t('Documents.View', { defaultValue: 'Open' }), to: `/documents/${data.documentId}` },
+    action: {
+      label: ctx.t('Documents.View', { defaultValue: 'Open' }),
+      to: `/documents/${data.documentId}`,
+    },
   }),
 });
 ```
@@ -158,7 +161,7 @@ registration of the built-in views.
 
 ## Injection
 
-- **API client** — the headless `NotificationProvider` (host-mounted) resolves the
+- **API client** — the headless `NotificationsProvider` (host-mounted) resolves the
   Axios client from a `GranitClientProvider`. The `PushNotificationManager` falls
   back to the same provider for its client; the VAPID public key is passed as a
   prop (the host reads it from its env).

--- a/packages/@granit/react-ui-notifications/package.json
+++ b/packages/@granit/react-ui-notifications/package.json
@@ -16,7 +16,6 @@
   "peerDependencies": {
     "@granit/notifications": "workspace:*",
     "@granit/react-activities": "workspace:*",
-    "@granit/react-api-client": "workspace:*",
     "@granit/react-localization": "workspace:*",
     "@granit/react-notifications": "workspace:*",
     "@granit/react-notifications-web-push": "workspace:*",

--- a/packages/@granit/react-ui-notifications/src/__tests__/notification-preferences-page.test.tsx
+++ b/packages/@granit/react-ui-notifications/src/__tests__/notification-preferences-page.test.tsx
@@ -5,21 +5,20 @@ import { NotificationPreferencesPage } from '../components/notification-preferen
 
 import { renderNotifications } from './test-utils';
 
-const { mockUseNotificationPreferences, mockUseNotificationTypes, mockUseNotificationConfig } =
-  vi.hoisted(() => ({
-    mockUseNotificationPreferences: vi.fn(),
-    mockUseNotificationTypes: vi.fn(),
-    mockUseNotificationConfig: vi.fn(),
-  }));
+const {
+  mockUseNotificationPreferences,
+  mockUseNotificationTypes,
+  mockUseUpsertNotificationPreference,
+} = vi.hoisted(() => ({
+  mockUseNotificationPreferences: vi.fn(),
+  mockUseNotificationTypes: vi.fn(),
+  mockUseUpsertNotificationPreference: vi.fn(),
+}));
 
 vi.mock('@granit/react-notifications', () => ({
   useNotificationPreferences: mockUseNotificationPreferences,
   useNotificationTypes: mockUseNotificationTypes,
-  useNotificationConfig: mockUseNotificationConfig,
-}));
-
-vi.mock('@granit/notifications', () => ({
-  updatePreference: vi.fn(),
+  useUpsertNotificationPreference: mockUseUpsertNotificationPreference,
 }));
 
 const mockDefinitions = [
@@ -38,8 +37,9 @@ const mockDefinitions = [
 ];
 
 beforeEach(() => {
-  mockUseNotificationConfig.mockReturnValue({
-    config: { apiClient: {}, basePath: '/api/v1' },
+  mockUseUpsertNotificationPreference.mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+    isPending: false,
   });
   mockUseNotificationTypes.mockReturnValue({ data: mockDefinitions, isLoading: false });
   mockUseNotificationPreferences.mockReturnValue({

--- a/packages/@granit/react-ui-notifications/src/__tests__/notification-preferences-panel.test.tsx
+++ b/packages/@granit/react-ui-notifications/src/__tests__/notification-preferences-panel.test.tsx
@@ -5,21 +5,20 @@ import { NotificationPreferencesPanel } from '../components/notification-prefere
 
 import { renderNotifications } from './test-utils';
 
-const { mockUseNotificationPreferences, mockUseNotificationTypes, mockUseNotificationConfig } =
-  vi.hoisted(() => ({
-    mockUseNotificationPreferences: vi.fn(),
-    mockUseNotificationTypes: vi.fn(),
-    mockUseNotificationConfig: vi.fn(),
-  }));
+const {
+  mockUseNotificationPreferences,
+  mockUseNotificationTypes,
+  mockUseUpsertNotificationPreference,
+} = vi.hoisted(() => ({
+  mockUseNotificationPreferences: vi.fn(),
+  mockUseNotificationTypes: vi.fn(),
+  mockUseUpsertNotificationPreference: vi.fn(),
+}));
 
 vi.mock('@granit/react-notifications', () => ({
   useNotificationPreferences: mockUseNotificationPreferences,
   useNotificationTypes: mockUseNotificationTypes,
-  useNotificationConfig: mockUseNotificationConfig,
-}));
-
-vi.mock('@granit/notifications', () => ({
-  updatePreference: vi.fn(),
+  useUpsertNotificationPreference: mockUseUpsertNotificationPreference,
 }));
 
 const mockDefinitions = [
@@ -63,8 +62,9 @@ const mockPreferences = [
 ];
 
 beforeEach(() => {
-  mockUseNotificationConfig.mockReturnValue({
-    config: { apiClient: {}, basePath: '/api/v1' },
+  mockUseUpsertNotificationPreference.mockReturnValue({
+    mutateAsync: vi.fn().mockResolvedValue(undefined),
+    isPending: false,
   });
   mockUseNotificationTypes.mockReturnValue({ data: mockDefinitions, isLoading: false });
   mockUseNotificationPreferences.mockReturnValue({

--- a/packages/@granit/react-ui-notifications/src/components/notification-bell.stories.tsx
+++ b/packages/@granit/react-ui-notifications/src/components/notification-bell.stories.tsx
@@ -1,5 +1,5 @@
 import { createApiClient } from '@granit/api-client';
-import { NotificationProvider } from '@granit/react-notifications';
+import { NotificationsProvider } from '@granit/react-notifications';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -21,11 +21,11 @@ const meta: Meta<typeof NotificationBell> = {
     (Story) => (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <NotificationProvider config={{ apiClient: client, basePath: '/api/v1' }}>
+          <NotificationsProvider config={{ apiClient: client, basePath: '/api/v1' }}>
             <div className="flex items-center gap-4 p-8">
               <Story />
             </div>
-          </NotificationProvider>
+          </NotificationsProvider>
         </MemoryRouter>
       </QueryClientProvider>
     ),

--- a/packages/@granit/react-ui-notifications/src/components/notification-inbox.stories.tsx
+++ b/packages/@granit/react-ui-notifications/src/components/notification-inbox.stories.tsx
@@ -1,5 +1,5 @@
 import { createApiClient } from '@granit/api-client';
-import { NotificationProvider } from '@granit/react-notifications';
+import { NotificationsProvider } from '@granit/react-notifications';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -21,9 +21,9 @@ const meta: Meta<typeof NotificationInbox> = {
     (Story) => (
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <NotificationProvider config={{ apiClient: client, basePath: '/api/v1' }}>
+          <NotificationsProvider config={{ apiClient: client, basePath: '/api/v1' }}>
             <Story />
-          </NotificationProvider>
+          </NotificationsProvider>
         </MemoryRouter>
       </QueryClientProvider>
     ),

--- a/packages/@granit/react-ui-notifications/src/components/notification-preferences-panel.stories.tsx
+++ b/packages/@granit/react-ui-notifications/src/components/notification-preferences-panel.stories.tsx
@@ -1,5 +1,5 @@
 import { createApiClient } from '@granit/api-client';
-import { NotificationProvider } from '@granit/react-notifications';
+import { NotificationsProvider } from '@granit/react-notifications';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { NotificationPreferencesPanel } from './notification-preferences-panel';
@@ -19,9 +19,9 @@ const meta: Meta<typeof NotificationPreferencesPanel> = {
   decorators: [
     (Story) => (
       <QueryClientProvider client={queryClient}>
-        <NotificationProvider config={{ apiClient: client, basePath: '/api/v1' }}>
+        <NotificationsProvider config={{ apiClient: client, basePath: '/api/v1' }}>
           <Story />
-        </NotificationProvider>
+        </NotificationsProvider>
       </QueryClientProvider>
     ),
   ],

--- a/packages/@granit/react-ui-notifications/src/components/notification-preferences-panel.tsx
+++ b/packages/@granit/react-ui-notifications/src/components/notification-preferences-panel.tsx
@@ -1,9 +1,8 @@
-import { updatePreference } from '@granit/notifications';
 import { useTranslation } from '@granit/react-localization';
 import {
-  useNotificationConfig,
   useNotificationPreferences,
   useNotificationTypes,
+  useUpsertNotificationPreference,
 } from '@granit/react-notifications';
 import {
   Card,
@@ -20,7 +19,6 @@ import { useState, useTransition } from 'react';
 import type { NotificationChannel, NotificationDefinition } from '@granit/notifications';
 
 const channels: NotificationChannel[] = ['InApp', 'Email', 'Push'];
-const DEFAULT_BASE_PATH = '/api/v1';
 
 type PendingKey = `${string}::${string}`;
 
@@ -28,16 +26,10 @@ const keyOf = (typeName: string, channel: string): PendingKey => `${typeName}::$
 
 export function NotificationPreferencesPanel() {
   const { t } = useTranslation();
-  const { config } = useNotificationConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
 
   const { data: definitions = [], isLoading: typesLoading } = useNotificationTypes();
-  const {
-    preferences,
-    loading: prefsLoading,
-    togglePreference,
-    refresh,
-  } = useNotificationPreferences();
+  const { preferences, loading: prefsLoading, togglePreference } = useNotificationPreferences();
+  const upsertPreference = useUpsertNotificationPreference();
 
   const [pending, setPending] = useState<Map<PendingKey, boolean>>(new Map());
   const [saving, startTransition] = useTransition();
@@ -76,16 +68,15 @@ export function NotificationPreferencesPanel() {
       return;
     }
 
-    // No preference row yet — create one via upsert.
+    // No preference row yet — create one via the headless upsert hook.
     setPending((prev) => new Map(prev).set(key, isEnabled));
     startTransition(async () => {
       try {
-        await updatePreference(config.apiClient, basePath, {
+        await upsertPreference.mutateAsync({
           notificationTypeName: def.name,
           channelName: channel,
           isEnabled,
         });
-        refresh();
       } finally {
         setPending((prev) => {
           const next = new Map(prev);

--- a/packages/@granit/react-ui-notifications/src/index.ts
+++ b/packages/@granit/react-ui-notifications/src/index.ts
@@ -1,7 +1,7 @@
 // @granit/react-ui-notifications — admin UI for the Granit.Notifications module.
 // Composes the headless @granit/react-notifications (data hooks + provider + the
 // presentation registry) with the foundation UI packages. The Axios client
-// resolves from the host-mounted NotificationProvider / GranitClientProvider.
+// resolves from the host-mounted NotificationsProvider / GranitClientProvider.
 
 // Pages
 export { NotificationListPage } from './components/notification-list-page';

--- a/packages/@granit/react-ui-webhooks/src/__tests__/webhook-signing-keys.test.tsx
+++ b/packages/@granit/react-ui-webhooks/src/__tests__/webhook-signing-keys.test.tsx
@@ -33,8 +33,8 @@ const signingKeysState = {
 
 vi.mock('@granit/react-webhooks', () => ({
   useSigningKeys: () => signingKeysState,
-  useRotateSigningKey: () => ({ mutateAsync: rotateMutateAsync, isPending: false }),
-  useRevokeSigningKey: () => ({ mutateAsync: revokeMutateAsync, isPending: false }),
+  useCreateSigningKey: () => ({ mutateAsync: rotateMutateAsync, isPending: false }),
+  useDeleteSigningKey: () => ({ mutateAsync: revokeMutateAsync, isPending: false }),
 }));
 
 beforeEach(() => {

--- a/packages/@granit/react-ui-webhooks/src/components/webhook-signing-keys.tsx
+++ b/packages/@granit/react-ui-webhooks/src/components/webhook-signing-keys.tsx
@@ -10,7 +10,7 @@ import {
   TableRow,
 } from '@granit/react-ui';
 import { ConfirmActionDialog } from '@granit/react-ui-kit';
-import { useRevokeSigningKey, useRotateSigningKey, useSigningKeys } from '@granit/react-webhooks';
+import { useCreateSigningKey, useDeleteSigningKey, useSigningKeys } from '@granit/react-webhooks';
 import { WebhookSigningKeyStatus } from '@granit/webhooks';
 import { RefreshCw } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
@@ -32,8 +32,8 @@ export function WebhookSigningKeys({
   const { formatDateTime } = useDateFormatter();
 
   const { data: keys, isLoading } = useSigningKeys(subscriptionId);
-  const rotateMutation = useRotateSigningKey();
-  const revokeMutation = useRevokeSigningKey();
+  const rotateMutation = useCreateSigningKey();
+  const revokeMutation = useDeleteSigningKey();
 
   const [rotatedSecret, setRotatedSecret] = useState<string | null>(null);
   const [keyToRevoke, setKeyToRevoke] = useState<string | null>(null);

--- a/packages/@granit/react-webhooks/src/__tests__/use-signing-keys.test.tsx
+++ b/packages/@granit/react-webhooks/src/__tests__/use-signing-keys.test.tsx
@@ -9,8 +9,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { webhooksKeys } from '../hooks/query-keys';
 import {
-  useRevokeSigningKey,
-  useRotateSigningKey,
+  useCreateSigningKey,
+  useDeleteSigningKey,
   useSigningKeys,
 } from '../hooks/use-signing-keys';
 import { WebhooksProvider } from '../providers/webhooks-provider';
@@ -67,7 +67,7 @@ describe('useSigningKeys', () => {
   });
 });
 
-describe('useRotateSigningKey', () => {
+describe('useCreateSigningKey', () => {
   it('should POST /{id}/keys and invalidate keys + subscription', async () => {
     const client = createMockClient();
     const response: WebhookSigningKeyCreatedResponse = {
@@ -81,7 +81,7 @@ describe('useRotateSigningKey', () => {
     const { wrapper, queryClient } = createWrapper(client);
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
-    const { result } = renderHook(() => useRotateSigningKey(), { wrapper });
+    const { result } = renderHook(() => useCreateSigningKey(), { wrapper });
     result.current.mutate('sub-001');
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -101,7 +101,7 @@ describe('useRotateSigningKey', () => {
     vi.mocked(client.post).mockRejectedValueOnce(new Error('Forbidden'));
 
     const { wrapper } = createWrapper(client);
-    const { result } = renderHook(() => useRotateSigningKey(), { wrapper });
+    const { result } = renderHook(() => useCreateSigningKey(), { wrapper });
     result.current.mutate('sub-001');
 
     await waitFor(() => expect(result.current.isError).toBe(true));
@@ -109,7 +109,7 @@ describe('useRotateSigningKey', () => {
   });
 });
 
-describe('useRevokeSigningKey', () => {
+describe('useDeleteSigningKey', () => {
   it('should DELETE /{id}/keys/{keyId} and invalidate keys', async () => {
     const client = createMockClient();
     vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
@@ -117,7 +117,7 @@ describe('useRevokeSigningKey', () => {
     const { wrapper, queryClient } = createWrapper(client);
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
-    const { result } = renderHook(() => useRevokeSigningKey(), { wrapper });
+    const { result } = renderHook(() => useDeleteSigningKey(), { wrapper });
     result.current.mutate({ subscriptionId: 'sub-001', keyId: 'wsk-001' });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -135,7 +135,7 @@ describe('useRevokeSigningKey', () => {
     vi.mocked(client.delete).mockRejectedValueOnce(new Error('Bad Request'));
 
     const { wrapper } = createWrapper(client);
-    const { result } = renderHook(() => useRevokeSigningKey(), { wrapper });
+    const { result } = renderHook(() => useDeleteSigningKey(), { wrapper });
     result.current.mutate({ subscriptionId: 'sub-001', keyId: 'wsk-001' });
 
     await waitFor(() => expect(result.current.isError).toBe(true));

--- a/packages/@granit/react-webhooks/src/hooks/use-signing-keys.ts
+++ b/packages/@granit/react-webhooks/src/hooks/use-signing-keys.ts
@@ -1,4 +1,4 @@
-import { listSigningKeys, revokeSigningKey, rotateSigningKey } from '@granit/webhooks';
+import { createSigningKey, deleteSigningKey, listSigningKeys } from '@granit/webhooks';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { useWebhooksConfig } from '../providers/webhooks-provider';
@@ -27,13 +27,13 @@ export function useSigningKeys(
 }
 
 /**
- * Mutation hook to rotate a subscription's signing key.
+ * Mutation hook to create a new signing key for a subscription.
  *
  * The new plaintext secret is returned exactly once — store it securely.
  * Invalidates the keys list and the subscription (its `signingSecretHint`
  * is refreshed) on success.
  */
-export function useRotateSigningKey(): UseMutationResult<
+export function useCreateSigningKey(): UseMutationResult<
   WebhookSigningKeyCreatedResponse,
   Error,
   string
@@ -42,7 +42,7 @@ export function useRotateSigningKey(): UseMutationResult<
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (id: string) => rotateSigningKey(client, `${basePath}/subscriptions`, id),
+    mutationFn: (id: string) => createSigningKey(client, `${basePath}/subscriptions`, id),
     onSuccess: async (_data, id) => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: webhooksKeys.signingKeys(id) }),
@@ -53,12 +53,13 @@ export function useRotateSigningKey(): UseMutationResult<
 }
 
 /**
- * Mutation hook to revoke a specific signing key.
+ * Mutation hook to delete a specific signing key.
  *
- * The last Active key cannot be revoked — rotate first, then revoke the old one
- * (the backend rejects the request otherwise). Invalidates the keys list on success.
+ * The last Active key cannot be deleted — create a new key first, then delete
+ * the old one (the backend rejects the request otherwise). Invalidates the keys
+ * list on success.
  */
-export function useRevokeSigningKey(): UseMutationResult<
+export function useDeleteSigningKey(): UseMutationResult<
   void,
   Error,
   { subscriptionId: string; keyId: string }
@@ -68,7 +69,7 @@ export function useRevokeSigningKey(): UseMutationResult<
 
   return useMutation({
     mutationFn: ({ subscriptionId, keyId }) =>
-      revokeSigningKey(client, `${basePath}/subscriptions`, subscriptionId, keyId),
+      deleteSigningKey(client, `${basePath}/subscriptions`, subscriptionId, keyId),
     onSuccess: async (_data, { subscriptionId }) => {
       await queryClient.invalidateQueries({
         queryKey: webhooksKeys.signingKeys(subscriptionId),

--- a/packages/@granit/react-webhooks/src/index.ts
+++ b/packages/@granit/react-webhooks/src/index.ts
@@ -19,7 +19,7 @@ export {
   useSuspendSubscription,
 } from './hooks/use-subscription-lifecycle';
 export { useTestPing } from './hooks/use-subscription-operations';
-export { useRevokeSigningKey, useRotateSigningKey, useSigningKeys } from './hooks/use-signing-keys';
+export { useCreateSigningKey, useDeleteSigningKey, useSigningKeys } from './hooks/use-signing-keys';
 export { useRetryDelivery } from './hooks/use-retry-delivery';
 export { useEventTypes } from './hooks/use-event-types';
 export { useWebhookConfig } from './hooks/use-webhook-config';

--- a/packages/@granit/webhooks/src/__tests__/webhooks-api.test.ts
+++ b/packages/@granit/webhooks/src/__tests__/webhooks-api.test.ts
@@ -4,8 +4,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   activateSubscription,
+  createSigningKey,
   createSubscription,
   deactivateSubscription,
+  deleteSigningKey,
   deleteSubscription,
   getConfig,
   getEventTypes,
@@ -13,8 +15,6 @@ import {
   getSubscription,
   listSigningKeys,
   retryDelivery,
-  revokeSigningKey,
-  rotateSigningKey,
   suspendSubscription,
   testPing,
   updateSubscription,
@@ -189,7 +189,7 @@ describe('webhooks-api', () => {
     });
   });
 
-  describe('rotateSigningKey', () => {
+  describe('createSigningKey', () => {
     it('sends POST to /{id}/keys and returns the created key', async () => {
       const client = createMockClient();
       const response: WebhookSigningKeyCreatedResponse = {
@@ -200,19 +200,19 @@ describe('webhooks-api', () => {
       };
       vi.mocked(client.post).mockResolvedValueOnce({ data: response });
 
-      const result = await rotateSigningKey(client, BASE, 'sub-001');
+      const result = await createSigningKey(client, BASE, 'sub-001');
 
       expect(client.post).toHaveBeenCalledWith(`${BASE}/sub-001/keys`);
       expect(result).toEqual(response);
     });
   });
 
-  describe('revokeSigningKey', () => {
+  describe('deleteSigningKey', () => {
     it('sends DELETE to /{id}/keys/{keyId}', async () => {
       const client = createMockClient();
       vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
 
-      await revokeSigningKey(client, BASE, 'sub-001', 'wsk-001');
+      await deleteSigningKey(client, BASE, 'sub-001', 'wsk-001');
 
       expect(client.delete).toHaveBeenCalledWith(`${BASE}/sub-001/keys/wsk-001`);
     });
@@ -221,7 +221,7 @@ describe('webhooks-api', () => {
       const client = createMockClient();
       vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
 
-      await revokeSigningKey(client, BASE, 'id/slash', 'key/slash');
+      await deleteSigningKey(client, BASE, 'id/slash', 'key/slash');
 
       expect(client.delete).toHaveBeenCalledWith(`${BASE}/id%2Fslash/keys/key%2Fslash`);
     });

--- a/packages/@granit/webhooks/src/api/webhooks-api.ts
+++ b/packages/@granit/webhooks/src/api/webhooks-api.ts
@@ -147,12 +147,12 @@ export async function listSigningKeys(
 }
 
 /**
- * Rotate the signing key of a subscription. The previous Active key moves to
+ * Create a new signing key for a subscription. The previous Active key moves to
  * Retired for a grace period; the new plaintext secret is returned exactly once.
  *
  * `POST {basePath}/{id}/keys`
  */
-export async function rotateSigningKey(
+export async function createSigningKey(
   client: AxiosInstance,
   basePath: string,
   id: string
@@ -164,12 +164,12 @@ export async function rotateSigningKey(
 }
 
 /**
- * Revoke a specific signing key. The last Active key cannot be revoked — rotate
- * first to introduce a new Active key, then revoke the old one.
+ * Delete a specific signing key. The last Active key cannot be deleted — create
+ * a new key first to introduce a fresh Active key, then delete the old one.
  *
  * `DELETE {basePath}/{id}/keys/{keyId}`
  */
-export async function revokeSigningKey(
+export async function deleteSigningKey(
   client: AxiosInstance,
   basePath: string,
   id: string,

--- a/packages/@granit/webhooks/src/index.ts
+++ b/packages/@granit/webhooks/src/index.ts
@@ -22,8 +22,10 @@ export type {
 // API
 export {
   activateSubscription,
+  createSigningKey,
   createSubscription,
   deactivateSubscription,
+  deleteSigningKey,
   deleteSubscription,
   getConfig,
   getEventTypes,
@@ -31,8 +33,6 @@ export {
   getSubscription,
   listSigningKeys,
   retryDelivery,
-  revokeSigningKey,
-  rotateSigningKey,
   suspendSubscription,
   testPing,
   updateSubscription,


### PR DESCRIPTION
Part of the 2026-07-01 framework audit remediation (`/audit`). One PR per bounded-context family.

- **BREAKING layer fix**: route preference upsert through a new `useUpsertNotificationPreference` headless hook (was raw core HTTP in the UI tier)
- config-scoped `buildNotificationsQueryKey` factory
- rename `NotificationProvider`→`NotificationsProvider`, `rotate/revokeSigningKey`→`create/deleteSigningKey`

⚠️ Breaking: needs a coordinated **showcase-admin-react** MR (draft) for the renamed exports.