### PR TITLE
feat(analytics): gate KPI comparison on the metric's supportsPeriod

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3451,6 +3451,11 @@
           "kind": "interface",
           "signature": "interface FormatMetricValueArgs",
           "members": []
+        },
+        {
+          "name": "metricRequestFromTimeWindow",
+          "kind": "function",
+          "signature": "function metricRequestFromTimeWindow( timeWindow: DashboardTimeWindow, supportsPeriod: boolean ): MetricRequest"
         }
       ]
     },

--- a/contracts/openapi/analytics.json
+++ b/contracts/openapi/analytics.json
@@ -1095,7 +1095,8 @@
           "aggregation",
           "isHigherBetter",
           "refreshHint",
-          "currencyCode"
+          "currencyCode",
+          "supportsPeriod"
         ],
         "type": "object",
         "properties": {
@@ -1119,6 +1120,9 @@
           },
           "currencyCode": {
             "type": ["null", "string"]
+          },
+          "supportsPeriod": {
+            "type": "boolean"
           }
         }
       },

--- a/packages/@granit/analytics/src/types/metric.ts
+++ b/packages/@granit/analytics/src/types/metric.ts
@@ -116,4 +116,12 @@ export interface MetricCatalogEntryResponse {
   readonly refreshHint: RefreshHint;
   /** ISO 4217 currency code when `valueKind === 'Currency'`, else `null`. */
   readonly currencyCode: string | null;
+  /**
+   * Whether the metric declares a `PeriodSelector` — `true` when it accepts a
+   * period filter and comparison window, `false` for a time-invariant snapshot
+   * metric (e.g. a live count). Drives whether the editor offers a comparison
+   * option and whether the KPI tile may send a `compareTo` (the endpoint rejects
+   * a comparison on a period-less metric with a 422).
+   */
+  readonly supportsPeriod: boolean;
 }

--- a/packages/@granit/react-analytics/src/__tests__/metric-request-from-time-window.test.ts
+++ b/packages/@granit/react-analytics/src/__tests__/metric-request-from-time-window.test.ts
@@ -1,0 +1,43 @@
+import { DASHBOARD_TIME_WINDOW } from '@granit/dashboards';
+import { describe, expect, it } from 'vitest';
+
+import { metricRequestFromTimeWindow } from '../lib/metric-request-from-time-window';
+
+import type { DashboardTimeWindow } from '@granit/dashboards';
+
+describe('metricRequestFromTimeWindow', () => {
+  const withCompare: DashboardTimeWindow = {
+    ...DASHBOARD_TIME_WINDOW.Last30Days,
+    compareTo: { token: 'previous_period' },
+  };
+
+  it('forwards the comparison window when the metric supports a period', () => {
+    expect(metricRequestFromTimeWindow(withCompare, true)).toEqual({
+      period: { token: 'last_30d' },
+      compareTo: { token: 'previous_period' },
+    });
+  });
+
+  it('drops the comparison window for a period-less snapshot metric', () => {
+    // The endpoint rejects a comparison on a metric with no PeriodSelector
+    // (422 Granit.Analytics:ComparisonWithoutPeriodSelector) — never send it.
+    expect(metricRequestFromTimeWindow(withCompare, false)).toEqual({
+      period: { token: 'last_30d' },
+    });
+  });
+
+  it('omits compareTo when the window declares none, even for a periodised metric', () => {
+    expect(metricRequestFromTimeWindow(DASHBOARD_TIME_WINDOW.Last30Days, true)).toEqual({
+      period: { token: 'last_30d' },
+    });
+  });
+
+  it('re-brands an absolute range as ISO date strings', () => {
+    const absolute: DashboardTimeWindow = {
+      period: { from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' },
+    };
+    expect(metricRequestFromTimeWindow(absolute, true)).toEqual({
+      period: { from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' },
+    });
+  });
+});

--- a/packages/@granit/react-analytics/src/components/kpi-tile.tsx
+++ b/packages/@granit/react-analytics/src/components/kpi-tile.tsx
@@ -1,32 +1,32 @@
 import { isMetricDatasource } from '@granit/dashboards';
-import { useWidgetTriggerHandler } from '@granit/react-dashboards';
+import { useEffectiveTimeWindow, useWidgetTriggerHandler } from '@granit/react-dashboards';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useMetric } from '../hooks/use-metric';
+import { useMetricCatalog } from '../hooks/use-metric-catalog';
+import { metricRequestFromTimeWindow } from '../lib/metric-request-from-time-window';
 
 import { KpiTileView } from './kpi-tile-view';
 
-import type { KpiWidgetDefinition, MetricRequest } from '@granit/analytics';
-
-const DEFAULT_PERIOD: MetricRequest = {
-  period: { token: 'last_30d' },
-  compareTo: { token: 'previous_period' },
-};
+import type { KpiWidgetDefinition } from '@granit/analytics';
 
 /**
  * Smart KPI tile — registered as the renderer for `KpiWidgetDefinition`
- * (`type: 'kpi'`) in the analytics widget registry. Reads dashboard context
- * for breadcrumb data, fetches the metric snapshot via {@link useMetric},
- * delegates rendering to {@link KpiTileView}.
+ * (`type: 'kpi'`) in the analytics widget registry. Resolves the active time
+ * window from dashboard context, fetches the metric snapshot via
+ * {@link useMetric}, delegates rendering to {@link KpiTileView}.
  *
  * v1 only handles {@link MetricDatasource}. Other datasource kinds
  * ({@link QueryAggregateDatasource}, {@link TelemetryDatasource}) await the
  * query-engine evaluator (B5) and the SSE telemetry transport (B7-2)
  * respectively, and currently render an "unsupported" KpiTileView.
  *
- * v1 also uses a hardcoded `last_30d / previous_period` request shape — the
- * runtime `DashboardTimeWindow` (proposals doc P1.3) will replace this once
- * the dashboard context propagates it.
+ * The period comes from {@link useEffectiveTimeWindow} (override → dashboard
+ * context → framework default), so a dashboard-level time-window control
+ * propagates without touching the tile. A comparison window is only requested
+ * for a metric whose catalogue entry reports `supportsPeriod` — a period-less
+ * snapshot metric would otherwise be rejected with a 422.
  */
 export interface KpiTileProps {
   readonly widget: KpiWidgetDefinition;
@@ -42,7 +42,21 @@ export function KpiTile({ widget }: KpiTileProps) {
   // crashing on `datasource.kind`.
   const metricName = datasource && isMetricDatasource(datasource) ? datasource.metricName : '';
 
-  const query = useMetric(metricName, DEFAULT_PERIOD, { enabled: metricName !== '' });
+  const timeWindow = useEffectiveTimeWindow();
+
+  // Catalogue is shared (single React Query key) across every KPI tile, so this
+  // is one fetch regardless of tile count. Until it resolves, `supportsPeriod`
+  // defaults to `false` — the tile requests the period-only shape (never a 422)
+  // and upgrades to a comparison once the entry confirms the metric supports it.
+  const { data: catalog } = useMetricCatalog();
+  const supportsPeriod = catalog?.find((entry) => entry.name === metricName)?.supportsPeriod ?? false;
+
+  const request = useMemo(
+    () => metricRequestFromTimeWindow(timeWindow, supportsPeriod),
+    [timeWindow, supportsPeriod]
+  );
+
+  const query = useMetric(metricName, request, { enabled: metricName !== '' });
 
   // `Click` actions on the widget definition. Hook lives at the top
   // of the component (before any conditional return) so the rules-of-

--- a/packages/@granit/react-analytics/src/index.ts
+++ b/packages/@granit/react-analytics/src/index.ts
@@ -41,3 +41,5 @@ export { defaultAnalyticsSnapshotWidgetRegistry } from './registry/default-analy
 // Formatters (re-exported for convenience — also available standalone)
 export { formatDeltaRatio, formatMetricValue } from './lib/format-metric-value';
 export type { FormatMetricValueArgs } from './lib/format-metric-value';
+
+export { metricRequestFromTimeWindow } from './lib/metric-request-from-time-window';

--- a/packages/@granit/react-analytics/src/lib/metric-request-from-time-window.ts
+++ b/packages/@granit/react-analytics/src/lib/metric-request-from-time-window.ts
@@ -1,0 +1,33 @@
+import { toISODateString } from '@granit/types';
+
+import type { MetricRequest, PeriodSpec } from '@granit/analytics';
+import type { DashboardTimeWindow } from '@granit/dashboards';
+
+/**
+ * Maps a dashboard {@link DashboardTimeWindow} to a metric {@link MetricRequest},
+ * reconciling two axes the two packages model independently:
+ *
+ * - A `DashboardPeriod` keeps its absolute range as plain `string`s (the
+ *   dashboards package stays free of the analytics `ISODateString` brand); this
+ *   re-brands them via {@link toISODateString} so the request typechecks.
+ * - `compareTo` is forwarded only when `supportsPeriod` is `true`. A metric that
+ *   declares no `PeriodSelector` rejects a comparison window with a 422
+ *   (`Granit.Analytics:ComparisonWithoutPeriodSelector`), so a snapshot metric
+ *   silently drops the comparison instead of firing a doomed request.
+ */
+export function metricRequestFromTimeWindow(
+  timeWindow: DashboardTimeWindow,
+  supportsPeriod: boolean
+): MetricRequest {
+  const period: PeriodSpec =
+    'token' in timeWindow.period
+      ? { token: timeWindow.period.token }
+      : {
+          from: toISODateString(timeWindow.period.from),
+          to: toISODateString(timeWindow.period.to),
+        };
+
+  return supportsPeriod && timeWindow.compareTo
+    ? { period, compareTo: { token: timeWindow.compareTo.token } }
+    : { period };
+}

--- a/packages/@granit/react-analytics/src/testing/data.ts
+++ b/packages/@granit/react-analytics/src/testing/data.ts
@@ -17,6 +17,7 @@ export const mockMetricCatalog: readonly MetricCatalogEntryResponse[] = [
     isHigherBetter: true,
     refreshHint: 'Dynamic',
     currencyCode: 'EUR',
+    supportsPeriod: true,
   },
   {
     name: 'active-users',
@@ -26,6 +27,8 @@ export const mockMetricCatalog: readonly MetricCatalogEntryResponse[] = [
     isHigherBetter: true,
     refreshHint: 'Realtime',
     currencyCode: null,
+    // Live snapshot count — no PeriodSelector, so comparison windows are rejected.
+    supportsPeriod: false,
   },
   {
     name: 'conversion-rate',
@@ -35,6 +38,7 @@ export const mockMetricCatalog: readonly MetricCatalogEntryResponse[] = [
     isHigherBetter: true,
     refreshHint: 'Static',
     currencyCode: null,
+    supportsPeriod: true,
   },
 ];
 


### PR DESCRIPTION
## Context

A KPI tile hardcoded `compareTo: { token: 'previous_period' }` for **every** metric. A period-less snapshot metric — e.g. `Granit.Documents.DocumentCountMetric`, which deliberately declares no `PeriodSelector` — was therefore rejected with a **422** (`Granit.Analytics:ComparisonWithoutPeriodSelector`) the moment its tile rendered. The catalogue exposed no way for the client to know a metric is a snapshot.

Backend side landed in granit-business **!189** (merged): the metric catalogue now carries `supportsPeriod`.

## Changes

- **`MetricCatalogEntryResponse`** mirrors the new `supportsPeriod` field. The `analytics.json` snapshot is resynced for that single field (ValueKind convergence is out of scope here — tracked separately); the `@granit/contract-tests` oracle is green.
- **`metricRequestFromTimeWindow`** (new): derives the period from the effective dashboard time window and forwards `compareTo` **only** when the metric supports a period, re-branding an absolute range as `ISODateString`.
- **`KpiTile`** now reads `useEffectiveTimeWindow()` + the catalogue's `supportsPeriod` instead of the hardcoded `last_30d / previous_period` request. A dashboard-level time-window control will therefore propagate without touching the tile.

## Cross-repo

Depends on granit-business **!189** (merged). No FHIR/app-specific code.

## Verification

- `tsc --noEmit` (analytics + react-analytics): clean
- Vitest (analytics + react-analytics + contract-tests): **678 passing** (oracle included)
- ESLint `--max-warnings 0`: clean
- New unit tests cover the mapper: comparison forwarded when supported, dropped for a snapshot metric, absolute range re-branded

## Follow-up

The dashboard **time-window selector** (P1.3) — `DashboardTimeWindowToolbar` + `dashboard.tsx` wiring — is now purely additive: the tile already reads the effective window from context.