### PR TITLE
fix(parties): normalize primaryEmail to address in grid column

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -8770,6 +8770,27 @@
           "kind": "interface",
           "signature": "interface PendingLifecycle",
           "members": []
+        },
+        {
+          "name": "DashboardMarkdown",
+          "kind": "function",
+          "signature": "function DashboardMarkdown("
+        },
+        {
+          "name": "DashboardMarkdownProps",
+          "kind": "interface",
+          "signature": "interface DashboardMarkdownProps",
+          "members": []
+        },
+        {
+          "name": "RichMarkdownWidget",
+          "kind": "function",
+          "signature": "function RichMarkdownWidget("
+        },
+        {
+          "name": "RichMarkdownSnapshotWidget",
+          "kind": "function",
+          "signature": "function RichMarkdownSnapshotWidget("
         }
       ]
     },

--- a/packages/@granit/parties/src/types/index.ts
+++ b/packages/@granit/parties/src/types/index.ts
@@ -154,8 +154,13 @@ export interface PartyListItemResponse {
   readonly roles: string;
   readonly status: PartyStatus;
   readonly defaultCurrency: string;
-  /** Flattened from the projection's `primaryEmail.address` (denormalized). */
-  readonly primaryEmail: string | null;
+  /**
+   * The primary email. Mock/denormalized sources flatten this to the display
+   * string (`primaryEmail.address`); the live `MapGranitQuery<Party>` endpoint
+   * serializes the full `Party` aggregate, so the wire carries the `PartyEmail`
+   * object. `party-columns.tsx` normalizes both to the address for display.
+   */
+  readonly primaryEmail: string | PartyEmailResponse | null;
   /** Flattened from the projection's `primaryPhone.number` (denormalized). */
   readonly primaryPhone: string | null;
 }

--- a/packages/@granit/react-ui-parties/src/components/party-columns.tsx
+++ b/packages/@granit/react-ui-parties/src/components/party-columns.tsx
@@ -62,9 +62,14 @@ export function createPartyColumns({
       id: 'primaryEmail',
       accessorKey: 'primaryEmail',
       header: t('Parties.Columns.PrimaryEmail'),
-      cell: ({ row }) => (
-        <span className="text-sm text-muted-foreground">{row.original.primaryEmail ?? '—'}</span>
-      ),
+      cell: ({ row }) => {
+        // The live grid serializes the raw Party aggregate, so `primaryEmail`
+        // arrives as a `PartyEmail` object; mock/denormalized sources flatten it
+        // to the address string. Normalize both to the address for display.
+        const primaryEmail = row.original.primaryEmail;
+        const address = typeof primaryEmail === 'string' ? primaryEmail : primaryEmail?.address;
+        return <span className="text-sm text-muted-foreground">{address ?? '—'}</span>;
+      },
     },
     {
       id: 'actions',


### PR DESCRIPTION
## Context

The live `MapGranitQuery<Party>` endpoint serializes the full `Party` aggregate, so `primaryEmail` arrives on the wire as a `PartyEmail` object. Mock/denormalized sources flatten it to the display string (`primaryEmail.address`). The grid column previously rendered the raw value, showing `[object Object]` against the live endpoint.

## Change

- Widen `PartyListItemResponse.primaryEmail` to `string | PartyEmailResponse | null` to reflect both shapes.
- Normalize both to the address string for display in `party-columns.tsx`.

## Notes

Follow-up to #885 (already merged); branched fresh from `develop`.