### PR TITLE
fix(blob-storage): resync OpenAPI contract with the direct download endpoint

### DIFF
--- a/contracts/openapi/blob-storage.json
+++ b/contracts/openapi/blob-storage.json
@@ -169,6 +169,81 @@
         }
       }
     },
+    "/blob-storage/blobs/{id}/download": {
+      "get": {
+        "tags": ["Blob Storage"],
+        "summary": "Redirects to a fresh pre-signed URL for direct blob download.",
+        "description": "Resolves a Valid blob by its identifier within the current tenant and issues a 302 redirect to a freshly generated pre-signed download URL. Designed for direct <img src>/browser consumption over the cookie/BFF session: honouring the module's Direct-to-Cloud contract, the application server never streams the bytes. The container is resolved server-side from the identifier, so no query parameter is required. Only blobs in the Valid state are served; returns 404 for missing, pending, rejected, or deleted blobs.",
+        "operationId": "DownloadBlob",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Found"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/blob-storage/blobs/upload": {
       "post": {
         "tags": ["Blob Storage"],

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -140,7 +140,11 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'BlobCleanupOrphansResponse',
     ],
     checkEndpoints: true,
-    endpointIgnore: ['', '/meta'],
+    // '' + '/meta' → the query grid, consumed generically via @granit/react-query-engine.
+    // '/{}/download' → the direct download-by-id route (DownloadBlob): a 302 redirect
+    //   consumed as a plain <img src> by @granit/react-blob-storage's BlobImage — no
+    //   axios api function by design (browser-native request, no JS fetch).
+    endpointIgnore: ['', '/meta', '/{}/download'],
   },
   {
     slug: 'api-keys',


### PR DESCRIPTION
## Context

granit-dotnet **#2891** (merged to develop) added the direct download-by-id route that
`<BlobImage>` (`@granit/react-blob-storage`) already points at:

```
GET /api/v1/blob-storage/blobs/{id}/download   → 302 → fresh presigned URL
```

Resolved by id server-side (no `containerName`), cookie/BFF auth, serves only `Valid`
blobs. Consumed as a plain `<img src>` — no component change, no new prop.

## Changes

- **Resync** `contracts/openapi/blob-storage.json` from the refreshed
  `Granit.OpenApi.Generator` snapshot (`node scripts/sync-openapi-contracts.mjs blob-storage`).
  Only semantic change: the new `DownloadBlob` operation (GET, `id`/uuid path param,
  `302/404/429/401/403/500`). No DTO/schema drift.
- **`@granit/contract-tests` manifest** — add `/{}/download` to the blob-storage
  `endpointIgnore`. The route has no axios api function *by design* (browser-native
  `<img src>`, no JS fetch), so the endpoint-coverage oracle must skip it — same rationale
  as the existing `''` / `/meta` query-grid ignores.

## Verification

- `@granit/contract-tests` — **576/576 passed** (was 1 failing: `missing-endpoint` on
  `/download`, now correctly ignored).
- Snapshot diff verified order-insensitively: only the `/download` operation added.

Ref: granit-dotnet#2891