### PR TITLE
feat(dashboards): Grafana-style time-window quick ranges

### DIFF
--- a/packages/@granit/analytics/src/types/metric.ts
+++ b/packages/@granit/analytics/src/types/metric.ts
@@ -38,15 +38,40 @@ import type { ISODateString } from '@granit/types';
  * type bump.
  */
 export type PeriodToken =
-  | 'today'
-  | 'yesterday'
+  // Rolling — minutes / hours (end = now).
   | 'last_60s'
   | 'last_5m'
+  | 'last_15m'
+  | 'last_30m'
+  | 'last_1h'
+  | 'last_3h'
+  | 'last_6h'
+  | 'last_12h'
+  | 'last_24h'
+  // Rolling — days / months / years (day-aligned).
+  | 'last_2d'
   | 'last_7d'
   | 'last_30d'
+  | 'last_3mo'
+  | 'last_6mo'
+  | 'last_1y'
+  | 'last_2y'
+  | 'last_5y'
+  // Relative single days.
+  | 'today'
+  | 'yesterday'
+  | 'day_before_yesterday'
+  | 'this_day_last_week'
+  // To-date ("so far").
+  | 'wtd'
   | 'mtd'
   | 'qtd'
   | 'ytd'
+  // Previous complete periods.
+  | 'pw'
+  | 'pm'
+  | 'pq'
+  | 'py'
   | (string & {});
 
 export type CompareToken = 'previous_period' | (string & {});

--- a/packages/@granit/dashboards/src/__tests__/resolve-time-window-request.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/resolve-time-window-request.test.ts
@@ -4,54 +4,96 @@ import { resolveTimeWindowToRenderRequest } from '../rendering/resolve-time-wind
 
 import type { DashboardTimeWindow } from '../types/dashboard-time-window';
 
-// Fixed reference instant: 2026-07-03T14:30:00Z (a Friday in Q3).
+// Fixed reference: 2026-07-03T14:30:00Z — a Friday, in Q3, month day 3.
 const NOW = new Date('2026-07-03T14:30:00.000Z');
+const END_OF_TODAY = '2026-07-04T00:00:00.000Z';
+
+function resolve(token: string, opts?: { now?: Date; weekStartsOn?: 0 | 1 }) {
+  const window: DashboardTimeWindow = { period: { token } };
+  return resolveTimeWindowToRenderRequest(window, { now: NOW, ...opts });
+}
 
 describe('resolveTimeWindowToRenderRequest', () => {
-  it('resolves a rolling-duration token to now-minus-duration bounds', () => {
-    const window: DashboardTimeWindow = { period: { token: 'last_7d' } };
-    expect(resolveTimeWindowToRenderRequest(window, NOW)).toEqual({
-      periodFrom: '2026-06-26T14:30:00.000Z',
+  it('resolves a sub-day token as [now - duration, now)', () => {
+    expect(resolve('last_1h')).toEqual({
+      periodFrom: '2026-07-03T13:30:00.000Z',
       periodTo: '2026-07-03T14:30:00.000Z',
-      periodToken: 'last_7d',
+      periodToken: 'last_1h',
     });
   });
 
-  it('resolves mtd to the first of the current UTC month', () => {
-    expect(resolveTimeWindowToRenderRequest({ period: { token: 'mtd' } }, NOW)).toEqual({
-      periodFrom: '2026-07-01T00:00:00.000Z',
-      periodTo: '2026-07-03T14:30:00.000Z',
-      periodToken: 'mtd',
+  it.each([
+    ['last_2d', '2026-07-01T00:00:00.000Z'],
+    ['last_7d', '2026-06-26T00:00:00.000Z'],
+    ['last_30d', '2026-06-03T00:00:00.000Z'],
+    ['last_3mo', '2026-04-03T00:00:00.000Z'],
+    ['last_6mo', '2026-01-03T00:00:00.000Z'],
+    ['last_1y', '2025-07-03T00:00:00.000Z'],
+    ['last_5y', '2021-07-03T00:00:00.000Z'],
+  ])('day-aligns %s through the end of today', (token, from) => {
+    expect(resolve(token)).toEqual({ periodFrom: from, periodTo: END_OF_TODAY, periodToken: token });
+  });
+
+  it.each([
+    ['today', '2026-07-03T00:00:00.000Z', '2026-07-04T00:00:00.000Z'],
+    ['yesterday', '2026-07-02T00:00:00.000Z', '2026-07-03T00:00:00.000Z'],
+    ['day_before_yesterday', '2026-07-01T00:00:00.000Z', '2026-07-02T00:00:00.000Z'],
+    ['this_day_last_week', '2026-06-26T00:00:00.000Z', '2026-06-27T00:00:00.000Z'],
+  ])('resolves the single day %s', (token, from, to) => {
+    expect(resolve(token)).toEqual({ periodFrom: from, periodTo: to, periodToken: token });
+  });
+
+  it.each([
+    ['mtd', '2026-07-01T00:00:00.000Z'],
+    ['qtd', '2026-07-01T00:00:00.000Z'],
+    ['ytd', '2026-01-01T00:00:00.000Z'],
+  ])('resolves the to-date token %s through the end of today', (token, from) => {
+    expect(resolve(token)).toEqual({ periodFrom: from, periodTo: END_OF_TODAY, periodToken: token });
+  });
+
+  it.each([
+    ['pm', '2026-06-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z'],
+    ['pq', '2026-04-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z'],
+    ['py', '2025-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z'],
+  ])('resolves the previous complete period %s', (token, from, to) => {
+    expect(resolve(token)).toEqual({ periodFrom: from, periodTo: to, periodToken: token });
+  });
+
+  it('resolves wtd / pw against the configured first day of week', () => {
+    // NOW is a Friday. Monday-start week began 2026-06-29; Sunday-start 2026-06-28.
+    expect(resolve('wtd', { weekStartsOn: 1 }).periodFrom).toBe('2026-06-29T00:00:00.000Z');
+    expect(resolve('wtd', { weekStartsOn: 0 }).periodFrom).toBe('2026-06-28T00:00:00.000Z');
+    expect(resolve('pw', { weekStartsOn: 1 })).toEqual({
+      periodFrom: '2026-06-22T00:00:00.000Z',
+      periodTo: '2026-06-29T00:00:00.000Z',
+      periodToken: 'pw',
     });
   });
 
-  it('resolves qtd to the first day of the current quarter', () => {
-    expect(resolveTimeWindowToRenderRequest({ period: { token: 'qtd' } }, NOW).periodFrom).toBe(
-      '2026-07-01T00:00:00.000Z'
-    );
+  it('defaults the first day of week to Monday', () => {
+    expect(resolve('wtd').periodFrom).toBe('2026-06-29T00:00:00.000Z');
   });
 
-  it('resolves ytd to Jan 1 of the current UTC year', () => {
-    expect(resolveTimeWindowToRenderRequest({ period: { token: 'ytd' } }, NOW).periodFrom).toBe(
-      '2026-01-01T00:00:00.000Z'
-    );
+  it('clamps month arithmetic to the target month like .NET AddMonths', () => {
+    // From May 31, last_3mo lands on "Feb 31" → clamped to Feb 28 (2026 is not leap).
+    const window: DashboardTimeWindow = { period: { token: 'last_3mo' } };
+    expect(
+      resolveTimeWindowToRenderRequest(window, { now: new Date('2026-05-31T09:00:00.000Z') })
+        .periodFrom
+    ).toBe('2026-02-28T00:00:00.000Z');
   });
 
   it('passes an absolute range through unchanged (no token)', () => {
     const window: DashboardTimeWindow = {
       period: { from: '2026-01-01T00:00:00.000Z', to: '2026-02-01T00:00:00.000Z' },
     };
-    expect(resolveTimeWindowToRenderRequest(window, NOW)).toEqual({
+    expect(resolveTimeWindowToRenderRequest(window, { now: NOW })).toEqual({
       periodFrom: '2026-01-01T00:00:00.000Z',
       periodTo: '2026-02-01T00:00:00.000Z',
     });
   });
 
   it('degrades an unresolvable token to an echo with no bounds', () => {
-    // The endpoint requires periodFrom/periodTo as a pair; emitting one alone is
-    // a 400, so an unknown token renders unbounded with just the echo.
-    expect(resolveTimeWindowToRenderRequest({ period: { token: 'fortnight' } }, NOW)).toEqual({
-      periodToken: 'fortnight',
-    });
+    expect(resolve('fortnight')).toEqual({ periodToken: 'fortnight' });
   });
 });

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -143,6 +143,8 @@ export type {
   DashboardRenderRequest,
   DashboardRenderResponse,
   ResolvedRenderPeriod,
+  ResolveTimeWindowOptions,
+  Weekday,
   ImageSnapshotEnvelope,
   ImageWidgetSnapshot,
   MarkdownSnapshotEnvelope,

--- a/packages/@granit/dashboards/src/rendering/index.ts
+++ b/packages/@granit/dashboards/src/rendering/index.ts
@@ -9,7 +9,11 @@
 export type { DashboardDriftStatus } from './dashboard-drift-status';
 export type { DashboardRenderRequest } from './dashboard-render-request';
 export { resolveTimeWindowToRenderRequest } from './resolve-time-window-request';
-export type { ResolvedRenderPeriod } from './resolve-time-window-request';
+export type {
+  ResolvedRenderPeriod,
+  ResolveTimeWindowOptions,
+  Weekday,
+} from './resolve-time-window-request';
 export type {
   DashboardRenderedWidget,
   DashboardRenderPeriod,

--- a/packages/@granit/dashboards/src/rendering/resolve-time-window-request.ts
+++ b/packages/@granit/dashboards/src/rendering/resolve-time-window-request.ts
@@ -7,17 +7,30 @@ export type ResolvedRenderPeriod = Pick<
   'periodFrom' | 'periodTo' | 'periodToken'
 >;
 
+/** First day of week: `0` = Sunday … `6` = Saturday (matches `Date.getUTCDay`). */
+export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface ResolveTimeWindowOptions {
+  /** Reference instant. Injectable for deterministic tests; defaults to now. */
+  readonly now?: Date;
+  /** First day of week for `wtd` / `pw`. Defaults to Monday (`1`). */
+  readonly weekStartsOn?: Weekday;
+}
+
 const MINUTE_MS = 60_000;
 const HOUR_MS = 60 * MINUTE_MS;
-const DAY_MS = 24 * HOUR_MS;
 
-/** Rolling-window tokens resolvable as `now - duration`. */
+/** Rolling sub-day tokens, resolved as `[now - duration, now)`. */
 const DURATION_MS: Readonly<Record<string, number>> = {
   last_60s: MINUTE_MS,
   last_5m: 5 * MINUTE_MS,
-  last_24h: DAY_MS,
-  last_7d: 7 * DAY_MS,
-  last_30d: 30 * DAY_MS,
+  last_15m: 15 * MINUTE_MS,
+  last_30m: 30 * MINUTE_MS,
+  last_1h: HOUR_MS,
+  last_3h: 3 * HOUR_MS,
+  last_6h: 6 * HOUR_MS,
+  last_12h: 12 * HOUR_MS,
+  last_24h: 24 * HOUR_MS,
 };
 
 /**
@@ -26,19 +39,23 @@ const DURATION_MS: Readonly<Record<string, number>> = {
  *
  * The bundle render endpoint (`POST /dashboards/{id}/render`) does NOT resolve
  * named tokens server-side — unlike the inline-metric endpoint — so calendar
- * tokens (`last_30d`, `mtd`, `ytd`, …) must be turned into UTC bounds here. The
- * originating token is echoed back as `periodToken` for client convenience.
+ * tokens (`last_30d`, `mtd`, `pw`, …) are turned into UTC bounds here. **The
+ * semantics mirror `Granit.Analytics` `PeriodResolver` exactly** so a widget
+ * bound through either path resolves the same window: sub-day tokens end at
+ * `now`; day / calendar tokens are day-aligned and run through the end of today
+ * (`todayStart + 1d`, exclusive); month/year arithmetic clamps the day to the
+ * target month like .NET `DateTime.AddMonths`.
  *
  * - An absolute-range window passes its `from` / `to` through unchanged.
- * - A token with no known resolution (e.g. an app-specific one) degrades to
- *   `periodToken` alone — the endpoint requires the two bounds as a pair, so
- *   emitting only one would be a 400; omitting both renders unbounded.
+ * - A token with no known resolution degrades to `periodToken` alone — the
+ *   endpoint requires the two bounds as a pair, so emitting only one is a 400;
+ *   omitting both renders unbounded.
  *
- * `now` is injectable for deterministic tests; it defaults to the current time.
+ * `now` and `weekStartsOn` are injectable via {@link ResolveTimeWindowOptions}.
  */
 export function resolveTimeWindowToRenderRequest(
   timeWindow: DashboardTimeWindow,
-  now: Date = new Date()
+  options: ResolveTimeWindowOptions = {}
 ): ResolvedRenderPeriod {
   const { period } = timeWindow;
 
@@ -46,35 +63,127 @@ export function resolveTimeWindowToRenderRequest(
     return { periodFrom: period.from, periodTo: period.to };
   }
 
-  const { token } = period;
-  const from = resolveTokenStart(token, now);
-  if (from === null) {
-    return { periodToken: token };
+  const now = options.now ?? new Date();
+  const weekStartsOn = options.weekStartsOn ?? 1;
+  const bounds = resolveToken(period.token, now, weekStartsOn);
+
+  if (bounds === null) {
+    return { periodToken: period.token };
   }
 
-  return { periodFrom: from.toISOString(), periodTo: now.toISOString(), periodToken: token };
+  return {
+    periodFrom: bounds.from.toISOString(),
+    periodTo: bounds.to.toISOString(),
+    periodToken: period.token,
+  };
 }
 
-/** Absolute start instant for a token, or `null` when the token is not resolvable. */
-function resolveTokenStart(token: string, now: Date): Date | null {
+interface Bounds {
+  readonly from: Date;
+  readonly to: Date;
+}
+
+function resolveToken(token: string, now: Date, weekStartsOn: Weekday): Bounds | null {
   const duration = DURATION_MS[token];
   if (duration !== undefined) {
-    return new Date(now.getTime() - duration);
+    return { from: new Date(now.getTime() - duration), to: now };
   }
 
-  const year = now.getUTCFullYear();
-  const month = now.getUTCMonth();
+  const day0 = startOfUtcDay(now);
+  const endOfToday = addUtcDays(day0, 1);
 
   switch (token) {
+    // Day / month / year rolling — day-aligned, through end of today.
+    case 'last_2d':
+      return { from: addUtcDays(day0, -2), to: endOfToday };
+    case 'last_7d':
+      return { from: addUtcDays(day0, -7), to: endOfToday };
+    case 'last_30d':
+      return { from: addUtcDays(day0, -30), to: endOfToday };
+    case 'last_3mo':
+      return { from: addUtcMonths(day0, -3), to: endOfToday };
+    case 'last_6mo':
+      return { from: addUtcMonths(day0, -6), to: endOfToday };
+    case 'last_1y':
+      return { from: addUtcMonths(day0, -12), to: endOfToday };
+    case 'last_2y':
+      return { from: addUtcMonths(day0, -24), to: endOfToday };
+    case 'last_5y':
+      return { from: addUtcMonths(day0, -60), to: endOfToday };
+
+    // Relative single days.
     case 'today':
-      return new Date(Date.UTC(year, month, now.getUTCDate()));
+      return { from: day0, to: endOfToday };
+    case 'yesterday':
+      return { from: addUtcDays(day0, -1), to: day0 };
+    case 'day_before_yesterday':
+      return { from: addUtcDays(day0, -2), to: addUtcDays(day0, -1) };
+    case 'this_day_last_week':
+      return { from: addUtcDays(day0, -7), to: addUtcDays(day0, -6) };
+
+    // To-date ("so far") — start of period through end of today.
+    case 'wtd':
+      return { from: startOfUtcWeek(day0, weekStartsOn), to: endOfToday };
     case 'mtd':
-      return new Date(Date.UTC(year, month, 1));
+      return { from: startOfUtcMonth(day0), to: endOfToday };
     case 'qtd':
-      return new Date(Date.UTC(year, Math.floor(month / 3) * 3, 1));
+      return { from: startOfUtcQuarter(day0), to: endOfToday };
     case 'ytd':
-      return new Date(Date.UTC(year, 0, 1));
+      return { from: startOfUtcYear(day0), to: endOfToday };
+
+    // Previous complete periods.
+    case 'pw': {
+      const weekStart = startOfUtcWeek(day0, weekStartsOn);
+      return { from: addUtcDays(weekStart, -7), to: weekStart };
+    }
+    case 'pm': {
+      const monthStart = startOfUtcMonth(day0);
+      return { from: addUtcMonths(monthStart, -1), to: monthStart };
+    }
+    case 'pq': {
+      const quarterStart = startOfUtcQuarter(day0);
+      return { from: addUtcMonths(quarterStart, -3), to: quarterStart };
+    }
+    case 'py': {
+      const yearStart = startOfUtcYear(day0);
+      return { from: addUtcMonths(yearStart, -12), to: yearStart };
+    }
+
     default:
       return null;
   }
+}
+
+function startOfUtcDay(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+function addUtcDays(d: Date, days: number): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + days));
+}
+
+/** Adds months, clamping the day to the target month's last day (matches .NET `AddMonths`). */
+function addUtcMonths(d: Date, months: number): Date {
+  const total = d.getUTCMonth() + months;
+  const year = d.getUTCFullYear() + Math.floor(total / 12);
+  const month = ((total % 12) + 12) % 12;
+  const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  return new Date(Date.UTC(year, month, Math.min(d.getUTCDate(), lastDay)));
+}
+
+function startOfUtcMonth(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
+}
+
+function startOfUtcQuarter(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), Math.floor(d.getUTCMonth() / 3) * 3, 1));
+}
+
+function startOfUtcYear(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+}
+
+function startOfUtcWeek(d: Date, weekStartsOn: Weekday): Date {
+  const diff = (d.getUTCDay() - weekStartsOn + 7) % 7;
+  return addUtcDays(d, -diff);
 }

--- a/packages/@granit/dashboards/src/types/dashboard-time-window.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-time-window.ts
@@ -44,15 +44,55 @@ export type DashboardPeriod =
   | { readonly token: string }
   | { readonly from: string; readonly to: string };
 
-/** Convenience constants matching the conventional tokens. */
+/**
+ * Grafana-style quick ranges. Every preset is `History` — live cadence is now a
+ * separate dashboard-level refresh control, not a property of the time window,
+ * so no preset carries `kind: 'Realtime'`.
+ *
+ * Token semantics are resolved identically on both data paths: server-side by
+ * `Granit.Analytics` `PeriodResolver` (inline-metric / definition path) and
+ * client-side by `resolveTimeWindowToRenderRequest` (bundle path). `wtd` / `pw`
+ * depend on the configured first day of week.
+ */
 export const DASHBOARD_TIME_WINDOW = Object.freeze({
+  // Minutes / hours — rolling window ending now.
+  Last5Minutes: { period: { token: 'last_5m' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Last15Minutes: { period: { token: 'last_15m' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Last30Minutes: { period: { token: 'last_30m' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Last1Hour: { period: { token: 'last_1h' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Last3Hours: { period: { token: 'last_3h' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Last6Hours: { period: { token: 'last_6h' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Last12Hours: { period: { token: 'last_12h' }, kind: 'History' } satisfies DashboardTimeWindow,
   Last24Hours: { period: { token: 'last_24h' }, kind: 'History' } satisfies DashboardTimeWindow,
+  // Days — day-aligned, through the end of today.
+  Last2Days: { period: { token: 'last_2d' }, kind: 'History' } satisfies DashboardTimeWindow,
   Last7Days: { period: { token: 'last_7d' }, kind: 'History' } satisfies DashboardTimeWindow,
   Last30Days: { period: { token: 'last_30d' }, kind: 'History' } satisfies DashboardTimeWindow,
-  Mtd: { period: { token: 'mtd' }, kind: 'History' } satisfies DashboardTimeWindow,
-  Ytd: { period: { token: 'ytd' }, kind: 'History' } satisfies DashboardTimeWindow,
-  RealtimeLast5Minutes: {
-    period: { token: 'last_5m' },
-    kind: 'Realtime',
+  // Months / years.
+  Last3Months: { period: { token: 'last_3mo' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Last6Months: { period: { token: 'last_6mo' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Last1Year: { period: { token: 'last_1y' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Last2Years: { period: { token: 'last_2y' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Last5Years: { period: { token: 'last_5y' }, kind: 'History' } satisfies DashboardTimeWindow,
+  // Relative single days.
+  Today: { period: { token: 'today' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Yesterday: { period: { token: 'yesterday' }, kind: 'History' } satisfies DashboardTimeWindow,
+  DayBeforeYesterday: {
+    period: { token: 'day_before_yesterday' },
+    kind: 'History',
   } satisfies DashboardTimeWindow,
+  ThisDayLastWeek: {
+    period: { token: 'this_day_last_week' },
+    kind: 'History',
+  } satisfies DashboardTimeWindow,
+  // To-date ("so far") — start of the period through the end of today.
+  Wtd: { period: { token: 'wtd' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Mtd: { period: { token: 'mtd' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Qtd: { period: { token: 'qtd' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Ytd: { period: { token: 'ytd' }, kind: 'History' } satisfies DashboardTimeWindow,
+  // Previous complete periods.
+  Pw: { period: { token: 'pw' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Pm: { period: { token: 'pm' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Pq: { period: { token: 'pq' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Py: { period: { token: 'py' }, kind: 'History' } satisfies DashboardTimeWindow,
 });

--- a/packages/@granit/react-dashboards/src/components/dashboard-time-window-toolbar.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-time-window-toolbar.tsx
@@ -6,10 +6,10 @@ import { useDashboardContext } from './dashboard-context';
 import type { DashboardTimeWindow } from '@granit/dashboards';
 
 /**
- * Preset windows the selector offers, in display order. Each carries the token
- * that identifies it in {@link DashboardTimeWindow.period} plus a localization
- * key (with an English fallback, mirroring {@link DashboardFilterToolbar} — the
- * package ships no locale files, host translations override via the key).
+ * One quick-range option. Carries the token that identifies it in
+ * {@link DashboardTimeWindow.period} plus a localization key (with an English
+ * fallback, mirroring {@link DashboardFilterToolbar} — the package ships no
+ * locale files, host translations override via the key).
  */
 interface TimeWindowPreset {
   readonly token: string;
@@ -18,44 +18,92 @@ interface TimeWindowPreset {
   readonly defaultLabel: string;
 }
 
-const PRESETS: readonly TimeWindowPreset[] = [
+interface TimeWindowGroup {
+  readonly labelKey: string;
+  readonly defaultLabel: string;
+  readonly presets: readonly TimeWindowPreset[];
+}
+
+const W = DASHBOARD_TIME_WINDOW;
+
+function preset(window: DashboardTimeWindow, labelKey: string, defaultLabel: string): TimeWindowPreset {
+  const token = 'token' in window.period ? window.period.token : '';
+  return { token, window, labelKey, defaultLabel };
+}
+
+/** Grafana-style quick ranges, grouped for a scannable dropdown. */
+const GROUPS: readonly TimeWindowGroup[] = [
   {
-    token: 'last_24h',
-    window: DASHBOARD_TIME_WINDOW.Last24Hours,
-    labelKey: 'Dashboard:TimeWindow.Last24Hours',
-    defaultLabel: 'Last 24 hours',
+    labelKey: 'Dashboard:TimeWindow.Group.MinutesHours',
+    defaultLabel: 'Minutes & hours',
+    presets: [
+      preset(W.Last5Minutes, 'Dashboard:TimeWindow.Last5Minutes', 'Last 5 minutes'),
+      preset(W.Last15Minutes, 'Dashboard:TimeWindow.Last15Minutes', 'Last 15 minutes'),
+      preset(W.Last30Minutes, 'Dashboard:TimeWindow.Last30Minutes', 'Last 30 minutes'),
+      preset(W.Last1Hour, 'Dashboard:TimeWindow.Last1Hour', 'Last 1 hour'),
+      preset(W.Last3Hours, 'Dashboard:TimeWindow.Last3Hours', 'Last 3 hours'),
+      preset(W.Last6Hours, 'Dashboard:TimeWindow.Last6Hours', 'Last 6 hours'),
+      preset(W.Last12Hours, 'Dashboard:TimeWindow.Last12Hours', 'Last 12 hours'),
+      preset(W.Last24Hours, 'Dashboard:TimeWindow.Last24Hours', 'Last 24 hours'),
+    ],
   },
   {
-    token: 'last_7d',
-    window: DASHBOARD_TIME_WINDOW.Last7Days,
-    labelKey: 'Dashboard:TimeWindow.Last7Days',
-    defaultLabel: 'Last 7 days',
+    labelKey: 'Dashboard:TimeWindow.Group.Days',
+    defaultLabel: 'Days',
+    presets: [
+      preset(W.Last2Days, 'Dashboard:TimeWindow.Last2Days', 'Last 2 days'),
+      preset(W.Last7Days, 'Dashboard:TimeWindow.Last7Days', 'Last 7 days'),
+      preset(W.Last30Days, 'Dashboard:TimeWindow.Last30Days', 'Last 30 days'),
+    ],
   },
   {
-    token: 'last_30d',
-    window: DASHBOARD_TIME_WINDOW.Last30Days,
-    labelKey: 'Dashboard:TimeWindow.Last30Days',
-    defaultLabel: 'Last 30 days',
+    labelKey: 'Dashboard:TimeWindow.Group.MonthsYears',
+    defaultLabel: 'Months & years',
+    presets: [
+      preset(W.Last3Months, 'Dashboard:TimeWindow.Last3Months', 'Last 3 months'),
+      preset(W.Last6Months, 'Dashboard:TimeWindow.Last6Months', 'Last 6 months'),
+      preset(W.Last1Year, 'Dashboard:TimeWindow.Last1Year', 'Last 1 year'),
+      preset(W.Last2Years, 'Dashboard:TimeWindow.Last2Years', 'Last 2 years'),
+      preset(W.Last5Years, 'Dashboard:TimeWindow.Last5Years', 'Last 5 years'),
+    ],
   },
   {
-    token: 'mtd',
-    window: DASHBOARD_TIME_WINDOW.Mtd,
-    labelKey: 'Dashboard:TimeWindow.Mtd',
-    defaultLabel: 'Month to date',
+    labelKey: 'Dashboard:TimeWindow.Group.RelativeDays',
+    defaultLabel: 'Relative days',
+    presets: [
+      preset(W.Today, 'Dashboard:TimeWindow.Today', 'Today'),
+      preset(W.Yesterday, 'Dashboard:TimeWindow.Yesterday', 'Yesterday'),
+      preset(
+        W.DayBeforeYesterday,
+        'Dashboard:TimeWindow.DayBeforeYesterday',
+        'Day before yesterday'
+      ),
+      preset(W.ThisDayLastWeek, 'Dashboard:TimeWindow.ThisDayLastWeek', 'This day last week'),
+    ],
   },
   {
-    token: 'ytd',
-    window: DASHBOARD_TIME_WINDOW.Ytd,
-    labelKey: 'Dashboard:TimeWindow.Ytd',
-    defaultLabel: 'Year to date',
+    labelKey: 'Dashboard:TimeWindow.Group.ToDate',
+    defaultLabel: 'To date',
+    presets: [
+      preset(W.Wtd, 'Dashboard:TimeWindow.Wtd', 'This week (WTD)'),
+      preset(W.Mtd, 'Dashboard:TimeWindow.Mtd', 'This month (MTD)'),
+      preset(W.Qtd, 'Dashboard:TimeWindow.Qtd', 'This quarter (QTD)'),
+      preset(W.Ytd, 'Dashboard:TimeWindow.Ytd', 'This year (YTD)'),
+    ],
   },
   {
-    token: 'last_5m',
-    window: DASHBOARD_TIME_WINDOW.RealtimeLast5Minutes,
-    labelKey: 'Dashboard:TimeWindow.RealtimeLast5Minutes',
-    defaultLabel: 'Realtime (last 5 min)',
+    labelKey: 'Dashboard:TimeWindow.Group.Previous',
+    defaultLabel: 'Previous',
+    presets: [
+      preset(W.Pw, 'Dashboard:TimeWindow.Pw', 'Previous week (PW)'),
+      preset(W.Pm, 'Dashboard:TimeWindow.Pm', 'Previous month (PM)'),
+      preset(W.Pq, 'Dashboard:TimeWindow.Pq', 'Previous quarter (PQ)'),
+      preset(W.Py, 'Dashboard:TimeWindow.Py', 'Previous year (PY)'),
+    ],
   },
 ];
+
+const ALL_PRESETS: readonly TimeWindowPreset[] = GROUPS.flatMap((group) => group.presets);
 
 export interface DashboardTimeWindowToolbarProps {
   readonly className?: string;
@@ -73,10 +121,11 @@ export interface DashboardTimeWindowToolbarProps {
  * (`context.setTimeWindow` absent — embedded / preview / printable
  * dashboards), so apps can mount it unconditionally.
  *
- * v1 offers the framework's {@link DASHBOARD_TIME_WINDOW} presets. A window
- * carrying an absolute range or a token outside the preset set stays selected
- * as a disabled "Custom range" entry; a richer picker (absolute ranges, custom
- * comparison) is a follow-up an app composes on the same context.
+ * Offers the framework's {@link DASHBOARD_TIME_WINDOW} quick ranges, grouped
+ * (minutes/hours, days, months/years, relative days, to-date, previous). A
+ * window carrying an absolute range or a token outside the preset set stays
+ * selected as a disabled "Custom range" entry; a richer picker (absolute
+ * ranges) is a follow-up an app composes on the same context.
  */
 export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToolbarProps) {
   const { t } = useTranslation();
@@ -86,7 +135,7 @@ export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToo
 
   const { timeWindow, setTimeWindow } = ctx;
   const currentToken = 'token' in timeWindow.period ? timeWindow.period.token : '';
-  const matched = PRESETS.some((preset) => preset.token === currentToken);
+  const matched = ALL_PRESETS.some((p) => p.token === currentToken);
 
   return (
     <div
@@ -103,11 +152,11 @@ export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToo
           data-slot="dashboard-time-window-select"
           value={matched ? currentToken : ''}
           onChange={(event) => {
-            const preset = PRESETS.find((p) => p.token === event.target.value);
+            const next = ALL_PRESETS.find((p) => p.token === event.target.value);
             // Spread over the current window so an app-set `compareTo` /
             // `aggregation` survives a period change; the preset owns `period`
-            // and `kind` (History vs Realtime).
-            if (preset) setTimeWindow({ ...timeWindow, ...preset.window });
+            // and `kind`.
+            if (next) setTimeWindow({ ...timeWindow, ...next.window });
           }}
           className="rounded-md border bg-background px-2.5 py-1.5 text-sm"
         >
@@ -116,10 +165,14 @@ export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToo
               {t('Dashboard:TimeWindow.Custom', { defaultValue: 'Custom range' })}
             </option>
           )}
-          {PRESETS.map((preset) => (
-            <option key={preset.token} value={preset.token}>
-              {t(preset.labelKey, { defaultValue: preset.defaultLabel })}
-            </option>
+          {GROUPS.map((group) => (
+            <optgroup key={group.labelKey} label={t(group.labelKey, { defaultValue: group.defaultLabel })}>
+              {group.presets.map((p) => (
+                <option key={p.token} value={p.token}>
+                  {t(p.labelKey, { defaultValue: p.defaultLabel })}
+                </option>
+              ))}
+            </optgroup>
           ))}
         </select>
       </label>


### PR DESCRIPTION
## Context

Toward Grafana-style dashboard time controls. Expands the time-window selector from 6 presets to the full Grafana quick-range set (~28), grouped for a scannable dropdown.

## Changes

- **`DASHBOARD_TIME_WINDOW`** — full preset set, grouped: minutes/hours (`last_5m`…`last_24h`), days (`last_2d/7d/30d`), months/years (`last_3mo/6mo`, `last_1y/2y/5y`), relative days (`today`, `yesterday`, `day_before_yesterday`, `this_day_last_week`), to-date (`wtd/mtd/qtd/ytd`), previous complete periods (`pw/pm/pq/py`).
- **Drop `Realtime` kind** from presets — live cadence is becoming a **separate dashboard refresh control** (next PR), not a property of the window. `RealtimeLast5Minutes` → `Last5Minutes` (History).
- **`PeriodToken`** union extended with every new token.
- **`resolveTimeWindowToRenderRequest`** (bundle path) rewritten to **mirror the backend `PeriodResolver` exactly**: sub-day tokens end at `now`; day/calendar tokens are day-aligned through the end of today; month/year arithmetic **clamps like .NET `AddMonths`**. New `weekStartsOn` option (default Monday) for `wtd`/`pw`. *(This also fixes a day-alignment mismatch introduced in #898, where the front used rolling `now - Nd` instead of the backend's day-aligned bounds.)*
- **Selector** grouped into `<optgroup>`s with i18n labels (BI acronyms surfaced, e.g. "This month (MTD)").

## Cross-repo

The **token vocabulary is shared with the backend** `Granit.Analytics.PeriodResolver` (definition / inline-metric path), which resolves the same tokens server-side and throws on unknown ones. A companion granit-business change extends `PeriodResolver` with the identical semantics + a first-day-of-week setting (delegated). This PR covers the **bundle path** resolver; parity is locked by per-token tests.

## Verification

- `tsc --noEmit`: clean across dashboards, analytics, react-dashboards, react-dashboard-editor, react-ui-dashboards, react-analytics
- Vitest: **458 passing** (per-token resolver tests incl. week-start + AddMonths-clamping parity, toolbar, view/edit wiring); arch + contract tests **3798 passing**
- ESLint `--max-warnings 0`: clean

## Follow-up

- **Refresh control** (next PR): `Off / Auto / 5s…1d` + manual refresh button (Grafana parity).
- **Backend** (granit-business): `PeriodResolver` token expansion + first-day-of-week setting; `defaultTimeWindow` projection onto `DashboardDetailResponse`.
- Absolute-range calendar picker; time-shift arrows.