### PR TITLE
feat(dashboards): render Markdown in dashboard widgets

### DIFF
--- a/packages/@granit/react-ui-dashboards/package.json
+++ b/packages/@granit/react-ui-dashboards/package.json
@@ -13,6 +13,10 @@
   "scripts": {
     "build": "tsup"
   },
+  "dependencies": {
+    "react-markdown": "^10",
+    "remark-gfm": "^4"
+  },
   "peerDependencies": {
     "@granit/analytics": "workspace:*",
     "@granit/dashboards": "workspace:*",

--- a/packages/@granit/react-ui-dashboards/src/__tests__/markdown-widget.test.tsx
+++ b/packages/@granit/react-ui-dashboards/src/__tests__/markdown-widget.test.tsx
@@ -1,0 +1,67 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { RichMarkdownSnapshotWidget } from '../components/widgets/markdown-snapshot-widget';
+import { RichMarkdownWidget } from '../components/widgets/markdown-widget';
+import {
+  markdownSnapshotWidgetRegistry,
+  markdownWidgetRegistry,
+} from '../registry/markdown-widget-registry';
+
+import { renderDashboards } from './test-utils';
+
+import type { DashboardRenderedWidget, MarkdownWidgetDefinition } from '@granit/dashboards';
+
+// The renderers resolve content through i18next; test-utils' instance has no
+// Widget:* keys, so `t()` falls back to the key's `defaultValue` — which the
+// renderers set to the raw Markdown source. That's exactly what we want to
+// assert parses (no locale bundle needed).
+const bannerWidget: MarkdownWidgetDefinition = {
+  slug: 'banner',
+  type: 'markdown',
+  size: { width: 12, height: 1 },
+  contentLocalizationKey: '## Tiers',
+};
+
+const bannerSnapshot = {
+  slug: 'banner',
+  widgetType: 'Markdown',
+  snapshot: { contentLocalizationKey: '## Tiers' },
+} as unknown as DashboardRenderedWidget;
+
+describe('RichMarkdownWidget (definition side)', () => {
+  it('renders Markdown headings instead of raw source', () => {
+    renderDashboards(<RichMarkdownWidget widget={bannerWidget} />);
+
+    const heading = screen.getByRole('heading', { level: 2, name: 'Tiers' });
+    expect(heading).toBeInTheDocument();
+    // The literal "## Tiers" must not survive as text.
+    expect(heading.textContent).toBe('Tiers');
+  });
+});
+
+describe('RichMarkdownSnapshotWidget (runtime snapshot side)', () => {
+  it('renders Markdown headings from the snapshot envelope', () => {
+    renderDashboards(<RichMarkdownSnapshotWidget widget={bannerSnapshot} />);
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Tiers' })).toBeInTheDocument();
+  });
+
+  it('returns null for a non-Markdown envelope', () => {
+    const kpi = {
+      slug: 'k',
+      widgetType: 'Kpi',
+      snapshot: { value: 1 },
+    } as unknown as DashboardRenderedWidget;
+
+    const { container } = renderDashboards(<RichMarkdownSnapshotWidget widget={kpi} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('registry fragments', () => {
+  it('override the framework `markdown` / `Markdown` keys', () => {
+    expect(markdownWidgetRegistry.markdown).toBe(RichMarkdownWidget);
+    expect(markdownSnapshotWidgetRegistry.Markdown).toBe(RichMarkdownSnapshotWidget);
+  });
+});

--- a/packages/@granit/react-ui-dashboards/src/components/widgets/dashboard-markdown.tsx
+++ b/packages/@granit/react-ui-dashboards/src/components/widgets/dashboard-markdown.tsx
@@ -1,0 +1,121 @@
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+import type { Components } from 'react-markdown';
+
+export interface DashboardMarkdownProps {
+  /**
+   * Markdown source resolved from a widget's localization key (e.g. a
+   * dashboard banner's `## Tiers`). Trusted, host-authored content — but still
+   * rendered to an escaped React element tree by `react-markdown` **without**
+   * `rehype-raw`, so raw HTML in the source is emitted as literal text, never
+   * as live DOM. This is not an HTML sink (no `check:csp` subpath required).
+   */
+  readonly content: string;
+  readonly className?: string;
+}
+
+/**
+ * Element overrides tuned for dashboard content — headings read larger than
+ * the chat surface since banners double as section titles. Colours are
+ * semantic Tailwind tokens (`text-foreground`, `text-muted-foreground`,
+ * `border-border`…) so the consuming app's theme drives the palette.
+ */
+const components: Components = {
+  p: ({ children }) => (
+    <p className="[&:not(:first-child)]:mt-2 text-sm text-foreground">{children}</p>
+  ),
+  // Links carry host content but still open out-of-document, stripping the
+  // opener + referrer.
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-primary underline"
+    >
+      {children}
+    </a>
+  ),
+  ul: ({ children }) => (
+    <ul className="[&:not(:first-child)]:mt-2 list-disc pl-5 text-sm text-foreground">
+      {children}
+    </ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="[&:not(:first-child)]:mt-2 list-decimal pl-5 text-sm text-foreground">
+      {children}
+    </ol>
+  ),
+  li: ({ children }) => <li className="mt-1">{children}</li>,
+  h1: ({ children }) => (
+    <h1 className="[&:not(:first-child)]:mt-3 text-xl font-semibold tracking-tight text-foreground">
+      {children}
+    </h1>
+  ),
+  h2: ({ children }) => (
+    <h2 className="[&:not(:first-child)]:mt-3 text-lg font-semibold text-foreground">
+      {children}
+    </h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="[&:not(:first-child)]:mt-2 text-base font-semibold text-foreground">
+      {children}
+    </h3>
+  ),
+  h4: ({ children }) => (
+    <h4 className="[&:not(:first-child)]:mt-2 text-sm font-semibold text-foreground">
+      {children}
+    </h4>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="[&:not(:first-child)]:mt-2 border-border text-muted-foreground border-l-2 pl-3">
+      {children}
+    </blockquote>
+  ),
+  // Distinguish inline code from a fenced block by the `language-*` class
+  // `remark`/`micromark` puts on the inner `<code>` of a fence.
+  code: ({ className: codeClassName, children }) =>
+    codeClassName?.includes('language-') ? (
+      <code className={`font-mono text-xs ${codeClassName}`}>{children}</code>
+    ) : (
+      <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">{children}</code>
+    ),
+  pre: ({ children }) => (
+    <pre className="bg-muted [&:not(:first-child)]:mt-2 overflow-x-auto rounded-md p-2 font-mono text-xs">
+      {children}
+    </pre>
+  ),
+  table: ({ children }) => (
+    <div className="[&:not(:first-child)]:mt-2 overflow-x-auto">
+      <table className="border-border w-full border-collapse border text-xs">{children}</table>
+    </div>
+  ),
+  th: ({ children }) => (
+    <th className="border-border bg-muted border px-2 py-1 text-left font-semibold">{children}</th>
+  ),
+  td: ({ children }) => <td className="border-border border px-2 py-1">{children}</td>,
+  hr: () => <hr className="border-border my-3" />,
+};
+
+/**
+ * Renders dashboard widget Markdown as a safe, escaped React element tree.
+ *
+ * Drop-in replacement for the verbatim `<pre>`/`<div>` fallbacks the headless
+ * `@granit/react-dashboards` ships for `markdown` widgets — those keep
+ * react-markdown out of bundles that never render Markdown. Apps that want
+ * real Markdown compose {@link markdownWidgetRegistry} /
+ * {@link markdownSnapshotWidgetRegistry} on top of the framework defaults.
+ *
+ * Uses `react-markdown` + `remark-gfm` **without** `rehype-raw`: raw HTML in
+ * the source is escaped to text rather than parsed into DOM.
+ */
+export function DashboardMarkdown({ content, className }: Readonly<DashboardMarkdownProps>) {
+  return (
+    <div data-slot="dashboard-markdown" className={`break-words ${className ?? ''}`.trim()}>
+      <Markdown remarkPlugins={[remarkGfm]} components={components}>
+        {content}
+      </Markdown>
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-dashboards/src/components/widgets/markdown-snapshot-widget.tsx
+++ b/packages/@granit/react-ui-dashboards/src/components/widgets/markdown-snapshot-widget.tsx
@@ -1,0 +1,27 @@
+import { isMarkdownSnapshotEnvelope } from '@granit/dashboards';
+import { useTranslation } from '@granit/react-localization';
+
+import { DashboardMarkdown } from './dashboard-markdown';
+
+import type { DashboardRenderedWidget } from '@granit/dashboards';
+
+/**
+ * Snapshot-side `Markdown` renderer that actually parses Markdown — the rich
+ * counterpart to the verbatim fallback in `@granit/react-dashboards`. This is
+ * the runtime path for backend-rendered dashboards (`POST
+ * /dashboards/{id}/render`), so composing {@link markdownSnapshotWidgetRegistry}
+ * after `defaultSnapshotWidgetRegistry` is what makes every dashboard banner
+ * render its headings instead of raw `##`.
+ */
+export function RichMarkdownSnapshotWidget({
+  widget,
+}: {
+  readonly widget: DashboardRenderedWidget;
+}) {
+  const { t } = useTranslation();
+  if (!isMarkdownSnapshotEnvelope(widget) || !widget.snapshot) return null;
+  const content = t(widget.snapshot.contentLocalizationKey, {
+    defaultValue: widget.snapshot.contentLocalizationKey,
+  });
+  return <DashboardMarkdown content={content} />;
+}

--- a/packages/@granit/react-ui-dashboards/src/components/widgets/markdown-widget.tsx
+++ b/packages/@granit/react-ui-dashboards/src/components/widgets/markdown-widget.tsx
@@ -1,0 +1,38 @@
+import { useWidgetTriggerHandler } from '@granit/react-dashboards';
+import { useTranslation } from '@granit/react-localization';
+
+import { DashboardMarkdown } from './dashboard-markdown';
+
+import type { MarkdownWidgetDefinition } from '@granit/dashboards';
+
+/**
+ * Definition-side `markdown` renderer that actually parses Markdown — the
+ * rich counterpart to the verbatim fallback in `@granit/react-dashboards`.
+ * Register it via {@link markdownWidgetRegistry} (composed after
+ * `defaultWidgetRegistry`) so the editor preview and fixture-driven demos
+ * render headings/lists/tables instead of raw `##`.
+ *
+ * `Click` actions on `widget.actions` fire on body click via
+ * {@link useWidgetTriggerHandler}; the interactive affordances (cursor,
+ * `role`, keyboard) apply only when at least one Click action is wired.
+ */
+export function RichMarkdownWidget({ widget }: { readonly widget: MarkdownWidgetDefinition }) {
+  const { t } = useTranslation();
+  const content = t(widget.contentLocalizationKey, { defaultValue: widget.contentLocalizationKey });
+  const onClick = useWidgetTriggerHandler('Click', widget.actions);
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        data-slot="markdown-widget"
+        data-interactive=""
+        onClick={() => onClick()}
+        className="w-full cursor-pointer border-0 bg-transparent p-0 text-left"
+      >
+        <DashboardMarkdown content={content} />
+      </button>
+    );
+  }
+  return <DashboardMarkdown content={content} />;
+}

--- a/packages/@granit/react-ui-dashboards/src/index.ts
+++ b/packages/@granit/react-ui-dashboards/src/index.ts
@@ -17,6 +17,19 @@ export { LifecycleConfirmDialog } from './components/dashboard-lifecycle-dialog'
 export { DashboardImportFromCatalog } from './components/dashboard-import-from-catalog';
 export type { LifecycleAction, PendingLifecycle } from './components/dashboard-lifecycle-types';
 
+// Rich Markdown renderers — opt-in react-markdown overrides for the verbatim
+// `markdown` fallbacks in @granit/react-dashboards. Compose the registry
+// fragments after the framework defaults; the components are exported for apps
+// that wire their own registries.
+export { DashboardMarkdown } from './components/widgets/dashboard-markdown';
+export type { DashboardMarkdownProps } from './components/widgets/dashboard-markdown';
+export { RichMarkdownWidget } from './components/widgets/markdown-widget';
+export { RichMarkdownSnapshotWidget } from './components/widgets/markdown-snapshot-widget';
+export {
+  markdownWidgetRegistry,
+  markdownSnapshotWidgetRegistry,
+} from './registry/markdown-widget-registry';
+
 // i18next resource bundles (flat keys, "translation" ns)
 export { dashboardsTranslationsEn, dashboardsTranslationsFr } from './locales/index';
 export type { DashboardsTranslations } from './locales/index';

--- a/packages/@granit/react-ui-dashboards/src/registry/markdown-widget-registry.ts
+++ b/packages/@granit/react-ui-dashboards/src/registry/markdown-widget-registry.ts
@@ -1,0 +1,42 @@
+import { RichMarkdownSnapshotWidget } from '../components/widgets/markdown-snapshot-widget';
+import { RichMarkdownWidget } from '../components/widgets/markdown-widget';
+
+import type {
+  SnapshotWidgetRegistry,
+  WidgetRegistry,
+  WidgetRendererFn,
+} from '@granit/react-dashboards';
+
+/**
+ * Definition-side override that swaps the verbatim `markdown` fallback for the
+ * react-markdown-backed {@link RichMarkdownWidget}. Compose it **after**
+ * `defaultWidgetRegistry` so it wins the `markdown` key:
+ *
+ * @example
+ *   const registries = [
+ *     defaultWidgetRegistry,
+ *     defaultAnalyticsWidgetRegistry,
+ *     markdownWidgetRegistry, // real Markdown for the editor preview + fixtures
+ *   ];
+ */
+export const markdownWidgetRegistry: WidgetRegistry = Object.freeze({
+  // The registry renderer is typed over the full `WidgetDefinition` union;
+  // this one narrows to `markdown`, so cast like `defaultWidgetRegistry` does.
+  markdown: RichMarkdownWidget as WidgetRendererFn,
+});
+
+/**
+ * Snapshot-side override — the runtime path for backend-rendered dashboards.
+ * Compose it **after** `defaultSnapshotWidgetRegistry` so it wins the
+ * `Markdown` key:
+ *
+ * @example
+ *   const snapshotRegistries = [
+ *     defaultSnapshotWidgetRegistry,
+ *     defaultAnalyticsSnapshotWidgetRegistry,
+ *     markdownSnapshotWidgetRegistry, // real Markdown for every banner
+ *   ];
+ */
+export const markdownSnapshotWidgetRegistry: SnapshotWidgetRegistry = Object.freeze({
+  Markdown: RichMarkdownSnapshotWidget,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5057,9 +5057,15 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
+      react-markdown:
+        specifier: ^10
+        version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      remark-gfm:
+        specifier: ^4
+        version: 4.0.1
     devDependencies:
       '@granit/analytics':
         specifier: workspace:*


### PR DESCRIPTION
## Problem

Dashboard banner widgets render their Markdown source **verbatim** — e.g. `Widget:Showcase.Parties.banner.Body` = `## Tiers` shows the literal `## Tiers` instead of an H2 heading. This affects every dashboard, since each backend definition (`ShowcasePartiesDashboardDefinition` & siblings) declares a `markdown` banner.

**Root cause (by design):** `@granit/react-dashboards` ships a dependency-free verbatim fallback for `markdown` widgets (`<pre>` / `<div whitespace-pre-wrap>`) to keep react-markdown out of bundles that never render Markdown. Real Markdown rendering is opt-in via a renderer registered in the widget registry.

## Change

Adds react-markdown-backed renderers in the **`@granit/react-ui-dashboards`** UI tier (the published tier where UI deps belong):

- `DashboardMarkdown` — shared renderer (`react-markdown` + `remark-gfm`), headings sized for banners, semantic Tailwind tokens.
- `RichMarkdownWidget` (definition side) and `RichMarkdownSnapshotWidget` (snapshot side — the **runtime path** for backend-rendered dashboards via `POST /dashboards/{id}/render`).
- `markdownWidgetRegistry` / `markdownSnapshotWidgetRegistry` fragments that apps compose **after** the framework defaults (last-wins) to override the `markdown` / `Markdown` keys.

No backend or i18n content change needed — wiring the two registry fragments fixes every dashboard banner at once.

## Security

`react-markdown` + `remark-gfm` **without `rehype-raw`**: raw HTML in the source is escaped to text, never parsed into DOM. No DOM script sink → no `/csp` subpath required (`pnpm check:csp` passes). Deps already vetted in `THIRD-PARTY-NOTICES.md` (used by `@granit/react-ai-chat`).

## Verification

- `@granit/react-ui-dashboards`: 21 tests pass (4 new), `tsc` clean, `eslint` clean, `pnpm check:csp` OK.

## Consumer wiring (separate MR)

`granit-showcase-react` `App.tsx` composes both fragments into its widget registries — shipped as a **Draft** GitLab MR, to merge after this PR.