### PR TITLE
feat(entities): resolve edit input from field valueKind (Phase 6.2)

### DIFF
--- a/contracts/openapi/entities.json
+++ b/contracts/openapi/entities.json
@@ -909,6 +909,9 @@
                 "$ref": "#/components/schemas/EntityProvenance"
               }
             ]
+          },
+          "valueKind": {
+            "type": ["null", "string"]
           }
         }
       },

--- a/packages/@granit/entities/src/types/form.ts
+++ b/packages/@granit/entities/src/types/form.ts
@@ -67,6 +67,16 @@ export interface EntityFormFieldManifest {
    * base-layer fields without a tracked origin.
    */
   readonly provenance: EntityProvenance | null;
+  /**
+   * Optional semantic display-type (`Currency`, `Url`, `Email`, …) — the same
+   * vocabulary a query column carries (`ColumnDefinition.valueKind`). Lets the
+   * renderer upgrade the default edit input when {@link component} was left at
+   * its CLR-type default; an explicit component always wins. Wire values are
+   * the .NET `ValueKind` enum member names verbatim (PascalCase). `null` when
+   * no hint is declared. Mirrors `FieldDescriptor.ValueKind`. Optional key so
+   * the addition stays non-breaking for manifest consumers.
+   */
+  readonly valueKind?: string | null;
 }
 
 /**

--- a/packages/@granit/react-entities/src/__tests__/entity-form.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-form.test.tsx
@@ -140,6 +140,38 @@ describe('EntityForm', () => {
     expect(missing?.getAttribute('data-component')).toBe('unknown-component');
   });
 
+  it('upgrades a CLR-default component to the valueKind input when registered', () => {
+    const moneyWidget: EntityFormComponent = ({ field: f }) => (
+      <input data-testid={`money-${f.propertyName}`} />
+    );
+    const richCatalog: EntityComponentCatalog = { form: { text: textWidget, money: moneyWidget } };
+    const variant = manifest(
+      section('main', 0, [field('Price', 0, { component: 'decimal', valueKind: 'Currency' })])
+    );
+    const { container } = render(
+      withProvider(
+        <EntityForm variant={variant} values={{}} onChange={() => undefined} />,
+        richCatalog
+      )
+    );
+    expect(container.querySelector('[data-property="Price"]')?.getAttribute('data-component')).toBe(
+      'money'
+    );
+  });
+
+  it('keeps the CLR-default component when the valueKind input is not registered', () => {
+    const variant = manifest(
+      section('main', 0, [field('Price', 0, { component: 'decimal', valueKind: 'Currency' })])
+    );
+    // Default catalog registers only `text`, so the `money` upgrade is skipped.
+    const { container } = render(
+      withProvider(<EntityForm variant={variant} values={{}} onChange={() => undefined} />)
+    );
+    expect(container.querySelector('[data-property="Price"]')?.getAttribute('data-component')).toBe(
+      'decimal'
+    );
+  });
+
   it('forwards readOnly to widgets (form prop OR field flag)', () => {
     const variant = manifest(
       section('main', 0, [field('Editable', 0), field('LockedByField', 1, { readOnly: true })])

--- a/packages/@granit/react-entities/src/__tests__/resolve-form-component.test.ts
+++ b/packages/@granit/react-entities/src/__tests__/resolve-form-component.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveFormComponentId,
+  VALUE_KIND_FORM_COMPONENTS,
+} from '../field-components/resolve-form-component';
+
+import type { EntityFormComponent } from '../providers/component-catalog';
+import type { EntityFormFieldManifest } from '@granit/entities';
+
+const noop: EntityFormComponent = () => null;
+
+// A catalog that registers the richer inputs the valueKind map targets.
+const RICH_CATALOG: Readonly<Record<string, EntityFormComponent>> = {
+  text: noop,
+  decimal: noop,
+  money: noop,
+  url: noop,
+  email: noop,
+  phone: noop,
+  lookup: noop,
+};
+
+// The minimal standard catalog — none of the richer inputs are registered.
+const STANDARD_CATALOG: Readonly<Record<string, EntityFormComponent>> = {
+  text: noop,
+  decimal: noop,
+  lookup: noop,
+};
+
+function makeField(overrides: Partial<EntityFormFieldManifest> = {}): EntityFormFieldManifest {
+  return {
+    propertyName: 'Field',
+    clrTypeName: 'String',
+    component: 'text',
+    config: null,
+    labelKey: null,
+    helpKey: null,
+    order: 0,
+    readOnly: false,
+    visibleIf: null,
+    lookup: null,
+    provenance: null,
+    ...overrides,
+  };
+}
+
+describe('resolveFormComponentId', () => {
+  it('upgrades a CLR-default component from valueKind when the input is registered', () => {
+    const field = makeField({ component: 'decimal', valueKind: 'Currency' });
+    expect(resolveFormComponentId(field, RICH_CATALOG)).toBe('money');
+  });
+
+  it('upgrades text → url / email / phone', () => {
+    expect(resolveFormComponentId(makeField({ valueKind: 'Url' }), RICH_CATALOG)).toBe('url');
+    expect(resolveFormComponentId(makeField({ valueKind: 'Email' }), RICH_CATALOG)).toBe('email');
+    expect(resolveFormComponentId(makeField({ valueKind: 'Phone' }), RICH_CATALOG)).toBe('phone');
+  });
+
+  it('keeps an explicit (non-CLR-default) component even when valueKind is set', () => {
+    // component=money is an explicit choice, not a CLR default → no override.
+    const field = makeField({ component: 'money', valueKind: 'Currency' });
+    expect(resolveFormComponentId(field, RICH_CATALOG)).toBe('money');
+    // textarea is an explicit opt-in, never a CLR default.
+    const notes = makeField({ component: 'textarea', valueKind: 'Url' });
+    expect(resolveFormComponentId(notes, RICH_CATALOG)).toBe('textarea');
+  });
+
+  it('falls back to the base component when the mapped input is not registered', () => {
+    const field = makeField({ component: 'decimal', valueKind: 'Currency' });
+    expect(resolveFormComponentId(field, STANDARD_CATALOG)).toBe('decimal');
+  });
+
+  it('keeps the base component for a valueKind with no form-component mapping', () => {
+    // Bytes edits as a raw number — no entry in the input map.
+    const field = makeField({ component: 'decimal', valueKind: 'Bytes' });
+    expect(resolveFormComponentId(field, RICH_CATALOG)).toBe('decimal');
+    expect(VALUE_KIND_FORM_COMPONENTS['Bytes']).toBeUndefined();
+  });
+
+  it('keeps the base component when no valueKind is present', () => {
+    expect(resolveFormComponentId(makeField({ component: 'text' }), RICH_CATALOG)).toBe('text');
+    expect(resolveFormComponentId(makeField({ valueKind: null }), RICH_CATALOG)).toBe('text');
+  });
+
+  it('lets a declared lookup win over everything', () => {
+    const field = makeField({
+      component: 'text',
+      valueKind: 'Url',
+      lookup: { source: 'parties' } as unknown as EntityFormFieldManifest['lookup'],
+    });
+    expect(resolveFormComponentId(field, RICH_CATALOG)).toBe('lookup');
+  });
+});

--- a/packages/@granit/react-entities/src/components/entity-form.tsx
+++ b/packages/@granit/react-entities/src/components/entity-form.tsx
@@ -1,6 +1,7 @@
 import { evaluateVisibility } from '@granit/entities';
 import { useCallback, useMemo, type ReactNode } from 'react';
 
+import { resolveFormComponentId } from '../field-components/resolve-form-component';
 import { useEntityRenderer } from '../providers/entity-renderer-provider';
 
 import { MissingComponent } from './missing-component';
@@ -144,11 +145,10 @@ function EntityFormField({
     return null;
   }
 
-  // A declared lookup wins over the type-derived component: the backend's
-  // FieldBuilder.Lookup(...) keeps Component as the CLR-default (e.g. "text"),
-  // so presence of `field.lookup` is what routes a foreign-key field to the
-  // server-backed picker. Apps override the picker via `components.form.lookup`.
-  const componentId = field.lookup ? 'lookup' : field.component;
+  // Resolve the component id: a declared lookup wins, else a `valueKind` hint
+  // may upgrade a CLR-default component to a richer input (money / url / …)
+  // when that input is registered, else the manifest `component` is used as-is.
+  const componentId = resolveFormComponentId(field, components.form);
   const Component = components.form[componentId];
 
   // Always render a label: fields whose entity definition never called

--- a/packages/@granit/react-entities/src/field-components/resolve-form-component.ts
+++ b/packages/@granit/react-entities/src/field-components/resolve-form-component.ts
@@ -1,0 +1,57 @@
+import type { EntityFormComponent } from '../providers/component-catalog';
+import type { EntityFormFieldManifest } from '@granit/entities';
+
+/**
+ * Component ids the backend emits as the CLR-type default (mirrors
+ * `FieldBuilder.ChooseDefaultComponent()`). A field still carrying one of
+ * these was never given an explicit `.Component(...)`, so a `valueKind` hint
+ * is allowed to upgrade it. Anything else (`textarea`, `money`, `url`, a
+ * `custom:` id, …) is an explicit choice that always wins.
+ */
+const CLR_DEFAULT_COMPONENTS: ReadonlySet<string> = new Set([
+  'text',
+  'integer',
+  'decimal',
+  'boolean',
+  'date',
+  'time',
+  'datetime',
+  'select',
+  'multiselect',
+]);
+
+/**
+ * `valueKind` → edit form-component id. Deliberately separate from the
+ * data-table cell map (`@granit/react-query-engine`): the same semantic kind
+ * maps to a mode-appropriate widget (e.g. `Bytes` displays "1.2 MB" in a grid
+ * but edits as a raw number, so it has no entry here). Only kinds with a
+ * richer input than their CLR default are listed; the rest keep the default.
+ */
+export const VALUE_KIND_FORM_COMPONENTS: Readonly<Record<string, string>> = Object.freeze({
+  Currency: 'money',
+  Url: 'url',
+  Email: 'email',
+  Phone: 'phone',
+});
+
+/**
+ * Resolves the form-component id for a field, in descending priority:
+ *   1. `lookup` — a declared data-lookup routes to the server-backed picker.
+ *   2. `valueKind` upgrade — only when `component` is still the CLR default
+ *      AND the mapped component is registered in the catalog (else it would
+ *      render as a missing component).
+ *   3. `component` — the manifest value as-is (explicit choice or CLR default).
+ */
+export function resolveFormComponentId(
+  field: EntityFormFieldManifest,
+  catalog: Readonly<Record<string, EntityFormComponent>>
+): string {
+  if (field.lookup) return 'lookup';
+
+  const base = field.component;
+  if (field.valueKind && CLR_DEFAULT_COMPONENTS.has(base)) {
+    const mapped = VALUE_KIND_FORM_COMPONENTS[field.valueKind];
+    if (mapped && catalog[mapped]) return mapped;
+  }
+  return base;
+}


### PR DESCRIPTION
> **Backend dependency merged** — granit-business MR !187 (`valueKind` on the form-field wire manifest) is in `develop`. This PR is ready.
>
> **On the vendored `entities.json`:** I rebuilt the backend generator and diffed the authoritative output — the *only* semantic change is the added `ValueKind` enum schema + the `valueKind` property (no backend drift; the rest of a full resync is a generator array-formatting bump). The minimal edit here (`valueKind: ["null", "string"]`) is oracle-faithful (family `string`, nullable, correct field order); converging to the enum `$ref` form belongs in a repo-wide openapi-resync sweep, not this feature PR.

## Summary

Phase 6.2 companion to the display-side valueKind work (#889 / #890). When a **form field** carries a `valueKind` hint **and** its `component` is still the CLR-type default, upgrade the edit input to the richer registered component. An explicit component, a declared lookup, and unmapped kinds all keep today's behaviour.

## Resolution order (`resolveFormComponentId`)

1. `lookup` → server-backed picker (unchanged).
2. **`valueKind` upgrade** — only when `component` ∈ the CLR-default set (`text/integer/decimal/boolean/date/time/datetime/select/multiselect`, per `FieldBuilder.ChooseDefaultComponent()`) **and** the mapped input is registered in the catalog.
3. `component` as-is.

Mapping: `Currency→money`, `Url→url`, `Email→email`, `Phone→phone`. Other kinds have no entry (e.g. `Bytes` edits as a raw number) → keep the CLR default. **Deliberately separate from the display cell map** (`@granit/react-query-engine`): same `valueKind`, mode-appropriate widget.

## Changes

- **`@granit/entities`** — optional `EntityFormFieldManifest.valueKind` (mirrors the backend record from !187). Vendored `contracts/openapi/entities.json` updated so the conformance oracle stays green.
- **`@granit/react-entities`** — `resolveFormComponentId` + `VALUE_KIND_FORM_COMPONENTS`; `entity-form` routes the component id through it. **Validation untouched** — constraints keep flowing from the OpenAPI schema.

## Safety

- **Additive & optional**: `valueKind` absent → nothing changes. Target input not registered → falls back to the CLR default (no `MissingComponent` regression).
- **Non-breaking for consumers**: `valueKind` is an optional key, so showcase manifest literals don't need updating.

## Tests

- `resolve-form-component.test.ts` (7): upgrade / explicit-wins / lookup-wins / unregistered-fallback / no-mapping / no-valueKind.
- `entity-form.test.tsx` (+2): end-to-end wiring (upgrade renders `money`; unregistered keeps `decimal`).
- Full green: react-entities + entities (421), arch-tests + contract-tests (incl. the resynced oracle).