### PR TITLE
fix(dashboards): audit remediation across data-exchange/analytics/dashboards query-keys

### DIFF
--- a/packages/@granit/dashboards/src/types/paged-response.ts
+++ b/packages/@granit/dashboards/src/types/paged-response.ts
@@ -1,9 +1,18 @@
 /**
- * Generic pagination envelope used by every Granit list endpoint.
- * Mirrors `Granit.Dashboards.Endpoints.Dtos.PagedResponse<T>`.
+ * Pagination envelope for the dashboards list endpoint. Faithfully mirrors
+ * `Granit.Dashboards.Endpoints.Dtos.PagedResponse<T>`
+ * (`PagedResponseOfDashboardSummaryResponse` in `contracts/openapi/dashboards.json`,
+ * required fields: `items`, `totalCount`, `page`, `pageSize`).
  *
  * `page` is **0-based**, matching the backend convention. `pageSize`
  * defaults to 50 server-side and is capped at 200.
+ *
+ * NOTE — intentional divergence from `@granit/query-engine`'s `PagedResult<T>`:
+ * that canonical envelope is cursor/offset-agnostic (`items` + nullable
+ * `totalCount` + optional `hasMore`/`nextCursor`) and echoes neither `page` nor
+ * `pageSize`. This shape is a wire-faithful mirror of the dashboards backend DTO,
+ * which DOES echo the 0-based `page`/`pageSize`. Do NOT unify onto `PagedResult`
+ * or hand-roll a third variant — consume this type directly for dashboards lists.
  */
 export interface PagedResponse<T> {
   /** Page slice — at most {@link pageSize} items. */

--- a/packages/@granit/react-analytics/src/hooks/query-keys.ts
+++ b/packages/@granit/react-analytics/src/hooks/query-keys.ts
@@ -1,17 +1,19 @@
-import type { MetricRequest } from '@granit/analytics';
-
 /**
- * Query-key factory for analytics queries. The key shape
+ * Query-key factory for analytics queries — variadic `build*QueryKey` idiom,
+ * aligned with `@granit/react-catalog`'s `buildCatalogQueryKey` and
+ * `@granit/react-data-exchange`'s `buildExportQueryKey`/`buildImportQueryKey`
+ * (`[...prefix, ...segments]`).
+ *
+ * react-analytics has no config provider (`useMetric` resolves the Axios client
+ * directly via `useGranitClient`), so the prefix is fixed rather than sourced
+ * from a `config.queryKeyPrefix`. The metric key shape
  * `['analytics', 'metric', name, request]` IS the future SSE subscription
- * identity (proposals doc P2.4) — don't change it without updating that
- * invariant comment in `useMetric`.
+ * identity (proposals doc P2.4) — keep it byte-identical; any push transport
+ * reuses the same composition to address subscriptions.
  */
-export const analyticsKeys = {
-  all: (): readonly string[] => ['analytics'],
-  metric: (name: string, normalizedRequest: MetricRequest): readonly unknown[] => [
-    'analytics',
-    'metric',
-    name,
-    normalizedRequest,
-  ],
-} as const;
+const ANALYTICS_QUERY_KEY_PREFIX = ['analytics'] as const;
+
+/** Builds a consistent React Query key for analytics operations. */
+export function buildAnalyticsQueryKey(...segments: readonly unknown[]): readonly unknown[] {
+  return [...ANALYTICS_QUERY_KEY_PREFIX, ...segments];
+}

--- a/packages/@granit/react-analytics/src/hooks/use-metric.ts
+++ b/packages/@granit/react-analytics/src/hooks/use-metric.ts
@@ -4,7 +4,7 @@ import { useGranitClient } from '@granit/react-api-client';
 import { useQuery, type Query, type UseQueryResult } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
-import { analyticsKeys } from './query-keys';
+import { buildAnalyticsQueryKey } from './query-keys';
 
 import type { MetricRequest, MetricResponse } from '@granit/analytics';
 
@@ -53,7 +53,7 @@ export function useMetric(
   const normalizedRequest = useMemo(() => normalizeMetricRequest(request), [request]);
 
   const queryKey = useMemo(
-    () => analyticsKeys.metric(metricName, normalizedRequest),
+    () => buildAnalyticsQueryKey('metric', metricName, normalizedRequest),
     [metricName, normalizedRequest]
   );
 

--- a/packages/@granit/react-ui-data-exchange/package.json
+++ b/packages/@granit/react-ui-data-exchange/package.json
@@ -15,7 +15,6 @@
   },
   "peerDependencies": {
     "@granit/data-exchange": "workspace:*",
-    "@granit/react-api-client": "workspace:*",
     "@granit/react-data-exchange": "workspace:*",
     "@granit/react-localization": "workspace:*",
     "@granit/react-ui": "workspace:*",

--- a/packages/@granit/react-ui-data-exchange/src/__tests__/export-list-page.test.tsx
+++ b/packages/@granit/react-ui-data-exchange/src/__tests__/export-list-page.test.tsx
@@ -11,8 +11,8 @@ import type { ExportJobResponse } from '@granit/data-exchange';
 import type * as DataExchange from '@granit/data-exchange';
 
 // The page consumes the @granit/react-data-exchange hooks directly. ExportProvider
-// is stubbed to a passthrough; useGranitClient still resolves from the real
-// GranitClientProvider supplied by the render helper.
+// is stubbed to a passthrough and useExportConfig returns a stub resolved config
+// (the real provider resolves the Axios client from the GranitClientProvider).
 const jobsState: {
   data: { items: ExportJobResponse[]; totalCount: number };
   isLoading: boolean;
@@ -27,6 +27,7 @@ const downloadExportFile = vi.fn();
 
 vi.mock('@granit/react-data-exchange', () => ({
   ExportProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useExportConfig: () => ({ client: {}, basePath: '/api/v1/data-exchange' }),
   useExportJobs: () => ({
     data: jobsState.data,
     isLoading: jobsState.isLoading,

--- a/packages/@granit/react-ui-data-exchange/src/__tests__/import-list-page.test.tsx
+++ b/packages/@granit/react-ui-data-exchange/src/__tests__/import-list-page.test.tsx
@@ -9,8 +9,8 @@ import { renderDataExchange } from './test-utils';
 import type { ImportJobResponse } from '@granit/data-exchange';
 
 // The page consumes the @granit/react-data-exchange hooks directly. ImportProvider
-// is stubbed to a passthrough; useGranitClient still resolves from the real
-// GranitClientProvider supplied by the render helper.
+// is stubbed to a passthrough (the real provider resolves the Axios client from the
+// GranitClientProvider supplied by the render helper).
 const jobsState: {
   data: { items: ImportJobResponse[]; totalCount: number };
   isLoading: boolean;

--- a/packages/@granit/react-ui-data-exchange/src/constants.ts
+++ b/packages/@granit/react-ui-data-exchange/src/constants.ts
@@ -1,4 +1,18 @@
 import type { ExportJobStatus, ImportJobStatus } from '@granit/data-exchange';
+import type { ExportConfig, ImportConfig } from '@granit/react-data-exchange';
+
+/**
+ * Static provider config for the export/import history pages. The Axios client
+ * is intentionally omitted: {@link ExportProvider}/{@link ImportProvider} resolve
+ * it from the host's `GranitClientProvider`, so this UI package never touches
+ * `@granit/react-api-client` (aligned with `@granit/react-ui-catalog`'s
+ * `QUERY_CONFIG`, which passes only a `basePath`).
+ */
+const DATA_EXCHANGE_BASE_PATH = '/api/v1/data-exchange';
+
+export const EXPORT_CONFIG: ExportConfig = { basePath: DATA_EXCHANGE_BASE_PATH };
+
+export const IMPORT_CONFIG: ImportConfig = { basePath: DATA_EXCHANGE_BASE_PATH };
 
 export const DEFAULT_PAGE_SIZE = 20;
 

--- a/packages/@granit/react-ui-data-exchange/src/export-list-page.tsx
+++ b/packages/@granit/react-ui-data-exchange/src/export-list-page.tsx
@@ -1,6 +1,5 @@
 import { downloadExportFile } from '@granit/data-exchange';
-import { useGranitClient } from '@granit/react-api-client';
-import { ExportProvider, useExportJobs } from '@granit/react-data-exchange';
+import { ExportProvider, useExportConfig, useExportJobs } from '@granit/react-data-exchange';
 import { useDateFormatter, useTranslation } from '@granit/react-localization';
 import { Spinner } from '@granit/react-ui';
 import { QueryDataTable } from '@granit/react-ui-kit';
@@ -8,27 +7,24 @@ import { useCallback, useMemo, useState } from 'react';
 
 import { createExportHistoryColumns } from './components/export-history-columns';
 import { HistoryFilters } from './components/history-filters';
-import { DEFAULT_PAGE_SIZE } from './constants';
+import { DEFAULT_PAGE_SIZE, EXPORT_CONFIG } from './constants';
 
-import type { AxiosInstance } from '@granit/api-client';
 import type { ExportJobResponse, ExportJobStatus } from '@granit/data-exchange';
 
-const EXPORT_BASE_PATH = '/api/v1/data-exchange';
-
 export function ExportListPage() {
-  // The Axios client is resolved from the GranitClientProvider in the host tree
-  // and handed to the headless data provider — no `@/lib/api` coupling.
-  const client = useGranitClient();
+  // Static config: ExportProvider resolves the Axios client from the host's
+  // GranitClientProvider — the UI page never touches @granit/react-api-client.
   return (
-    <ExportProvider config={{ client, basePath: EXPORT_BASE_PATH }}>
-      <ExportListPageContent client={client} />
+    <ExportProvider config={EXPORT_CONFIG}>
+      <ExportListPageContent />
     </ExportProvider>
   );
 }
 
-function ExportListPageContent({ client }: Readonly<{ client: AxiosInstance }>) {
+function ExportListPageContent() {
   const { t } = useTranslation();
   const { formatDateTime } = useDateFormatter();
+  const { client, basePath } = useExportConfig();
   const [page, setPage] = useState(1);
   const [status, setStatus] = useState<ExportJobStatus | undefined>();
 
@@ -40,7 +36,7 @@ function ExportListPageContent({ client }: Readonly<{ client: AxiosInstance }>) 
 
   const handleDownload = useCallback(
     async (job: ExportJobResponse) => {
-      const { blob, fileName } = await downloadExportFile(client, EXPORT_BASE_PATH, job.id);
+      const { blob, fileName } = await downloadExportFile(client, basePath, job.id);
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
@@ -48,7 +44,7 @@ function ExportListPageContent({ client }: Readonly<{ client: AxiosInstance }>) 
       a.click();
       URL.revokeObjectURL(url);
     },
-    [client]
+    [client, basePath]
   );
 
   const columns = useMemo(

--- a/packages/@granit/react-ui-data-exchange/src/import-list-page.tsx
+++ b/packages/@granit/react-ui-data-exchange/src/import-list-page.tsx
@@ -1,4 +1,3 @@
-import { useGranitClient } from '@granit/react-api-client';
 import { ImportProvider, useImportJobs } from '@granit/react-data-exchange';
 import { useDateFormatter, useTranslation } from '@granit/react-localization';
 import { Spinner } from '@granit/react-ui';
@@ -8,18 +7,15 @@ import { useCallback, useMemo, useState } from 'react';
 import { HistoryFilters } from './components/history-filters';
 import { createImportHistoryColumns } from './components/import-history-columns';
 import { ImportReportDialog } from './components/import-report-dialog';
-import { DEFAULT_PAGE_SIZE } from './constants';
+import { DEFAULT_PAGE_SIZE, IMPORT_CONFIG } from './constants';
 
 import type { ImportJobResponse, ImportJobStatus } from '@granit/data-exchange';
 
-const IMPORT_BASE_PATH = '/api/v1/data-exchange';
-
 export function ImportListPage() {
-  // The Axios client is resolved from the GranitClientProvider in the host tree
-  // and handed to the headless data provider — no `@/lib/api` coupling.
-  const client = useGranitClient();
+  // Static config: ImportProvider resolves the Axios client from the host's
+  // GranitClientProvider — the UI page never touches @granit/react-api-client.
   return (
-    <ImportProvider config={{ client, basePath: IMPORT_BASE_PATH }}>
+    <ImportProvider config={IMPORT_CONFIG}>
       <ImportListPageContent />
     </ImportProvider>
   );


### PR DESCRIPTION
Part of the 2026-07-01 framework audit remediation (`/audit`). One PR per bounded-context family.

- react-ui-data-exchange: drop UI-tier client self-wiring (static config, drop react-api-client peer)
- document dashboards `PagedResponse` divergence vs query-engine `PagedResult`; analytics query-key idiom. Non-breaking.
- Deferred: react-dashboards query-key rename (touches SSE push identity); `react-ui-analytics` extraction.