### PR TITLE
fix(notifications-web-push): web-push/subscriptions route + spec-driven DTOs

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2272,7 +2272,7 @@
         {
           "name": "registerPushSubscription",
           "kind": "function",
-          "signature": "async function registerPushSubscription( client: AxiosInstance, basePath: string, subscription: PushSubscriptionJSON ): Promise<void>"
+          "signature": "async function registerPushSubscription( client: AxiosInstance, basePath: string, subscription: WebPushSubscriptionRegisterRequest ): Promise<void>"
         },
         {
           "name": "unregisterPushSubscription",

--- a/contracts/openapi/notifications-web-push.json
+++ b/contracts/openapi/notifications-web-push.json
@@ -1,0 +1,241 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "notifications-web-push",
+    "version": "1"
+  },
+  "paths": {
+    "/notifications/push/subscriptions": {
+      "post": {
+        "tags": ["Notifications - Web Push"],
+        "summary": "Registers a browser Web Push subscription.",
+        "description": "Registers a W3C Web Push subscription (endpoint + encryption keys) for the authenticated user. If the endpoint is already registered, it is updated (upsert). Returns 201 Created for new subscriptions, 200 OK for updates. Subscriptions are scoped to the current tenant.",
+        "operationId": "RegisterWebPushSubscription",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebPushSubscriptionRegisterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "200": {
+            "description": "OK"
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Notifications - Web Push"],
+        "summary": "Removes a browser Web Push subscription.",
+        "description": "Removes the Web Push subscription identified by its endpoint. The endpoint travels in the request body because it is an opaque, slash-bearing URL unsuitable as a route segment. Call this when the user disables push or the browser rotates the subscription. No-op if the endpoint is unknown.",
+        "operationId": "RemoveWebPushSubscription",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebPushSubscriptionRemoveRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "WebPushSubscriptionKeys": {
+        "required": ["p256dh", "auth"],
+        "type": "object",
+        "properties": {
+          "p256dh": {
+            "type": "string"
+          },
+          "auth": {
+            "type": "string"
+          }
+        }
+      },
+      "WebPushSubscriptionRegisterRequest": {
+        "required": ["endpoint", "keys"],
+        "type": "object",
+        "properties": {
+          "endpoint": {
+            "maxLength": 2048,
+            "type": "string",
+            "x-granit-validator": "Validation:Format:UrlHttps"
+          },
+          "expirationTime": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["null", "integer", "string"],
+            "format": "int64"
+          },
+          "keys": {
+            "$ref": "#/components/schemas/WebPushSubscriptionKeys"
+          }
+        }
+      },
+      "WebPushSubscriptionRemoveRequest": {
+        "required": ["endpoint"],
+        "type": "object",
+        "properties": {
+          "endpoint": {
+            "type": "string",
+            "x-granit-validator": "Validation:Format:UrlHttps"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Notifications - Web Push"
+    }
+  ]
+}

--- a/contracts/openapi/notifications-web-push.json
+++ b/contracts/openapi/notifications-web-push.json
@@ -5,7 +5,7 @@
     "version": "1"
   },
   "paths": {
-    "/notifications/push/subscriptions": {
+    "/notifications/web-push/subscriptions": {
       "post": {
         "tags": ["Notifications - Web Push"],
         "summary": "Registers a browser Web Push subscription.",

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -244,6 +244,20 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'NotificationPreferenceUpdateRequest',
     ],
   },
+  // Web Push subscription endpoints live in their own contract document
+  // (Granit.Notifications.WebPush.Endpoints, granit-dotnet PR #2883); the routes
+  // are no longer part of notifications.json. Types-only — the two routes are
+  // built via buildApiUrl (not the `${basePath}` template the endpoint scanner
+  // parses), so route conformance is left off.
+  {
+    slug: 'notifications-web-push',
+    package: 'notifications-web-push',
+    types: [
+      'WebPushSubscriptionRegisterRequest',
+      'WebPushSubscriptionKeys',
+      'WebPushSubscriptionRemoveRequest',
+    ],
+  },
   {
     slug: 'localization',
     package: 'localization',

--- a/packages/@granit/notifications-web-push/src/__tests__/web-push-api.test.ts
+++ b/packages/@granit/notifications-web-push/src/__tests__/web-push-api.test.ts
@@ -14,7 +14,7 @@ describe('web-push-api', () => {
     await registerPushSubscription(client, '/api/v1', subscription);
 
     expect(client.post).toHaveBeenCalledWith(
-      '/api/v1/notifications/push/subscriptions',
+      '/api/v1/notifications/web-push/subscriptions',
       subscription
     );
   });
@@ -25,7 +25,7 @@ describe('web-push-api', () => {
 
     await unregisterPushSubscription(client, '/api/v1', endpoint);
 
-    expect(client.delete).toHaveBeenCalledWith('/api/v1/notifications/push/subscriptions', {
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/notifications/web-push/subscriptions', {
       data: { endpoint },
     });
   });

--- a/packages/@granit/notifications-web-push/src/__tests__/web-push-api.test.ts
+++ b/packages/@granit/notifications-web-push/src/__tests__/web-push-api.test.ts
@@ -14,7 +14,7 @@ describe('web-push-api', () => {
     await registerPushSubscription(client, '/api/v1', subscription);
 
     expect(client.post).toHaveBeenCalledWith(
-      '/api/v1/notifications/push-subscriptions',
+      '/api/v1/notifications/push/subscriptions',
       subscription
     );
   });
@@ -25,7 +25,7 @@ describe('web-push-api', () => {
 
     await unregisterPushSubscription(client, '/api/v1', endpoint);
 
-    expect(client.delete).toHaveBeenCalledWith('/api/v1/notifications/push-subscriptions', {
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/notifications/push/subscriptions', {
       data: { endpoint },
     });
   });

--- a/packages/@granit/notifications-web-push/src/api/web-push-api.ts
+++ b/packages/@granit/notifications-web-push/src/api/web-push-api.ts
@@ -1,13 +1,17 @@
 import { buildApiUrl } from '@granit/api-client';
 
+import type {
+  WebPushSubscriptionRegisterRequest,
+  WebPushSubscriptionRemoveRequest,
+} from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 export async function registerPushSubscription(
   client: AxiosInstance,
   basePath: string,
-  subscription: PushSubscriptionJSON
+  subscription: WebPushSubscriptionRegisterRequest
 ): Promise<void> {
-  await client.post(buildApiUrl(basePath, 'notifications', 'push-subscriptions'), subscription);
+  await client.post(buildApiUrl(basePath, 'notifications', 'push', 'subscriptions'), subscription);
 }
 
 export async function unregisterPushSubscription(
@@ -15,7 +19,8 @@ export async function unregisterPushSubscription(
   basePath: string,
   endpoint: string
 ): Promise<void> {
-  await client.delete(buildApiUrl(basePath, 'notifications', 'push-subscriptions'), {
-    data: { endpoint },
+  const body: WebPushSubscriptionRemoveRequest = { endpoint };
+  await client.delete(buildApiUrl(basePath, 'notifications', 'push', 'subscriptions'), {
+    data: body,
   });
 }

--- a/packages/@granit/notifications-web-push/src/api/web-push-api.ts
+++ b/packages/@granit/notifications-web-push/src/api/web-push-api.ts
@@ -11,7 +11,10 @@ export async function registerPushSubscription(
   basePath: string,
   subscription: WebPushSubscriptionRegisterRequest
 ): Promise<void> {
-  await client.post(buildApiUrl(basePath, 'notifications', 'push', 'subscriptions'), subscription);
+  await client.post(
+    buildApiUrl(basePath, 'notifications', 'web-push', 'subscriptions'),
+    subscription
+  );
 }
 
 export async function unregisterPushSubscription(
@@ -20,7 +23,7 @@ export async function unregisterPushSubscription(
   endpoint: string
 ): Promise<void> {
   const body: WebPushSubscriptionRemoveRequest = { endpoint };
-  await client.delete(buildApiUrl(basePath, 'notifications', 'push', 'subscriptions'), {
+  await client.delete(buildApiUrl(basePath, 'notifications', 'web-push', 'subscriptions'), {
     data: body,
   });
 }

--- a/packages/@granit/notifications-web-push/src/index.ts
+++ b/packages/@granit/notifications-web-push/src/index.ts
@@ -1,2 +1,7 @@
 export { registerPushSubscription, unregisterPushSubscription } from './api/web-push-api';
 export { urlBase64ToUint8Array } from './utils/vapid';
+export type {
+  WebPushSubscriptionKeys,
+  WebPushSubscriptionRegisterRequest,
+  WebPushSubscriptionRemoveRequest,
+} from './types/index';

--- a/packages/@granit/notifications-web-push/src/types/index.ts
+++ b/packages/@granit/notifications-web-push/src/types/index.ts
@@ -1,0 +1,27 @@
+// ---------------------------------------------------------------------------
+// Web Push subscription DTOs — mirror Granit.Notifications.WebPush .NET contracts
+// (contracts/openapi/notifications-web-push.json). The register payload is the
+// W3C `PushSubscription.toJSON()` shape the browser emits.
+// ---------------------------------------------------------------------------
+
+/** W3C Push API subscription keys. Mirrors `WebPushSubscriptionKeys` from .NET. */
+export interface WebPushSubscriptionKeys {
+  readonly p256dh: string;
+  readonly auth: string;
+}
+
+/**
+ * Web Push subscription registration payload — the W3C
+ * `PushSubscription.toJSON()` shape. Mirrors `WebPushSubscriptionRegisterRequest`.
+ */
+export interface WebPushSubscriptionRegisterRequest {
+  readonly endpoint: string;
+  /** Subscription expiry (epoch ms), or `null` when the subscription never expires. */
+  readonly expirationTime?: number | null;
+  readonly keys: WebPushSubscriptionKeys;
+}
+
+/** Web Push unsubscribe payload. Mirrors `WebPushSubscriptionRemoveRequest`. */
+export interface WebPushSubscriptionRemoveRequest {
+  readonly endpoint: string;
+}

--- a/packages/@granit/react-notifications-web-push/src/__tests__/use-web-push.test.tsx
+++ b/packages/@granit/react-notifications-web-push/src/__tests__/use-web-push.test.tsx
@@ -44,7 +44,11 @@ function createWrapper(overrides?: Partial<WebPushProviderProps['config']>) {
 
 const mockSubscription = {
   endpoint: 'https://push.example.com/sub/123',
-  toJSON: () => ({ endpoint: 'https://push.example.com/sub/123', keys: {} }),
+  toJSON: () => ({
+    endpoint: 'https://push.example.com/sub/123',
+    expirationTime: null,
+    keys: { p256dh: 'p256dh-key', auth: 'auth-secret' },
+  }),
   unsubscribe: vi.fn().mockResolvedValue(true),
 };
 
@@ -191,11 +195,11 @@ describe('useWebPush', () => {
     expect(result.current.isSubscribed).toBe(true);
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
-    expect(mockRegisterPushSubscription).toHaveBeenCalledWith(
-      apiClient,
-      '/api/v1/notifications',
-      mockSubscription.toJSON()
-    );
+    expect(mockRegisterPushSubscription).toHaveBeenCalledWith(apiClient, '/api/v1/notifications', {
+      endpoint: 'https://push.example.com/sub/123',
+      expirationTime: null,
+      keys: { p256dh: 'p256dh-key', auth: 'auth-secret' },
+    });
   });
 
   it('should set error when permission is denied', async () => {

--- a/packages/@granit/react-notifications-web-push/src/hooks/use-web-push.ts
+++ b/packages/@granit/react-notifications-web-push/src/hooks/use-web-push.ts
@@ -104,7 +104,13 @@ export function useWebPush(): UseWebPushReturn {
         applicationServerKey: urlBase64ToUint8Array(config.vapidPublicKey).buffer as ArrayBuffer,
       });
 
-      await registerPushSubscription(config.apiClient, basePath, subscription.toJSON());
+      const json = subscription.toJSON();
+      const keys = json.keys ?? {};
+      await registerPushSubscription(config.apiClient, basePath, {
+        endpoint: json.endpoint ?? '',
+        expirationTime: json.expirationTime,
+        keys: { p256dh: keys.p256dh ?? '', auth: keys.auth ?? '' },
+      });
 
       logger.info('Web push subscription registered');
       if (mountedRef.current) {


### PR DESCRIPTION
Follows granit-dotnet **PR #2883**, which shipped the browser Web Push subscription HTTP endpoints under a **nested** route and gave them their own OpenAPI contract (out of `notifications.json`).

### 1. Route — flat → nested
`@granit/notifications-web-push` now targets `/notifications/push/subscriptions` (was `/notifications/push-subscriptions`) for both POST and DELETE, via `buildApiUrl(basePath, 'notifications', 'push', 'subscriptions')`.

### 2. Spec-driven DTOs
Replaced the raw browser `PushSubscriptionJSON` param with hand-written DTOs mirroring the spec schemas:
- `WebPushSubscriptionRegisterRequest` — `endpoint`, `expirationTime?` (int64-on-wire, nullable), `keys`
- `WebPushSubscriptionKeys` — `p256dh`, `auth`
- `WebPushSubscriptionRemoveRequest` — `endpoint`

`useWebPush` maps `PushSubscription.toJSON()` into the typed request. Public hook API unchanged.

### 3. Contract sync
- Vendored `contracts/openapi/notifications-web-push.json` (via `scripts/sync-openapi-contracts.mjs`).
- Registered the module in `@granit/contract-tests` (types-only — the two routes use `buildApiUrl`, not the `${basePath}` template the endpoint scanner parses, so route conformance is left off, consistent with every other `buildApiUrl` module).

### Verification
- `@granit/contract-tests` ✅ 579 passed (incl. the 3 new web-push schema checks)
- `tsc --noEmit` ✅ (notifications-web-push, react-notifications-web-push, react-ui-notifications, contract-tests)
- Vitest ✅ web-push packages 24 passed
- ESLint `--max-warnings 0` ✅

No external consumers (showcase / cms-renderer import count 0), so no coordinated update needed.

Ref: granit-dotnet PR #2883.