### PR TITLE
fix(ai): audit remediation across ai modules

### DIFF
--- a/packages/@granit/react-ai-chat/src/logger.ts
+++ b/packages/@granit/react-ai-chat/src/logger.ts
@@ -1,3 +1,5 @@
 import { createLogger } from '@granit/logger';
 
+/** Package-scoped logger. Mutation errors surface to the user via the host's
+ * MutationCache toast; this records the developer-facing detail. */
 export const logger = createLogger('react-ai-chat');


### PR DESCRIPTION
Part of the 2026-07-01 framework audit remediation (`/audit`). One PR per bounded-context family.

- logger docblock parity (react-ai-chat). Non-breaking.
- Note: the flagged `data-lookup` dead-dep was a false positive (used in the `/testing` subpath) — kept.