### PR TITLE
feat(dashboards): surface the time-window selector on the real render paths

### DIFF
--- a/packages/@granit/dashboards/src/__tests__/resolve-time-window-request.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/resolve-time-window-request.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveTimeWindowToRenderRequest } from '../rendering/resolve-time-window-request';
+
+import type { DashboardTimeWindow } from '../types/dashboard-time-window';
+
+// Fixed reference instant: 2026-07-03T14:30:00Z (a Friday in Q3).
+const NOW = new Date('2026-07-03T14:30:00.000Z');
+
+describe('resolveTimeWindowToRenderRequest', () => {
+  it('resolves a rolling-duration token to now-minus-duration bounds', () => {
+    const window: DashboardTimeWindow = { period: { token: 'last_7d' } };
+    expect(resolveTimeWindowToRenderRequest(window, NOW)).toEqual({
+      periodFrom: '2026-06-26T14:30:00.000Z',
+      periodTo: '2026-07-03T14:30:00.000Z',
+      periodToken: 'last_7d',
+    });
+  });
+
+  it('resolves mtd to the first of the current UTC month', () => {
+    expect(resolveTimeWindowToRenderRequest({ period: { token: 'mtd' } }, NOW)).toEqual({
+      periodFrom: '2026-07-01T00:00:00.000Z',
+      periodTo: '2026-07-03T14:30:00.000Z',
+      periodToken: 'mtd',
+    });
+  });
+
+  it('resolves qtd to the first day of the current quarter', () => {
+    expect(resolveTimeWindowToRenderRequest({ period: { token: 'qtd' } }, NOW).periodFrom).toBe(
+      '2026-07-01T00:00:00.000Z'
+    );
+  });
+
+  it('resolves ytd to Jan 1 of the current UTC year', () => {
+    expect(resolveTimeWindowToRenderRequest({ period: { token: 'ytd' } }, NOW).periodFrom).toBe(
+      '2026-01-01T00:00:00.000Z'
+    );
+  });
+
+  it('passes an absolute range through unchanged (no token)', () => {
+    const window: DashboardTimeWindow = {
+      period: { from: '2026-01-01T00:00:00.000Z', to: '2026-02-01T00:00:00.000Z' },
+    };
+    expect(resolveTimeWindowToRenderRequest(window, NOW)).toEqual({
+      periodFrom: '2026-01-01T00:00:00.000Z',
+      periodTo: '2026-02-01T00:00:00.000Z',
+    });
+  });
+
+  it('degrades an unresolvable token to an echo with no bounds', () => {
+    // The endpoint requires periodFrom/periodTo as a pair; emitting one alone is
+    // a 400, so an unknown token renders unbounded with just the echo.
+    expect(resolveTimeWindowToRenderRequest({ period: { token: 'fortnight' } }, NOW)).toEqual({
+      periodToken: 'fortnight',
+    });
+  });
+});

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -134,12 +134,15 @@ export type {
   WidgetRenderKind,
 } from './types/index';
 
+export { resolveTimeWindowToRenderRequest } from './rendering/index';
+
 export type {
   DashboardDriftStatus,
   DashboardRenderedWidget,
   DashboardRenderPeriod,
   DashboardRenderRequest,
   DashboardRenderResponse,
+  ResolvedRenderPeriod,
   ImageSnapshotEnvelope,
   ImageWidgetSnapshot,
   MarkdownSnapshotEnvelope,

--- a/packages/@granit/dashboards/src/rendering/index.ts
+++ b/packages/@granit/dashboards/src/rendering/index.ts
@@ -8,6 +8,8 @@
 
 export type { DashboardDriftStatus } from './dashboard-drift-status';
 export type { DashboardRenderRequest } from './dashboard-render-request';
+export { resolveTimeWindowToRenderRequest } from './resolve-time-window-request';
+export type { ResolvedRenderPeriod } from './resolve-time-window-request';
 export type {
   DashboardRenderedWidget,
   DashboardRenderPeriod,

--- a/packages/@granit/dashboards/src/rendering/resolve-time-window-request.ts
+++ b/packages/@granit/dashboards/src/rendering/resolve-time-window-request.ts
@@ -1,0 +1,80 @@
+import type { DashboardRenderRequest } from './dashboard-render-request';
+import type { DashboardTimeWindow } from '../types/dashboard-time-window';
+
+/** Period portion of a {@link DashboardRenderRequest} — the subset a time window resolves to. */
+export type ResolvedRenderPeriod = Pick<
+  DashboardRenderRequest,
+  'periodFrom' | 'periodTo' | 'periodToken'
+>;
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+/** Rolling-window tokens resolvable as `now - duration`. */
+const DURATION_MS: Readonly<Record<string, number>> = {
+  last_60s: MINUTE_MS,
+  last_5m: 5 * MINUTE_MS,
+  last_24h: DAY_MS,
+  last_7d: 7 * DAY_MS,
+  last_30d: 30 * DAY_MS,
+};
+
+/**
+ * Resolves a {@link DashboardTimeWindow} into the absolute `[periodFrom, periodTo)`
+ * bounds a {@link DashboardRenderRequest} requires.
+ *
+ * The bundle render endpoint (`POST /dashboards/{id}/render`) does NOT resolve
+ * named tokens server-side — unlike the inline-metric endpoint — so calendar
+ * tokens (`last_30d`, `mtd`, `ytd`, …) must be turned into UTC bounds here. The
+ * originating token is echoed back as `periodToken` for client convenience.
+ *
+ * - An absolute-range window passes its `from` / `to` through unchanged.
+ * - A token with no known resolution (e.g. an app-specific one) degrades to
+ *   `periodToken` alone — the endpoint requires the two bounds as a pair, so
+ *   emitting only one would be a 400; omitting both renders unbounded.
+ *
+ * `now` is injectable for deterministic tests; it defaults to the current time.
+ */
+export function resolveTimeWindowToRenderRequest(
+  timeWindow: DashboardTimeWindow,
+  now: Date = new Date()
+): ResolvedRenderPeriod {
+  const { period } = timeWindow;
+
+  if ('from' in period) {
+    return { periodFrom: period.from, periodTo: period.to };
+  }
+
+  const { token } = period;
+  const from = resolveTokenStart(token, now);
+  if (from === null) {
+    return { periodToken: token };
+  }
+
+  return { periodFrom: from.toISOString(), periodTo: now.toISOString(), periodToken: token };
+}
+
+/** Absolute start instant for a token, or `null` when the token is not resolvable. */
+function resolveTokenStart(token: string, now: Date): Date | null {
+  const duration = DURATION_MS[token];
+  if (duration !== undefined) {
+    return new Date(now.getTime() - duration);
+  }
+
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+
+  switch (token) {
+    case 'today':
+      return new Date(Date.UTC(year, month, now.getUTCDate()));
+    case 'mtd':
+      return new Date(Date.UTC(year, month, 1));
+    case 'qtd':
+      return new Date(Date.UTC(year, Math.floor(month / 3) * 3, 1));
+    case 'ytd':
+      return new Date(Date.UTC(year, 0, 1));
+    default:
+      return null;
+  }
+}

--- a/packages/@granit/react-dashboard-editor/src/__tests__/editable-dashboard.test.tsx
+++ b/packages/@granit/react-dashboard-editor/src/__tests__/editable-dashboard.test.tsx
@@ -79,6 +79,14 @@ describe('EditableDashboard — initial render', () => {
     expect(root?.querySelector('.react-grid-layout')).not.toBeNull();
   });
 
+  it('mounts the time-window selector so the editor previews at a chosen period', () => {
+    const { container } = wrap(<EditableDashboard definition={definition} onChange={vi.fn()} />);
+    const toolbar = container.querySelector('[data-slot="dashboard-time-window-toolbar"]');
+    expect(toolbar).toBeInTheDocument();
+    // Seeded to Last 30 days (no default declared on the fixture).
+    expect((toolbar?.querySelector('select') as HTMLSelectElement).value).toBe('last_30d');
+  });
+
   it('drives cell height from the row height (1-row widget = rowHeight px)', () => {
     const { container } = wrap(
       <EditableDashboard definition={definition} onChange={vi.fn()} rowHeight={120} />

--- a/packages/@granit/react-dashboard-editor/src/components/editable-dashboard.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/editable-dashboard.tsx
@@ -1,7 +1,10 @@
+import { DASHBOARD_TIME_WINDOW } from '@granit/dashboards';
 import {
   DashboardContextProvider,
+  DashboardTimeWindowToolbar,
   resolveEffectiveLayout,
   useDashboardBreakpoint,
+  useDashboardTimeWindowState,
   WidgetRenderer,
 } from '@granit/react-dashboards';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -79,6 +82,15 @@ export function EditableDashboard({
 }: EditableDashboardProps) {
   const breakpoint = useDashboardBreakpoint();
 
+  // Preview time window for the editor canvas. Widgets render through the same
+  // context path as read mode (`WidgetRenderer` → `useEffectiveTimeWindow`), so
+  // the toolbar re-fetches every tile without editing the persisted definition.
+  // Seeded from the dashboard's declared default, falling back to Last 30 days
+  // so the selector always shows.
+  const [timeWindow, setTimeWindow] = useDashboardTimeWindowState(
+    definition.defaultTimeWindow ?? DASHBOARD_TIME_WINDOW.Last30Days
+  );
+
   const { layout, widgets: orderedWidgets } = useMemo(
     () => resolveEffectiveLayout(definition.layout, definition.widgets, breakpoint),
     [definition.layout, definition.widgets, breakpoint]
@@ -117,7 +129,9 @@ export function EditableDashboard({
   };
 
   return (
-    <DashboardContextProvider value={{ dashboardName: definition.name }}>
+    <DashboardContextProvider
+      value={{ dashboardName: definition.name, timeWindow, setTimeWindow }}
+    >
       <div
         ref={wrapperRef}
         data-slot="editable-dashboard"
@@ -126,6 +140,7 @@ export function EditableDashboard({
         className={className}
       >
         <GridStyles />
+        <DashboardTimeWindowToolbar className="mb-3" />
         <GridLayout
           width={width || FALLBACK_WIDTH_PX}
           layout={gridLayout}

--- a/packages/@granit/react-ui-dashboards/src/__tests__/dashboard-view-page.test.tsx
+++ b/packages/@granit/react-ui-dashboards/src/__tests__/dashboard-view-page.test.tsx
@@ -37,9 +37,24 @@ const useDashboardDetail = vi.fn();
 
 vi.mock('@granit/react-dashboards', () => ({
   useDashboardDetail: (id: string) => useDashboardDetail(id),
-  RenderedDashboard: ({ dashboardId }: { readonly dashboardId: string }) => (
-    <div data-slot="rendered-dashboard" data-dashboard-id={dashboardId} />
+  RenderedDashboard: ({
+    dashboardId,
+    request,
+  }: {
+    readonly dashboardId: string;
+    readonly request?: { readonly periodToken?: string };
+  }) => (
+    <div
+      data-slot="rendered-dashboard"
+      data-dashboard-id={dashboardId}
+      data-period-token={request?.periodToken}
+    />
   ),
+  // Context + selector are covered by their own suites; here they only need to
+  // mount so the view page's wiring renders.
+  DashboardContextProvider: ({ children }: { readonly children: React.ReactNode }) => children,
+  DashboardTimeWindowToolbar: () => <div data-slot="dashboard-time-window-toolbar" />,
+  useDashboardTimeWindowState: <T,>(initial: T) => [initial, vi.fn()] as const,
 }));
 
 describe('DashboardViewPage', () => {
@@ -50,6 +65,19 @@ describe('DashboardViewPage', () => {
     expect(document.querySelector('[data-slot="dashboard-view-page"]')).toBeInTheDocument();
     expect(screen.getByText('Invoicing overview')).toBeInTheDocument();
     expect(document.querySelector('[data-slot="rendered-dashboard"]')).toBeInTheDocument();
+  });
+
+  it('mounts the time-window selector and feeds the resolved period to the render request', () => {
+    useDashboardDetail.mockReturnValue({ data: detail, isLoading: false });
+    renderDashboards(<DashboardViewPage />);
+
+    expect(
+      document.querySelector('[data-slot="dashboard-time-window-toolbar"]')
+    ).toBeInTheDocument();
+    // Seeded to Last 30 days → the render request echoes that token.
+    expect(
+      document.querySelector('[data-slot="rendered-dashboard"]')?.getAttribute('data-period-token')
+    ).toBe('last_30d');
   });
 
   it('shows the status badge for the persisted dashboard', () => {

--- a/packages/@granit/react-ui-dashboards/src/components/dashboard-view-page.tsx
+++ b/packages/@granit/react-ui-dashboards/src/components/dashboard-view-page.tsx
@@ -1,9 +1,16 @@
-import { RenderedDashboard, useDashboardDetail } from '@granit/react-dashboards';
+import { DASHBOARD_TIME_WINDOW, resolveTimeWindowToRenderRequest } from '@granit/dashboards';
+import {
+  DashboardContextProvider,
+  DashboardTimeWindowToolbar,
+  RenderedDashboard,
+  useDashboardDetail,
+  useDashboardTimeWindowState,
+} from '@granit/react-dashboards';
 import { useTranslation } from '@granit/react-localization';
 import { Button, Spinner } from '@granit/react-ui';
 import { EmptyState } from '@granit/react-ui-kit';
 import { ArrowLeft, LayoutDashboard, Pencil } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { DashboardComposer } from './dashboard-composer';
@@ -32,6 +39,16 @@ export function DashboardViewPage() {
 
   const dashboardId = decodeURIComponent(id);
   const { data: detail, isLoading } = useDashboardDetail(dashboardId);
+
+  // Active render window. The bundle path needs absolute bounds, so the chosen
+  // window is resolved to `periodFrom` / `periodTo` and fed to the render
+  // request — changing it re-fetches the bundle. Seeded to Last 30 days until
+  // the backend surfaces the dashboard's declared default on the detail payload.
+  const [timeWindow, setTimeWindow] = useDashboardTimeWindowState(DASHBOARD_TIME_WINDOW.Last30Days);
+  const renderRequest = useMemo(
+    () => (timeWindow ? resolveTimeWindowToRenderRequest(timeWindow) : undefined),
+    [timeWindow]
+  );
 
   if (isLoading) {
     return (
@@ -69,42 +86,50 @@ export function DashboardViewPage() {
   }
 
   return (
-    <div
-      data-slot="dashboard-view-page"
-      data-mode="view"
-      data-dashboard-id={detail.id}
-      data-dashboard-status={detail.status}
-      className="space-y-4"
+    <DashboardContextProvider
+      value={{ dashboardName: detail.name, timeWindow, setTimeWindow }}
     >
-      <div className="flex items-center justify-between gap-4">
-        <div className="flex items-center gap-3">
-          <Button variant="ghost" size="sm" onClick={() => navigate('/dashboards/manage')}>
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            {t('Common.Back', { defaultValue: 'Back' })}
-          </Button>
-          <div>
-            <h2 className="text-2xl font-semibold text-foreground">{detail.name}</h2>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              <StatusBadge status={detail.status} /> · {detail.category}
-            </p>
+      <div
+        data-slot="dashboard-view-page"
+        data-mode="view"
+        data-dashboard-id={detail.id}
+        data-dashboard-status={detail.status}
+        className="space-y-4"
+      >
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <Button variant="ghost" size="sm" onClick={() => navigate('/dashboards/manage')}>
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              {t('Common.Back', { defaultValue: 'Back' })}
+            </Button>
+            <div>
+              <h2 className="text-2xl font-semibold text-foreground">{detail.name}</h2>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                <StatusBadge status={detail.status} /> · {detail.category}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-end gap-3">
+            <DashboardTimeWindowToolbar />
+            <Button
+              data-slot="dashboard-view-edit-toggle"
+              variant="outline"
+              size="sm"
+              onClick={() => setEditing(true)}
+            >
+              <Pencil className="mr-2 h-4 w-4" />
+              {t('Common.Edit', { defaultValue: 'Edit' })}
+            </Button>
           </div>
         </div>
-        <Button
-          data-slot="dashboard-view-edit-toggle"
-          variant="outline"
-          size="sm"
-          onClick={() => setEditing(true)}
-        >
-          <Pencil className="mr-2 h-4 w-4" />
-          {t('Common.Edit', { defaultValue: 'Edit' })}
-        </Button>
-      </div>
 
-      <RenderedDashboard
-        dashboardId={dashboardId}
-        columns={detail.layoutColumns}
-        rowHeight={detail.layoutRowHeight}
-      />
-    </div>
+        <RenderedDashboard
+          dashboardId={dashboardId}
+          request={renderRequest}
+          columns={detail.layoutColumns}
+          rowHeight={detail.layoutRowHeight}
+        />
+      </div>
+    </DashboardContextProvider>
   );
 }


### PR DESCRIPTION
## Context

Follow-up to #894. That PR wired the time-window selector into `<Dashboard>` (the definition path) — but that component is used **only by the playground**. The surfaces real apps render never showed a selector, so it was invisible in the app. There are three dashboard render surfaces:

| Surface | Package | Where | Data path |
|---|---|---|---|
| `<Dashboard>` | react-dashboards | playground only | context (`useEffectiveTimeWindow`) — **#894** |
| `<EditableDashboard>` | react-dashboard-editor | `/manage/:id/edit` (edit mode) | context (same as `<Dashboard>`) |
| `<RenderedDashboard>` | react-dashboards | `/manage/:id` (view mode) | bundle request (`periodFrom`/`periodTo`) |

## Changes

- **Edit mode** (`EditableDashboard`): it already renders tiles via `WidgetRenderer` (the context path) but only provided `{ dashboardName }`. Now seeds a **preview** time window (default `Last30Days`) into its `DashboardContextProvider` and renders `DashboardTimeWindowToolbar` above the canvas. Tiles re-fetch through `useEffectiveTimeWindow` — no per-widget change. The window is a preview control, not an edit to the persisted definition.
- **View mode** (`DashboardViewPage` → `RenderedDashboard`): the bundle path needs **absolute** bounds. New **`resolveTimeWindowToRenderRequest`** (`@granit/dashboards`) turns a token window (`last_30d`, `mtd`, `ytd`, …) into absolute UTC `[periodFrom, periodTo)` client-side — the `/render` endpoint doesn't resolve tokens. The selector sits in the page header (next to Edit); its window resolves into `RenderedDashboard`'s `request`, so a change re-fetches the bundle.

## Product note (option 1, agreed)

`DashboardDetailResponse` carries no `defaultTimeWindow` yet, so the window is **seeded to `Last30Days`** — the selector now shows on **every** dashboard (view + edit), and the render request is bounded to the last 30 days by default. **Follow-up (backend):** project `DashboardDefinition.defaultTimeWindow` onto the detail payload so a dashboard's declared default is honored; the front already falls back to `Last30Days` when it's absent.

## Verification

- `tsc --noEmit` (dashboards, react-dashboard-editor, react-ui-dashboards): clean
- Vitest: **3398 passing** across the touched packages + arch-tests (3216) — no layering violation; new resolver unit test (tokens → absolute bounds, absolute passthrough, unresolvable-token echo), edit-mode + view-mode selector presence + request wiring
- ESLint `--max-warnings 0`: clean