### PR TITLE
refactor(dashboards): standardize query-key factory (deprecation-aliased)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4652,6 +4652,11 @@
           "signature": "const useDashboardsConfig"
         },
         {
+          "name": "buildDashboardsQueryKey",
+          "kind": "function",
+          "signature": "function buildDashboardsQueryKey( config: Pick<DashboardsConfig, 'queryKeyPrefix'>, ...segments: readonly unknown[] ): readonly unknown[]"
+        },
+        {
           "name": "UseDashboardRenderOptions",
           "kind": "interface",
           "signature": "interface UseDashboardRenderOptions",

--- a/packages/@granit/react-dashboards/src/__tests__/query-keys.test.ts
+++ b/packages/@granit/react-dashboards/src/__tests__/query-keys.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDashboardsQueryKey } from '../hooks/query-keys';
+import { dashboardCatalogQueryKey } from '../hooks/use-dashboard-catalog';
+import { dashboardDetailQueryKey } from '../hooks/use-dashboard-detail';
+import { dashboardListQueryKey } from '../hooks/use-dashboard-list';
+import { dashboardRenderQueryKey, dashboardWidgetQueryKey } from '../hooks/use-dashboard-render';
+import { widgetRenderQueryKey } from '../hooks/use-widget-render';
+
+const DASHBOARD_ID = '11111111-1111-1111-1111-111111111111';
+const WIDGET_ID = '22222222-2222-2222-2222-222222222222';
+
+describe('buildDashboardsQueryKey — family-standard factory', () => {
+  it('returns the raw segments when no prefix is configured', () => {
+    expect(buildDashboardsQueryKey({}, 'dashboards', 'detail', DASHBOARD_ID)).toEqual([
+      'dashboards',
+      'detail',
+      DASHBOARD_ID,
+    ]);
+  });
+
+  it('prepends a configured queryKeyPrefix', () => {
+    expect(
+      buildDashboardsQueryKey(
+        { queryKeyPrefix: ['tenant-a'] },
+        'dashboards',
+        'detail',
+        DASHBOARD_ID
+      )
+    ).toEqual(['tenant-a', 'dashboards', 'detail', DASHBOARD_ID]);
+  });
+});
+
+describe('deprecated per-operation aliases — byte-identical to the pre-refactor tuples', () => {
+  it('dashboardCatalogQueryKey', () => {
+    expect(dashboardCatalogQueryKey()).toEqual(['dashboards', 'catalog']);
+    expect(dashboardCatalogQueryKey('Finance')).toEqual(['dashboards', 'catalog', 'Finance']);
+  });
+
+  it('dashboardListQueryKey', () => {
+    const params = { status: 'Published', page: 1, pageSize: 25 } as const;
+    expect(dashboardListQueryKey(params)).toEqual(['dashboards', 'list', params]);
+  });
+
+  it('dashboardDetailQueryKey', () => {
+    expect(dashboardDetailQueryKey(DASHBOARD_ID)).toEqual(['dashboards', 'detail', DASHBOARD_ID]);
+  });
+
+  it('dashboardRenderQueryKey', () => {
+    const request = { periodToken: 'mtd' } as const;
+    expect(dashboardRenderQueryKey(DASHBOARD_ID, request)).toEqual([
+      'dashboard',
+      DASHBOARD_ID,
+      'render',
+      request,
+    ]);
+  });
+
+  it('dashboardWidgetQueryKey', () => {
+    expect(dashboardWidgetQueryKey(DASHBOARD_ID, WIDGET_ID)).toEqual([
+      'dashboard',
+      DASHBOARD_ID,
+      'widget',
+      WIDGET_ID,
+    ]);
+  });
+
+  it('widgetRenderQueryKey', () => {
+    const definition = { type: 'chart' } as const;
+    const context = { locale: 'en' } as const;
+    expect(widgetRenderQueryKey('chart', definition, context)).toEqual([
+      'widget',
+      'chart',
+      'render',
+      definition,
+      context,
+    ]);
+  });
+
+  it('each alias equals the builder invoked with the same segments', () => {
+    expect(dashboardWidgetQueryKey(DASHBOARD_ID, WIDGET_ID)).toEqual(
+      buildDashboardsQueryKey({}, 'dashboard', DASHBOARD_ID, 'widget', WIDGET_ID)
+    );
+    expect(dashboardDetailQueryKey(DASHBOARD_ID)).toEqual(
+      buildDashboardsQueryKey({}, 'dashboards', 'detail', DASHBOARD_ID)
+    );
+  });
+});
+
+describe('SSE push cache-identity invariant', () => {
+  // The SSE push (`usePushedDashboard`) writes per-widget snapshots via
+  // `setQueryData(dashboardWidgetQueryKey(id, widgetId))`; `useDashboardWidget`
+  // reads the same key and `useDashboardRender` populates it. All three MUST
+  // resolve to a byte-identical tuple or real-time widget updates silently
+  // land on a cache entry nobody reads.
+  it('the push write key equals the expected per-widget read tuple', () => {
+    // `usePushedDashboard` builds its `setQueryData` key with exactly this call
+    // (see use-pushed-dashboard.ts → handleSnapshot). `useDashboardWidget` and
+    // `useDashboardRender` populate/read the same tuple. Pin it here so a future
+    // refactor of the builder cannot silently shift the push target.
+    const writeKey = dashboardWidgetQueryKey(DASHBOARD_ID, WIDGET_ID);
+    expect(writeKey).toEqual(['dashboard', DASHBOARD_ID, 'widget', WIDGET_ID]);
+  });
+
+  it('the per-widget key is stable across independent invocations', () => {
+    const first = dashboardWidgetQueryKey(DASHBOARD_ID, WIDGET_ID);
+    const second = dashboardWidgetQueryKey(DASHBOARD_ID, WIDGET_ID);
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+
+  it('distinct widgets resolve to distinct keys', () => {
+    expect(dashboardWidgetQueryKey(DASHBOARD_ID, WIDGET_ID)).not.toEqual(
+      dashboardWidgetQueryKey(DASHBOARD_ID, 'other-widget')
+    );
+  });
+});

--- a/packages/@granit/react-dashboards/src/hooks/query-keys.ts
+++ b/packages/@granit/react-dashboards/src/hooks/query-keys.ts
@@ -1,0 +1,28 @@
+import type { DashboardsConfig } from '../providers/dashboards-provider';
+
+/**
+ * Single query-key factory for the dashboards package — the family-standard
+ * `build{Module}QueryKey(config, ...segments)` shape (mirrors
+ * `buildBlobStorageQueryKey` / `buildTaxonomyQueryKey` in sibling packages).
+ *
+ * When the provider supplies a `queryKeyPrefix` it is prepended; otherwise the
+ * `segments` alone form the tuple. The per-operation factories in this package
+ * are thin, `@deprecated` wrappers over this builder that pass their historical
+ * literal roots as the leading segments, so every produced tuple stays
+ * **byte-identical** to the pre-refactor keys.
+ *
+ * @remarks
+ * Byte-identity matters: the SSE push path (`usePushedDashboard`) writes
+ * per-widget cache entries via `setQueryData(dashboardWidgetQueryKey(...))` and
+ * the passive reader (`useDashboardWidget`) reads the same key. Any drift
+ * between the two would silently break real-time widget updates.
+ *
+ * @param config - Provider config carrying an optional `queryKeyPrefix`.
+ * @param segments - Segments appended after the (optional) prefix.
+ */
+export function buildDashboardsQueryKey(
+  config: Pick<DashboardsConfig, 'queryKeyPrefix'>,
+  ...segments: readonly unknown[]
+): readonly unknown[] {
+  return [...(config.queryKeyPrefix ?? []), ...segments];
+}

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-catalog.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-catalog.ts
@@ -3,14 +3,21 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
+import { buildDashboardsQueryKey } from './query-keys';
+
 import type { DashboardCatalogEntryResponse, DashboardCategory } from '@granit/dashboards';
 
 /**
  * Cache key for the dashboard catalog. Keyed by category so per-category
  * queries stay isolated from the full-catalog fetch.
+ *
+ * @deprecated Use {@link buildDashboardsQueryKey} with the segments
+ * `'dashboards', 'catalog'[, category]`. Kept as a byte-identical alias.
  */
 export const dashboardCatalogQueryKey = (category?: DashboardCategory) =>
-  category ? (['dashboards', 'catalog', category] as const) : (['dashboards', 'catalog'] as const);
+  category
+    ? buildDashboardsQueryKey({}, 'dashboards', 'catalog', category)
+    : buildDashboardsQueryKey({}, 'dashboards', 'catalog');
 
 /**
  * `GET /dashboards/catalog?category=` — returns the catalog of available

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-detail.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-detail.ts
@@ -3,14 +3,20 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
+import { buildDashboardsQueryKey } from './query-keys';
+
 import type { DashboardDetailResponse } from '@granit/dashboards';
 
 /**
  * Cache key for a single persisted dashboard, keyed by its Guid. Used by
  * the editor + by the lifecycle-mutation hooks to invalidate the right
  * entry after archive / publish / metadata edits.
+ *
+ * @deprecated Use {@link buildDashboardsQueryKey} with the segments
+ * `'dashboards', 'detail', id`. Kept as a byte-identical alias.
  */
-export const dashboardDetailQueryKey = (id: string) => ['dashboards', 'detail', id] as const;
+export const dashboardDetailQueryKey = (id: string) =>
+  buildDashboardsQueryKey({}, 'dashboards', 'detail', id);
 
 /**
  * `GET /dashboards/{id:guid}` — returns the full payload for one

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-list.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-list.ts
@@ -3,6 +3,8 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
+import { buildDashboardsQueryKey } from './query-keys';
+
 import type { DashboardStatus, DashboardSummaryResponse, PagedResponse } from '@granit/dashboards';
 
 export interface UseDashboardListParams {
@@ -18,9 +20,12 @@ export interface UseDashboardListParams {
  * Cache key composer for the persisted-dashboard list. The params get
  * baked into the key so each filter / page combination caches
  * independently.
+ *
+ * @deprecated Use {@link buildDashboardsQueryKey} with the segments
+ * `'dashboards', 'list', params`. Kept as a byte-identical alias.
  */
 export const dashboardListQueryKey = (params: UseDashboardListParams) =>
-  ['dashboards', 'list', params] as const;
+  buildDashboardsQueryKey({}, 'dashboards', 'list', params);
 
 /**
  * `GET /dashboards/?status=&page=&pageSize=` — returns a paged list of

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-render.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-render.ts
@@ -11,6 +11,8 @@ import { useEffect, useMemo } from 'react';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
+import { buildDashboardsQueryKey } from './query-keys';
+
 import type {
   DashboardRenderedWidget,
   DashboardRenderRequest,
@@ -53,17 +55,27 @@ export interface UseDashboardRenderOptions {
 /**
  * Cache key composer. Exported for tests + for sibling hooks that need to
  * address the same query without going through the hook itself.
+ *
+ * @deprecated Use {@link buildDashboardsQueryKey} with the segments
+ * `'dashboard', dashboardId, 'render', request`. Kept as a byte-identical alias.
  */
 export const dashboardRenderQueryKey = (dashboardId: string, request: DashboardRenderRequest) =>
-  ['dashboard', dashboardId, 'render', request] as const;
+  buildDashboardsQueryKey({}, 'dashboard', dashboardId, 'render', request);
 
 /**
  * Cache key composer for the **per-widget** TanStack entries the hook
  * populates from the bundle response (ADR-039 §6.2). Use it from
  * {@link useDashboardWidget} to read a single widget's envelope.
+ *
+ * **SSE-identity anchor**: `usePushedDashboard` writes push snapshots to this
+ * exact key and `useDashboardWidget` reads it — the tuple must stay
+ * byte-identical. See the `push-key-identity` test.
+ *
+ * @deprecated Use {@link buildDashboardsQueryKey} with the segments
+ * `'dashboard', dashboardId, 'widget', widgetId`. Kept as a byte-identical alias.
  */
 export const dashboardWidgetQueryKey = (dashboardId: string, widgetId: string) =>
-  ['dashboard', dashboardId, 'widget', widgetId] as const;
+  buildDashboardsQueryKey({}, 'dashboard', dashboardId, 'widget', widgetId);
 
 /**
  * Calls `POST /dashboards/{id}/render` and returns the bundle response.

--- a/packages/@granit/react-dashboards/src/hooks/use-widget-render.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-widget-render.ts
@@ -7,6 +7,8 @@ import { useDashboardFilters } from '../components/dashboard-filter-context';
 import { mergeFilterValuesIntoRequest } from '../lib/merge-filter-values';
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
+import { buildDashboardsQueryKey } from './query-keys';
+
 import type {
   DashboardRenderedWidget,
   RefreshHint,
@@ -63,12 +65,16 @@ export type WidgetRenderKind = 'kpi' | 'chart' | 'table' | 'pivot' | 'map';
  * `(kind, definition, context)` so semantically-identical inputs
  * collapse to the same cache entry / in-flight request — same
  * convention as the bundle path's `dashboardRenderQueryKey`.
+ *
+ * @deprecated Use {@link buildDashboardsQueryKey} with the segments
+ * `'widget', kind, 'render', definition, context`. Kept as a byte-identical
+ * alias.
  */
 export const widgetRenderQueryKey = <TDefinition extends WidgetDefinitionBase>(
   kind: WidgetRenderKind,
   definition: TDefinition,
   context: WidgetRenderContext
-) => ['widget', kind, 'render', definition, context] as const;
+) => buildDashboardsQueryKey({}, 'widget', kind, 'render', definition, context);
 
 export interface UseWidgetRenderOptions {
   /** Disable the request — useful when the parent isn't ready (e.g. tenant pending). */

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -10,6 +10,10 @@ export type {
   ResolvedDashboardsConfig,
 } from './providers/dashboards-provider';
 
+// Query-key factory (family-standard `build{Module}QueryKey(config, ...segments)`).
+// The per-operation `*QueryKey` fns below are `@deprecated` byte-identical aliases.
+export { buildDashboardsQueryKey } from './hooks/query-keys';
+
 // Render hook (B4-render — POST /dashboards/{id}/render bundle + per-widget cache split)
 export {
   dashboardRenderQueryKey,


### PR DESCRIPTION
## What

Standardizes the `@granit/react-dashboards` query-key surface onto the family convention: a single `buildDashboardsQueryKey(config, ...segments)` factory (`hooks/query-keys.ts`), mirroring `buildBlobStorageQueryKey` / `buildTaxonomyQueryKey` in sibling packages. It prepends the provider's optional `queryKeyPrefix`, then the caller's segments.

## How (non-breaking)

The six pre-existing per-operation factories become **thin `@deprecated` aliases** over the builder, each passing its historical literal root segments:

| alias | tuple |
|---|---|
| `dashboardCatalogQueryKey(cat?)` | `['dashboards','catalog'(,cat)]` |
| `dashboardListQueryKey(params)` | `['dashboards','list',params]` |
| `dashboardDetailQueryKey(id)` | `['dashboards','detail',id]` |
| `dashboardRenderQueryKey(id,req)` | `['dashboard',id,'render',req]` |
| `dashboardWidgetQueryKey(id,wid)` | `['dashboard',id,'widget',wid]` |
| `widgetRenderQueryKey(kind,def,ctx)` | `['widget',kind,'render',def,ctx]` |

All exported names are **kept** — `showcase-admin-react` and any other consumer keep compiling. `buildDashboardsQueryKey` is now the recommended entry point and is barrel-exported.

## SSE cache-identity invariant

The push path (`usePushedDashboard`) writes per-widget snapshots via `setQueryData(dashboardWidgetQueryKey(...))`; `useDashboardWidget` reads and `useDashboardRender` populates the same tuple. Every alias produces a **byte-identical** tuple to before, so real-time widget updates cannot silently land on an unread cache entry.

A focused `query-keys.test.ts` pins this: it asserts the push write key equals the expected per-widget read tuple, that the key is stable across invocations, and that each deprecated alias returns its exact pre-refactor tuple.

## Verification

- `tsc --noEmit` (react-dashboards): clean
- `eslint --max-warnings 0`: clean
- `vitest run` across react-dashboards + react-ui-dashboards + react-dashboard-editor: **254 passed** (32 files), incl. 12 new query-key tests

All 6 factories were aliased — none deferred.