### PR TITLE
feat(analytics): dashboard tables format cells via the shared query formatCell

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3451,6 +3451,11 @@
           "kind": "interface",
           "signature": "interface FormatMetricValueArgs",
           "members": []
+        },
+        {
+          "name": "metricRequestFromTimeWindow",
+          "kind": "function",
+          "signature": "function metricRequestFromTimeWindow( timeWindow: DashboardTimeWindow, supportsPeriod: boolean ): MetricRequest"
         }
       ]
     },

--- a/packages/@granit/analytics/src/types/table-snapshot.ts
+++ b/packages/@granit/analytics/src/types/table-snapshot.ts
@@ -22,6 +22,21 @@ export interface TableWidgetColumn {
    * so a table mixing AmountEur and AmountUsd surfaces both independently.
    */
   readonly currencyCode?: string | null;
+  /**
+   * Semantic display-type of the source query column (`Currency`, `Percentage`,
+   * `Url`, `Date`, …), or `null`. Drives the shared cell formatter so a
+   * dashboard table renders values the same way the query grids do. Wire
+   * values are the .NET `ValueKind` enum member names verbatim. Mirrors
+   * `ColumnDescriptor.ValueKind`.
+   */
+  readonly valueKind?: string | null;
+  /**
+   * Name (camelCase) of the sibling column carrying the per-row ISO 4217 code
+   * for a multi-currency table, or `null`. Consulted only when
+   * {@link currencyCode} is absent; the code is read from
+   * `row[currencyCodeField]` on each row.
+   */
+  readonly currencyCodeField?: string | null;
 }
 
 /**

--- a/packages/@granit/react-analytics/src/__tests__/table-snapshot-widget.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/table-snapshot-widget.test.tsx
@@ -98,6 +98,49 @@ describe('TableSnapshotWidget — rendering', () => {
     expect(cells[1]?.textContent).toBe('1,234');
   });
 
+  it('renders cells from column valueKind (Url link, Percentage, no /100 currency)', () => {
+    const snapshot: TableWidgetSnapshot = {
+      columns: [
+        { name: 'site', labelLocalizationKey: null, valueKind: 'Url' },
+        { name: 'rate', labelLocalizationKey: null, valueKind: 'Percentage' },
+        { name: 'total', labelLocalizationKey: null, valueKind: 'Currency', currencyCode: 'EUR' },
+      ],
+      rows: [{ site: 'https://acme.test', rate: 42.5, total: 1234.56 }],
+      totalRowCount: 1,
+    };
+    const { container } = wrap(<TableSnapshotWidget widget={tableEnvelope(snapshot)} />);
+    const link = container.querySelector('[data-column-name="site"] a');
+    expect(link?.getAttribute('href')).toBe('https://acme.test');
+    const rate = container.querySelectorAll('[data-column-name="rate"]')[1];
+    expect(rate?.textContent).toBe('42.5%');
+    const total = container.querySelectorAll('[data-column-name="total"]')[1];
+    expect(normalizeSpaces(total?.textContent ?? '')).toBe('€1,234.56');
+  });
+
+  it('formats per-row currency from currencyCodeField (multi-currency)', () => {
+    const snapshot: TableWidgetSnapshot = {
+      columns: [
+        {
+          name: 'amount',
+          labelLocalizationKey: null,
+          valueKind: 'Currency',
+          currencyCodeField: 'code',
+        },
+        { name: 'code', labelLocalizationKey: null },
+      ],
+      rows: [
+        { amount: 100, code: 'USD' },
+        { amount: 100, code: 'EUR' },
+      ],
+      totalRowCount: 2,
+    };
+    const { container } = wrap(<TableSnapshotWidget widget={tableEnvelope(snapshot)} />);
+    const amounts = container.querySelectorAll('[data-column-name="amount"]');
+    // amounts[0] is the header <th>; rows follow.
+    expect(normalizeSpaces(amounts[1]?.textContent ?? '')).toContain('$');
+    expect(normalizeSpaces(amounts[2]?.textContent ?? '')).toContain('€');
+  });
+
   it('renders an empty-state row when no data', () => {
     const snapshot: TableWidgetSnapshot = {
       columns: [{ name: 'id', labelLocalizationKey: null }],

--- a/packages/@granit/react-analytics/src/components/table-snapshot-widget.tsx
+++ b/packages/@granit/react-analytics/src/components/table-snapshot-widget.tsx
@@ -1,19 +1,23 @@
 import { isTableSnapshotEnvelope } from '@granit/analytics';
+import { createDefaultCellDateFormatters, formatCell } from '@granit/react-query-engine';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { TableWidgetColumn, TableWidgetSnapshot } from '@granit/analytics';
 import type { DashboardRenderedWidget } from '@granit/dashboards';
+import type { ColumnDefinition } from '@granit/query-engine';
 
 /**
  * Snapshot-driven renderer for the `'Table'` widget kind. Reads the rows
  * inline from `widget.snapshot.rows` (no per-row fetching — the bundle
  * carried them already), with localized headers via `useTranslation()`.
  *
- * Per-column currency formatting (B3-8b): when a column declares
- * `currencyCode`, numeric cell values format via
- * `Intl.NumberFormat({ style: 'currency', currency })` using the active
- * locale. Mixing currencies across columns is supported by design (a
- * table with `AmountEur` + `AmountUsd` shows both symbols side by side).
+ * Cells render through the shared query-engine `formatCell`, so a dashboard
+ * table formats values exactly like the query grids: `valueKind` drives the
+ * renderer (`Currency` symbol + locale, `Percentage` as `%`, `Url`/`Email`/
+ * `Phone` as links, dates via locale formatters, …), with per-column and
+ * per-row currency codes honoured. `valueKind` absent → locale number / text
+ * fallback.
  *
  * The renderer stays narrow on purpose — sorting / pagination /
  * client-side filtering belong to the host (apps that need them override
@@ -27,6 +31,8 @@ export function TableSnapshotWidget({ widget }: { readonly widget: DashboardRend
 function TableBody({ snapshot }: { readonly snapshot: TableWidgetSnapshot }) {
   const { t, i18n } = useTranslation();
   const { columns, rows, totalRowCount } = snapshot;
+  const locale = i18n.language || 'en-US';
+  const dateFormatters = useMemo(() => createDefaultCellDateFormatters(locale), [locale]);
 
   return (
     <div data-slot="table-snapshot-widget" className="flex h-full flex-col gap-2">
@@ -78,7 +84,13 @@ function TableBody({ snapshot }: { readonly snapshot: TableWidgetSnapshot }) {
                       data-column-name={col.name}
                       className="py-1 pr-3 tabular-nums"
                     >
-                      {formatCell(row[col.name], col, i18n.language)}
+                      {formatCell({
+                        row,
+                        column: toColumnDefinition(col),
+                        locale,
+                        formatDate: dateFormatters.formatDate,
+                        formatDateTime: dateFormatters.formatDateTime,
+                      })}
                     </td>
                   ))}
                 </tr>
@@ -92,24 +104,23 @@ function TableBody({ snapshot }: { readonly snapshot: TableWidgetSnapshot }) {
 }
 
 /**
- * Per-column cell formatter. Honors `currencyCode` (B3-8b) for numeric
- * values; otherwise falls back to locale-aware number formatting; falls
- * through to `String()` for non-number primitives.
+ * Adapts a dashboard `TableWidgetColumn` to the `ColumnDefinition` shape the
+ * shared `formatCell` consumes. The snapshot carries no CLR `type`, so the
+ * formatter relies on `valueKind` (+ ISO-date detection for string cells).
  */
-function formatCell(value: unknown, column: TableWidgetColumn, locale: string): string {
-  if (value === null || value === undefined) return '—';
-  if (typeof value === 'number') {
-    if (column.currencyCode) {
-      return new Intl.NumberFormat(locale, {
-        style: 'currency',
-        currency: column.currencyCode,
-      }).format(value);
-    }
-    return value.toLocaleString(locale);
-  }
-  if (typeof value === 'string') return value;
-  if (typeof value === 'boolean' || typeof value === 'bigint') return value.toString();
-  return JSON.stringify(value);
+function toColumnDefinition(col: TableWidgetColumn): ColumnDefinition {
+  return {
+    name: col.name,
+    label: col.labelLocalizationKey ?? col.name,
+    type: '',
+    order: 0,
+    isSortable: false,
+    isFilterable: false,
+    isVisible: true,
+    valueKind: col.valueKind ?? undefined,
+    currencyCode: col.currencyCode ?? undefined,
+    currencyCodeField: col.currencyCodeField ?? undefined,
+  };
 }
 
 /**

--- a/packages/@granit/react-entities/src/__tests__/entity-list.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-list.test.tsx
@@ -240,7 +240,7 @@ describe('EntityList', () => {
       http.get(`http://localhost${BASE_PATH}/meta`, () => HttpResponse.json(valueKindMeta)),
       http.get(`http://localhost${BASE_PATH}`, () =>
         HttpResponse.json({
-          items: [{ id: '1', website: 'https://acme.test', balance: 12345 }],
+          items: [{ id: '1', website: 'https://acme.test', balance: 1234.56 }],
           totalCount: 1,
           page: 1,
           pageSize: 20,
@@ -260,7 +260,7 @@ describe('EntityList', () => {
     const link = container.querySelector('td[data-column="website"] a');
     expect(link?.getAttribute('href')).toBe('https://acme.test');
     const balance = container.querySelector('td[data-column="balance"]')?.textContent ?? '';
-    expect(balance).toContain('123.45');
+    expect(balance).toContain('1,234.56');
     expect(balance).toContain('€');
   });
 

--- a/packages/@granit/react-query-engine/src/__tests__/cell-formatters.test.tsx
+++ b/packages/@granit/react-query-engine/src/__tests__/cell-formatters.test.tsx
@@ -63,6 +63,11 @@ describe('formatCell — empty & fallback', () => {
     const col = makeColumn({ valueKind: 'Currency' });
     expect(textOf(makeCtx(col, { value: 'N/A' }))).toBe('N/A');
   });
+
+  it('locale-formats a plain number with no valueKind', () => {
+    const col = makeColumn();
+    expect(textOf(makeCtx(col, { value: 1234567 }))).toBe('1,234,567');
+  });
 });
 
 describe('formatCell — resolution priority', () => {
@@ -81,18 +86,21 @@ describe('formatCell — resolution priority', () => {
 });
 
 describe('formatCell — Currency valueKind', () => {
-  it('formats with a fixed currencyCode (design-time constant)', () => {
+  // Query-engine Currency values are the actual decimal amount (major units),
+  // not minor units — the formatter must NOT divide by 100.
+  it('formats with a fixed currencyCode (design-time constant), no /100', () => {
     const col = makeColumn({ valueKind: 'Currency', currencyCode: 'GBP' });
-    const text = textOf(makeCtx(col, { value: 12345 }));
-    expect(text).toContain('123.45');
+    const text = textOf(makeCtx(col, { value: 1234.56 }));
+    expect(text).toContain('1,234.56');
     expect(text).toContain('£');
   });
 
   it('reads the per-row code from currencyCodeField (multi-currency)', () => {
     const col = makeColumn({ valueKind: 'Currency', currencyCodeField: 'currency' });
-    const usd = textOf(makeCtx(col, { value: 12345, currency: 'USD' }));
-    const eur = textOf(makeCtx(col, { value: 12345, currency: 'EUR' }));
+    const usd = textOf(makeCtx(col, { value: 1234.56, currency: 'USD' }));
+    const eur = textOf(makeCtx(col, { value: 1234.56, currency: 'EUR' }));
     expect(usd).toContain('$');
+    expect(usd).toContain('1,234.56');
     expect(eur).toContain('€');
     expect(usd).not.toBe(eur);
   });
@@ -103,21 +111,21 @@ describe('formatCell — Currency valueKind', () => {
       currencyCode: 'GBP',
       currencyCodeField: 'currency',
     });
-    const text = textOf(makeCtx(col, { value: 12345, currency: 'USD' }));
+    const text = textOf(makeCtx(col, { value: 1234.56, currency: 'USD' }));
     expect(text).toContain('£');
     expect(text).not.toContain('$');
   });
 
   it('falls back to a plain locale number when no code resolves', () => {
     const col = makeColumn({ valueKind: 'Currency' });
-    const text = textOf(makeCtx(col, { value: 12345 }));
-    expect(text).toBe('123.45');
+    const text = textOf(makeCtx(col, { value: 1234.56 }));
+    expect(text).toBe('1,234.56');
   });
 
   it('falls back to a plain number when the referenced field is missing', () => {
     const col = makeColumn({ valueKind: 'Currency', currencyCodeField: 'currency' });
-    const text = textOf(makeCtx(col, { value: 12345 }));
-    expect(text).toBe('123.45');
+    const text = textOf(makeCtx(col, { value: 1234.56 }));
+    expect(text).toBe('1,234.56');
   });
 });
 

--- a/packages/@granit/react-query-engine/src/cell-formatters.tsx
+++ b/packages/@granit/react-query-engine/src/cell-formatters.tsx
@@ -52,11 +52,19 @@ function tryFormatDateCell(
   return null;
 }
 
-// Monetary amounts arrive in minor units (cents); scale to the major unit.
-// When no ISO code resolves, fall back to a plain locale number (no symbol).
-function formatMoney(value: number, currency: string | undefined, locale: string): string {
+// Formats a monetary amount. Query-engine `valueKind: 'Currency'` columns
+// carry the actual decimal amount (major units), so no scaling by default;
+// the legacy entity `money` form-component stores Int64 minor units (cents),
+// so that path opts into `minorUnits`. When no ISO code resolves, falls back
+// to a plain locale number (no symbol).
+function formatMoney(
+  value: number,
+  currency: string | undefined,
+  locale: string,
+  minorUnits = false
+): string {
   const options: Intl.NumberFormatOptions = currency ? { style: 'currency', currency } : {};
-  return new Intl.NumberFormat(locale, options).format(value / 100);
+  return new Intl.NumberFormat(locale, options).format(minorUnits ? value / 100 : value);
 }
 
 // Currency ISO code precedence for a `Currency` column:
@@ -212,7 +220,15 @@ export function formatCell(ctx: CellFormatterContext): ReactNode {
   }
 
   if (component === 'money' && currencyResolver && typeof value === 'number') {
-    return formatMoney(value, currencyResolver(row), locale);
+    // Legacy entity `money` widget: Int64 minor units (cents) on the wire.
+    return formatMoney(value, currencyResolver(row), locale, true);
+  }
+
+  // A column declaring a currency code (fixed or per-row) formats as money even
+  // when no `valueKind` is present — preserves the currency-code-only contract
+  // (major units, like `valueKind: 'Currency'`).
+  if ((column.currencyCode || column.currencyCodeField) && typeof value === 'number') {
+    return formatMoney(value, resolveColumnCurrency(column, row), locale);
   }
 
   const formattedDate = tryFormatDateCell(
@@ -225,6 +241,7 @@ export function formatCell(ctx: CellFormatterContext): ReactNode {
   if (formattedDate !== null) return formattedDate;
 
   if (typeof value === 'boolean') return renderBoolean(value);
+  if (typeof value === 'number') return new Intl.NumberFormat(locale).format(value);
   if (typeof value === 'object') return JSON.stringify(value);
   return String(value); // NOSONAR: remaining types (symbol, function) stringify safely
 }


### PR DESCRIPTION
> **Depends on granit-business MR !188** (adds `valueKind` + `currencyCodeField` to the Table widget snapshot column). Merge order: !188 first, then un-draft. The change is additive — a snapshot without `valueKind` still renders (locale number / text / currency-by-code), so this is safe to review now.

## Problem

Dashboard **Table** widgets rendered cells with a bespoke `formatCell` that only knew `currencyCode` → numbers and strings. They did **not** honour the column's semantic type, so a query column typed `Url` / `Percentage` / `Date` / … showed raw values — unlike the query grids, which already format from `valueKind` (#889/#890).

## Changes

- **`@granit/react-analytics`** — `TableSnapshotWidget` now renders through the shared `@granit/react-query-engine` `formatCell`, adapting `TableWidgetColumn` → the `ColumnDefinition` shape. `valueKind` drives the renderer (Url/Email/Phone links, `Percentage` `%`, `Bytes`/`Duration`, dates, per-row currency); absent → locale number / text fallback.
- **`@granit/analytics`** — `TableWidgetColumn` gains `valueKind` + `currencyCodeField` (mirrors the backend record from !188).
- **`@granit/react-query-engine`** — **currency-scaling fix**: query-engine `Currency` values are the actual `decimal` amount (major units — all `.Currency()` columns sit on `decimal` domain properties), so `formatMoney` no longer divides by 100 for `valueKind: 'Currency'` / currency-code columns. `/100` is kept **only** for the legacy entity `money` component (Int64 cents, `MoneyFormComponent`). This corrects a latent bug from #889 where workspace Currency grids (Invoice/Payment) showed amounts ÷100. A currency-code-without-valueKind column still formats as money (preserves the dashboard contract), and a locale-number fallback keeps untyped numeric cells grouped.

## Why major units (long-term)

`.NET` models money as `decimal`; the query engine projects the raw value. The frontend should format it as-is (symbol + locale) with no hidden scaling. Cents (`/100`) is a legacy **edit-side** storage choice confined to `MoneyFormComponent`.

## Tests

- `table-snapshot-widget.test.tsx` (+2): Url link + Percentage + no-/100 currency; per-row `currencyCodeField` (USD/EUR).
- `cell-formatters.test.tsx`: currency expectations updated to major units; new locale-number fallback case; legacy `money` path still ÷100.
- `entity-list.test.tsx`: currency expectation updated to major units.
- Full green across the 6 touched packages + arch-tests (3843).