### PR TITLE
fix(payments): send required partyId on the charge request

### DIFF
--- a/contracts/openapi/payments.json
+++ b/contracts/openapi/payments.json
@@ -2860,10 +2860,14 @@
         }
       },
       "PaymentChargeRequest": {
-        "required": ["invoiceId", "amount", "currency", "methodType"],
+        "required": ["invoiceId", "partyId", "amount", "currency", "methodType"],
         "type": "object",
         "properties": {
           "invoiceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "partyId": {
             "type": "string",
             "format": "uuid"
           },

--- a/packages/@granit/payments/src/__tests__/payments-api.test.ts
+++ b/packages/@granit/payments/src/__tests__/payments-api.test.ts
@@ -163,6 +163,7 @@ describe('payments-api', () => {
       const client = createMockClient();
       const request: PaymentChargeRequest = {
         invoiceId: 'inv-1',
+        partyId: 'party-1',
         amount: 5000,
         currency: 'EUR',
         methodType: 'card',

--- a/packages/@granit/payments/src/constraints.ts
+++ b/packages/@granit/payments/src/constraints.ts
@@ -26,6 +26,10 @@ export const paymentsConstraints = {
       "required": true,
       "format": "uuid"
     },
+    "partyId": {
+      "required": true,
+      "format": "uuid"
+    },
     "amount": {
       "required": true,
       "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",

--- a/packages/@granit/payments/src/types/index.ts
+++ b/packages/@granit/payments/src/types/index.ts
@@ -1,12 +1,7 @@
 import type { ISODateString } from '@granit/types';
 
 export type PaymentStatus =
-  | 'Created'
-  | 'RequiresAction'
-  | 'Processing'
-  | 'Succeeded'
-  | 'Failed'
-  | 'Canceled';
+  'Created' | 'RequiresAction' | 'Processing' | 'Succeeded' | 'Failed' | 'Canceled';
 
 export type RefundStatus = 'Pending' | 'Succeeded' | 'Failed';
 
@@ -24,6 +19,7 @@ export type PaymentMethodCategory =
 
 export interface PaymentChargeRequest {
   readonly invoiceId: string;
+  readonly partyId: string;
   readonly amount: number;
   readonly currency: string;
   readonly methodType: string;

--- a/packages/@granit/react-payments/src/__tests__/use-payments.test.tsx
+++ b/packages/@granit/react-payments/src/__tests__/use-payments.test.tsx
@@ -178,6 +178,7 @@ describe('use-payments', () => {
 
       result.current.mutate({
         invoiceId: 'inv-1',
+        partyId: 'party-1',
         amount: 5000,
         currency: 'EUR',
         methodType: 'card',
@@ -198,6 +199,7 @@ describe('use-payments', () => {
 
       result.current.mutate({
         invoiceId: 'inv-1',
+        partyId: 'party-1',
         amount: 5000,
         currency: 'EUR',
         methodType: 'card',

--- a/packages/@granit/react-ui-payments/src/__tests__/charge-dialog.test.tsx
+++ b/packages/@granit/react-ui-payments/src/__tests__/charge-dialog.test.tsx
@@ -1,0 +1,43 @@
+import { screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ChargeDialog } from '../components/charge-dialog';
+
+import { renderWithProviders } from './test-utils';
+
+import type * as ReactPaymentsModule from '@granit/react-payments';
+
+const mutate = vi.fn();
+
+vi.mock('@granit/react-payments', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactPaymentsModule>();
+  return {
+    ...actual,
+    useInitiatePaymentCharge: () => ({ mutate, isPending: false }),
+  };
+});
+
+const UUID_A = '00000000-0000-0000-0000-000000000001';
+const UUID_B = '00000000-0000-0000-0000-000000000002';
+
+describe('ChargeDialog', () => {
+  it('collects partyId and submits it on the charge request', async () => {
+    mutate.mockClear();
+    const { user } = renderWithProviders(<ChargeDialog open onOpenChange={() => undefined} />);
+
+    await user.type(screen.getByLabelText('Invoice ID'), UUID_A);
+    await user.type(screen.getByLabelText('Party ID'), UUID_B);
+    await user.clear(screen.getByLabelText('Amount'));
+    await user.type(screen.getByLabelText('Amount'), '5000');
+    await user.type(screen.getByLabelText('Method Type'), 'Card');
+    await user.click(screen.getByRole('button', { name: 'Charge' }));
+
+    await waitFor(() => expect(mutate).toHaveBeenCalledTimes(1));
+    expect(mutate.mock.calls[0][0]).toMatchObject({
+      invoiceId: UUID_A,
+      partyId: UUID_B,
+      currency: 'EUR',
+      methodType: 'Card',
+    });
+  });
+});

--- a/packages/@granit/react-ui-payments/src/components/charge-dialog.tsx
+++ b/packages/@granit/react-ui-payments/src/components/charge-dialog.tsx
@@ -26,6 +26,7 @@ import type { CurrencyCode } from '@granit/types';
 
 interface ChargeFormValues {
   invoiceId: string;
+  partyId: string;
   amount: number;
   currency: string;
   methodType: string;
@@ -57,6 +58,7 @@ export function ChargeDialog({ open, onOpenChange }: ChargeDialogProps) {
     resolver: formResolver,
     defaultValues: {
       invoiceId: '',
+      partyId: '',
       amount: 0,
       currency: 'EUR',
       methodType: '',
@@ -68,6 +70,7 @@ export function ChargeDialog({ open, onOpenChange }: ChargeDialogProps) {
     mutation.mutate(
       {
         invoiceId: toEntityId<'Invoice'>(values.invoiceId),
+        partyId: toEntityId<'Party'>(values.partyId),
         amount: values.amount,
         currency: values.currency as CurrencyCode,
         methodType: values.methodType,
@@ -100,6 +103,20 @@ export function ChargeDialog({ open, onOpenChange }: ChargeDialogProps) {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>{t('Payments.Fields.InvoiceId')}</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="partyId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('Payments.Fields.PartyId')}</FormLabel>
                   <FormControl>
                     <Input {...field} />
                   </FormControl>

--- a/packages/@granit/react-ui-payments/src/locales/en.ts
+++ b/packages/@granit/react-ui-payments/src/locales/en.ts
@@ -19,6 +19,7 @@ export const paymentsTranslationsEn = {
   'Payments.Fields.Amount': 'Amount',
   'Payments.Fields.Currency': 'Currency',
   'Payments.Fields.InvoiceId': 'Invoice ID',
+  'Payments.Fields.PartyId': 'Party ID',
   'Payments.Fields.MethodType': 'Method Type',
   'Payments.Fields.ProviderName': 'Provider',
   'Payments.Fields.Reason': 'Reason',

--- a/packages/@granit/react-ui-payments/src/locales/fr.ts
+++ b/packages/@granit/react-ui-payments/src/locales/fr.ts
@@ -19,6 +19,7 @@ export const paymentsTranslationsFr: Record<keyof PaymentsTranslations, string> 
   'Payments.Fields.Amount': 'Montant',
   'Payments.Fields.Currency': 'Devise',
   'Payments.Fields.InvoiceId': 'ID de facture',
+  'Payments.Fields.PartyId': 'ID de tiers',
   'Payments.Fields.MethodType': 'Type de méthode',
   'Payments.Fields.ProviderName': 'Fournisseur',
   'Payments.Fields.Reason': 'Motif',


### PR DESCRIPTION
## Summary

While auditing OpenAPI drift (point 3 of the ValueKind follow-ups), a resync surfaced a **real contract gap**: the backend `PaymentChargeRequest` now **requires `partyId`** (uuid), but the front DTO, the ChargeDialog form, and the vendored spec were behind — so a charge was submitted **without** `partyId`. The conformance oracle was passing only because the vendored spec was stale.

## Changes

- **`@granit/payments`** — `PaymentChargeRequest` gains `readonly partyId: string`. `constraints.ts` regenerated from the spec (adds the required uuid constraint).
- **`@granit/react-ui-payments`** — `ChargeDialog` collects a **Party ID** field and submits it as a branded `PartyId`. `Payments.Fields.PartyId` label added (en + fr).
- **`contracts/openapi/payments.json`** — resynced **only** the `PaymentChargeRequest` schema (added `partyId` to `properties` + `required`, in field order). The broader repo-wide resync (mostly cosmetic array reformatting + unrelated multi-domain drift) is intentionally **not** included.

## Tests

- New `charge-dialog.test.tsx`: fills the form (incl. Party ID) and asserts the charge mutation receives `partyId`.
- Updated the two existing `PaymentChargeRequest` fixtures (`payments-api`, `use-payments`) to include `partyId`.
- Green: payments + react-payments + react-ui-payments + contract-tests (oracle now passes for `PaymentChargeRequest`).

## Context

The full OpenAPI resync revealed ~32 files with real drift (list-response DTO renames in CMS/parties, `MetricValueKind`→`ValueKind`, request-DTO changes) mixed with ~36 pure-formatting files. Per the agreed scope, only this one oracle-flagged front bug is fixed here; the rest is left for per-domain follow-ups rather than one giant mixed PR.