### PR TITLE
fix(infra): audit remediation across shell-core/settings/query-keys

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3905,7 +3905,13 @@
     {
       "name": "@granit/react-background-jobs",
       "description": "React hooks for background job monitoring — useBackgroundJobs, usePauseJob, useResumeJob, useTriggerJob",
-      "exports": []
+      "exports": [
+        {
+          "name": "buildBackgroundJobsQueryKey",
+          "kind": "function",
+          "signature": "function buildBackgroundJobsQueryKey( config: Pick<BackgroundJobsConfig, 'queryKeyPrefix'>, ...segments: readonly unknown[] ): readonly unknown[]"
+        }
+      ]
     },
     {
       "name": "@granit/react-bank-accounts",
@@ -4055,9 +4061,9 @@
           "signature": "function blobListQueryKey(config:"
         },
         {
-          "name": "blobStorageKeys",
-          "kind": "const",
-          "signature": "const blobStorageKeys"
+          "name": "buildBlobStorageQueryKey",
+          "kind": "function",
+          "signature": "function buildBlobStorageQueryKey( config: Pick<BlobStorageConfig, 'queryKeyPrefix'>, ...segments: readonly unknown[] ): readonly unknown[]"
         }
       ]
     },
@@ -7228,25 +7234,24 @@
       "exports": [
         {
           "name": "SettingsProvider",
-          "kind": "function",
-          "signature": "function SettingsProvider("
+          "kind": "const",
+          "signature": "const SettingsProvider"
         },
         {
           "name": "useSettingsConfig",
-          "kind": "function",
-          "signature": "function useSettingsConfig(): ResolvedSettingsConfig"
+          "kind": "const",
+          "signature": "const useSettingsConfig"
         },
         {
           "name": "SettingsConfig",
           "kind": "interface",
-          "signature": "interface SettingsConfig",
+          "signature": "interface SettingsConfig extends GranitProviderConfig",
           "members": []
         },
         {
           "name": "SettingsProviderProps",
-          "kind": "interface",
-          "signature": "interface SettingsProviderProps",
-          "members": []
+          "kind": "type",
+          "signature": "type SettingsProviderProps = GranitProviderProps<SettingsConfig>"
         },
         {
           "name": "buildSettingsQueryKey",

--- a/packages/@granit/arch-tests/src/__tests__/helpers.ts
+++ b/packages/@granit/arch-tests/src/__tests__/helpers.ts
@@ -82,11 +82,9 @@ export const RSC_PACKAGES: ReadonlyArray<string> = ['@granit/react-cms'];
  * R1 (checklist 7g) — framework-agnostic (non-`react-`) packages must not import the
  * React ecosystem (`react`, `react-dom`, `@tanstack/react-query`) so a future
  * non-React adapter can reuse the core. The framework-neutral query core is
- * `@tanstack/query-core`. Allowlisted debt:
- *   @granit/shell-core — `src/query-client.ts` still imports `@tanstack/react-query`
- *   (migrate to `@tanstack/query-core`).
+ * `@tanstack/query-core`. No allowlisted debt remains.
  */
-export const REACT_ECOSYSTEM_CORE_ALLOWLIST: ReadonlyArray<string> = ['@granit/shell-core'];
+export const REACT_ECOSYSTEM_CORE_ALLOWLIST: ReadonlyArray<string> = [];
 
 /**
  * R3 (checklist 7g) — `react-ui-*` packages that currently import a web router

--- a/packages/@granit/react-background-jobs/README.md
+++ b/packages/@granit/react-background-jobs/README.md
@@ -88,24 +88,24 @@ function JobsTable() {
 
 `useBackgroundJobs` returns a `PagedResult<BackgroundJobStatus>` (`items`,
 `totalCount`, `hasMore`). Use `useBackgroundJob(name)` for a single job; it stays
-disabled while `name` is empty. Every mutation invalidates `backgroundJobKeys.all`
-on success.
+disabled while `name` is empty. Every mutation invalidates the module root key
+(`buildBackgroundJobsQueryKey(config)`) on success.
 
 ## Public API
 
-| Symbol                         | Kind     | Purpose                                                  |
-| ------------------------------ | -------- | -------------------------------------------------------- |
-| `BackgroundJobsProvider`       | provider | Resolves the Axios client + base path into context       |
-| `useBackgroundJobsConfig`      | hook     | Reads the `ResolvedBackgroundJobsConfig` from context    |
-| `useBackgroundJobs`            | hook     | Paginated list of all jobs; polls 15s (`GET .../jobs`)   |
-| `useBackgroundJob`             | hook     | Single job by name; polls 15s, disabled when empty       |
-| `usePauseJob`                  | hook     | Pause mutation (`POST .../jobs/{name}/pause`)            |
-| `useResumeJob`                 | hook     | Resume mutation (`POST .../jobs/{name}/resume`)          |
-| `useTriggerJob`                | hook     | Manual-run mutation (`POST .../jobs/{name}/trigger`)     |
-| `backgroundJobKeys`            | const    | Query key factory (`all` / `list(params)` / `job(name)`) |
-| `BackgroundJobsConfig`         | type     | Provider input: optional `client` and `basePath`         |
-| `ResolvedBackgroundJobsConfig` | type     | `BackgroundJobsConfig` with a guaranteed `client`        |
-| `BackgroundJobsProviderProps`  | type     | `{ config, children }` for the provider                  |
+| Symbol                         | Kind     | Purpose                                                   |
+| ------------------------------ | -------- | --------------------------------------------------------- |
+| `BackgroundJobsProvider`       | provider | Resolves the Axios client + base path into context        |
+| `useBackgroundJobsConfig`      | hook     | Reads the `ResolvedBackgroundJobsConfig` from context     |
+| `useBackgroundJobs`            | hook     | Paginated list of all jobs; polls 15s (`GET .../jobs`)    |
+| `useBackgroundJob`             | hook     | Single job by name; polls 15s, disabled when empty        |
+| `usePauseJob`                  | hook     | Pause mutation (`POST .../jobs/{name}/pause`)             |
+| `useResumeJob`                 | hook     | Resume mutation (`POST .../jobs/{name}/resume`)           |
+| `useTriggerJob`                | hook     | Manual-run mutation (`POST .../jobs/{name}/trigger`)      |
+| `buildBackgroundJobsQueryKey`  | fn       | Query key factory: `(config, ...segments)`                |
+| `BackgroundJobsConfig`         | type     | Provider input: `client?`, `basePath?`, `queryKeyPrefix?` |
+| `ResolvedBackgroundJobsConfig` | type     | `BackgroundJobsConfig` with a guaranteed `client`         |
+| `BackgroundJobsProviderProps`  | type     | `{ config, children }` for the provider                   |
 
 ### `/testing` subpath
 

--- a/packages/@granit/react-background-jobs/src/__tests__/use-background-jobs.test.tsx
+++ b/packages/@granit/react-background-jobs/src/__tests__/use-background-jobs.test.tsx
@@ -7,8 +7,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { mockBackgroundJobs } from '@granit/react-background-jobs/testing';
 
+import { buildBackgroundJobsQueryKey } from '../hooks/query-keys';
 import {
-  backgroundJobKeys,
   useBackgroundJobs,
   usePauseJob,
   useResumeJob,
@@ -42,13 +42,13 @@ const mockPage: PagedResult<BackgroundJobStatus> = {
   hasMore: false,
 };
 
-describe('backgroundJobKeys', () => {
+describe('buildBackgroundJobsQueryKey', () => {
   it('should produce stable list key without params', () => {
-    expect(backgroundJobKeys.list()).toEqual(['background-jobs', 'list', {}]);
+    expect(buildBackgroundJobsQueryKey({}, 'list', {})).toEqual(['background-jobs', 'list', {}]);
   });
 
   it('should produce stable list key with params', () => {
-    expect(backgroundJobKeys.list({ page: 2, pageSize: 10 })).toEqual([
+    expect(buildBackgroundJobsQueryKey({}, 'list', { page: 2, pageSize: 10 })).toEqual([
       'background-jobs',
       'list',
       { page: 2, pageSize: 10 },
@@ -56,7 +56,17 @@ describe('backgroundJobKeys', () => {
   });
 
   it('should produce stable job key', () => {
-    expect(backgroundJobKeys.job('InvoiceSync')).toEqual(['background-jobs', 'job', 'InvoiceSync']);
+    expect(buildBackgroundJobsQueryKey({}, 'job', 'InvoiceSync')).toEqual([
+      'background-jobs',
+      'job',
+      'InvoiceSync',
+    ]);
+  });
+
+  it('honours a custom queryKeyPrefix', () => {
+    expect(
+      buildBackgroundJobsQueryKey({ queryKeyPrefix: ['custom'] }, 'job', 'InvoiceSync')
+    ).toEqual(['custom', 'job', 'InvoiceSync']);
   });
 });
 
@@ -129,7 +139,7 @@ describe('usePauseJob', () => {
 
     expect(client.post).toHaveBeenCalledWith('/api/v1/background-jobs/jobs/InvoiceSync/pause');
     expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: backgroundJobKeys.all,
+      queryKey: buildBackgroundJobsQueryKey({}),
     });
   });
 
@@ -178,7 +188,7 @@ describe('useResumeJob', () => {
 
     expect(client.post).toHaveBeenCalledWith('/api/v1/background-jobs/jobs/InvoiceSync/resume');
     expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: backgroundJobKeys.all,
+      queryKey: buildBackgroundJobsQueryKey({}),
     });
   });
 
@@ -227,7 +237,7 @@ describe('useTriggerJob', () => {
 
     expect(client.post).toHaveBeenCalledWith('/api/v1/background-jobs/jobs/InvoiceSync/trigger');
     expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: backgroundJobKeys.all,
+      queryKey: buildBackgroundJobsQueryKey({}),
     });
   });
 

--- a/packages/@granit/react-background-jobs/src/hooks/query-keys.ts
+++ b/packages/@granit/react-background-jobs/src/hooks/query-keys.ts
@@ -1,0 +1,16 @@
+import type { BackgroundJobsConfig } from '../providers/background-jobs-provider';
+
+export const DEFAULT_BACKGROUND_JOBS_KEY_PREFIX = ['background-jobs'] as const;
+
+/**
+ * Builds a consistent React Query key for background-jobs operations.
+ *
+ * @param config - Provider config carrying an optional `queryKeyPrefix`.
+ * @param segments - Additional segments appended after the prefix.
+ */
+export function buildBackgroundJobsQueryKey(
+  config: Pick<BackgroundJobsConfig, 'queryKeyPrefix'>,
+  ...segments: readonly unknown[]
+): readonly unknown[] {
+  return [...(config.queryKeyPrefix ?? DEFAULT_BACKGROUND_JOBS_KEY_PREFIX), ...segments];
+}

--- a/packages/@granit/react-background-jobs/src/hooks/use-background-jobs.ts
+++ b/packages/@granit/react-background-jobs/src/hooks/use-background-jobs.ts
@@ -9,17 +9,11 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { useBackgroundJobsConfig } from '../providers/background-jobs-provider';
 
+import { buildBackgroundJobsQueryKey } from './query-keys';
+
 import type { BackgroundJobListParams, BackgroundJobStatus } from '@granit/background-jobs';
 import type { PagedResult } from '@granit/query-engine';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
-
-/** Query key factory for background jobs queries. */
-export const backgroundJobKeys = {
-  all: ['background-jobs'] as const,
-  list: (params?: BackgroundJobListParams) =>
-    [...backgroundJobKeys.all, 'list', params ?? {}] as const,
-  job: (name: string) => [...backgroundJobKeys.all, 'job', name] as const,
-};
 
 /**
  * Query hook that lists a paginated collection of all background jobs with their current status.
@@ -35,12 +29,12 @@ export const backgroundJobKeys = {
 export function useBackgroundJobs(
   params?: BackgroundJobListParams
 ): UseQueryResult<PagedResult<BackgroundJobStatus>> {
-  const { client, basePath } = useBackgroundJobsConfig();
-  const jobsPath = `${basePath}/jobs`;
+  const config = useBackgroundJobsConfig();
+  const jobsPath = `${config.basePath}/jobs`;
 
   return useQuery({
-    queryKey: backgroundJobKeys.list(params),
-    queryFn: () => listBackgroundJobs(client, jobsPath, params),
+    queryKey: buildBackgroundJobsQueryKey(config, 'list', params ?? {}),
+    queryFn: () => listBackgroundJobs(config.client, jobsPath, params),
     refetchInterval: 15_000,
   });
 }
@@ -57,12 +51,12 @@ export function useBackgroundJobs(
  * ```
  */
 export function useBackgroundJob(name: string): UseQueryResult<BackgroundJobStatus> {
-  const { client, basePath } = useBackgroundJobsConfig();
-  const jobsPath = `${basePath}/jobs`;
+  const config = useBackgroundJobsConfig();
+  const jobsPath = `${config.basePath}/jobs`;
 
   return useQuery({
-    queryKey: backgroundJobKeys.job(name),
-    queryFn: () => getBackgroundJob(client, jobsPath, name),
+    queryKey: buildBackgroundJobsQueryKey(config, 'job', name),
+    queryFn: () => getBackgroundJob(config.client, jobsPath, name),
     refetchInterval: 15_000,
     enabled: name.length > 0,
   });
@@ -80,16 +74,16 @@ export function useBackgroundJob(name: string): UseQueryResult<BackgroundJobStat
  * ```
  */
 export function usePauseJob(): UseMutationResult<void, Error, string> {
-  const { client, basePath } = useBackgroundJobsConfig();
-  const jobsPath = `${basePath}/jobs`;
+  const config = useBackgroundJobsConfig();
+  const jobsPath = `${config.basePath}/jobs`;
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (jobName: string) => {
-      await pauseJob(client, jobsPath, jobName);
+      await pauseJob(config.client, jobsPath, jobName);
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: backgroundJobKeys.all });
+      await queryClient.invalidateQueries({ queryKey: buildBackgroundJobsQueryKey(config) });
     },
   });
 }
@@ -106,16 +100,16 @@ export function usePauseJob(): UseMutationResult<void, Error, string> {
  * ```
  */
 export function useResumeJob(): UseMutationResult<void, Error, string> {
-  const { client, basePath } = useBackgroundJobsConfig();
-  const jobsPath = `${basePath}/jobs`;
+  const config = useBackgroundJobsConfig();
+  const jobsPath = `${config.basePath}/jobs`;
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (jobName: string) => {
-      await resumeJob(client, jobsPath, jobName);
+      await resumeJob(config.client, jobsPath, jobName);
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: backgroundJobKeys.all });
+      await queryClient.invalidateQueries({ queryKey: buildBackgroundJobsQueryKey(config) });
     },
   });
 }
@@ -132,16 +126,16 @@ export function useResumeJob(): UseMutationResult<void, Error, string> {
  * ```
  */
 export function useTriggerJob(): UseMutationResult<void, Error, string> {
-  const { client, basePath } = useBackgroundJobsConfig();
-  const jobsPath = `${basePath}/jobs`;
+  const config = useBackgroundJobsConfig();
+  const jobsPath = `${config.basePath}/jobs`;
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (jobName: string) => {
-      await triggerJob(client, jobsPath, jobName);
+      await triggerJob(config.client, jobsPath, jobName);
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: backgroundJobKeys.all });
+      await queryClient.invalidateQueries({ queryKey: buildBackgroundJobsQueryKey(config) });
     },
   });
 }

--- a/packages/@granit/react-background-jobs/src/index.ts
+++ b/packages/@granit/react-background-jobs/src/index.ts
@@ -4,9 +4,11 @@ export {
   useBackgroundJobsConfig,
 } from './providers/background-jobs-provider';
 
+// Query key factory
+export { buildBackgroundJobsQueryKey } from './hooks/query-keys';
+
 // Hooks
 export {
-  backgroundJobKeys,
   useBackgroundJob,
   useBackgroundJobs,
   usePauseJob,

--- a/packages/@granit/react-background-jobs/src/providers/background-jobs-provider.tsx
+++ b/packages/@granit/react-background-jobs/src/providers/background-jobs-provider.tsx
@@ -1,6 +1,7 @@
 import { createConfigProvider } from '@granit/react-api-client';
 
 import { DEFAULT_BASE_PATH } from '../constants';
+import { DEFAULT_BACKGROUND_JOBS_KEY_PREFIX } from '../hooks/query-keys';
 
 import type {
   GranitProviderConfig,
@@ -9,19 +10,31 @@ import type {
 } from '@granit/react-api-client';
 
 /** Configuration for the background jobs provider. */
-export type BackgroundJobsConfig = GranitProviderConfig;
+export interface BackgroundJobsConfig extends GranitProviderConfig {
+  readonly queryKeyPrefix?: readonly string[];
+}
 
 /**
  * BackgroundJobsConfig after the provider has resolved `client` from
- * `config.client` or the nearest `<GranitClientProvider>`.
+ * `config.client` or the nearest `<GranitClientProvider>`, and defaulted
+ * `queryKeyPrefix`.
  */
-export type ResolvedBackgroundJobsConfig = ResolvedGranitProviderConfig<BackgroundJobsConfig>;
+export interface ResolvedBackgroundJobsConfig extends ResolvedGranitProviderConfig<BackgroundJobsConfig> {
+  readonly queryKeyPrefix: readonly string[];
+}
 
 export type BackgroundJobsProviderProps = GranitProviderProps<BackgroundJobsConfig>;
 
-const { Provider, useConfig } = createConfigProvider<BackgroundJobsConfig>({
+const { Provider, useConfig } = createConfigProvider<
+  BackgroundJobsConfig,
+  ResolvedBackgroundJobsConfig
+>({
   name: 'BackgroundJobs',
   defaultBasePath: DEFAULT_BASE_PATH,
+  resolve: (base) => ({
+    ...base,
+    queryKeyPrefix: base.queryKeyPrefix ?? DEFAULT_BACKGROUND_JOBS_KEY_PREFIX,
+  }),
 });
 
 /** Provides background jobs configuration to child components and hooks. */

--- a/packages/@granit/react-blob-storage/README.md
+++ b/packages/@granit/react-blob-storage/README.md
@@ -69,9 +69,7 @@ function App() {
 // resulting blob id as its value. Renders an unstyled, data-attribute scaffold.
 function AvatarField() {
   const [blobId, setBlobId] = useState<string | null>(null);
-  return (
-    <BlobUploadField value={blobId} onChange={setBlobId} containerName="avatars" />
-  );
+  return <BlobUploadField value={blobId} onChange={setBlobId} containerName="avatars" />;
 }
 
 // Or drive the three-step flow manually.
@@ -129,7 +127,7 @@ function Avatar({ blobId }: { blobId: string | null }) {
 | `useCleanupOrphans`         | hook      | Mutation: `POST .../blobs/cleanup-orphans` -> sweep stuck `Pending` blobs        |
 | `BlobImage`                 | component | Headless `<img>` for a blob id (default BFF/cookie URL or `resolveUrl`)          |
 | `BlobUploadField`           | component | Headless upload field; stores the confirmed blob id as its value                 |
-| `blobStorageKeys`           | const     | React Query key factory for single-descriptor `useBlob` reads                    |
+| `buildBlobStorageQueryKey`  | fn        | Query key factory `(config, ...segments)` for single-descriptor `useBlob` reads  |
 | `blobListQueryKey`          | fn        | Query-engine key of the blobs **list**, for cross-invalidation                   |
 | `BlobStorageConfig`         | type      | Provider input (`client?`, `basePath?`, `queryKeyPrefix?`)                       |
 | `ResolvedBlobStorageConfig` | type      | `BlobStorageConfig` with `client` + `basePath` guaranteed                        |
@@ -146,12 +144,12 @@ Wire DTOs (`BlobDescriptorResponse`, `BlobUploadInitiateRequest`, …) and the
 
 ### Testing subpath (`@granit/react-blob-storage/testing`)
 
-| Symbol                       | Kind  | Purpose                                                     |
-| ---------------------------- | ----- | ----------------------------------------------------------- |
-| `createBlobStorageHandlers`  | fn    | MSW handlers for the blob-storage routes (CRUD + query)     |
-| `blobQueryMetadata`          | const | Mock `/meta` payload mirroring the backend query definition |
-| `mockBlobs`                  | const | Seed `BlobDescriptorResponse[]` fixtures                    |
-| `S`                          | const | Alias of `BlobStatus` for terse fixture construction        |
+| Symbol                      | Kind  | Purpose                                                     |
+| --------------------------- | ----- | ----------------------------------------------------------- |
+| `createBlobStorageHandlers` | fn    | MSW handlers for the blob-storage routes (CRUD + query)     |
+| `blobQueryMetadata`         | const | Mock `/meta` payload mirroring the backend query definition |
+| `mockBlobs`                 | const | Seed `BlobDescriptorResponse[]` fixtures                    |
+| `S`                         | const | Alias of `BlobStatus` for terse fixture construction        |
 
 ## Out of scope / caveats
 
@@ -162,7 +160,7 @@ Wire DTOs (`BlobDescriptorResponse`, `BlobUploadInitiateRequest`, …) and the
 - **Deletion is crypto-shredding (irreversible).** `useDeleteBlob` destroys the
   blob's encryption key — pass a meaningful `deletionReason` (e.g. RGPD Art. 17
   erasure). There is no undelete.
-- **Download URLs are ephemeral.** `useDownloadUrl` is a *mutation* by design so
+- **Download URLs are ephemeral.** `useDownloadUrl` is a _mutation_ by design so
   the pre-signed URL is never cached; presign on demand, don't store the URL.
 - **Direct-to-cloud PUT bypasses Axios.** `useBlobUpload` uploads the file body
   with `XMLHttpRequest` against the pre-signed URL (for progress events). Only the

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob-mutations.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob-mutations.test.tsx
@@ -7,7 +7,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { blobListQueryKey, blobStorageKeys } from '../hooks/query-keys';
+import { blobListQueryKey, buildBlobStorageQueryKey } from '../hooks/query-keys';
 import {
   useCancelPendingUpload,
   useConfirmUpload,
@@ -132,7 +132,7 @@ describe('useConfirmUpload', () => {
       containerName: 'docs',
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: blobStorageKeys.blobs(),
+      queryKey: buildBlobStorageQueryKey({}, 'blob'),
     });
     // Also refreshes the query-engine list (admin table) — the keys are disjoint.
     expect(invalidateSpy).toHaveBeenCalledWith({
@@ -176,7 +176,7 @@ describe('useDeleteBlob', () => {
       data: { containerName: 'docs', deletionReason: 'RGPD Art. 17' },
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: blobStorageKeys.blobs(),
+      queryKey: buildBlobStorageQueryKey({}, 'blob'),
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: blobListQueryKey({ basePath: '/api/v1/blob-storage' }),

--- a/packages/@granit/react-blob-storage/src/hooks/query-keys.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/query-keys.ts
@@ -1,18 +1,32 @@
 import { buildQueryKey } from '@granit/query-engine';
 
-/** Query key factory for blob storage queries. */
-export const blobStorageKeys = {
-  all: ['blob-storage'] as const,
-  blobs: () => [...blobStorageKeys.all, 'blob'] as const,
-  blob: (id: string, containerName: string) =>
-    [...blobStorageKeys.blobs(), id, containerName] as const,
-};
+import type { BlobStorageConfig } from '../providers/blob-storage-provider';
+
+export const DEFAULT_BLOB_STORAGE_KEY_PREFIX = ['blob-storage'] as const;
+
+/**
+ * Builds a consistent React Query key for single-descriptor blob operations
+ * (`useBlob` reads and their invalidation).
+ *
+ * Does NOT overlap with {@link blobListQueryKey}, which covers the query-engine
+ * blob **list** (`GET {basePath}/blobs`).
+ *
+ * @param config - Provider config carrying an optional `queryKeyPrefix`.
+ * @param segments - Additional segments appended after the prefix.
+ */
+export function buildBlobStorageQueryKey(
+  config: Pick<BlobStorageConfig, 'queryKeyPrefix'>,
+  ...segments: readonly unknown[]
+): readonly unknown[] {
+  return [...(config.queryKeyPrefix ?? DEFAULT_BLOB_STORAGE_KEY_PREFIX), ...segments];
+}
 
 /**
  * Query key of the blob **list** (`GET {basePath}/blobs`), as built by the
  * query-engine (`@granit/react-query-engine`'s `useQueryEndpoint`). Mutation
  * hooks invalidate this so the admin list refreshes — it does NOT overlap with
- * {@link blobStorageKeys}, which only covers single-descriptor `useBlob` reads.
+ * {@link buildBlobStorageQueryKey}, which only covers single-descriptor
+ * `useBlob` reads.
  *
  * The key mirrors `buildQueryKey({ basePath: \`${basePath}/blobs\` }, 'list')`,
  * matching a `QueryProvider`/`useQueryEndpoint` configured at `{basePath}/blobs`.

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-cleanup.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-cleanup.ts
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { useBlobStorageConfig } from '../providers/blob-storage-provider';
 
-import { blobListQueryKey, blobStorageKeys } from './query-keys';
+import { blobListQueryKey, buildBlobStorageQueryKey } from './query-keys';
 
 import type { BlobCleanupOrphansResponse } from '@granit/blob-storage';
 import type { UseMutationResult } from '@tanstack/react-query';
@@ -27,7 +27,7 @@ export function useCleanupOrphans(): UseMutationResult<BlobCleanupOrphansRespons
     mutationFn: () => cleanupOrphans(config.client, `${config.basePath}/blobs`),
     onSuccess: async () => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() }),
+        queryClient.invalidateQueries({ queryKey: buildBlobStorageQueryKey(config, 'blob') }),
         queryClient.invalidateQueries({ queryKey: blobListQueryKey(config) }),
       ]);
     },

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-mutations.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-mutations.ts
@@ -8,7 +8,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { useBlobStorageConfig } from '../providers/blob-storage-provider';
 
-import { blobListQueryKey, blobStorageKeys } from './query-keys';
+import { blobListQueryKey, buildBlobStorageQueryKey } from './query-keys';
 
 import type {
   BlobCancelPendingRequest,
@@ -69,7 +69,7 @@ export function useConfirmUpload(): UseMutationResult<
       confirmUpload(config.client, `${config.basePath}/blobs`, id, request),
     onSuccess: async () => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() }),
+        queryClient.invalidateQueries({ queryKey: buildBlobStorageQueryKey(config, 'blob') }),
         queryClient.invalidateQueries({ queryKey: blobListQueryKey(config) }),
       ]);
     },
@@ -101,7 +101,7 @@ export function useDeleteBlob(): UseMutationResult<
       deleteBlob(config.client, `${config.basePath}/blobs`, id, request),
     onSuccess: async () => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() }),
+        queryClient.invalidateQueries({ queryKey: buildBlobStorageQueryKey(config, 'blob') }),
         queryClient.invalidateQueries({ queryKey: blobListQueryKey(config) }),
       ]);
     },
@@ -137,7 +137,7 @@ export function useCancelPendingUpload(): UseMutationResult<
       cancelPendingUpload(config.client, `${config.basePath}/blobs`, id, request),
     onSuccess: async () => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() }),
+        queryClient.invalidateQueries({ queryKey: buildBlobStorageQueryKey(config, 'blob') }),
         queryClient.invalidateQueries({ queryKey: blobListQueryKey(config) }),
       ]);
     },

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-upload.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-upload.ts
@@ -5,18 +5,13 @@ import { useCallback, useRef, useState } from 'react';
 import { logger } from '../logger';
 import { useBlobStorageConfig } from '../providers/blob-storage-provider';
 
-import { blobListQueryKey, blobStorageKeys } from './query-keys';
+import { blobListQueryKey, buildBlobStorageQueryKey } from './query-keys';
 
 import type { BlobConfirmUploadResponse } from '@granit/blob-storage';
 
 /** Upload progress phase. */
 export type BlobUploadPhase =
-  | 'idle'
-  | 'initiating'
-  | 'uploading'
-  | 'confirming'
-  | 'complete'
-  | 'error';
+  'idle' | 'initiating' | 'uploading' | 'confirming' | 'complete' | 'error';
 
 /** Current state of the upload orchestration. */
 export interface BlobUploadState {
@@ -215,7 +210,7 @@ export function useBlobUpload(): UseBlobUploadReturn {
         });
 
         await Promise.all([
-          queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() }),
+          queryClient.invalidateQueries({ queryKey: buildBlobStorageQueryKey(config, 'blob') }),
           queryClient.invalidateQueries({ queryKey: blobListQueryKey(config) }),
         ]);
 

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { useBlobStorageConfig } from '../providers/blob-storage-provider';
 
-import { blobStorageKeys } from './query-keys';
+import { buildBlobStorageQueryKey } from './query-keys';
 
 import type { BlobDescriptorResponse } from '@granit/blob-storage';
 import type { UseQueryResult } from '@tanstack/react-query';
@@ -19,11 +19,11 @@ import type { UseQueryResult } from '@tanstack/react-query';
  * ```
  */
 export function useBlob(id: string, containerName: string): UseQueryResult<BlobDescriptorResponse> {
-  const { client, basePath } = useBlobStorageConfig();
+  const config = useBlobStorageConfig();
 
   return useQuery({
-    queryKey: blobStorageKeys.blob(id, containerName),
-    queryFn: () => getBlob(client, `${basePath}/blobs`, id, containerName),
+    queryKey: buildBlobStorageQueryKey(config, 'blob', id, containerName),
+    queryFn: () => getBlob(config.client, `${config.basePath}/blobs`, id, containerName),
     enabled: id.length > 0 && containerName.length > 0,
   });
 }

--- a/packages/@granit/react-blob-storage/src/index.ts
+++ b/packages/@granit/react-blob-storage/src/index.ts
@@ -28,4 +28,4 @@ export { useBlobUpload } from './hooks/use-blob-upload';
 export type { BlobUploadParams, BlobUploadPhase, BlobUploadState } from './hooks/use-blob-upload';
 
 // Query keys
-export { blobListQueryKey, blobStorageKeys } from './hooks/query-keys';
+export { blobListQueryKey, buildBlobStorageQueryKey } from './hooks/query-keys';

--- a/packages/@granit/react-settings/src/__tests__/settings-provider.test.tsx
+++ b/packages/@granit/react-settings/src/__tests__/settings-provider.test.tsx
@@ -34,7 +34,7 @@ describe('SettingsProvider', () => {
   it('should throw when used outside provider', () => {
     expect(() => {
       renderHook(() => useSettingsConfig());
-    }).toThrow('useSettingsConfig must be used within a SettingsProvider');
+    }).toThrow('useSettingsConfig must be used within a <SettingsProvider>');
   });
 
   it('falls back to the GranitClientProvider context client when config.client is omitted', () => {

--- a/packages/@granit/react-settings/src/hooks/query-keys.ts
+++ b/packages/@granit/react-settings/src/hooks/query-keys.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_SETTINGS_KEY_PREFIX } from '../providers/settings-provider';
+
 import type { SettingsConfig } from '../providers/settings-provider';
 
 /** Builds a consistent React Query key for settings operations. */
@@ -5,6 +7,6 @@ export function buildSettingsQueryKey(
   config: SettingsConfig,
   ...segments: readonly string[]
 ): readonly unknown[] {
-  const prefix = config.queryKeyPrefix ?? ['settings'];
+  const prefix = config.queryKeyPrefix ?? DEFAULT_SETTINGS_KEY_PREFIX;
   return [...prefix, ...segments];
 }

--- a/packages/@granit/react-settings/src/hooks/use-admin-app-settings.ts
+++ b/packages/@granit/react-settings/src/hooks/use-admin-app-settings.ts
@@ -30,7 +30,7 @@ export function useAdminAppSettings(
 
   return useQuery({
     queryKey: buildSettingsQueryKey(config, 'admin', 'definitions', scope),
-    queryFn: () => getAdminAppSettings(config.client, config.basePath ?? '', scope),
+    queryFn: () => getAdminAppSettings(config.client, config.basePath, scope),
     enabled: options?.enabled ?? true,
     staleTime: 5 * 60 * 1000,
   });
@@ -55,7 +55,7 @@ export function useBulkUpdateSettings(
 
   return useMutation({
     mutationFn: (settings: BulkUpdateSettingsVariables) =>
-      bulkUpdateSettings(config.client, config.basePath ?? '', scope, settings),
+      bulkUpdateSettings(config.client, config.basePath, scope, settings),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: buildSettingsQueryKey(config, 'admin', 'definitions', scope),

--- a/packages/@granit/react-settings/src/hooks/use-delete-setting.ts
+++ b/packages/@granit/react-settings/src/hooks/use-delete-setting.ts
@@ -31,7 +31,7 @@ export function useDeleteSetting(): UseDeleteSettingReturn {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: (name: string) => deleteSetting(config.client, config.basePath ?? '', 'user', name),
+    mutationFn: (name: string) => deleteSetting(config.client, config.basePath, 'user', name),
     onSuccess: (_data, name) => {
       queryClient
         .invalidateQueries({ queryKey: buildSettingsQueryKey(config, 'user') })

--- a/packages/@granit/react-settings/src/hooks/use-setting.ts
+++ b/packages/@granit/react-settings/src/hooks/use-setting.ts
@@ -26,7 +26,7 @@ export function useSetting(
 
   return useQuery({
     queryKey: buildSettingsQueryKey(config, scope, name),
-    queryFn: () => getSetting(config.client, config.basePath ?? '', scope, name),
+    queryFn: () => getSetting(config.client, config.basePath, scope, name),
     enabled: options?.enabled ?? true,
   });
 }

--- a/packages/@granit/react-settings/src/hooks/use-settings.ts
+++ b/packages/@granit/react-settings/src/hooks/use-settings.ts
@@ -25,7 +25,7 @@ export function useSettings(
 
   return useQuery({
     queryKey: buildSettingsQueryKey(config, scope),
-    queryFn: () => getSettings(config.client, config.basePath ?? '', scope),
+    queryFn: () => getSettings(config.client, config.basePath, scope),
     enabled: options?.enabled ?? true,
   });
 }

--- a/packages/@granit/react-settings/src/hooks/use-update-setting.ts
+++ b/packages/@granit/react-settings/src/hooks/use-update-setting.ts
@@ -33,7 +33,7 @@ export function useUpdateSetting(scope: SettingScope): UseUpdateSettingReturn {
 
   const mutation = useMutation({
     mutationFn: ({ name, value }: { name: string; value: string | null }) =>
-      updateSetting(config.client, config.basePath ?? '', scope, name, { value }),
+      updateSetting(config.client, config.basePath, scope, name, { value }),
     onSuccess: (_data, { name }) => {
       queryClient
         .invalidateQueries({ queryKey: buildSettingsQueryKey(config, scope) })

--- a/packages/@granit/react-settings/src/providers/settings-provider.tsx
+++ b/packages/@granit/react-settings/src/providers/settings-provider.tsx
@@ -1,12 +1,15 @@
-import { useOptionalGranitClient } from '@granit/react-api-client';
-import { createContext, useContext, useMemo } from 'react';
+import { createConfigProvider } from '@granit/react-api-client';
 
-import type { AxiosInstance } from '@granit/api-client';
-import type { ReactNode } from 'react';
+import type {
+  GranitProviderConfig,
+  GranitProviderProps,
+  ResolvedGranitProviderConfig,
+} from '@granit/react-api-client';
+
+export const DEFAULT_SETTINGS_KEY_PREFIX = ['settings'] as const;
 
 /** Configuration for the settings provider. */
-export interface SettingsConfig {
-  readonly client?: AxiosInstance;
+export interface SettingsConfig extends GranitProviderConfig {
   /** Base path prefix before `/settings/...` (default: empty string). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
@@ -14,39 +17,26 @@ export interface SettingsConfig {
 
 /**
  * SettingsConfig after the provider has resolved `client` from
- * `config.client` or the nearest `<GranitClientProvider>`.
+ * `config.client` or the nearest `<GranitClientProvider>`, and defaulted
+ * `basePath` and `queryKeyPrefix`.
  */
-export interface ResolvedSettingsConfig extends SettingsConfig {
-  readonly client: AxiosInstance;
+export interface ResolvedSettingsConfig extends ResolvedGranitProviderConfig<SettingsConfig> {
+  readonly queryKeyPrefix: readonly string[];
 }
 
-export interface SettingsProviderProps {
-  readonly config: SettingsConfig;
-  readonly children: ReactNode;
-}
+export type SettingsProviderProps = GranitProviderProps<SettingsConfig>;
 
-const SettingsConfigContext = createContext<ResolvedSettingsConfig | null>(null);
+const { Provider, useConfig } = createConfigProvider<SettingsConfig, ResolvedSettingsConfig>({
+  name: 'Settings',
+  defaultBasePath: '',
+  resolve: (base) => ({
+    ...base,
+    queryKeyPrefix: base.queryKeyPrefix ?? DEFAULT_SETTINGS_KEY_PREFIX,
+  }),
+});
 
 /** Provides settings configuration to child components and hooks. */
-export function SettingsProvider({ config, children }: Readonly<SettingsProviderProps>) {
-  const contextClient = useOptionalGranitClient();
-  const value = useMemo<ResolvedSettingsConfig>(() => {
-    const client = config.client ?? contextClient;
-    if (!client) {
-      throw new Error(
-        'SettingsProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
-      );
-    }
-    return { ...config, client };
-  }, [config, contextClient]);
-  return <SettingsConfigContext value={value}>{children}</SettingsConfigContext>;
-}
+export const SettingsProvider = Provider;
 
 /** Returns the settings configuration from the nearest `SettingsProvider`. */
-export function useSettingsConfig(): ResolvedSettingsConfig {
-  const ctx = useContext(SettingsConfigContext);
-  if (!ctx) {
-    throw new Error('useSettingsConfig must be used within a SettingsProvider');
-  }
-  return ctx;
-}
+export const useSettingsConfig = useConfig;

--- a/packages/@granit/shell-core/README.md
+++ b/packages/@granit/shell-core/README.md
@@ -31,8 +31,9 @@ these peers:
   403 interceptor installs onto.
 - `@granit/idempotency` — `shouldRetryIgnoringTombstone`, the mutation-retry
   predicate that short-circuits on a tombstoned (replayed) idempotent response.
-- `@tanstack/react-query` (`^5`) — `QueryClient` / `QueryCache` /
-  `MutationCache` built by `createAppQueryClient`.
+- `@tanstack/query-core` (`^5`) — the framework-agnostic `QueryClient` /
+  `QueryCache` / `MutationCache` built by `createAppQueryClient` (this core stays
+  React-free; a React app already has these via `@tanstack/react-query`).
 - `axios` (`^1.6`) — peer of the underlying client.
 - `zustand` (`^5`) — backs the vanilla colour-theme store.
 

--- a/packages/@granit/shell-core/package.json
+++ b/packages/@granit/shell-core/package.json
@@ -16,7 +16,7 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/idempotency": "workspace:*",
-    "@tanstack/react-query": "^5.0.0",
+    "@tanstack/query-core": "^5.0.0",
     "axios": "^1.6.0",
     "zustand": "^5.0.0"
   },
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/idempotency": "workspace:*",
-    "@tanstack/react-query": "^5.0.0",
+    "@tanstack/query-core": "^5.0.0",
     "axios": "^1.6.0",
     "zustand": "^5.0.14"
   }

--- a/packages/@granit/shell-core/src/__tests__/query-client.test.ts
+++ b/packages/@granit/shell-core/src/__tests__/query-client.test.ts
@@ -1,6 +1,6 @@
 import { createAppQueryClient } from '../query-client';
 
-import type { QueryClient } from '@tanstack/react-query';
+import type { QueryClient } from '@tanstack/query-core';
 
 function mutationRetry(client: QueryClient) {
   const retry = client.getDefaultOptions().mutations?.retry;

--- a/packages/@granit/shell-core/src/query-client.ts
+++ b/packages/@granit/shell-core/src/query-client.ts
@@ -1,5 +1,5 @@
 import { shouldRetryIgnoringTombstone } from '@granit/idempotency';
-import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query';
+import { MutationCache, QueryCache, QueryClient } from '@tanstack/query-core';
 
 export interface CreateAppQueryClientOptions {
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7410,9 +7410,9 @@ importers:
       '@granit/idempotency':
         specifier: workspace:*
         version: link:../idempotency
-      '@tanstack/react-query':
-        specifier: 5.101.2
-        version: 5.101.2(react@19.2.7)
+      '@tanstack/query-core':
+        specifier: ^5.100.11
+        version: 5.101.2
       axios:
         specifier: 1.18.1
         version: 1.18.1


### PR DESCRIPTION
Part of the 2026-07-01 framework audit remediation (`/audit`). One PR per bounded-context family.

- shell-core: import from `@tanstack/query-core` (framework-agnostic R1 seam); drop arch-test allowlist debt
- react-settings→createConfigProvider; background-jobs/blob-storage query-key factory standardization. Non-breaking.