### PR TITLE
fix(notifications-mobile-push)!: response returns masked deviceTokenPreview

### DIFF
--- a/contracts/openapi/notifications-mobile-push.json
+++ b/contracts/openapi/notifications-mobile-push.json
@@ -1,0 +1,275 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "notifications-mobile-push",
+    "version": "1"
+  },
+  "paths": {
+    "/notifications/mobile-push/tokens": {
+      "post": {
+        "tags": ["Notifications - Mobile Push"],
+        "summary": "Registers a mobile device token for push notifications.",
+        "description": "Registers a device token (FCM or APNs) for the authenticated user. If the token already exists, it is updated (upsert). Returns 201 Created for new registrations, 200 OK for updates. Tokens are scoped to the current tenant.",
+        "operationId": "RegisterMobilePushToken",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MobilePushTokenRegisterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "200": {
+            "description": "OK"
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Notifications - Mobile Push"],
+        "summary": "Returns the current user's registered device tokens.",
+        "description": "Returns all device tokens registered by the authenticated user for the current tenant, including the platform (iOS, Android) and registration timestamp. The device token itself is a sendable push credential, so only a masked preview (last 4 characters) is returned — never the plaintext token.",
+        "operationId": "GetMobilePushTokens",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MobilePushTokenResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/mobile-push/tokens/{deviceToken}": {
+      "delete": {
+        "tags": ["Notifications - Mobile Push"],
+        "summary": "Removes a mobile device token.",
+        "description": "Removes the specified device token for the authenticated user in the current tenant. Call this when the user logs out or the token becomes invalid. No-op if the token does not exist.",
+        "operationId": "RemoveMobilePushToken",
+        "parameters": [
+          {
+            "name": "deviceToken",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "MobilePlatform": {
+        "enum": ["Android", "Ios"]
+      },
+      "MobilePushTokenRegisterRequest": {
+        "required": ["deviceToken", "platform"],
+        "type": "object",
+        "properties": {
+          "deviceToken": {
+            "maxLength": 512,
+            "type": "string"
+          },
+          "platform": {
+            "$ref": "#/components/schemas/MobilePlatform"
+          }
+        }
+      },
+      "MobilePushTokenResponse": {
+        "required": ["deviceTokenPreview", "platform", "createdAt"],
+        "type": "object",
+        "properties": {
+          "deviceTokenPreview": {
+            "type": "string"
+          },
+          "platform": {
+            "$ref": "#/components/schemas/MobilePlatform"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Notifications - Mobile Push"
+    }
+  ]
+}

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -258,6 +258,16 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'WebPushSubscriptionRemoveRequest',
     ],
   },
+  // Mobile-push device-token endpoints ship their own contract document
+  // (Granit.Notifications.MobilePush.Endpoints). Types-only — the routes use
+  // buildApiUrl, not the `${basePath}` template the endpoint scanner parses.
+  // `MobilePlatform` is a standalone string enum, verified indirectly via the
+  // `platform` fields that reference it.
+  {
+    slug: 'notifications-mobile-push',
+    package: 'notifications-mobile-push',
+    types: ['MobilePushTokenRegisterRequest', 'MobilePushTokenResponse'],
+  },
   {
     slug: 'localization',
     package: 'localization',

--- a/packages/@granit/notifications-mobile-push/README.md
+++ b/packages/@granit/notifications-mobile-push/README.md
@@ -51,7 +51,7 @@ await registerDeviceToken(client, basePath, payload);
 // 2. List the tokens currently registered for the signed-in user.
 const tokens = await listDeviceTokens(client, basePath);
 for (const t of tokens) {
-  // t.deviceToken, t.platform, t.createdAt (ISODateString)
+  // t.deviceTokenPreview, t.platform, t.createdAt (ISODateString)
 }
 
 // 3. Unregister on sign-out / token rotation. The token is URL-encoded
@@ -65,7 +65,7 @@ await unregisterDeviceToken(client, basePath, fcmToken);
 | -------------------------------- | ---- | ------------------------------------------------------------ |
 | `MobilePlatform`                 | type | `'Android'` (FCM) \| `'Ios'` (APNs)                          |
 | `MobilePushTokenRegisterRequest` | type | Registration body: `deviceToken`, `platform`                 |
-| `MobilePushTokenResponse`        | type | Listed token: `deviceToken`, `platform`, `createdAt`         |
+| `MobilePushTokenResponse`        | type | Listed token: `deviceTokenPreview`, `platform`, `createdAt`  |
 | `registerDeviceToken`            | fn   | `POST {basePath}/notifications/mobile-push/tokens`           |
 | `listDeviceTokens`               | fn   | `GET {basePath}/notifications/mobile-push/tokens`            |
 | `unregisterDeviceToken`          | fn   | `DELETE .../tokens/{token}` (token is URL-encoded into path) |
@@ -79,14 +79,15 @@ await unregisterDeviceToken(client, basePath, fcmToken);
   This package only persists tokens server-side.
 - **No React Query / caching.** These are bare Axios calls; query keys,
   caching and invalidation live in the React layer (`useDeviceTokens`).
-- **Request and response DTOs both key the token as `deviceToken`.** Registration
-  sends a `MobilePushTokenRegisterRequest` (`deviceToken`, `platform`); the list
-  endpoint returns `MobilePushTokenResponse` (`deviceToken`, `platform`,
-  `createdAt`) — they mirror the backend `MobilePushTokenRegisterRequest` /
-  `MobilePushTokenResponse` shapes and are not interchangeable.
+- **Registration sends the full token; the list returns only a masked preview.**
+  Registration sends a `MobilePushTokenRegisterRequest` (`deviceToken`, `platform`);
+  the list endpoint returns `MobilePushTokenResponse` (`deviceTokenPreview`,
+  `platform`, `createdAt`) — the backend never echoes the full token back, so the
+  two DTOs are not interchangeable.
 - **Tokens are sensitive.** A device token can be used to push to a user's
-  device; treat it like a credential — never log it, and rely on the
-  `@granit/api-client` auth/CSRF interceptors for transport.
+  device; treat it like a credential — never log it (the backend returns only a
+  masked `deviceTokenPreview`), and rely on the `@granit/api-client` auth/CSRF
+  interceptors for transport.
 
 ## License
 

--- a/packages/@granit/notifications-mobile-push/src/__tests__/mobile-push-api.test.ts
+++ b/packages/@granit/notifications-mobile-push/src/__tests__/mobile-push-api.test.ts
@@ -47,12 +47,12 @@ describe('mobile-push-api', () => {
     const client = createMockClient();
     const tokens = [
       {
-        deviceToken: 'token-1',
+        deviceTokenPreview: 'token-1',
         platform: 'Android' as const,
         createdAt: toISODateString('2026-03-17T10:00:00Z'),
       },
       {
-        deviceToken: 'token-2',
+        deviceTokenPreview: 'token-2',
         platform: 'Ios' as const,
         createdAt: toISODateString('2026-03-17T11:00:00Z'),
       },

--- a/packages/@granit/notifications-mobile-push/src/types/index.ts
+++ b/packages/@granit/notifications-mobile-push/src/types/index.ts
@@ -9,7 +9,8 @@ export interface MobilePushTokenRegisterRequest {
 }
 
 export interface MobilePushTokenResponse {
-  readonly deviceToken: string;
+  /** Masked preview of the stored device token (the full token is never returned). */
+  readonly deviceTokenPreview: string;
   readonly platform: MobilePlatform;
   readonly createdAt: ISODateString;
 }

--- a/packages/@granit/react-notifications-mobile-push/README.md
+++ b/packages/@granit/react-notifications-mobile-push/README.md
@@ -88,7 +88,7 @@ function RegisteredDevices() {
   return (
     <ul>
       {tokens?.map((t) => (
-        <li key={t.deviceToken}>
+        <li key={t.deviceTokenPreview}>
           {t.platform} — registered {t.createdAt}
         </li>
       ))}

--- a/packages/@granit/react-notifications-mobile-push/src/testing/data.ts
+++ b/packages/@granit/react-notifications-mobile-push/src/testing/data.ts
@@ -14,12 +14,12 @@ import type {
  */
 export const mockMobilePushTokens: MobilePushTokenResponse[] = [
   {
-    deviceToken: 'token-abc-123',
+    deviceTokenPreview: 'token-abc-123',
     platform: 'Android',
     createdAt: toISODateString('2026-03-17T10:00:00Z'),
   },
   {
-    deviceToken: 'token-def-456',
+    deviceTokenPreview: 'token-def-456',
     platform: 'Ios',
     createdAt: toISODateString('2026-03-17T09:00:00Z'),
   },

--- a/packages/@granit/react-notifications-mobile-push/src/testing/handlers.ts
+++ b/packages/@granit/react-notifications-mobile-push/src/testing/handlers.ts
@@ -32,12 +32,12 @@ export function createMobilePushHandlers(baseUrl = DEFAULT_BASE_PATH) {
     // POST register a device token — 204 No Content
     http.post(tokensUrl, async ({ request }) => {
       const body = (await request.json()) as MobilePushTokenRegisterRequest;
-      const alreadyRegistered = tokens.some((t) => t.deviceToken === body.deviceToken);
+      const alreadyRegistered = tokens.some((t) => t.deviceTokenPreview === body.deviceToken);
       if (!alreadyRegistered) {
         tokens = [
           ...tokens,
           {
-            deviceToken: body.deviceToken,
+            deviceTokenPreview: body.deviceToken,
             platform: body.platform,
             createdAt: toISODateString('2026-03-17T12:00:00Z'),
           },
@@ -49,7 +49,7 @@ export function createMobilePushHandlers(baseUrl = DEFAULT_BASE_PATH) {
     // DELETE unregister a device token — 204 No Content
     http.delete(`${tokensUrl}/:token`, ({ params }) => {
       const token = decodeURIComponent(params.token as string);
-      tokens = tokens.filter((t) => t.deviceToken !== token);
+      tokens = tokens.filter((t) => t.deviceTokenPreview !== token);
       return noContent();
     }),
   ];


### PR DESCRIPTION
The regenerated `Granit.OpenApi.Generator_notifications-mobile-push.json` shows the list endpoint no longer echoes the full device token — it returns a masked **`deviceTokenPreview`**. The front response DTO still had `deviceToken`.

### Change
- `MobilePushTokenResponse.deviceToken` → **`deviceTokenPreview`** (masked; the full token is never returned).
- The register **request** (`MobilePushTokenRegisterRequest.deviceToken`) is unchanged — the backend still accepts the full token on write.
- Updated fixtures (`testing/data.ts`), MSW handlers, the api unit test, and both READMEs.

### Hardening
Added `@granit/notifications-mobile-push` to the `@granit/contract-tests` manifest (vendored `contracts/openapi/notifications-mobile-push.json`, types-only) — this drift would have been caught by the oracle. `MobilePlatform` is a standalone string enum, verified indirectly.

### Verification
- `@granit/contract-tests` ✅ 578 passed (incl. the new mobile-push slice)
- `tsc --noEmit` ✅ (core + headless + contract-tests)
- Vitest ✅ mobile-push packages 26 passed
- ESLint ✅ · markdownlint ✅

> [!WARNING]
> **BREAKING CHANGE**: `@granit/notifications-mobile-push` renames `MobilePushTokenResponse.deviceToken` → `deviceTokenPreview`. No showcase/cms consumers.