### PR TITLE
feat(entities): render table cells from column valueKind

### DIFF
--- a/packages/@granit/query-engine/src/types/query-metadata.ts
+++ b/packages/@granit/query-engine/src/types/query-metadata.ts
@@ -20,6 +20,28 @@ export interface ColumnDefinition {
   readonly isVisible: boolean;
   /** Display format (e.g. "dd/MM/yyyy"). */
   readonly format?: string;
+  /**
+   * Semantic cell kind, driving renderer selection ahead of the manifest
+   * `component` join and the CLR `type` fallback. Wire values are the .NET
+   * `ValueKind` enum member names verbatim (PascalCase, via
+   * `JsonStringEnumConverter`): `Count`, `Number`, `Currency`, `Percentage`,
+   * `Bytes`, `Duration`, `Date`, `DateTime`, `Time`, `RelativeTime`, `Url`,
+   * `Email`, `Phone`, `Boolean`, `Enum`, `Color`, `Image`, `Json`, `Markdown`,
+   * `Tags`, `Rating`, `Identifier`. Optional — absent columns keep the legacy
+   * CLR/component behaviour. Mirrors `Granit.QueryEngine.Meta.ColumnDefinition`.
+   */
+  readonly valueKind?: string;
+  /**
+   * ISO 4217 code for a `Currency` column, fixed at design time (e.g. `"EUR"`).
+   * Takes precedence over {@link currencyCodeField}.
+   */
+  readonly currencyCode?: string;
+  /**
+   * Name of a sibling column holding the ISO 4217 code per row (multi-currency
+   * entities). Consulted only when {@link currencyCode} is absent; the code is
+   * read from `row[currencyCodeField]` on each row.
+   */
+  readonly currencyCodeField?: string;
 }
 
 /** Filterable field with its allowed operators (inferred from type). */
@@ -85,13 +107,7 @@ export interface DateFilterMeta {
 
 /** Predefined date periods for DatePeriodPicker. */
 export type DatePeriod =
-  | 'Today'
-  | 'ThisWeek'
-  | 'ThisMonth'
-  | 'LastMonth'
-  | 'ThisQuarter'
-  | 'ThisYear'
-  | 'Custom';
+  'Today' | 'ThisWeek' | 'ThisMonth' | 'LastMonth' | 'ThisQuarter' | 'ThisYear' | 'Custom';
 
 /** Field available for group-by operations. */
 export interface GroupByField {

--- a/packages/@granit/react-ui-entities/src/__tests__/cell-formatters.test.tsx
+++ b/packages/@granit/react-ui-entities/src/__tests__/cell-formatters.test.tsx
@@ -1,0 +1,205 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { formatCell } from '../cell-formatters';
+
+import type { CellFormatterContext } from '../cell-formatters';
+import type { ColumnDefinition } from '@granit/query-engine';
+
+function makeColumn(overrides: Partial<ColumnDefinition> = {}): ColumnDefinition {
+  return {
+    name: 'value',
+    label: 'Value',
+    type: 'String',
+    order: 0,
+    isSortable: false,
+    isFilterable: false,
+    isVisible: true,
+    ...overrides,
+  };
+}
+
+function makeCtx(
+  column: ColumnDefinition,
+  row: Readonly<Record<string, unknown>>,
+  overrides: Partial<CellFormatterContext> = {}
+): CellFormatterContext {
+  return {
+    row,
+    column,
+    component: undefined,
+    currencyResolver: () => 'EUR',
+    locale: 'en-US',
+    formatDate: (d) => `D:${String(d)}`,
+    formatDateTime: (d) => `DT:${String(d)}`,
+    ...overrides,
+  };
+}
+
+/** Renders the node returned by formatCell and yields its DOM container. */
+function renderCell(ctx: CellFormatterContext): HTMLElement {
+  const { container } = render(<>{formatCell(ctx)}</>);
+  return container;
+}
+
+function textOf(ctx: CellFormatterContext): string {
+  return renderCell(ctx).textContent ?? '';
+}
+
+describe('formatCell — empty & fallback', () => {
+  it('renders an em dash for null / undefined', () => {
+    const col = makeColumn({ valueKind: 'Number' });
+    expect(textOf(makeCtx(col, { value: null }))).toBe('—');
+    expect(textOf(makeCtx(col, {}))).toBe('—');
+  });
+
+  it('falls back to text for an unmapped valueKind', () => {
+    const col = makeColumn({ valueKind: 'Json' });
+    expect(textOf(makeCtx(col, { value: 'raw-payload' }))).toBe('raw-payload');
+  });
+
+  it('falls through to text when a mapped formatter cannot render the value type', () => {
+    // Currency expects a number; a string cannot be rendered as money.
+    const col = makeColumn({ valueKind: 'Currency' });
+    expect(textOf(makeCtx(col, { value: 'N/A' }))).toBe('N/A');
+  });
+});
+
+describe('formatCell — resolution priority', () => {
+  it('lets valueKind win over the manifest component', () => {
+    // component=money would render €1.00; valueKind=Number must win → "100".
+    const col = makeColumn({ valueKind: 'Number' });
+    expect(textOf(makeCtx(col, { value: 100 }, { component: 'money' }))).toBe('100');
+  });
+
+  it('keeps the legacy money component path when valueKind is absent', () => {
+    const col = makeColumn();
+    const text = textOf(makeCtx(col, { value: 12345 }, { component: 'money' }));
+    expect(text).toContain('123.45');
+    expect(text).toContain('€');
+  });
+});
+
+describe('formatCell — Currency valueKind', () => {
+  it('formats with a fixed currencyCode (design-time constant)', () => {
+    const col = makeColumn({ valueKind: 'Currency', currencyCode: 'GBP' });
+    const text = textOf(makeCtx(col, { value: 12345 }));
+    expect(text).toContain('123.45');
+    expect(text).toContain('£');
+  });
+
+  it('reads the per-row code from currencyCodeField (multi-currency)', () => {
+    const col = makeColumn({ valueKind: 'Currency', currencyCodeField: 'currency' });
+    const usd = textOf(makeCtx(col, { value: 12345, currency: 'USD' }));
+    const eur = textOf(makeCtx(col, { value: 12345, currency: 'EUR' }));
+    expect(usd).toContain('$');
+    expect(eur).toContain('€');
+    expect(usd).not.toBe(eur);
+  });
+
+  it('prefers a fixed currencyCode over the per-row field', () => {
+    const col = makeColumn({
+      valueKind: 'Currency',
+      currencyCode: 'GBP',
+      currencyCodeField: 'currency',
+    });
+    const text = textOf(makeCtx(col, { value: 12345, currency: 'USD' }));
+    expect(text).toContain('£');
+    expect(text).not.toContain('$');
+  });
+
+  it('falls back to a plain locale number when no code resolves', () => {
+    const col = makeColumn({ valueKind: 'Currency' });
+    const text = textOf(makeCtx(col, { value: 12345 }));
+    expect(text).toBe('123.45');
+  });
+
+  it('falls back to a plain number when the referenced field is missing', () => {
+    const col = makeColumn({ valueKind: 'Currency', currencyCodeField: 'currency' });
+    const text = textOf(makeCtx(col, { value: 12345 }));
+    expect(text).toBe('123.45');
+  });
+});
+
+describe('formatCell — numeric & measure valueKinds', () => {
+  it('formats Number / Count with locale grouping', () => {
+    expect(textOf(makeCtx(makeColumn({ valueKind: 'Number' }), { value: 1234567 }))).toBe(
+      '1,234,567'
+    );
+    expect(textOf(makeCtx(makeColumn({ valueKind: 'Count' }), { value: 42 }))).toBe('42');
+  });
+
+  it('formats Percentage as xx%', () => {
+    expect(textOf(makeCtx(makeColumn({ valueKind: 'Percentage' }), { value: 42.5 }))).toBe('42.5%');
+  });
+
+  it('humanizes Bytes', () => {
+    expect(textOf(makeCtx(makeColumn({ valueKind: 'Bytes' }), { value: 500 }))).toBe('500 B');
+    expect(textOf(makeCtx(makeColumn({ valueKind: 'Bytes' }), { value: 1536 }))).toBe('1.5 KB');
+    expect(textOf(makeCtx(makeColumn({ valueKind: 'Bytes' }), { value: 5 * 1024 * 1024 }))).toBe(
+      '5 MB'
+    );
+  });
+
+  it('humanizes Duration (seconds)', () => {
+    expect(textOf(makeCtx(makeColumn({ valueKind: 'Duration' }), { value: 3660 }))).toBe('1h 01m');
+    expect(textOf(makeCtx(makeColumn({ valueKind: 'Duration' }), { value: 125 }))).toBe('2m 05s');
+    expect(textOf(makeCtx(makeColumn({ valueKind: 'Duration' }), { value: 45 }))).toBe('45s');
+  });
+});
+
+describe('formatCell — link valueKinds', () => {
+  it('renders Url as an anchor', () => {
+    const a = renderCell(
+      makeCtx(makeColumn({ valueKind: 'Url' }), { value: 'https://example.com' })
+    ).querySelector('a');
+    expect(a?.getAttribute('href')).toBe('https://example.com');
+    expect(a?.getAttribute('target')).toBe('_blank');
+    expect(a?.textContent).toBe('https://example.com');
+  });
+
+  it('renders Email as a mailto anchor', () => {
+    const a = renderCell(
+      makeCtx(makeColumn({ valueKind: 'Email' }), { value: 'jane@example.com' })
+    ).querySelector('a');
+    expect(a?.getAttribute('href')).toBe('mailto:jane@example.com');
+  });
+
+  it('renders Phone as a tel anchor', () => {
+    const a = renderCell(
+      makeCtx(makeColumn({ valueKind: 'Phone' }), { value: '+3225550100' })
+    ).querySelector('a');
+    expect(a?.getAttribute('href')).toBe('tel:+3225550100');
+  });
+});
+
+describe('formatCell — temporal valueKinds', () => {
+  it('formats Date with the date-only formatter', () => {
+    expect(
+      textOf(makeCtx(makeColumn({ valueKind: 'Date' }), { value: '2026-07-03T10:00:00Z' }))
+    ).toBe('D:2026-07-03T10:00:00Z');
+  });
+
+  it('formats DateTime / Time / RelativeTime with the datetime formatter', () => {
+    for (const kind of ['DateTime', 'Time', 'RelativeTime']) {
+      expect(
+        textOf(makeCtx(makeColumn({ valueKind: kind }), { value: '2026-07-03T10:00:00Z' }))
+      ).toBe('DT:2026-07-03T10:00:00Z');
+    }
+  });
+});
+
+describe('formatCell — other valueKinds', () => {
+  it('renders Boolean as a check / cross', () => {
+    expect(textOf(makeCtx(makeColumn({ valueKind: 'Boolean' }), { value: true }))).toBe('✓');
+    expect(textOf(makeCtx(makeColumn({ valueKind: 'Boolean' }), { value: false }))).toBe('✗');
+  });
+
+  it('renders Identifier in a monospace element', () => {
+    const code = renderCell(
+      makeCtx(makeColumn({ valueKind: 'Identifier' }), { value: 'ORD-2026-001' })
+    ).querySelector('code');
+    expect(code?.textContent).toBe('ORD-2026-001');
+    expect(code?.className).toContain('font-mono');
+  });
+});

--- a/packages/@granit/react-ui-entities/src/cell-formatters.tsx
+++ b/packages/@granit/react-ui-entities/src/cell-formatters.tsx
@@ -1,0 +1,213 @@
+// Data-table cell rendering for the generic workspace entity list.
+//
+// A column picks its renderer from three signals, in descending priority:
+//   1. `column.valueKind` — semantic cell kind emitted by the backend query
+//      metadata (Granit.QueryEngine.Meta.ColumnDefinition.ValueKind).
+//   2. manifest `component` — the form-widget hint joined by column name.
+//   3. CLR `column.type` — ISO-date detection, then a plain text fallback.
+//
+// Every signal is optional and purely additive: a column with no `valueKind`
+// and no matching component degrades to the legacy CLR/text behaviour.
+
+import type { ColumnDefinition } from '@granit/query-engine';
+import type { ReactNode } from 'react';
+
+export type DateFormatter = (date: string | Date) => string;
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
+
+function formatDateValue(
+  value: string,
+  formatDate: DateFormatter,
+  formatDateTime: DateFormatter,
+  withTime: boolean
+): string | null {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  // Timezone-aware (user PreferredTimezone) via useDateFormatter, not raw Intl.
+  return withTime ? formatDateTime(value) : formatDate(value);
+}
+
+function tryFormatDateCell(
+  value: unknown,
+  component: string | undefined,
+  columnType: string,
+  formatDate: DateFormatter,
+  formatDateTime: DateFormatter
+): string | null {
+  if (typeof value !== 'string') return null;
+  if (component === 'date' || component === 'datetime') {
+    return formatDateValue(value, formatDate, formatDateTime, component === 'datetime');
+  }
+  if (columnType === 'DateTime' || columnType === 'DateTimeOffset') {
+    return formatDateValue(value, formatDate, formatDateTime, false);
+  }
+  if (ISO_DATE_RE.test(value)) {
+    return formatDateValue(value, formatDate, formatDateTime, false);
+  }
+  return null;
+}
+
+// Monetary amounts arrive in minor units (cents); scale to the major unit.
+// When no ISO code resolves, fall back to a plain locale number (no symbol).
+function formatMoney(value: number, currency: string | undefined, locale: string): string {
+  const options: Intl.NumberFormatOptions = currency ? { style: 'currency', currency } : {};
+  return new Intl.NumberFormat(locale, options).format(value / 100);
+}
+
+// Currency ISO code precedence for a `Currency` column:
+//   1. column.currencyCode  — fixed design-time constant
+//   2. row[currencyCodeField] — sibling column, per row (multi-currency)
+//   3. undefined            — locale/number fallback
+function resolveColumnCurrency(
+  column: ColumnDefinition,
+  row: Readonly<Record<string, unknown>>
+): string | undefined {
+  if (column.currencyCode) return column.currencyCode;
+  if (column.currencyCodeField) {
+    const code = row[column.currencyCodeField];
+    if (typeof code === 'string' && code.length > 0) return code;
+  }
+  return undefined;
+}
+
+const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const;
+
+function formatBytes(value: number, locale: string): string {
+  let size = value;
+  let unit = 0;
+  while (Math.abs(size) >= 1024 && unit < BYTE_UNITS.length - 1) {
+    size /= 1024;
+    unit += 1;
+  }
+  const formatted = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: unit === 0 ? 0 : 1,
+  }).format(size);
+  return `${formatted} ${BYTE_UNITS[unit]}`;
+}
+
+// Humanizes a duration given in seconds to `1h 05m` / `12m 03s` / `45s`.
+function formatDuration(totalSeconds: number): string {
+  const seconds = Math.floor(Math.abs(totalSeconds));
+  const sign = totalSeconds < 0 ? '-' : '';
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  if (hours > 0) return `${sign}${hours}h ${String(minutes).padStart(2, '0')}m`;
+  if (minutes > 0) return `${sign}${minutes}m ${String(secs).padStart(2, '0')}s`;
+  return `${sign}${secs}s`;
+}
+
+type LinkKind = 'url' | 'email' | 'phone';
+
+function formatLinkCell(value: unknown, kind: LinkKind): ReactNode {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const href = kind === 'email' ? `mailto:${value}` : kind === 'phone' ? `tel:${value}` : value;
+  const external = kind === 'url';
+  return (
+    <a
+      href={href}
+      className="text-primary underline underline-offset-2"
+      onClick={(e) => e.stopPropagation()}
+      {...(external ? { target: '_blank', rel: 'noreferrer' } : {})}
+    >
+      {value}
+    </a>
+  );
+}
+
+/**
+ * Cell-level rendering context threaded to every valueKind formatter. A `null`
+ * return from a formatter means "cannot render this value" — {@link formatCell}
+ * then falls through to the manifest-component / CLR path.
+ */
+export interface CellFormatterContext {
+  readonly row: Readonly<Record<string, unknown>>;
+  readonly column: ColumnDefinition;
+  readonly component: string | undefined;
+  readonly currencyResolver: (row: Readonly<Record<string, unknown>>) => string;
+  readonly locale: string;
+  readonly formatDate: DateFormatter;
+  readonly formatDateTime: DateFormatter;
+}
+
+type CellFormatter = (value: unknown, ctx: CellFormatterContext) => ReactNode;
+
+function formatDateKind(value: unknown, ctx: CellFormatterContext, withTime: boolean): ReactNode {
+  if (typeof value !== 'string') return null;
+  return formatDateValue(value, ctx.formatDate, ctx.formatDateTime, withTime);
+}
+
+function formatNumberKind(value: unknown, locale: string): ReactNode {
+  if (typeof value !== 'number') return null;
+  return new Intl.NumberFormat(locale).format(value);
+}
+
+/**
+ * `valueKind` → cell formatter. Tier 1+2 kinds render here; unmapped kinds
+ * (`Enum`, `Color`, `Image`, `Json`, `Markdown`, `Tags`, `Rating`)
+ * intentionally have no entry and fall through to the manifest-component / CLR
+ * text path. Wire keys are the .NET `ValueKind` enum member names verbatim.
+ */
+export const VALUE_KIND_FORMATTERS: Readonly<Record<string, CellFormatter>> = Object.freeze({
+  Currency: (value, ctx) =>
+    typeof value === 'number'
+      ? formatMoney(value, resolveColumnCurrency(ctx.column, ctx.row), ctx.locale)
+      : null,
+  Percentage: (value, ctx) =>
+    typeof value === 'number'
+      ? `${new Intl.NumberFormat(ctx.locale, { maximumFractionDigits: 2 }).format(value)}%`
+      : null,
+  Number: (value, ctx) => formatNumberKind(value, ctx.locale),
+  Count: (value, ctx) => formatNumberKind(value, ctx.locale),
+  Bytes: (value, ctx) => (typeof value === 'number' ? formatBytes(value, ctx.locale) : null),
+  Duration: (value) => (typeof value === 'number' ? formatDuration(value) : null),
+  Url: (value) => formatLinkCell(value, 'url'),
+  Email: (value) => formatLinkCell(value, 'email'),
+  Phone: (value) => formatLinkCell(value, 'phone'),
+  Date: (value, ctx) => formatDateKind(value, ctx, false),
+  DateTime: (value, ctx) => formatDateKind(value, ctx, true),
+  Time: (value, ctx) => formatDateKind(value, ctx, true),
+  RelativeTime: (value, ctx) => formatDateKind(value, ctx, true),
+  Boolean: (value) =>
+    typeof value === 'boolean' ? (
+      <span data-granit-cell-boolean={String(value)}>{value ? '✓' : '✗'}</span>
+    ) : null,
+  Identifier: (value) => (
+    <code className="font-mono text-xs">{typeof value === 'object' ? '—' : String(value)}</code>
+  ),
+});
+
+/**
+ * Renders one data-table cell with graceful degradation across the three
+ * signals described at the top of this module.
+ */
+export function formatCell(ctx: CellFormatterContext): ReactNode {
+  const { row, column, component, currencyResolver, locale, formatDate, formatDateTime } = ctx;
+  const value = row[column.name];
+  if (value === null || value === undefined) return '—';
+
+  if (column.valueKind) {
+    const formatter = VALUE_KIND_FORMATTERS[column.valueKind];
+    if (formatter) {
+      const rendered = formatter(value, ctx);
+      if (rendered !== null) return rendered;
+    }
+  }
+
+  if (component === 'money' && typeof value === 'number') {
+    return formatMoney(value, currencyResolver(row), locale);
+  }
+
+  const formattedDate = tryFormatDateCell(
+    value,
+    component,
+    column.type,
+    formatDate,
+    formatDateTime
+  );
+  if (formattedDate !== null) return formattedDate;
+
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value); // NOSONAR: remaining types (symbol, function) stringify safely
+}

--- a/packages/@granit/react-ui-entities/src/workspace-entity-page.tsx
+++ b/packages/@granit/react-ui-entities/src/workspace-entity-page.tsx
@@ -34,6 +34,7 @@ import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { recapParentRefs } from './bulk-recap';
+import { formatCell } from './cell-formatters';
 import { useEntityActionScope } from './entity-action-scope';
 import { EntityCalendarView } from './entity-calendar-view';
 import { EntityGalleryView, type GalleryRenderImage } from './entity-gallery-view';
@@ -42,6 +43,7 @@ import { EntityPageLayout } from './entity-page-layout';
 import { EntityViewSwitcher } from './entity-view-switcher';
 import { asExtended } from './manifest-extensions';
 
+import type { DateFormatter } from './cell-formatters';
 import type { ExtendedEntityManifest } from './manifest-extensions';
 import type {
   EntityListLayoutKind,
@@ -49,12 +51,8 @@ import type {
   EntityManifestResponse,
   EntitySelectionActionManifest,
 } from '@granit/entities';
-import type { ColumnDefinition, QueryMetadata } from '@granit/query-engine';
+import type { QueryMetadata } from '@granit/query-engine';
 import type { ColumnDef } from '@tanstack/react-table';
-
-const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
-
-type DateFormatter = (date: string | Date) => string;
 
 // Builds TanStack table columns from the QueryMetadata + manifest field
 // widget hints. Cell rendering picks a formatter based on the widget id
@@ -119,15 +117,15 @@ function createGenericColumns({
         accessorKey: col.name,
         header: col.label,
         cell: ({ row }) =>
-          formatCell(
-            row.original,
-            col,
+          formatCell({
+            row: row.original,
+            column: col,
             component,
             currencyResolver,
             locale,
             formatDate,
-            formatDateTime
-          ),
+            formatDateTime,
+          }),
       };
     });
 
@@ -216,70 +214,6 @@ function createGenericColumns({
   };
 
   return [selectionColumn, ...dataColumns, actionsColumn];
-}
-
-function formatDateValue(
-  value: string,
-  formatDate: DateFormatter,
-  formatDateTime: DateFormatter,
-  withTime: boolean
-): string | null {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  // Timezone-aware (user PreferredTimezone) via useDateFormatter, not raw Intl.
-  return withTime ? formatDateTime(value) : formatDate(value);
-}
-
-function tryFormatDateCell(
-  value: unknown,
-  component: string | undefined,
-  columnType: string,
-  formatDate: DateFormatter,
-  formatDateTime: DateFormatter
-): string | null {
-  if (typeof value !== 'string') return null;
-  if (component === 'date' || component === 'datetime') {
-    return formatDateValue(value, formatDate, formatDateTime, component === 'datetime');
-  }
-  if (columnType === 'DateTime' || columnType === 'DateTimeOffset') {
-    return formatDateValue(value, formatDate, formatDateTime, false);
-  }
-  if (ISO_DATE_RE.test(value)) {
-    return formatDateValue(value, formatDate, formatDateTime, false);
-  }
-  return null;
-}
-
-function formatCell(
-  row: Readonly<Record<string, unknown>>,
-  column: ColumnDefinition,
-  component: string | undefined,
-  currencyResolver: (row: Readonly<Record<string, unknown>>) => string,
-  locale: string,
-  formatDate: DateFormatter,
-  formatDateTime: DateFormatter
-): string {
-  const value = row[column.name];
-  if (value === null || value === undefined) return '—';
-
-  if (component === 'money' && typeof value === 'number') {
-    return new Intl.NumberFormat(locale, {
-      style: 'currency',
-      currency: currencyResolver(row),
-    }).format(value / 100);
-  }
-
-  const formattedDate = tryFormatDateCell(
-    value,
-    component,
-    column.type,
-    formatDate,
-    formatDateTime
-  );
-  if (formattedDate !== null) return formattedDate;
-
-  if (typeof value === 'object') return JSON.stringify(value);
-  return String(value); // NOSONAR: remaining types (symbol, function) stringify safely
 }
 
 interface ContentProps {


### PR DESCRIPTION
## Summary

Renders generic workspace data-table cells from the backend's semantic column **`valueKind`** (query metadata), ahead of the manifest `component` join and the CLR `type` fallback. Purely additive — columns without `valueKind` keep today's behaviour, so this merges safely **before** the backend deploys (backend PRs `granit-dotnet#2911` + `#2912`).

## Changes

- **`@granit/query-engine`** — `ColumnDefinition` gains optional `valueKind`, `currencyCode`, `currencyCodeField` (mirrors `.NET Granit.QueryEngine.Meta.ColumnDefinition`).
- **`@granit/react-ui-entities`** — extracted a `valueKind → formatter` map into a new `cell-formatters.tsx`; `workspace-entity-page` now resolves cells as **`valueKind` → manifest `component` → CLR `type`**. Reuses the existing money/date formatters (no new libs).

### Covered kinds (Tier 1+2)
`Currency`, `Percentage`, `Number`, `Count`, `Bytes`, `Duration`, `Url`, `Email`, `Phone`, `Date`/`DateTime`/`Time`/`RelativeTime`, `Boolean`, `Identifier`. Unmapped kinds (`Enum`, `Color`, `Image`, `Json`, `Markdown`, `Tags`, `Rating`) fall through to the text/CLR path.

### Currency ISO code precedence
`column.currencyCode` (fixed) → `row[column.currencyCodeField]` (per row, multi-currency) → locale/number fallback.

## Tests

New `cell-formatters.test.tsx` (21 cases): per-kind resolution, all three currency code paths (fixed / per-row / neither), valueKind-wins-over-component priority, and unknown-kind → text fallback.

`pnpm --filter @granit/query-engine test` and `pnpm --filter @granit/react-ui-entities test` green (146 tests).

## Not in scope

- **Phase 6.2 (edit-input resolution)** deferred: applying a `valueKind → form-component-id` map "only when `field.component` is the CLR default" needs a `clrTypeName → default-component` mapping that the front doesn't yet expose, so it can't reliably distinguish an explicit component from a coincidental default. Better as a focused follow-up.
- **`entity-list.tsx` secondary renderer** skipped: it lives in `@granit/react-entities` (a lower tier than `@granit/react-ui-entities`), so it can't import the formatters — reuse would require duplicating the whole system across a layer boundary.