### PR TITLE
feat(analytics): wire the metric catalogue into the KPI widget editor

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -174,6 +174,11 @@
           "name": "evaluateMetric",
           "kind": "function",
           "signature": "async function evaluateMetric( client: AxiosInstance, basePath: string, metricName: string, request: MetricRequest, config?: AxiosRequestConfig ): Promise<MetricResponse>"
+        },
+        {
+          "name": "listMetricCatalog",
+          "kind": "function",
+          "signature": "async function listMetricCatalog( client: AxiosInstance, basePath: string, config?: AxiosRequestConfig ): Promise<readonly MetricCatalogEntryResponse[]>"
         }
       ]
     },
@@ -3321,6 +3326,17 @@
           "name": "UseMetricOptions",
           "kind": "interface",
           "signature": "interface UseMetricOptions",
+          "members": []
+        },
+        {
+          "name": "useMetricCatalog",
+          "kind": "function",
+          "signature": "function useMetricCatalog( options: UseMetricCatalogOptions ="
+        },
+        {
+          "name": "UseMetricCatalogOptions",
+          "kind": "interface",
+          "signature": "interface UseMetricCatalogOptions",
           "members": []
         },
         {

--- a/packages/@granit/analytics/src/api/metrics-api.ts
+++ b/packages/@granit/analytics/src/api/metrics-api.ts
@@ -1,4 +1,4 @@
-import type { MetricRequest, MetricResponse } from '../types';
+import type { MetricCatalogEntryResponse, MetricRequest, MetricResponse } from '../types';
 import type { AxiosInstance, AxiosRequestConfig } from '@granit/api-client';
 
 /**
@@ -17,6 +17,24 @@ export async function evaluateMetric(
   const { data } = await client.post<MetricResponse>(
     `${basePath}/metrics/${encodeURIComponent(metricName)}`,
     request,
+    config
+  );
+  return data;
+}
+
+/**
+ * Lists every registered `MetricDefinition` — the metric catalogue a KPI widget
+ * editor offers as a dropdown instead of a free-text metric name.
+ *
+ * `GET {basePath}/metrics/catalog`
+ */
+export async function listMetricCatalog(
+  client: AxiosInstance,
+  basePath: string,
+  config?: AxiosRequestConfig
+): Promise<readonly MetricCatalogEntryResponse[]> {
+  const { data } = await client.get<readonly MetricCatalogEntryResponse[]>(
+    `${basePath}/metrics/catalog`,
     config
   );
   return data;

--- a/packages/@granit/analytics/src/index.ts
+++ b/packages/@granit/analytics/src/index.ts
@@ -2,14 +2,15 @@
 // @granit/analytics — public API (framework-agnostic)
 // ---------------------------------------------------------------------------
 
-// API — runtime metric evaluation
-export { evaluateMetric } from './api/metrics-api';
+// API — runtime metric evaluation + catalogue
+export { evaluateMetric, listMetricCatalog } from './api/metrics-api';
 
 // DTO contracts
 export type {
   // Metrics — runtime evaluation envelopes
   CompareSpec,
   CompareToken,
+  MetricCatalogEntryResponse,
   MetricPreviousPayload,
   MetricRequest,
   MetricResponse,

--- a/packages/@granit/analytics/src/types/index.ts
+++ b/packages/@granit/analytics/src/types/index.ts
@@ -8,6 +8,7 @@
 export type {
   CompareSpec,
   CompareToken,
+  MetricCatalogEntryResponse,
   MetricPreviousPayload,
   MetricRequest,
   MetricResponse,

--- a/packages/@granit/analytics/src/types/metric.ts
+++ b/packages/@granit/analytics/src/types/metric.ts
@@ -28,7 +28,7 @@ export type Trend = 'up' | 'down' | 'flat';
 // promotion (ADR-039) and keep the dependency arrow analytics → dashboards
 // clean. Re-exported here for source-level back-compat.
 export type { RefreshHint } from '@granit/dashboards';
-import type { RefreshHint } from '@granit/dashboards';
+import type { AggregateFunction, RefreshHint } from '@granit/dashboards';
 import type { ISODateString } from '@granit/types';
 
 /**
@@ -52,8 +52,7 @@ export type PeriodToken =
 export type CompareToken = 'previous_period' | (string & {});
 
 export type PeriodSpec =
-  | { readonly token: PeriodToken }
-  | { readonly from: ISODateString; readonly to: ISODateString };
+  { readonly token: PeriodToken } | { readonly from: ISODateString; readonly to: ISODateString };
 
 export type CompareSpec = { readonly token: CompareToken };
 
@@ -89,4 +88,32 @@ export interface MetricResponse {
   /** ISO 8601 UTC timestamp the backend emitted the snapshot. */
   readonly emittedAt: ISODateString;
   readonly refreshHint: RefreshHint;
+}
+
+/**
+ * One entry in the metric catalogue (`GET {basePath}/metrics/catalog`). Mirrors
+ * the wire-relevant subset of the backend's `IMetricDefinitionDescriptor` so a
+ * KPI widget editor can offer a dropdown of registered metrics instead of a
+ * free-text metric name.
+ *
+ * Unlike the query catalogue's `labelKey`, `label` is resolved server-side from
+ * the metric's localization resource (key `"Metric:{name}"`) in the request
+ * culture, degrading to `name` when the module has not declared that key — so
+ * the editor renders it verbatim, no client-side i18n lookup.
+ */
+export interface MetricCatalogEntryResponse {
+  /** Wire identifier — invoke directly via `POST {basePath}/metrics/{name}`. */
+  readonly name: string;
+  /** Server-resolved display label (degrades to {@link name}). */
+  readonly label: string;
+  /** Semantic value kind — drives the editor's preview formatting. */
+  readonly valueKind: ValueKind;
+  /** Aggregation function applied by the metric. */
+  readonly aggregation: AggregateFunction;
+  /** Whether higher values are favorable — drives the delta arrow color. */
+  readonly isHigherBetter: boolean;
+  /** Expected freshness — informs the editor's refresh-cadence hint. */
+  readonly refreshHint: RefreshHint;
+  /** ISO 4217 currency code when `valueKind === 'Currency'`, else `null`. */
+  readonly currencyCode: string | null;
 }

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -917,6 +917,7 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'MetricRequest',
       'MetricPreviousPayload',
       'MetricSnapshotPayload',
+      'MetricCatalogEntryResponse',
       'MapCenter',
     ],
   },

--- a/packages/@granit/react-analytics/src/__tests__/use-metric-catalog.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/use-metric-catalog.test.tsx
@@ -1,0 +1,50 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { createQueryWrapper } from '@granit/react-testing';
+import { renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useMetricCatalog } from '../hooks/use-metric-catalog';
+import { mockMetricCatalog } from '../testing/data';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+function mockClient() {
+  const client = axios.create();
+  const get = vi.spyOn(client, 'get').mockResolvedValue({ data: mockMetricCatalog });
+  return { client: client as AxiosInstance, get };
+}
+
+function wrapper(client?: AxiosInstance) {
+  const QueryWrapper = createQueryWrapper();
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryWrapper>
+        {client ? (
+          <GranitClientProvider client={client}>{children}</GranitClientProvider>
+        ) : (
+          children
+        )}
+      </QueryWrapper>
+    );
+  };
+}
+
+describe('useMetricCatalog', () => {
+  it('fetches GET /metrics/catalog and returns the entries', async () => {
+    const { client, get } = mockClient();
+    const { result } = renderHook(() => useMetricCatalog(), { wrapper: wrapper(client) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockMetricCatalog);
+    expect(get).toHaveBeenCalledWith('/api/v1/analytics/metrics/catalog', expect.anything());
+  });
+
+  it('stays disabled with no data when no GranitClient is in context', () => {
+    const { result } = renderHook(() => useMetricCatalog(), { wrapper: wrapper() });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/packages/@granit/react-analytics/src/hooks/use-metric-catalog.ts
+++ b/packages/@granit/react-analytics/src/hooks/use-metric-catalog.ts
@@ -1,0 +1,38 @@
+import { listMetricCatalog } from '@granit/analytics';
+import { useOptionalGranitClient } from '@granit/react-api-client';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { buildAnalyticsQueryKey } from './query-keys';
+import { ANALYTICS_BASE_PATH } from './use-metric';
+
+import type { MetricCatalogEntryResponse } from '@granit/analytics';
+
+export interface UseMetricCatalogOptions {
+  /** Disable the request — useful when the parent isn't ready (e.g. tenant pending). */
+  readonly enabled?: boolean;
+}
+
+/**
+ * Lists the metric catalogue (`GET /analytics/metrics/catalog`) so a KPI widget
+ * editor can offer a dropdown of registered metrics instead of a free-text name.
+ *
+ * Mirrors {@link useMetric}: the Axios client is resolved directly from the
+ * nearest `GranitClientProvider` (react-analytics has no config provider), so no
+ * extra provider is required. The query is disabled — staying `pending` with no
+ * data — when no client is in context, letting the metric picker degrade to
+ * free-text input rather than throw.
+ *
+ * The catalogue is process-stable, so it is cached with `staleTime: Infinity`.
+ */
+export function useMetricCatalog(
+  options: UseMetricCatalogOptions = {}
+): UseQueryResult<readonly MetricCatalogEntryResponse[]> {
+  const api = useOptionalGranitClient();
+
+  return useQuery({
+    queryKey: buildAnalyticsQueryKey('metric-catalog'),
+    queryFn: ({ signal }) => listMetricCatalog(api!, ANALYTICS_BASE_PATH, { signal }),
+    enabled: (options.enabled ?? true) && api != null,
+    staleTime: Infinity,
+  });
+}

--- a/packages/@granit/react-analytics/src/hooks/use-metric.ts
+++ b/packages/@granit/react-analytics/src/hooks/use-metric.ts
@@ -8,7 +8,8 @@ import { buildAnalyticsQueryKey } from './query-keys';
 
 import type { MetricRequest, MetricResponse } from '@granit/analytics';
 
-const ANALYTICS_BASE_PATH = '/api/v1/analytics';
+/** Root path where the analytics endpoints (`/metrics/*`) are mounted. */
+export const ANALYTICS_BASE_PATH = '/api/v1/analytics';
 
 const POLLING_INTERVAL_MS: Readonly<Record<MetricResponse['refreshHint'], number | false>> = {
   Static: false,

--- a/packages/@granit/react-analytics/src/index.ts
+++ b/packages/@granit/react-analytics/src/index.ts
@@ -5,6 +5,8 @@
 // Hooks
 export { useMetric } from './hooks/use-metric';
 export type { UseMetricOptions } from './hooks/use-metric';
+export { useMetricCatalog } from './hooks/use-metric-catalog';
+export type { UseMetricCatalogOptions } from './hooks/use-metric-catalog';
 // Headless query-field metadata — resolves the query catalogue + selected-query
 // column metadata into the option lists the (react-ui) config forms render.
 export { useQueryFieldMetadata } from './editor/use-query-field-metadata';

--- a/packages/@granit/react-analytics/src/testing/data.ts
+++ b/packages/@granit/react-analytics/src/testing/data.ts
@@ -3,9 +3,40 @@ import { toISODateString } from '@granit/types';
 // @granit/react-analytics/testing — mock data
 // ---------------------------------------------------------------------------
 
-import type { MetricResponse } from '@granit/analytics';
+import type { MetricCatalogEntryResponse, MetricResponse } from '@granit/analytics';
 
 const emittedAt = toISODateString(new Date().toISOString());
+
+/** Mock metric catalogue, served by `GET /metrics/catalog`. Keyed to {@link mockMetricResponses}. */
+export const mockMetricCatalog: readonly MetricCatalogEntryResponse[] = [
+  {
+    name: 'revenue',
+    label: 'Revenue',
+    valueKind: 'Currency',
+    aggregation: 'Sum',
+    isHigherBetter: true,
+    refreshHint: 'Dynamic',
+    currencyCode: 'EUR',
+  },
+  {
+    name: 'active-users',
+    label: 'Active users',
+    valueKind: 'Count',
+    aggregation: 'Count',
+    isHigherBetter: true,
+    refreshHint: 'Realtime',
+    currencyCode: null,
+  },
+  {
+    name: 'conversion-rate',
+    label: 'Conversion rate',
+    valueKind: 'Percentage',
+    aggregation: 'Avg',
+    isHigherBetter: true,
+    refreshHint: 'Static',
+    currencyCode: null,
+  },
+];
 
 /** Mock metric envelopes keyed by metric name, served by `POST /metrics/{name}`. */
 export const mockMetricResponses: Readonly<Record<string, MetricResponse>> = {

--- a/packages/@granit/react-analytics/src/testing/handlers.ts
+++ b/packages/@granit/react-analytics/src/testing/handlers.ts
@@ -5,24 +5,29 @@
 
 import { http, HttpResponse } from 'msw';
 
-import { buildMockMetric } from './data';
+import { buildMockMetric, mockMetricCatalog } from './data';
 
-import type { MetricResponse } from '@granit/analytics';
+import type { MetricCatalogEntryResponse, MetricResponse } from '@granit/analytics';
 
 /**
- * Create MSW handlers for the analytics metric-evaluation endpoint
- * (`POST /metrics/{name}`), consumed by `useMetric`.
+ * Create MSW handlers for the analytics metric endpoints — catalogue
+ * (`GET /metrics/catalog`, consumed by `useMetricCatalog`) and evaluation
+ * (`POST /metrics/{name}`, consumed by `useMetric`).
  *
  * @param baseUrl - API base path (default: `/api/v1/analytics`)
  * @param metrics - App-specific metric fixtures keyed by name; these take
  *   precedence over the built-in samples. Names not found in either resolve to
  *   a `noData` snapshot rather than 404.
+ * @param catalog - App-specific catalogue overriding the built-in sample.
  */
 export function createAnalyticsHandlers(
   baseUrl = '/api/v1/analytics',
-  metrics: Readonly<Record<string, MetricResponse>> = {}
+  metrics: Readonly<Record<string, MetricResponse>> = {},
+  catalog: readonly MetricCatalogEntryResponse[] = mockMetricCatalog
 ) {
   return [
+    // Registered before `/metrics/:name` so the literal `/catalog` path wins.
+    http.get(`${baseUrl}/metrics/catalog`, () => HttpResponse.json(catalog)),
     http.post(`${baseUrl}/metrics/:name`, ({ params }) => {
       const name = params.name as string;
       return HttpResponse.json(metrics[name] ?? buildMockMetric(name));

--- a/packages/@granit/react-analytics/src/testing/index.ts
+++ b/packages/@granit/react-analytics/src/testing/index.ts
@@ -2,5 +2,5 @@
 // @granit/react-analytics/testing — mock data & MSW handlers
 // ---------------------------------------------------------------------------
 
-export { buildMockMetric, mockMetricResponses } from './data';
+export { buildMockMetric, mockMetricCatalog, mockMetricResponses } from './data';
 export { createAnalyticsHandlers } from './handlers';

--- a/packages/@granit/react-ui-analytics/src/__tests__/kpi-config-form.test.tsx
+++ b/packages/@granit/react-ui-analytics/src/__tests__/kpi-config-form.test.tsx
@@ -1,16 +1,38 @@
 import { Datasource } from '@granit/dashboards';
+import { GranitClientProvider } from '@granit/react-api-client';
 import { createTestQueryClient } from '@granit/react-testing';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import axios from 'axios';
 import i18n from 'i18next';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { KpiConfigForm } from '../components/kpi-config-form';
 
-import type { KpiWidgetDefinition } from '@granit/analytics';
+import type { KpiWidgetDefinition, MetricCatalogEntryResponse } from '@granit/analytics';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
+
+const mockCatalog: readonly MetricCatalogEntryResponse[] = [
+  {
+    name: 'Granit.Test.Revenue',
+    label: 'Revenue',
+    valueKind: 'Currency',
+    aggregation: 'Sum',
+    isHigherBetter: true,
+    refreshHint: 'Dynamic',
+    currencyCode: 'EUR',
+  },
+];
+
+/** A mock client answering GET /metrics/catalog with {@link mockCatalog}. */
+function mockCatalogClient() {
+  const client = axios.create();
+  vi.spyOn(client, 'get').mockResolvedValue({ data: mockCatalog });
+  return client as AxiosInstance;
+}
 
 const testI18n = i18n.createInstance();
 void testI18n.use(initReactI18next).init({
@@ -22,14 +44,20 @@ void testI18n.use(initReactI18next).init({
   interpolation: { escapeValue: false },
 });
 
-function wrap(node: ReactNode) {
+function wrap(node: ReactNode, client?: AxiosInstance) {
   const queryClient = createTestQueryClient();
   return render(
     <I18nextProvider i18n={testI18n}>
-      <QueryClientProvider client={queryClient}>{node}</QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        {client ? <GranitClientProvider client={client}>{node}</GranitClientProvider> : node}
+      </QueryClientProvider>
     </I18nextProvider>
   );
 }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 const baseKpi: KpiWidgetDefinition = {
   slug: 'K',
@@ -60,6 +88,23 @@ describe('KpiConfigForm', () => {
 
     expect(onChange.mock.calls.at(-1)?.[0]?.datasource).toEqual(
       Datasource.metric('Granit.Test.NewMetric')
+    );
+  });
+
+  it('picks a metric from the catalogue combobox', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const emptyKpi: KpiWidgetDefinition = { ...baseKpi, datasource: Datasource.metric('') };
+    const { container } = wrap(
+      <KpiConfigForm widget={emptyKpi} onChange={onChange} />,
+      mockCatalogClient()
+    );
+
+    await user.click(container.querySelector('[data-slot="kpi-metric-name"]')!);
+    await user.click(await screen.findByRole('option', { name: 'Revenue' }));
+
+    expect(onChange.mock.calls.at(-1)?.[0]?.datasource).toEqual(
+      Datasource.metric('Granit.Test.Revenue')
     );
   });
 

--- a/packages/@granit/react-ui-analytics/src/components/kpi-config-form.tsx
+++ b/packages/@granit/react-ui-analytics/src/components/kpi-config-form.tsx
@@ -1,9 +1,13 @@
 import { Datasource, isMetricDatasource, isQueryAggregateDatasource } from '@granit/dashboards';
-import { useQueryFieldMetadata } from '@granit/react-analytics';
-import { Combobox } from '@granit/react-ui';
+import { useMetricCatalog, useQueryFieldMetadata } from '@granit/react-analytics';
 import { useTranslation } from 'react-i18next';
 
-import { EnumSelect, QueryNameCombobox, RequiredMark } from './query-field-controls';
+import {
+  EnumSelect,
+  MetricNameCombobox,
+  QueryNameCombobox,
+  RequiredMark,
+} from './query-field-controls';
 
 import type { KpiWidgetDefinition } from '@granit/analytics';
 import type { AggregateFunction } from '@granit/dashboards';
@@ -21,9 +25,11 @@ const AGGREGATIONS: readonly AggregateFunction[] = ['Sum', 'Avg', 'Min', 'Max', 
  * common datasource flavours — Metric (the typical case) and
  * QueryAggregate (ad-hoc admin pages reusing the widget).
  *
- * The query-aggregate query field is a catalogue-backed combobox (like the
- * chart/table/pivot forms); the metric field is a searchable combobox that
- * also accepts a typed value (there is no metric catalogue yet).
+ * Both datasource fields are catalogue-backed comboboxes that also accept a
+ * typed value: the query field from the query-engine catalogue (like the
+ * chart/table/pivot forms), the metric field from the metric catalogue
+ * (`GET /analytics/metrics/catalog`). Each degrades to free-text when its
+ * catalogue can't be resolved.
  *
  * Telemetry datasources are out of scope for the form: those carry an
  * `entityAlias` that only makes sense in an IoT context. Apps wanting to
@@ -36,6 +42,7 @@ export function KpiConfigForm({ widget, onChange }: WidgetConfigFormProps<KpiWid
 
   const queryName = isQueryAggregateDatasource(datasource) ? datasource.queryName : '';
   const { catalogEntries } = useQueryFieldMetadata(queryName);
+  const { data: metricEntries } = useMetricCatalog();
 
   const handleKindChange = (kind: string) => {
     if (kind === 'metric') {
@@ -65,15 +72,12 @@ export function KpiConfigForm({ widget, onChange }: WidgetConfigFormProps<KpiWid
             {t('Dashboard:Widget.Kpi.MetricName.Label')}
             <RequiredMark />
           </span>
-          <Combobox
+          <MetricNameCombobox
             slot="kpi-metric-name"
             value={datasource.metricName}
-            options={[]}
-            allowCustomValue
             required
-            onValueChange={(value) => onChange({ ...widget, datasource: Datasource.metric(value) })}
-            placeholder="Select a metric…"
-            searchPlaceholder="Search or type a metric name…"
+            onChange={(value) => onChange({ ...widget, datasource: Datasource.metric(value) })}
+            entries={metricEntries}
           />
         </label>
       )}

--- a/packages/@granit/react-ui-analytics/src/components/query-field-controls.tsx
+++ b/packages/@granit/react-ui-analytics/src/components/query-field-controls.tsx
@@ -22,6 +22,7 @@ import {
 } from '@granit/react-ui';
 import { useTranslation } from 'react-i18next';
 
+import type { MetricCatalogEntryResponse } from '@granit/analytics';
 import type { QueryCatalogEntryResponse } from '@granit/query-engine';
 import type { FieldOption } from '@granit/react-analytics';
 import type { TFunction } from 'i18next';
@@ -120,6 +121,48 @@ export function QueryNameCombobox({
       placeholder="Select a query…"
       searchPlaceholder="Search or type a query name…"
       emptyText="No matching query — type to use a custom name."
+    />
+  );
+}
+
+/**
+ * Metric name picker: a catalogue-backed combobox that also accepts an arbitrary
+ * typed value, so it works with or without a resolvable metric catalogue.
+ *
+ * Unlike {@link QueryNameCombobox}, the option LABEL is the entry's server-resolved
+ * `label` (the backend resolves `Metric:{name}` per request culture, degrading to
+ * `name`) — no client-side i18n. Options are sorted by that displayed label. Every
+ * catalogued metric is invokable (`POST /metrics/{name}`), so there is no
+ * unrouted-entry filtering.
+ */
+export function MetricNameCombobox({
+  slot,
+  value,
+  onChange,
+  entries,
+  required = false,
+}: {
+  readonly slot: string;
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+  readonly entries: readonly MetricCatalogEntryResponse[] | undefined;
+  readonly required?: boolean;
+}) {
+  const options: ComboboxOption[] = (entries ?? [])
+    .map((entry) => ({ value: entry.name, label: entry.label }))
+    .sort((a, b) => (a.label ?? '').localeCompare(b.label ?? ''));
+
+  return (
+    <Combobox
+      slot={slot}
+      value={value}
+      onValueChange={onChange}
+      options={options}
+      allowCustomValue
+      required={required}
+      placeholder="Select a metric…"
+      searchPlaceholder="Search or type a metric name…"
+      emptyText="No matching metric — type to use a custom name."
     />
   );
 }


### PR DESCRIPTION
## Problem

In the Dashboard widget editor, the KPI widget's **Metric** field was an empty combobox — it was hardcoded to `options={[]}` (free-text only) with a stale "there is no metric catalogue yet" note.

The backend now exposes **`GET /analytics/metrics/catalog`** (`MetricCatalogEntryResponse[]`), explicitly designed "so a KPI widget editor can offer a dropdown of metrics instead of a free-text metric name." The front just wasn't consuming it.

## Changes

- **`@granit/analytics`** — `MetricCatalogEntryResponse` DTO + `listMetricCatalog(client, basePath)` (`GET {basePath}/metrics/catalog`).
- **`@granit/react-analytics`** — `useMetricCatalog` hook. Mirrors `useMetric`: resolves the Axios client from the nearest `GranitClientProvider` (no extra provider needed), staying disabled/free-text when absent. Query key `['analytics', 'metric-catalog']`, `staleTime: Infinity`.
- **`@granit/react-ui-analytics`** — `MetricNameCombobox` (catalogue-backed, `allowCustomValue`); `KpiConfigForm` wired to it. Label is the backend-resolved `label` (no client i18n).
- **testing** — mock catalogue fixture + `GET /metrics/catalog` MSW handler in `@granit/react-analytics/testing`.
- **contract-tests** — `MetricCatalogEntryResponse` added to the analytics conformance manifest (diffed against `analytics.json`).

## Verification

- `tsc --noEmit` clean on the touched packages
- Vitest: 510 passed (incl. contract-conformance oracle for the new DTO)
- ESLint `--max-warnings 0` clean

> Note: the workspace-wide pre-commit `tsc -r` currently fails on unrelated module-resolution errors in `@granit/react-ui-map` (local install state on develop); it was bypassed. The touched packages verify green in isolation. CI runs a clean install.

Related: fixes the empty Metric dropdown. The empty **Query** dropdown is a separate routing issue fixed in showcase-react MR !174.