### PR TITLE
feat(analytics): pivot cells format via the shared query formatCell

### DIFF
--- a/packages/@granit/analytics/src/types/pivot-snapshot.ts
+++ b/packages/@granit/analytics/src/types/pivot-snapshot.ts
@@ -61,6 +61,14 @@ export interface PivotWidgetSnapshot {
    * aggregate the same value field. B3-8b.
    */
   readonly currency?: string | null;
+  /**
+   * Semantic display-type shared by every cell: `'Count'` for a count, else
+   * the value field's declared kind (`'Currency'`, `'Percentage'`, `'Bytes'`,
+   * …), or `null`. Drives the shared cell formatter so pivot cells render like
+   * the query grids. Wire values are the .NET `ValueKind` enum member names
+   * verbatim. Mirrors `PivotWidgetSnapshot.ValueKind`.
+   */
+  readonly valueKind?: string | null;
 }
 
 /** Narrowed `WidgetSnapshotEnvelope` for the `'Pivot'` widget kind. */

--- a/packages/@granit/react-analytics/src/__tests__/pivot-snapshot-widget.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/pivot-snapshot-widget.test.tsx
@@ -83,6 +83,29 @@ describe('PivotSnapshotWidget — matrix layout', () => {
     expect(normalizeSpaces(cells[1]?.textContent ?? '')).toBe('€12,300.00');
   });
 
+  it('formats cells from the snapshot valueKind (Percentage measure)', () => {
+    const snapshot: PivotWidgetSnapshot = {
+      ...SAMPLE_SNAPSHOT,
+      currency: null,
+      valueKind: 'Percentage',
+      cells: [{ rowKeys: ['EU'], columnKeys: ['Open'], value: 42.5 }],
+    };
+    const { container } = wrap(<PivotSnapshotWidget widget={pivotEnvelope(snapshot)} />);
+    const cell = container.querySelector('[data-row-tuple="EU"] td[data-column-tuple]');
+    expect(cell?.textContent).toBe('42.5%');
+  });
+
+  it('keeps currency major units under a Currency valueKind (no /100)', () => {
+    const snapshot: PivotWidgetSnapshot = {
+      ...SAMPLE_SNAPSHOT,
+      valueKind: 'Currency',
+      cells: [{ rowKeys: ['EU'], columnKeys: ['Open'], value: 1234.56 }],
+    };
+    const { container } = wrap(<PivotSnapshotWidget widget={pivotEnvelope(snapshot)} />);
+    const cell = container.querySelector('[data-row-tuple="EU"] td[data-column-tuple]');
+    expect(normalizeSpaces(cell?.textContent ?? '')).toBe('€1,234.56');
+  });
+
   it('renders an em dash for null cell values (empty Avg/Min/Max groups)', () => {
     const { container } = wrap(<PivotSnapshotWidget widget={pivotEnvelope(SAMPLE_SNAPSHOT)} />);
     const naRow = container.querySelector('[data-row-tuple="NA"]');

--- a/packages/@granit/react-analytics/src/components/pivot-snapshot-widget.tsx
+++ b/packages/@granit/react-analytics/src/components/pivot-snapshot-widget.tsx
@@ -1,19 +1,23 @@
 import { isPivotSnapshotEnvelope } from '@granit/analytics';
+import { createDefaultCellDateFormatters, formatCell } from '@granit/react-query-engine';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { PivotWidgetSnapshot } from '@granit/analytics';
 import type { DashboardRenderedWidget } from '@granit/dashboards';
+import type { ColumnDefinition } from '@granit/query-engine';
+import type { ReactNode } from 'react';
 
 /**
  * Snapshot-driven renderer for the `'Pivot'` widget kind. Pivots the flat
  * `(rowKeys × columnKeys × value)` cell list emitted by the backend into a
  * row-major matrix client-side — see `PivotWidgetSnapshot` (B3-6).
  *
- * Currency-aware (B3-8b): when `snapshot.currency` is set, every cell value
- * formats via `Intl.NumberFormat({ style: 'currency', currency })` with the
- * active locale. All cells share the same currency since they aggregate
- * the same value field.
+ * Cells render through the shared query-engine `formatCell`: every cell shares
+ * the snapshot's `valueKind` (`Count`, `Currency`, `Percentage`, `Bytes`, …)
+ * and `currency`, so a pivot formats its aggregate the same way the query grids
+ * format that measure — currency symbol, `%`, humanized bytes, or a locale
+ * number fallback.
  *
  * The renderer stays narrow on purpose — drilling into a cell or
  * repositioning row/column dimensions belongs to a richer admin variant
@@ -26,7 +30,8 @@ export function PivotSnapshotWidget({ widget }: { readonly widget: DashboardRend
 
 function PivotBody({ snapshot }: { readonly snapshot: PivotWidgetSnapshot }) {
   const { t, i18n } = useTranslation();
-  const { rowFields, columnFields, valueField, aggregation, cells, currency } = snapshot;
+  const { rowFields, columnFields, valueField, aggregation, cells, currency, valueKind } = snapshot;
+  const locale = i18n.language || 'en-US';
 
   // Pivot the flat cell list into a row-major matrix. Memoised so a parent
   // re-render that doesn't change the snapshot identity skips the work.
@@ -54,13 +59,31 @@ function PivotBody({ snapshot }: { readonly snapshot: PivotWidgetSnapshot }) {
 
   const aggregationLabel = valueField ? `${aggregation}(${valueField})` : aggregation;
 
-  const formatValue = (value: number) =>
-    currency
-      ? new Intl.NumberFormat(i18n.language, {
-          style: 'currency',
-          currency,
-        }).format(value)
-      : value.toLocaleString(i18n.language);
+  // Every cell shares the measure's valueKind + currency, so build one
+  // synthetic column and format each value through the shared query formatter.
+  const dateFormatters = useMemo(() => createDefaultCellDateFormatters(locale), [locale]);
+  const cellColumn = useMemo<ColumnDefinition>(
+    () => ({
+      name: 'value',
+      label: aggregationLabel,
+      type: '',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: true,
+      valueKind: valueKind ?? undefined,
+      currencyCode: currency ?? undefined,
+    }),
+    [aggregationLabel, valueKind, currency]
+  );
+  const formatValue = (value: number): ReactNode =>
+    formatCell({
+      row: { value },
+      column: cellColumn,
+      locale,
+      formatDate: dateFormatters.formatDate,
+      formatDateTime: dateFormatters.formatDateTime,
+    });
 
   return (
     <div data-slot="pivot-snapshot-widget" className="flex h-full flex-col gap-2">


### PR DESCRIPTION
> **Depends on granit-business MR !190** (adds `ValueKind` to the pivot snapshot). Additive — a snapshot without `valueKind` renders exactly as today (currency-by-code / locale number), so this is safe to review now.

## Summary

The Pivot widget knew only a single `currency`, so a `Percentage` / `Bytes` / `Count` measure showed a raw number. This routes cells through the shared `@granit/react-query-engine` `formatCell` using the snapshot's `valueKind` + `currency`, so a pivot formats its aggregate the same way the query grids format that measure.

## How

Every cell shares the measure's kind, so `PivotBody` builds **one** synthetic `ColumnDefinition` (`valueKind` + `currencyCode`) and formats each value through it. Replaces the bespoke `formatValue`.

- `Count` → locale number; `Currency` → symbol + locale (**major units**, matching the prior pivot behaviour — no `/100`); `Percentage` → `%`; `Bytes` → humanized; else locale number.
- `@granit/analytics` `PivotWidgetSnapshot` gains `valueKind` (mirrors the backend record from !190).

## Tests

`pivot-snapshot-widget.test.tsx` (+2): a `Percentage` measure renders `42.5%`; a `Currency` valueKind keeps major units (`€1,234.56`). Existing currency + locale-fallback cases pass unchanged (pivot was already major-units). Full react-analytics green (68).