### PR TITLE
feat(dashboards): add a dashboard time-window selector (P1.3)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4857,6 +4857,17 @@
           "members": []
         },
         {
+          "name": "DashboardTimeWindowToolbar",
+          "kind": "function",
+          "signature": "function DashboardTimeWindowToolbar("
+        },
+        {
+          "name": "DashboardTimeWindowToolbarProps",
+          "kind": "interface",
+          "signature": "interface DashboardTimeWindowToolbarProps",
+          "members": []
+        },
+        {
           "name": "mergeFilterValuesIntoRequest",
           "kind": "function",
           "signature": "function mergeFilterValuesIntoRequest( request: DashboardRenderRequest, values: DashboardFilterValues | null | undefined ): DashboardRenderRequest"

--- a/packages/@granit/react-dashboards/src/__tests__/dashboard-time-window-toolbar.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/dashboard-time-window-toolbar.test.tsx
@@ -1,0 +1,97 @@
+import { DASHBOARD_TIME_WINDOW } from '@granit/dashboards';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DashboardContextProvider } from '../components/dashboard-context';
+import { DashboardTimeWindowToolbar } from '../components/dashboard-time-window-toolbar';
+
+import type { DashboardTimeWindow } from '@granit/dashboards';
+
+function Harness({
+  initial = DASHBOARD_TIME_WINDOW.Last30Days,
+  setTimeWindow,
+}: {
+  readonly initial?: DashboardTimeWindow;
+  readonly setTimeWindow?: (w: DashboardTimeWindow | undefined) => void;
+}) {
+  const [timeWindow, setLocal] = useState<DashboardTimeWindow | undefined>(initial);
+  return (
+    <DashboardContextProvider
+      value={{
+        dashboardName: 'Test',
+        timeWindow,
+        setTimeWindow: (next) => {
+          const resolved = typeof next === 'function' ? next(timeWindow) : next;
+          setLocal(resolved);
+          setTimeWindow?.(resolved);
+        },
+      }}
+    >
+      <DashboardTimeWindowToolbar />
+    </DashboardContextProvider>
+  );
+}
+
+describe('DashboardTimeWindowToolbar', () => {
+  it('renders nothing outside a dashboard context', () => {
+    const { container } = render(<DashboardTimeWindowToolbar />);
+    expect(container.querySelector('[data-slot="dashboard-time-window-toolbar"]')).toBeNull();
+  });
+
+  it('renders nothing when the window is read-only (no setter)', () => {
+    const { container } = render(
+      <DashboardContextProvider
+        value={{ dashboardName: 'Test', timeWindow: DASHBOARD_TIME_WINDOW.Last30Days }}
+      >
+        <DashboardTimeWindowToolbar />
+      </DashboardContextProvider>
+    );
+    expect(container.querySelector('[data-slot="dashboard-time-window-toolbar"]')).toBeNull();
+  });
+
+  it('selects the preset matching the active token', () => {
+    render(<Harness initial={DASHBOARD_TIME_WINDOW.Last7Days} />);
+    const select = screen.getByRole('combobox') as HTMLSelectElement;
+    expect(select.value).toBe('last_7d');
+  });
+
+  it('propagates the chosen preset through setTimeWindow', () => {
+    const onChange = vi.fn();
+    render(<Harness initial={DASHBOARD_TIME_WINDOW.Last30Days} setTimeWindow={onChange} />);
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'mtd' } });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ period: { token: 'mtd' }, kind: 'History' })
+    );
+  });
+
+  it('preserves an app-set compareTo across a period change', () => {
+    const onChange = vi.fn();
+    render(
+      <Harness
+        initial={{ ...DASHBOARD_TIME_WINDOW.Last30Days, compareTo: { token: 'previous_period' } }}
+        setTimeWindow={onChange}
+      />
+    );
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'last_7d' } });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        period: { token: 'last_7d' },
+        compareTo: { token: 'previous_period' },
+      })
+    );
+  });
+
+  it('shows a disabled Custom entry for an absolute range not in the presets', () => {
+    render(
+      <Harness initial={{ period: { from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' } }} />
+    );
+    const select = screen.getByRole('combobox') as HTMLSelectElement;
+    expect(select.value).toBe('');
+    expect(screen.getByRole('option', { name: /custom range/i })).toBeDisabled();
+  });
+});

--- a/packages/@granit/react-dashboards/src/__tests__/dashboard.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/dashboard.test.tsx
@@ -118,6 +118,33 @@ describe('Dashboard', () => {
     expect(screen.getByText(/analytics-kpi/)).toBeInTheDocument();
   });
 
+  it('renders the time-window toolbar when the dashboard declares a default window', () => {
+    const { container } = renderDashboard({
+      name: 'Windowed',
+      category: 'General',
+      isSystem: false,
+      version: '1.0.0',
+      layout: { columns: 12, rowHeight: 80 },
+      defaultTimeWindow: { period: { token: 'last_7d' }, kind: 'History' },
+      widgets: [],
+    });
+    const toolbar = container.querySelector('[data-slot="dashboard-time-window-toolbar"]');
+    expect(toolbar).toBeInTheDocument();
+    expect((toolbar?.querySelector('select') as HTMLSelectElement).value).toBe('last_7d');
+  });
+
+  it('omits the time-window toolbar when no default window is declared', () => {
+    const { container } = renderDashboard({
+      name: 'Windowless',
+      category: 'General',
+      isSystem: false,
+      version: '1.0.0',
+      layout: { columns: 12, rowHeight: 80 },
+      widgets: [],
+    });
+    expect(container.querySelector('[data-slot="dashboard-time-window-toolbar"]')).toBeNull();
+  });
+
   it('renders the TextWidget with style-aware HTML element', () => {
     const { container } = renderDashboard({
       name: 'Test',

--- a/packages/@granit/react-dashboards/src/components/dashboard-time-window-toolbar.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-time-window-toolbar.tsx
@@ -1,0 +1,132 @@
+import { DASHBOARD_TIME_WINDOW } from '@granit/dashboards';
+import { useTranslation } from 'react-i18next';
+
+import { useDashboardContext } from './dashboard-context';
+
+import type { DashboardTimeWindow } from '@granit/dashboards';
+
+/**
+ * Preset windows the selector offers, in display order. Each carries the token
+ * that identifies it in {@link DashboardTimeWindow.period} plus a localization
+ * key (with an English fallback, mirroring {@link DashboardFilterToolbar} — the
+ * package ships no locale files, host translations override via the key).
+ */
+interface TimeWindowPreset {
+  readonly token: string;
+  readonly window: DashboardTimeWindow;
+  readonly labelKey: string;
+  readonly defaultLabel: string;
+}
+
+const PRESETS: readonly TimeWindowPreset[] = [
+  {
+    token: 'last_24h',
+    window: DASHBOARD_TIME_WINDOW.Last24Hours,
+    labelKey: 'Dashboard:TimeWindow.Last24Hours',
+    defaultLabel: 'Last 24 hours',
+  },
+  {
+    token: 'last_7d',
+    window: DASHBOARD_TIME_WINDOW.Last7Days,
+    labelKey: 'Dashboard:TimeWindow.Last7Days',
+    defaultLabel: 'Last 7 days',
+  },
+  {
+    token: 'last_30d',
+    window: DASHBOARD_TIME_WINDOW.Last30Days,
+    labelKey: 'Dashboard:TimeWindow.Last30Days',
+    defaultLabel: 'Last 30 days',
+  },
+  {
+    token: 'mtd',
+    window: DASHBOARD_TIME_WINDOW.Mtd,
+    labelKey: 'Dashboard:TimeWindow.Mtd',
+    defaultLabel: 'Month to date',
+  },
+  {
+    token: 'ytd',
+    window: DASHBOARD_TIME_WINDOW.Ytd,
+    labelKey: 'Dashboard:TimeWindow.Ytd',
+    defaultLabel: 'Year to date',
+  },
+  {
+    token: 'last_5m',
+    window: DASHBOARD_TIME_WINDOW.RealtimeLast5Minutes,
+    labelKey: 'Dashboard:TimeWindow.RealtimeLast5Minutes',
+    defaultLabel: 'Realtime (last 5 min)',
+  },
+];
+
+export interface DashboardTimeWindowToolbarProps {
+  readonly className?: string;
+}
+
+/**
+ * Top-of-dashboard control selecting the active {@link DashboardTimeWindow}.
+ * Reads / writes the surrounding {@link DashboardContextProvider}: the chosen
+ * window propagates through context to every data-bound widget via
+ * {@link useEffectiveTimeWindow}, so a KPI / chart tile re-fetches without any
+ * prop drilling.
+ *
+ * Renders nothing when the dashboard declares no time window
+ * (`context.timeWindow` absent) or when the window is read-only
+ * (`context.setTimeWindow` absent — embedded / preview / printable
+ * dashboards), so apps can mount it unconditionally.
+ *
+ * v1 offers the framework's {@link DASHBOARD_TIME_WINDOW} presets. A window
+ * carrying an absolute range or a token outside the preset set stays selected
+ * as a disabled "Custom range" entry; a richer picker (absolute ranges, custom
+ * comparison) is a follow-up an app composes on the same context.
+ */
+export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToolbarProps) {
+  const { t } = useTranslation();
+  const ctx = useDashboardContext();
+
+  if (!ctx?.timeWindow || !ctx.setTimeWindow) return null;
+
+  const { timeWindow, setTimeWindow } = ctx;
+  const currentToken = 'token' in timeWindow.period ? timeWindow.period.token : '';
+  const matched = PRESETS.some((preset) => preset.token === currentToken);
+
+  return (
+    <div
+      data-slot="dashboard-time-window-toolbar"
+      role="toolbar"
+      aria-label="Dashboard time window"
+      className={joinClasses('flex items-end gap-3', className)}
+    >
+      <label className="flex flex-col gap-1 text-xs">
+        <span data-slot="dashboard-time-window-label" className="text-muted-foreground">
+          {t('Dashboard:TimeWindow.Label', { defaultValue: 'Period' })}
+        </span>
+        <select
+          data-slot="dashboard-time-window-select"
+          value={matched ? currentToken : ''}
+          onChange={(event) => {
+            const preset = PRESETS.find((p) => p.token === event.target.value);
+            // Spread over the current window so an app-set `compareTo` /
+            // `aggregation` survives a period change; the preset owns `period`
+            // and `kind` (History vs Realtime).
+            if (preset) setTimeWindow({ ...timeWindow, ...preset.window });
+          }}
+          className="rounded-md border bg-background px-2.5 py-1.5 text-sm"
+        >
+          {!matched && (
+            <option value="" disabled>
+              {t('Dashboard:TimeWindow.Custom', { defaultValue: 'Custom range' })}
+            </option>
+          )}
+          {PRESETS.map((preset) => (
+            <option key={preset.token} value={preset.token}>
+              {t(preset.labelKey, { defaultValue: preset.defaultLabel })}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}
+
+function joinClasses(...parts: ReadonlyArray<string | undefined>): string {
+  return parts.filter(Boolean).join(' ');
+}

--- a/packages/@granit/react-dashboards/src/components/dashboard.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard.tsx
@@ -4,7 +4,8 @@ import { useDashboardBreakpoint } from '../hooks/use-dashboard-breakpoint';
 import { resolveActiveView } from '../lib/resolve-active-view';
 import { resolveEffectiveLayout } from '../lib/resolve-effective-layout';
 
-import { DashboardContextProvider } from './dashboard-context';
+import { DashboardContextProvider, useDashboardTimeWindowState } from './dashboard-context';
+import { DashboardTimeWindowToolbar } from './dashboard-time-window-toolbar';
 import { DashboardViewProvider } from './dashboard-view-context';
 import { WidgetRenderer } from './widget-renderer';
 
@@ -77,6 +78,14 @@ export function Dashboard({
     [currentView, onViewChange]
   );
 
+  // Time window in effect for every data-bound widget. Seeded from the
+  // dashboard's declared default; a `null`/absent default leaves it undefined,
+  // so widgets keep their `useEffectiveTimeWindow` fallback and no selector is
+  // shown — filter-less dashboards render exactly as before.
+  const [timeWindow, setTimeWindow] = useDashboardTimeWindowState(
+    definition.defaultTimeWindow ?? undefined
+  );
+
   const breakpoint = useDashboardBreakpoint();
 
   const {
@@ -108,8 +117,9 @@ export function Dashboard({
   };
 
   return (
-    <DashboardContextProvider value={{ dashboardName: definition.name }}>
+    <DashboardContextProvider value={{ dashboardName: definition.name, timeWindow, setTimeWindow }}>
       <DashboardViewProvider value={{ currentView: resolvedView, setCurrentView: setView }}>
+        {timeWindow && <DashboardTimeWindowToolbar />}
         <div
           data-slot="dashboard"
           data-dashboard-name={definition.name}

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -98,6 +98,8 @@ export type {
 } from './components/dashboard-filter-context';
 export { DashboardFilterToolbar } from './components/dashboard-filter-toolbar';
 export type { DashboardFilterToolbarProps } from './components/dashboard-filter-toolbar';
+export { DashboardTimeWindowToolbar } from './components/dashboard-time-window-toolbar';
+export type { DashboardTimeWindowToolbarProps } from './components/dashboard-time-window-toolbar';
 export { mergeFilterValuesIntoRequest } from './lib/merge-filter-values';
 
 // Entity alias runtime (P2.3) — resolution context, provider, helpers


### PR DESCRIPTION
## Context

Follow-up to #893. The `DashboardTimeWindow` plumbing already existed — `DashboardContext`, `useEffectiveTimeWindow`, `DASHBOARD_TIME_WINDOW` presets — and after #893 KPI tiles read the effective window from context. But nothing let a user **pick** the window at runtime, so tiles always fell back to the framework default (`Last30Days`).

This adds the missing control.

## Changes

- **`DashboardTimeWindowToolbar`** (new): a headless `<select>` over the `DASHBOARD_TIME_WINDOW` presets (24h / 7d / 30d / MTD / YTD / Realtime), reading & writing the surrounding `DashboardContextProvider`. Follows the `DashboardFilterToolbar` idiom exactly — plain HTML + Tailwind, `useTranslation` with English fallbacks (no locale files), **renders `null`** when the window is absent or read-only (embedded / preview / printable). Preserves an app-set `compareTo` / `aggregation` across a period change.
- **`Dashboard`** now seeds `useDashboardTimeWindowState` from `definition.defaultTimeWindow` and renders the toolbar above the grid **only when a window is declared** — so window-less dashboards render exactly as before.

The chosen window propagates through context to every data-bound widget via `useEffectiveTimeWindow` (a KPI/chart tile re-fetches), no prop drilling.

## Layering

`DashboardTimeWindowToolbar` lives in the headless `@granit/react-dashboards` tier and imports only `@granit/dashboards` + `react-i18next` — **no `react-ui-kit` dependency** (arch-tests green, 3216 passing). A richer picker (absolute ranges via `DatePeriodPicker`) is a follow-up an app composes in the UI tier on the same context.

## Verification

- `tsc --noEmit` (react-dashboards): clean
- Vitest: react-dashboards **191 passing** (new toolbar + Dashboard integration tests), react-analytics/analytics **96 passing**, arch-tests **3216 passing**
- ESLint `--max-warnings 0`: clean

## Follow-up

- Editor: hide the KPI comparison option for `!supportsPeriod` metrics (`kpi-config-form`).
- A UI-tier absolute-range picker on the same context.