### PR TITLE
test(arch): enforce strict UI-tier layering — no @granit/react-ui below the UI tier

### DIFF
--- a/packages/@granit/arch-tests/src/__tests__/helpers.ts
+++ b/packages/@granit/arch-tests/src/__tests__/helpers.ts
@@ -138,6 +138,29 @@ export const UI_ROUTER_BASELINE: ReadonlyArray<string> = [
 ];
 
 /**
+ * ADR-010 (strict 3-tier layering) — headless `@granit/react-{module}` packages
+ * (prefixed `react-`, but NOT `react-ui-`) that currently pull the shadcn/`@granit/react-ui`
+ * stack BELOW the UI tier, either via a runtime import in `src/` or via a
+ * (peer)dependency declaration. The rule: the UI stack must live at the UI tier only, so a
+ * headless adapter package stays framework/design-system-agnostic and composable by any
+ * UI shell (web shadcn today, React Native / a different design system tomorrow). The
+ * banned surface is the barrel `@granit/react-ui` (incl. subpaths) plus the shadcn
+ * primitives it re-exports: `radix-ui` / `@radix-ui/*`, `cmdk`, `sonner`,
+ * `class-variance-authority`, `vaul`. This is a RATCHET baseline: no NEW package may be
+ * added, and it must only ever SHRINK to `[]` as the open extraction PRs land
+ * (#878/#880/#881/#882 — analytics/geocoding/entity-merge extracted, rich-text renamed to
+ * `react-ui-rich-text`). It is already EMPTY on develop: those PRs have merged, so the
+ * baseline documents zero remaining debt and any regression fails immediately. Note:
+ * `react-map` is NOT listed — it does not import `@granit/react-ui` directly; it composes
+ * `@granit/react-ui-analytics` (a UI package) and is a candidate for a separate
+ * `react-ui-map` rename, tracked as an ADR-010 follow-up (out of scope for this rule).
+ * Regenerate: for each `packages/@granit/react-*` package that is NOT `react-ui-*`, grep
+ * `src` (excluding test/stories) for the banned specifiers and inspect its
+ * peer/dependencies; map hits to package names, sort -u.
+ */
+export const UI_STACK_BELOW_TIER_BASELINE: ReadonlyArray<string> = [];
+
+/**
  * Storybook coverage ratchet (checklist 7f) — per `react-ui-*` package, the number
  * of `*-page.tsx` / `*-dialog.tsx` components that currently LACK a co-located
  * same-name `*.stories.tsx`. The test asserts each package stays at or below its

--- a/packages/@granit/arch-tests/src/__tests__/imports.test.ts
+++ b/packages/@granit/arch-tests/src/__tests__/imports.test.ts
@@ -22,6 +22,7 @@ import {
   REACT_ECOSYSTEM_CORE_ALLOWLIST,
   REPO_ROOT,
   UI_ROUTER_BASELINE,
+  UI_STACK_BELOW_TIER_BASELINE,
   listPackages,
   toModules,
 } from './helpers';
@@ -176,6 +177,63 @@ describe('imports — granit-specific rules', () => {
       }
     }
     const newOffenders = [...offenders].filter((n) => !UI_ROUTER_BASELINE.includes(n)).sort();
+    expect(newOffenders).toEqual([]);
+  });
+
+  // ADR-010 (strict 3-tier layering) — the shadcn/`@granit/react-ui` stack must NOT
+  // appear below the UI tier. A headless `@granit/react-{module}` package (prefixed
+  // `react-`, NOT `react-ui-`) must not import or (peer)depend on `@granit/react-ui` nor
+  // the shadcn primitives it re-exports (`radix-ui`/`@radix-ui/*`, `cmdk`, `sonner`,
+  // `class-variance-authority`, `vaul`). This keeps the headless adapter tier design-system
+  // -agnostic (multi-platform readiness, single UI source of truth). Ratchet: no NEW
+  // offender beyond UI_STACK_BELOW_TIER_BASELINE (which is `[]` on develop and only shrinks).
+  // Cores (no `react-` prefix) are already covered by the framework-agnostic rule above.
+  it('headless react-{module} packages keep the UI stack at the UI tier (no @granit/react-ui below it)', () => {
+    // Barrel `@granit/react-ui` (and its subpaths) but NOT the `@granit/react-ui-*` UI
+    // packages, plus the shadcn primitives the barrel re-exports.
+    const isBannedSpecifier = (spec: string): boolean =>
+      /^@granit\/react-ui(\/.*)?$/.test(spec) ||
+      /^(radix-ui|cmdk|sonner|class-variance-authority|vaul)$/.test(spec) ||
+      /^@radix-ui\//.test(spec);
+
+    const isHeadlessReactModule = (pkg: (typeof packages)[number]): boolean =>
+      pkg.dirName.startsWith('react-') &&
+      !pkg.dirName.startsWith('react-ui-') &&
+      pkg.dirName !== 'react-ui';
+
+    const notTestSupport = (file: string): boolean =>
+      !isTestFile(file) &&
+      !isTestingDir(file) &&
+      !/[\\/]__tests__[\\/]/.test(file) &&
+      !/test-utils\.tsx?$/.test(file) &&
+      !/\.stories\.tsx?$/.test(file);
+
+    const offenders = new Set<string>();
+    for (const pkg of packages) {
+      if (!isHeadlessReactModule(pkg)) continue;
+
+      // (a) runtime source imports
+      for (const f of walkSourceFiles(pkg.srcDir, notTestSupport)) {
+        for (const spec of collectImports(f)) {
+          if (isBannedSpecifier(spec)) {
+            offenders.add(pkg.name);
+            break;
+          }
+        }
+      }
+
+      // (b) declared (peer)dependencies — a headless package must not even list the
+      // UI stack as a contract, independent of whether it imports it today.
+      const declared = {
+        ...((pkg.packageJson.dependencies ?? {}) as Record<string, string>),
+        ...((pkg.packageJson.peerDependencies ?? {}) as Record<string, string>),
+      };
+      if (Object.keys(declared).some(isBannedSpecifier)) offenders.add(pkg.name);
+    }
+
+    const newOffenders = [...offenders]
+      .filter((n) => !UI_STACK_BELOW_TIER_BASELINE.includes(n))
+      .sort();
     expect(newOffenders).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

Adds a **ratchet arch-test** (mirroring `UI_ROUTER_BASELINE`) that enforces **strict 3-tier layering** (ADR-010): the shadcn/`@granit/react-ui` stack must not appear **below the UI tier**.

A headless `@granit/react-{module}` package (prefixed `react-`, **not** `react-ui-`) must not import — nor (peer)depend on — `@granit/react-ui` (barrel or subpath) or the shadcn primitives it re-exports: `radix-ui`/`@radix-ui/*`, `cmdk`, `sonner`, `class-variance-authority`, `vaul`. The check covers **both** runtime `src` imports **and** declared (peer)dependencies. Cores (no `react-` prefix) are already covered by the existing framework-agnostic rule.

## Baseline: empty

`UI_STACK_BELOW_TIER_BASELINE` ships as `[]` — the target end-state. Any NEW offender fails CI immediately (proven locally by injecting a fake peerDep).

## Merge ordering

The extraction PRs this depends on have **already merged** to develop, so the baseline is empty on merge:

- #878 / #880 / #881 / #882 — analytics / geocoding / entity-merge extracted; rich-text renamed to `react-ui-rich-text`.

If any of those is re-opened/reverted, this baseline would need to temporarily list the affected package(s); the intent is that it stays `[]`.

## react-map

Intentionally **not** baselined: `@granit/react-map` composes `@granit/react-ui-analytics` (a UI package), **not** `@granit/react-ui` directly — not a violation of this rule. It is a `react-ui-map` rename candidate, tracked as an ADR-010 follow-up.

## Companion PR

ADR-010 in **granit-docs**: granit-fx/granit-docs#162.

## Checklist
- [x] `vitest run @granit/arch-tests` green (3215 tests, incl. new test)
- [x] `tsc --noEmit` clean
- [x] eslint clean on changed files