### PR TITLE
fix(taxonomy): audit remediation across reference-data/entity-merge/taxonomy/geocoding

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1683,17 +1683,6 @@
           "name": "executeMerge",
           "kind": "function",
           "signature": "async function executeMerge<TId extends string = string>( client: AxiosInstance, basePath: string, survivorId: TId, request: MergeRequest<TId>, idempotencyKey?: string ): Promise<MergeResult<TId>>"
-        },
-        {
-          "name": "MergeErrorKind",
-          "kind": "type",
-          "signature": "type MergeErrorKind = 'conflict' | 'domain' | 'notFound' | 'validation' | 'unknown'"
-        },
-        {
-          "name": "ClassifiedMergeError",
-          "kind": "interface",
-          "signature": "interface ClassifiedMergeError",
-          "members": []
         }
       ]
     },
@@ -5939,6 +5928,11 @@
       "description": "React bindings for @granit/geocoding — GeocodingProvider, hooks and AddressAutocompleteInput",
       "exports": [
         {
+          "name": "buildGeocodingQueryKey",
+          "kind": "function",
+          "signature": "function buildGeocodingQueryKey( config: GeocodingConfig | null, ...segments: readonly unknown[] ): readonly unknown[]"
+        },
+        {
           "name": "useAddressSuggestions",
           "kind": "function",
           "signature": "function useAddressSuggestions( search: string, options: UseAddressSuggestionsOptions ="
@@ -7385,6 +7379,21 @@
       "name": "@granit/react-taxonomy",
       "description": "React bindings for @granit/taxonomy — TaxonomyProvider, hooks, components",
       "exports": [
+        {
+          "name": "TaxonomyProvider",
+          "kind": "function",
+          "signature": "function TaxonomyProvider("
+        },
+        {
+          "name": "useTaxonomyConfig",
+          "kind": "function",
+          "signature": "function useTaxonomyConfig(): ResolvedTaxonomyConfig"
+        },
+        {
+          "name": "buildTaxonomyQueryKey",
+          "kind": "function",
+          "signature": "function buildTaxonomyQueryKey( config: ResolvedTaxonomyConfig, ...segments: readonly unknown[] ): readonly unknown[]"
+        },
         {
           "name": "API_VERSION",
           "kind": "const",

--- a/packages/@granit/entity-merge/src/helpers.ts
+++ b/packages/@granit/entity-merge/src/helpers.ts
@@ -1,4 +1,10 @@
-import type { FieldConflict, MergeFieldChoices, WinnerSide } from './types/index';
+import type {
+  ClassifiedMergeError,
+  FieldConflict,
+  MergeErrorKind,
+  MergeFieldChoices,
+  WinnerSide,
+} from './types/index';
 
 /**
  * Generate a fresh idempotency key for a merge submission. Prefers
@@ -43,19 +49,6 @@ export function seedFieldChoices(
  */
 export function resolveWinner(conflict: FieldConflict, choices: MergeFieldChoices): WinnerSide {
   return choices[conflict.fieldPath] ?? conflict.default;
-}
-
-/** Coarse classification of a failed merge request, independent of i18n. */
-export type MergeErrorKind = 'conflict' | 'domain' | 'notFound' | 'validation' | 'unknown';
-
-/** Result of {@link classifyMergeError}. */
-export interface ClassifiedMergeError {
-  /** Stable kind the UI maps to a localized message. */
-  readonly kind: MergeErrorKind;
-  /** RFC 7807 `detail`/`title` from the ProblemDetails body, if any. */
-  readonly detail: string | null;
-  /** HTTP status code, when available. */
-  readonly status: number | null;
 }
 
 /**

--- a/packages/@granit/entity-merge/src/index.ts
+++ b/packages/@granit/entity-merge/src/index.ts
@@ -5,6 +5,8 @@ export type {
   MergeFieldChoices,
   MergeRequest,
   MergeResult,
+  MergeErrorKind,
+  ClassifiedMergeError,
 } from './types/index';
 
 // API
@@ -17,4 +19,3 @@ export {
   resolveWinner,
   classifyMergeError,
 } from './helpers';
-export type { MergeErrorKind, ClassifiedMergeError } from './helpers';

--- a/packages/@granit/entity-merge/src/types/index.ts
+++ b/packages/@granit/entity-merge/src/types/index.ts
@@ -83,3 +83,16 @@ export interface MergeResult<TId extends string = string> {
   /** `true` for previews and explicit dry-runs; `false` for committed merges. */
   readonly dryRun: boolean;
 }
+
+/** Coarse classification of a failed merge request, independent of i18n. */
+export type MergeErrorKind = 'conflict' | 'domain' | 'notFound' | 'validation' | 'unknown';
+
+/** Result of classifying a failed merge request. */
+export interface ClassifiedMergeError {
+  /** Stable kind the UI maps to a localized message. */
+  readonly kind: MergeErrorKind;
+  /** RFC 7807 `detail`/`title` from the ProblemDetails body, if any. */
+  readonly detail: string | null;
+  /** HTTP status code, when available. */
+  readonly status: number | null;
+}

--- a/packages/@granit/react-geocoding/src/__tests__/geocoding-provider.test.tsx
+++ b/packages/@granit/react-geocoding/src/__tests__/geocoding-provider.test.tsx
@@ -3,9 +3,9 @@ import * as React from 'react';
 import { describe, expect, it } from 'vitest';
 
 import { DEFAULT_BASE_PATH } from '../constants';
+import { buildGeocodingQueryKey } from '../hooks/query-keys';
 import {
   GeocodingProvider,
-  buildGeocodingQueryKey,
   useGeocodingConfig,
   useOptionalGeocodingConfig,
 } from '../providers/geocoding-provider';

--- a/packages/@granit/react-geocoding/src/hooks/query-keys.ts
+++ b/packages/@granit/react-geocoding/src/hooks/query-keys.ts
@@ -1,0 +1,14 @@
+import type { GeocodingConfig } from '../providers/geocoding-provider';
+
+/**
+ * Builds a consistent React Query key for geocoding operations. Accepts a `null`
+ * config (no provider in scope) so callers can build a stable key for a disabled
+ * query without duplicating the default prefix.
+ */
+export function buildGeocodingQueryKey(
+  config: GeocodingConfig | null,
+  ...segments: readonly unknown[]
+): readonly unknown[] {
+  const prefix = config?.queryKeyPrefix ?? ['geocoding'];
+  return [...prefix, ...segments];
+}

--- a/packages/@granit/react-geocoding/src/hooks/use-address-suggestions.ts
+++ b/packages/@granit/react-geocoding/src/hooks/use-address-suggestions.ts
@@ -8,11 +8,9 @@ import {
   DEFAULT_MIN_QUERY_LENGTH,
   DEFAULT_SUGGESTION_LIMIT,
 } from '../constants';
-import {
-  buildGeocodingQueryKey,
-  useOptionalGeocodingConfig,
-} from '../providers/geocoding-provider';
+import { useOptionalGeocodingConfig } from '../providers/geocoding-provider';
 
+import { buildGeocodingQueryKey } from './query-keys';
 import { useDebouncedValue } from './use-debounced-value';
 
 import type { GeocodingSuggestionResponse } from '@granit/geocoding';

--- a/packages/@granit/react-geocoding/src/hooks/use-reverse-geocode.ts
+++ b/packages/@granit/react-geocoding/src/hooks/use-reverse-geocode.ts
@@ -3,10 +3,9 @@
 import { getReverseGeocode } from '@granit/geocoding';
 import { useQuery } from '@tanstack/react-query';
 
-import {
-  buildGeocodingQueryKey,
-  useOptionalGeocodingConfig,
-} from '../providers/geocoding-provider';
+import { useOptionalGeocodingConfig } from '../providers/geocoding-provider';
+
+import { buildGeocodingQueryKey } from './query-keys';
 
 import type { GeocodingReverseResponse } from '@granit/geocoding';
 

--- a/packages/@granit/react-geocoding/src/index.ts
+++ b/packages/@granit/react-geocoding/src/index.ts
@@ -1,7 +1,6 @@
 // Provider
 export {
   GeocodingProvider,
-  buildGeocodingQueryKey,
   useGeocodingConfig,
   useOptionalGeocodingConfig,
 } from './providers/geocoding-provider';
@@ -10,6 +9,9 @@ export type {
   GeocodingProviderProps,
   ResolvedGeocodingConfig,
 } from './providers/geocoding-provider';
+
+// Query keys
+export { buildGeocodingQueryKey } from './hooks/query-keys';
 
 // Hooks
 export { useAddressSuggestions } from './hooks/use-address-suggestions';

--- a/packages/@granit/react-geocoding/src/providers/geocoding-provider.tsx
+++ b/packages/@granit/react-geocoding/src/providers/geocoding-provider.tsx
@@ -40,16 +40,3 @@ export const useGeocodingConfig = useConfig;
  * when geocoding is not wired up.
  */
 export const useOptionalGeocodingConfig = useOptionalConfig;
-
-/**
- * Builds a consistent React Query key for geocoding operations. Accepts a `null`
- * config (no provider in scope) so callers can build a stable key for a disabled
- * query without duplicating the default prefix.
- */
-export function buildGeocodingQueryKey(
-  config: GeocodingConfig | null,
-  ...segments: readonly unknown[]
-): readonly unknown[] {
-  const prefix = config?.queryKeyPrefix ?? ['geocoding'];
-  return [...prefix, ...segments];
-}

--- a/packages/@granit/react-taxonomy/src/__tests__/taxonomy-provider.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/taxonomy-provider.test.tsx
@@ -2,11 +2,8 @@ import { createMockClient } from '@granit/testing';
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import {
-  buildTaxonomyQueryKey,
-  TaxonomyProvider,
-  useTaxonomyConfig,
-} from '../providers/taxonomy-provider';
+import { buildTaxonomyQueryKey } from '../hooks/query-keys';
+import { TaxonomyProvider, useTaxonomyConfig } from '../providers/taxonomy-provider';
 
 import type { TaxonomyConfig } from '../providers/taxonomy-provider';
 import type { ReactNode } from 'react';

--- a/packages/@granit/react-taxonomy/src/hooks/query-keys.ts
+++ b/packages/@granit/react-taxonomy/src/hooks/query-keys.ts
@@ -1,0 +1,9 @@
+import type { ResolvedTaxonomyConfig } from '../providers/taxonomy-provider';
+
+/** Builds a consistent React Query key for taxonomy operations. */
+export function buildTaxonomyQueryKey(
+  config: ResolvedTaxonomyConfig,
+  ...segments: readonly unknown[]
+): readonly unknown[] {
+  return [...config.queryKeyPrefix, ...segments];
+}

--- a/packages/@granit/react-taxonomy/src/hooks/use-categories.ts
+++ b/packages/@granit/react-taxonomy/src/hooks/use-categories.ts
@@ -1,7 +1,9 @@
 import { getCategory, listCategories } from '@granit/taxonomy';
 import { useQuery } from '@tanstack/react-query';
 
-import { buildTaxonomyQueryKey, useTaxonomyConfig } from '../providers/taxonomy-provider';
+import { useTaxonomyConfig } from '../providers/taxonomy-provider';
+
+import { buildTaxonomyQueryKey } from './query-keys';
 
 import type {
   CategoryDetailResponse,

--- a/packages/@granit/react-taxonomy/src/hooks/use-category-mutations.ts
+++ b/packages/@granit/react-taxonomy/src/hooks/use-category-mutations.ts
@@ -9,7 +9,9 @@ import {
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { logMutationError } from '../logger';
-import { buildTaxonomyQueryKey, useTaxonomyConfig } from '../providers/taxonomy-provider';
+import { useTaxonomyConfig } from '../providers/taxonomy-provider';
+
+import { buildTaxonomyQueryKey } from './query-keys';
 
 import type { ResolvedTaxonomyConfig } from '../providers/taxonomy-provider';
 import type {

--- a/packages/@granit/react-taxonomy/src/hooks/use-document-tags.ts
+++ b/packages/@granit/react-taxonomy/src/hooks/use-document-tags.ts
@@ -2,7 +2,9 @@ import { attachTagToDocument, detachTagFromDocument, listDocumentTags } from '@g
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { logMutationError } from '../logger';
-import { buildTaxonomyQueryKey, useTaxonomyConfig } from '../providers/taxonomy-provider';
+import { useTaxonomyConfig } from '../providers/taxonomy-provider';
+
+import { buildTaxonomyQueryKey } from './query-keys';
 
 import type { TagResponse } from '@granit/taxonomy';
 import type { QueryClient, UseMutationResult, UseQueryResult } from '@tanstack/react-query';

--- a/packages/@granit/react-taxonomy/src/hooks/use-tag-mutations.ts
+++ b/packages/@granit/react-taxonomy/src/hooks/use-tag-mutations.ts
@@ -2,7 +2,9 @@ import { assignTag, createTag, deleteTag, unassignTag, updateTag } from '@granit
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { logMutationError } from '../logger';
-import { buildTaxonomyQueryKey, useTaxonomyConfig } from '../providers/taxonomy-provider';
+import { useTaxonomyConfig } from '../providers/taxonomy-provider';
+
+import { buildTaxonomyQueryKey } from './query-keys';
 
 import type { ResolvedTaxonomyConfig } from '../providers/taxonomy-provider';
 import type {

--- a/packages/@granit/react-taxonomy/src/hooks/use-tags.ts
+++ b/packages/@granit/react-taxonomy/src/hooks/use-tags.ts
@@ -1,7 +1,9 @@
 import { listAssignedTags, listTags } from '@granit/taxonomy';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
-import { buildTaxonomyQueryKey, useTaxonomyConfig } from '../providers/taxonomy-provider';
+import { useTaxonomyConfig } from '../providers/taxonomy-provider';
+
+import { buildTaxonomyQueryKey } from './query-keys';
 
 import type { TagListFilter, TagResponse, TaxonomyTargetRef } from '@granit/taxonomy';
 import type { UseQueryResult } from '@tanstack/react-query';

--- a/packages/@granit/react-taxonomy/src/hooks/use-taxonomy-search.ts
+++ b/packages/@granit/react-taxonomy/src/hooks/use-taxonomy-search.ts
@@ -1,7 +1,9 @@
 import { searchTaxonomy } from '@granit/taxonomy';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
-import { buildTaxonomyQueryKey, useTaxonomyConfig } from '../providers/taxonomy-provider';
+import { useTaxonomyConfig } from '../providers/taxonomy-provider';
+
+import { buildTaxonomyQueryKey } from './query-keys';
 
 import type { TaxonomySearchFilter, TaxonomySearchResult } from '@granit/taxonomy';
 import type { UseQueryResult } from '@tanstack/react-query';

--- a/packages/@granit/react-taxonomy/src/index.ts
+++ b/packages/@granit/react-taxonomy/src/index.ts
@@ -1,14 +1,13 @@
 // Provider
-export {
-  buildTaxonomyQueryKey,
-  TaxonomyProvider,
-  useTaxonomyConfig,
-} from './providers/taxonomy-provider';
+export { TaxonomyProvider, useTaxonomyConfig } from './providers/taxonomy-provider';
 export type {
   ResolvedTaxonomyConfig,
   TaxonomyConfig,
   TaxonomyProviderProps,
 } from './providers/taxonomy-provider';
+
+// Query keys
+export { buildTaxonomyQueryKey } from './hooks/query-keys';
 
 // Constants
 export { API_VERSION, DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX, MODULE } from './constants';

--- a/packages/@granit/react-taxonomy/src/providers/taxonomy-provider.tsx
+++ b/packages/@granit/react-taxonomy/src/providers/taxonomy-provider.tsx
@@ -59,11 +59,3 @@ export function useTaxonomyConfig(): ResolvedTaxonomyConfig {
   }
   return ctx;
 }
-
-/** Builds a consistent React Query key for taxonomy operations. */
-export function buildTaxonomyQueryKey(
-  config: ResolvedTaxonomyConfig,
-  ...segments: readonly unknown[]
-): readonly unknown[] {
-  return [...config.queryKeyPrefix, ...segments];
-}

--- a/packages/@granit/react-ui-reference-data/src/components/reference-data-columns.tsx
+++ b/packages/@granit/react-ui-reference-data/src/components/reference-data-columns.tsx
@@ -111,7 +111,7 @@ export function createReferenceDataColumns({
                 variant="ghost"
                 size="icon"
                 className="h-8 w-8"
-                aria-label={`Actions for ${entry.labelEn}`}
+                aria-label={t(`${i18nPrefix}.Actions.Menu`, { name: entry.labelEn })}
               >
                 <MoreHorizontal className="h-4 w-4" />
               </Button>

--- a/packages/@granit/react-ui-reference-data/src/locales/en.ts
+++ b/packages/@granit/react-ui-reference-data/src/locales/en.ts
@@ -8,6 +8,7 @@
 export const referenceDataTranslationsEn = {
   'ReferenceData.Common.Actions.Deactivate': 'Deactivate',
   'ReferenceData.Common.Actions.Edit': 'Edit',
+  'ReferenceData.Common.Actions.Menu': 'Actions for {{name}}',
   'ReferenceData.Common.Actions.Reactivate': 'Reactivate',
   'ReferenceData.Common.Columns.Active': 'Active',
   'ReferenceData.Common.Columns.Code': 'Code',

--- a/packages/@granit/react-ui-reference-data/src/locales/fr.ts
+++ b/packages/@granit/react-ui-reference-data/src/locales/fr.ts
@@ -5,6 +5,7 @@
 export const referenceDataTranslationsFr = {
   'ReferenceData.Common.Actions.Deactivate': 'Désactiver',
   'ReferenceData.Common.Actions.Edit': 'Modifier',
+  'ReferenceData.Common.Actions.Menu': 'Actions pour {{name}}',
   'ReferenceData.Common.Actions.Reactivate': 'Réactiver',
   'ReferenceData.Common.Columns.Active': 'Actif',
   'ReferenceData.Common.Columns.Code': 'Code',

--- a/packages/@granit/reference-data/src/__tests__/reference-data-types.test.ts
+++ b/packages/@granit/reference-data/src/__tests__/reference-data-types.test.ts
@@ -85,7 +85,7 @@ describe('@granit/reference-data types', () => {
     it('should have optional sortOrder and validity dates', () => {
       expectTypeOf<ReferenceDataCreateRequest['sortOrder']>().toEqualTypeOf<number | undefined>();
       expectTypeOf<ReferenceDataCreateRequest['validFrom']>().toEqualTypeOf<
-        string | null | undefined
+        ISODateString | null | undefined
       >();
     });
 

--- a/packages/@granit/reference-data/src/types/index.ts
+++ b/packages/@granit/reference-data/src/types/index.ts
@@ -54,8 +54,8 @@ export interface ReferenceDataCreateRequest extends Partial<ReferenceDataLabels>
   readonly code: string;
   readonly labelEn: string;
   readonly sortOrder?: number;
-  readonly validFrom?: string | null;
-  readonly validTo?: string | null;
+  readonly validFrom?: ISODateString | null;
+  readonly validTo?: ISODateString | null;
   readonly parentCode?: string | null;
   readonly metadata?: Record<string, string> | null;
 }
@@ -70,8 +70,8 @@ export interface ReferenceDataUpdateRequest extends Partial<ReferenceDataLabels>
   readonly labelEn: string;
   readonly sortOrder?: number;
   readonly activated?: boolean;
-  readonly validFrom?: string | null;
-  readonly validTo?: string | null;
+  readonly validFrom?: ISODateString | null;
+  readonly validTo?: ISODateString | null;
   readonly parentCode?: string | null;
   readonly metadata?: Record<string, string> | null;
 }


### PR DESCRIPTION
Part of the 2026-07-01 framework audit remediation (`/audit`). One PR per bounded-context family.

- reference-data request DTOs → ISODateString; i18n the actions aria-label; entity-merge type placement; relocate query-key factories to hooks/query-keys.ts. Non-breaking (same exported names).