### PR TITLE
feat(dashboards): add a dashboard auto-refresh control (Grafana-style)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4868,6 +4868,17 @@
           "members": []
         },
         {
+          "name": "DashboardRefreshToolbar",
+          "kind": "function",
+          "signature": "function DashboardRefreshToolbar("
+        },
+        {
+          "name": "DashboardRefreshToolbarProps",
+          "kind": "interface",
+          "signature": "interface DashboardRefreshToolbarProps",
+          "members": []
+        },
+        {
           "name": "mergeFilterValuesIntoRequest",
           "kind": "function",
           "signature": "function mergeFilterValuesIntoRequest( request: DashboardRenderRequest, values: DashboardFilterValues | null | undefined ): DashboardRenderRequest"
@@ -4912,6 +4923,11 @@
           "name": "useEffectiveTimeWindow",
           "kind": "function",
           "signature": "function useEffectiveTimeWindow(override?: DashboardTimeWindow): DashboardTimeWindow"
+        },
+        {
+          "name": "useEffectiveRefreshInterval",
+          "kind": "function",
+          "signature": "function useEffectiveRefreshInterval( override?: DashboardRefreshInterval ): DashboardRefreshInterval"
         },
         {
           "name": "useWidgetTriggerHandler",

--- a/packages/@granit/dashboards/src/__tests__/dashboard-refresh-interval.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/dashboard-refresh-interval.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DASHBOARD_REFRESH_INTERVAL,
+  toRefetchInterval,
+} from '../types/dashboard-refresh-interval';
+
+describe('toRefetchInterval', () => {
+  it('disables refetching for "off"', () => {
+    expect(toRefetchInterval('off')).toBe(false);
+  });
+
+  it('defers to the query default for "auto"', () => {
+    expect(toRefetchInterval('auto')).toBeUndefined();
+  });
+
+  it('passes a fixed millisecond interval through', () => {
+    expect(toRefetchInterval(DASHBOARD_REFRESH_INTERVAL.Sec30)).toBe(30_000);
+    expect(toRefetchInterval(DASHBOARD_REFRESH_INTERVAL.Hour1)).toBe(3_600_000);
+  });
+
+  it('maps the preset sentinels', () => {
+    expect(DASHBOARD_REFRESH_INTERVAL.Off).toBe('off');
+    expect(DASHBOARD_REFRESH_INTERVAL.Auto).toBe('auto');
+    expect(DASHBOARD_REFRESH_INTERVAL.Day1).toBe(86_400_000);
+  });
+});

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -3,6 +3,7 @@
 // ---------------------------------------------------------------------------
 
 export {
+  DASHBOARD_REFRESH_INTERVAL,
   DASHBOARD_TIME_WINDOW,
   Datasource,
   DEFAULT_DASHBOARD_LAYOUT,
@@ -18,6 +19,7 @@ export {
   packWidgetCoordinates,
   parseDurationToMs,
   resolveWidgetCoordinates,
+  toRefetchInterval,
   WIDGET_SIZE,
 } from './types/index';
 export type {
@@ -34,6 +36,7 @@ export type {
   DashboardLayout,
   DashboardLayoutOverride,
   DashboardPeriod,
+  DashboardRefreshInterval,
   DashboardTimeWindow,
   DashboardView,
   DataKeyFormat,

--- a/packages/@granit/dashboards/src/types/dashboard-refresh-interval.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-refresh-interval.ts
@@ -1,0 +1,38 @@
+/**
+ * Dashboard auto-refresh cadence — the second top-of-dashboard control alongside
+ * the time window (Grafana's refresh picker). Decoupled from the time window's
+ * `kind`: liveness is now this setting, not a property of the range.
+ *
+ * - `'off'` — never auto-refetch.
+ * - `'auto'` — defer to each data source's natural cadence (a metric's
+ *   `RefreshHint`, the bundle's per-widget hint). This is the default.
+ * - a number — a fixed interval in milliseconds.
+ */
+export type DashboardRefreshInterval = 'off' | 'auto' | number;
+
+/** Grafana-style refresh options, in display order. Values are milliseconds. */
+export const DASHBOARD_REFRESH_INTERVAL = Object.freeze({
+  Off: 'off',
+  Auto: 'auto',
+  Sec5: 5_000,
+  Sec10: 10_000,
+  Sec30: 30_000,
+  Min1: 60_000,
+  Min5: 300_000,
+  Min15: 900_000,
+  Min30: 1_800_000,
+  Hour1: 3_600_000,
+  Hour2: 7_200_000,
+  Day1: 86_400_000,
+} satisfies Record<string, DashboardRefreshInterval>);
+
+/**
+ * Maps a {@link DashboardRefreshInterval} to a TanStack Query `refetchInterval`:
+ * `'off'` → `false` (disabled), `'auto'` → `undefined` (let the query keep its
+ * own default), a number → that number of milliseconds.
+ */
+export function toRefetchInterval(refresh: DashboardRefreshInterval): number | false | undefined {
+  if (refresh === 'off') return false;
+  if (refresh === 'auto') return undefined;
+  return refresh;
+}

--- a/packages/@granit/dashboards/src/types/index.ts
+++ b/packages/@granit/dashboards/src/types/index.ts
@@ -4,6 +4,8 @@ export type { ResolvedPeriod } from './resolved-period';
 export type { DataKeyFormat } from './data-key-format';
 export type { DashboardCategory } from './dashboard-category';
 export { DASHBOARD_TIME_WINDOW } from './dashboard-time-window';
+export { DASHBOARD_REFRESH_INTERVAL, toRefetchInterval } from './dashboard-refresh-interval';
+export type { DashboardRefreshInterval } from './dashboard-refresh-interval';
 export {
   Datasource,
   isMetricDatasource,

--- a/packages/@granit/react-analytics/src/components/kpi-tile.tsx
+++ b/packages/@granit/react-analytics/src/components/kpi-tile.tsx
@@ -1,5 +1,9 @@
-import { isMetricDatasource } from '@granit/dashboards';
-import { useEffectiveTimeWindow, useWidgetTriggerHandler } from '@granit/react-dashboards';
+import { isMetricDatasource, toRefetchInterval } from '@granit/dashboards';
+import {
+  useEffectiveRefreshInterval,
+  useEffectiveTimeWindow,
+  useWidgetTriggerHandler,
+} from '@granit/react-dashboards';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -56,7 +60,15 @@ export function KpiTile({ widget }: KpiTileProps) {
     [timeWindow, supportsPeriod]
   );
 
-  const query = useMetric(metricName, request, { enabled: metricName !== '' });
+  // Dashboard-level refresh cadence. `'auto'` maps to `undefined`, letting
+  // useMetric keep its `refreshHint`-derived polling; `'off'`/a fixed interval
+  // overrides it.
+  const refetchInterval = toRefetchInterval(useEffectiveRefreshInterval());
+
+  const query = useMetric(metricName, request, {
+    enabled: metricName !== '',
+    refetchInterval,
+  });
 
   // `Click` actions on the widget definition. Hook lives at the top
   // of the component (before any conditional return) so the rules-of-

--- a/packages/@granit/react-dashboard-editor/src/__tests__/editable-dashboard.test.tsx
+++ b/packages/@granit/react-dashboard-editor/src/__tests__/editable-dashboard.test.tsx
@@ -1,4 +1,6 @@
 import { defaultWidgetRegistry, WidgetRegistryProvider } from '@granit/react-dashboards';
+import { createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render } from '@testing-library/react';
 import i18n from 'i18next';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
@@ -24,7 +26,9 @@ void testI18n.use(initReactI18next).init({
 function wrap(node: ReactNode) {
   return render(
     <I18nextProvider i18n={testI18n}>
-      <WidgetRegistryProvider registries={[defaultWidgetRegistry]}>{node}</WidgetRegistryProvider>
+      <QueryClientProvider client={createTestQueryClient()}>
+        <WidgetRegistryProvider registries={[defaultWidgetRegistry]}>{node}</WidgetRegistryProvider>
+      </QueryClientProvider>
     </I18nextProvider>
   );
 }
@@ -85,6 +89,10 @@ describe('EditableDashboard — initial render', () => {
     expect(toolbar).toBeInTheDocument();
     // Seeded to Last 30 days (no default declared on the fixture).
     expect((toolbar?.querySelector('select') as HTMLSelectElement).value).toBe('last_30d');
+    // The refresh control mounts alongside the period selector.
+    expect(
+      container.querySelector('[data-slot="dashboard-refresh-toolbar"]')
+    ).toBeInTheDocument();
   });
 
   it('drives cell height from the row height (1-row widget = rowHeight px)', () => {

--- a/packages/@granit/react-dashboard-editor/src/components/editable-dashboard.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/editable-dashboard.tsx
@@ -1,9 +1,11 @@
 import { DASHBOARD_TIME_WINDOW } from '@granit/dashboards';
 import {
   DashboardContextProvider,
+  DashboardRefreshToolbar,
   DashboardTimeWindowToolbar,
   resolveEffectiveLayout,
   useDashboardBreakpoint,
+  useDashboardRefreshIntervalState,
   useDashboardTimeWindowState,
   WidgetRenderer,
 } from '@granit/react-dashboards';
@@ -90,6 +92,7 @@ export function EditableDashboard({
   const [timeWindow, setTimeWindow] = useDashboardTimeWindowState(
     definition.defaultTimeWindow ?? DASHBOARD_TIME_WINDOW.Last30Days
   );
+  const [refreshInterval, setRefreshInterval] = useDashboardRefreshIntervalState('auto');
 
   const { layout, widgets: orderedWidgets } = useMemo(
     () => resolveEffectiveLayout(definition.layout, definition.widgets, breakpoint),
@@ -130,7 +133,13 @@ export function EditableDashboard({
 
   return (
     <DashboardContextProvider
-      value={{ dashboardName: definition.name, timeWindow, setTimeWindow }}
+      value={{
+        dashboardName: definition.name,
+        timeWindow,
+        setTimeWindow,
+        refreshInterval,
+        setRefreshInterval,
+      }}
     >
       <div
         ref={wrapperRef}
@@ -140,7 +149,13 @@ export function EditableDashboard({
         className={className}
       >
         <GridStyles />
-        <DashboardTimeWindowToolbar className="mb-3" />
+        <div
+          data-slot="dashboard-controls"
+          className="mb-3 flex flex-wrap items-end justify-end gap-3"
+        >
+          <DashboardTimeWindowToolbar />
+          <DashboardRefreshToolbar />
+        </div>
         <GridLayout
           width={width || FALLBACK_WIDTH_PX}
           layout={gridLayout}

--- a/packages/@granit/react-dashboards/src/__tests__/dashboard-refresh-toolbar.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/dashboard-refresh-toolbar.test.tsx
@@ -1,0 +1,77 @@
+import { DASHBOARD_REFRESH_INTERVAL } from '@granit/dashboards';
+import { createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DashboardContextProvider } from '../components/dashboard-context';
+import { DashboardRefreshToolbar } from '../components/dashboard-refresh-toolbar';
+
+import type { DashboardRefreshInterval } from '@granit/dashboards';
+import type { ReactNode } from 'react';
+
+function withQuery(node: ReactNode) {
+  return (
+    <QueryClientProvider client={createTestQueryClient()}>{node}</QueryClientProvider>
+  );
+}
+
+function Harness({
+  initial = DASHBOARD_REFRESH_INTERVAL.Auto,
+  onChange,
+  onRefresh,
+}: {
+  readonly initial?: DashboardRefreshInterval;
+  readonly onChange?: (v: DashboardRefreshInterval | undefined) => void;
+  readonly onRefresh?: () => void;
+}) {
+  const [refreshInterval, setLocal] = useState<DashboardRefreshInterval | undefined>(initial);
+  return (
+    <DashboardContextProvider
+      value={{
+        dashboardName: 'Test',
+        refreshInterval,
+        setRefreshInterval: (next) => {
+          const resolved = typeof next === 'function' ? next(refreshInterval) : next;
+          setLocal(resolved);
+          onChange?.(resolved);
+        },
+      }}
+    >
+      <DashboardRefreshToolbar onRefresh={onRefresh} />
+    </DashboardContextProvider>
+  );
+}
+
+describe('DashboardRefreshToolbar', () => {
+  it('renders nothing when the cadence is read-only (no setter)', () => {
+    const { container } = render(
+      withQuery(
+        <DashboardContextProvider value={{ dashboardName: 'Test', refreshInterval: 'auto' }}>
+          <DashboardRefreshToolbar />
+        </DashboardContextProvider>
+      )
+    );
+    expect(container.querySelector('[data-slot="dashboard-refresh-toolbar"]')).toBeNull();
+  });
+
+  it('selects the active cadence', () => {
+    render(withQuery(<Harness initial={DASHBOARD_REFRESH_INTERVAL.Sec30} />));
+    expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('30000');
+  });
+
+  it('propagates a chosen cadence through setRefreshInterval', () => {
+    const onChange = vi.fn();
+    render(withQuery(<Harness onChange={onChange} />));
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '60000' } });
+    expect(onChange).toHaveBeenCalledWith(60_000);
+  });
+
+  it('fires the manual refresh handler', () => {
+    const onRefresh = vi.fn();
+    render(withQuery(<Harness onRefresh={onRefresh} />));
+    fireEvent.click(screen.getByRole('button'));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/@granit/react-dashboards/src/__tests__/dashboard.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/dashboard.test.tsx
@@ -1,3 +1,5 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import i18n from 'i18next';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
@@ -37,9 +39,11 @@ void testI18n.use(initReactI18next).init({
 function renderDashboard(definition: DashboardDefinition) {
   return render(
     <I18nextProvider i18n={testI18n}>
-      <WidgetRegistryProvider registries={[defaultWidgetRegistry]}>
-        <Dashboard definition={definition} />
-      </WidgetRegistryProvider>
+      <QueryClientProvider client={createTestQueryClient()}>
+        <WidgetRegistryProvider registries={[defaultWidgetRegistry]}>
+          <Dashboard definition={definition} />
+        </WidgetRegistryProvider>
+      </QueryClientProvider>
     </I18nextProvider>
   );
 }

--- a/packages/@granit/react-dashboards/src/components/dashboard-context.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-context.tsx
@@ -8,7 +8,7 @@ import {
   type SetStateAction,
 } from 'react';
 
-import type { DashboardTimeWindow } from '@granit/dashboards';
+import type { DashboardRefreshInterval, DashboardTimeWindow } from '@granit/dashboards';
 
 /**
  * Read-only ambient context for a rendered dashboard. Surfaces the dashboard
@@ -32,6 +32,16 @@ export interface DashboardContextValue {
    * embedded / preview / printable dashboards.
    */
   readonly setTimeWindow?: Dispatch<SetStateAction<DashboardTimeWindow | undefined>>;
+  /**
+   * Active auto-refresh cadence. When omitted, data sources keep their own
+   * default cadence (equivalent to `'auto'`).
+   */
+  readonly refreshInterval?: DashboardRefreshInterval;
+  /**
+   * Setter the refresh control binds to. When omitted the cadence is read-only
+   * (no refresh control shown).
+   */
+  readonly setRefreshInterval?: Dispatch<SetStateAction<DashboardRefreshInterval | undefined>>;
 }
 
 const DashboardContext = createContext<DashboardContextValue | null>(null);
@@ -46,7 +56,13 @@ export function DashboardContextProvider({ value, children }: DashboardContextPr
     () => value,
     // Identity-stable on the primitive fields; the setter is assumed stable
     // (typically returned from useState).
-    [value.dashboardName, value.timeWindow, value.setTimeWindow]
+    [
+      value.dashboardName,
+      value.timeWindow,
+      value.setTimeWindow,
+      value.refreshInterval,
+      value.setRefreshInterval,
+    ]
   );
   return <DashboardContext.Provider value={memoised}>{children}</DashboardContext.Provider>;
 }
@@ -81,4 +97,13 @@ export function useDashboardContext(): DashboardContextValue | null {
  */
 export function useDashboardTimeWindowState(initial?: DashboardTimeWindow) {
   return useState<DashboardTimeWindow | undefined>(initial);
+}
+
+/**
+ * State hook for the dashboard's auto-refresh cadence — mirrors
+ * {@link useDashboardTimeWindowState}. Exposes a `[refreshInterval,
+ * setRefreshInterval]` pair the refresh control binds to.
+ */
+export function useDashboardRefreshIntervalState(initial?: DashboardRefreshInterval) {
+  return useState<DashboardRefreshInterval | undefined>(initial);
 }

--- a/packages/@granit/react-dashboards/src/components/dashboard-refresh-toolbar.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-refresh-toolbar.tsx
@@ -1,0 +1,111 @@
+import { DASHBOARD_REFRESH_INTERVAL } from '@granit/dashboards';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+
+import { useDashboardContext } from './dashboard-context';
+
+import type { DashboardRefreshInterval } from '@granit/dashboards';
+
+interface RefreshOption {
+  readonly value: DashboardRefreshInterval;
+  readonly labelKey: string;
+  readonly defaultLabel: string;
+}
+
+const R = DASHBOARD_REFRESH_INTERVAL;
+
+/** Grafana-style refresh cadences, in display order. */
+const OPTIONS: readonly RefreshOption[] = [
+  { value: R.Off, labelKey: 'Dashboard:Refresh.Off', defaultLabel: 'Off' },
+  { value: R.Auto, labelKey: 'Dashboard:Refresh.Auto', defaultLabel: 'Auto' },
+  { value: R.Sec5, labelKey: 'Dashboard:Refresh.Sec5', defaultLabel: '5s' },
+  { value: R.Sec10, labelKey: 'Dashboard:Refresh.Sec10', defaultLabel: '10s' },
+  { value: R.Sec30, labelKey: 'Dashboard:Refresh.Sec30', defaultLabel: '30s' },
+  { value: R.Min1, labelKey: 'Dashboard:Refresh.Min1', defaultLabel: '1m' },
+  { value: R.Min5, labelKey: 'Dashboard:Refresh.Min5', defaultLabel: '5m' },
+  { value: R.Min15, labelKey: 'Dashboard:Refresh.Min15', defaultLabel: '15m' },
+  { value: R.Min30, labelKey: 'Dashboard:Refresh.Min30', defaultLabel: '30m' },
+  { value: R.Hour1, labelKey: 'Dashboard:Refresh.Hour1', defaultLabel: '1h' },
+  { value: R.Hour2, labelKey: 'Dashboard:Refresh.Hour2', defaultLabel: '2h' },
+  { value: R.Day1, labelKey: 'Dashboard:Refresh.Day1', defaultLabel: '1d' },
+];
+
+export interface DashboardRefreshToolbarProps {
+  readonly className?: string;
+  /**
+   * Manual "refresh now" handler. Defaults to invalidating every active query
+   * (Grafana re-runs all panel queries), which refetches the dashboard bundle,
+   * KPI metrics and grids at once. Apps that want to scope the invalidation
+   * pass their own.
+   */
+  readonly onRefresh?: () => void;
+}
+
+/**
+ * Top-of-dashboard auto-refresh control (Grafana's refresh picker): a cadence
+ * dropdown plus a manual "refresh now" button. Reads / writes the surrounding
+ * {@link DashboardContextProvider}; the cadence propagates through context to
+ * every data-bound widget via {@link useEffectiveRefreshInterval}.
+ *
+ * Renders nothing when the cadence is read-only (`context.setRefreshInterval`
+ * absent — embedded / preview / printable dashboards), so apps mount it
+ * unconditionally.
+ */
+export function DashboardRefreshToolbar({ className, onRefresh }: DashboardRefreshToolbarProps) {
+  const { t } = useTranslation();
+  const ctx = useDashboardContext();
+  const queryClient = useQueryClient();
+
+  const refreshNow =
+    onRefresh ??
+    (() => {
+      void queryClient.invalidateQueries();
+    });
+
+  if (!ctx?.setRefreshInterval) return null;
+
+  const { refreshInterval = 'auto', setRefreshInterval } = ctx;
+
+  return (
+    <div
+      data-slot="dashboard-refresh-toolbar"
+      role="toolbar"
+      aria-label="Dashboard refresh"
+      className={joinClasses('flex items-end gap-2', className)}
+    >
+      <button
+        type="button"
+        data-slot="dashboard-refresh-now"
+        aria-label={t('Dashboard:Refresh.Now', { defaultValue: 'Refresh now' })}
+        onClick={refreshNow}
+        className="rounded-md border bg-background px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+      >
+        <span aria-hidden>↻</span>
+      </button>
+      <label className="flex flex-col gap-1 text-xs">
+        <span data-slot="dashboard-refresh-label" className="text-muted-foreground">
+          {t('Dashboard:Refresh.Label', { defaultValue: 'Refresh' })}
+        </span>
+        <select
+          data-slot="dashboard-refresh-select"
+          value={String(refreshInterval)}
+          onChange={(event) => {
+            const option = OPTIONS.find((o) => String(o.value) === event.target.value);
+            if (option) setRefreshInterval(option.value);
+          }}
+          className="rounded-md border bg-background px-2.5 py-1.5 text-sm"
+        >
+          {OPTIONS.map((option) => (
+            <option key={String(option.value)} value={String(option.value)}>
+              {t(option.labelKey, { defaultValue: option.defaultLabel })}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}
+
+function joinClasses(...parts: ReadonlyArray<string | undefined>): string {
+  return parts.filter(Boolean).join(' ');
+}

--- a/packages/@granit/react-dashboards/src/components/dashboard.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard.tsx
@@ -4,7 +4,12 @@ import { useDashboardBreakpoint } from '../hooks/use-dashboard-breakpoint';
 import { resolveActiveView } from '../lib/resolve-active-view';
 import { resolveEffectiveLayout } from '../lib/resolve-effective-layout';
 
-import { DashboardContextProvider, useDashboardTimeWindowState } from './dashboard-context';
+import {
+  DashboardContextProvider,
+  useDashboardRefreshIntervalState,
+  useDashboardTimeWindowState,
+} from './dashboard-context';
+import { DashboardRefreshToolbar } from './dashboard-refresh-toolbar';
 import { DashboardTimeWindowToolbar } from './dashboard-time-window-toolbar';
 import { DashboardViewProvider } from './dashboard-view-context';
 import { WidgetRenderer } from './widget-renderer';
@@ -85,6 +90,7 @@ export function Dashboard({
   const [timeWindow, setTimeWindow] = useDashboardTimeWindowState(
     definition.defaultTimeWindow ?? undefined
   );
+  const [refreshInterval, setRefreshInterval] = useDashboardRefreshIntervalState('auto');
 
   const breakpoint = useDashboardBreakpoint();
 
@@ -117,9 +123,25 @@ export function Dashboard({
   };
 
   return (
-    <DashboardContextProvider value={{ dashboardName: definition.name, timeWindow, setTimeWindow }}>
+    <DashboardContextProvider
+      value={{
+        dashboardName: definition.name,
+        timeWindow,
+        setTimeWindow,
+        refreshInterval,
+        setRefreshInterval,
+      }}
+    >
       <DashboardViewProvider value={{ currentView: resolvedView, setCurrentView: setView }}>
-        {timeWindow && <DashboardTimeWindowToolbar />}
+        {timeWindow && (
+          <div
+            data-slot="dashboard-controls"
+            className="mb-3 flex flex-wrap items-end justify-end gap-3"
+          >
+            <DashboardTimeWindowToolbar />
+            <DashboardRefreshToolbar />
+          </div>
+        )}
         <div
           data-slot="dashboard"
           data-dashboard-name={definition.name}

--- a/packages/@granit/react-dashboards/src/hooks/use-effective-refresh-interval.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-effective-refresh-interval.ts
@@ -1,0 +1,20 @@
+import { useDashboardContext } from '../components/dashboard-context';
+
+import type { DashboardRefreshInterval } from '@granit/dashboards';
+
+/**
+ * Resolves the auto-refresh cadence in effect for the calling widget. Cascade:
+ *
+ * 1. Explicit `override` passed by the caller.
+ * 2. The active dashboard cadence from {@link useDashboardContext}.
+ * 3. `'auto'` — each data source keeps its own natural cadence.
+ *
+ * Always returns a defined {@link DashboardRefreshInterval}; pair with
+ * `toRefetchInterval` to feed a TanStack Query `refetchInterval`.
+ */
+export function useEffectiveRefreshInterval(
+  override?: DashboardRefreshInterval
+): DashboardRefreshInterval {
+  const context = useDashboardContext();
+  return override ?? context?.refreshInterval ?? 'auto';
+}

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -72,6 +72,7 @@ export type { DashboardProps } from './components/dashboard';
 export {
   DashboardContextProvider,
   useDashboardContext,
+  useDashboardRefreshIntervalState,
   useDashboardTimeWindowState,
 } from './components/dashboard-context';
 export type {
@@ -100,6 +101,8 @@ export { DashboardFilterToolbar } from './components/dashboard-filter-toolbar';
 export type { DashboardFilterToolbarProps } from './components/dashboard-filter-toolbar';
 export { DashboardTimeWindowToolbar } from './components/dashboard-time-window-toolbar';
 export type { DashboardTimeWindowToolbarProps } from './components/dashboard-time-window-toolbar';
+export { DashboardRefreshToolbar } from './components/dashboard-refresh-toolbar';
+export type { DashboardRefreshToolbarProps } from './components/dashboard-refresh-toolbar';
 export { mergeFilterValuesIntoRequest } from './lib/merge-filter-values';
 
 // Entity alias runtime (P2.3) — resolution context, provider, helpers
@@ -139,6 +142,7 @@ export type {
   WidgetActionHandlerRegistry,
 } from './lib/widget-action-handler';
 export { useEffectiveTimeWindow } from './hooks/use-effective-time-window';
+export { useEffectiveRefreshInterval } from './hooks/use-effective-refresh-interval';
 export { useWidgetTriggerHandler } from './hooks/use-widget-trigger-handler';
 export {
   DASHBOARD_BREAKPOINT_MIN_WIDTH,

--- a/packages/@granit/react-ui-dashboards/src/__tests__/dashboard-view-page.test.tsx
+++ b/packages/@granit/react-ui-dashboards/src/__tests__/dashboard-view-page.test.tsx
@@ -50,11 +50,13 @@ vi.mock('@granit/react-dashboards', () => ({
       data-period-token={request?.periodToken}
     />
   ),
-  // Context + selector are covered by their own suites; here they only need to
+  // Context + selectors are covered by their own suites; here they only need to
   // mount so the view page's wiring renders.
   DashboardContextProvider: ({ children }: { readonly children: React.ReactNode }) => children,
   DashboardTimeWindowToolbar: () => <div data-slot="dashboard-time-window-toolbar" />,
+  DashboardRefreshToolbar: () => <div data-slot="dashboard-refresh-toolbar" />,
   useDashboardTimeWindowState: <T,>(initial: T) => [initial, vi.fn()] as const,
+  useDashboardRefreshIntervalState: <T,>(initial: T) => [initial, vi.fn()] as const,
 }));
 
 describe('DashboardViewPage', () => {
@@ -73,6 +75,9 @@ describe('DashboardViewPage', () => {
 
     expect(
       document.querySelector('[data-slot="dashboard-time-window-toolbar"]')
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-slot="dashboard-refresh-toolbar"]')
     ).toBeInTheDocument();
     // Seeded to Last 30 days → the render request echoes that token.
     expect(

--- a/packages/@granit/react-ui-dashboards/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-ui-dashboards/src/__tests__/test-utils.tsx
@@ -1,3 +1,5 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import i18next from 'i18next';
@@ -52,7 +54,9 @@ export function renderDashboards(ui: ReactElement) {
     ...render(ui, {
       wrapper: ({ children }: { readonly children: ReactNode }) => (
         <I18nextProvider i18n={testI18n}>
-          <MemoryRouter>{children}</MemoryRouter>
+          <QueryClientProvider client={createTestQueryClient()}>
+            <MemoryRouter>{children}</MemoryRouter>
+          </QueryClientProvider>
         </I18nextProvider>
       ),
     }),

--- a/packages/@granit/react-ui-dashboards/src/components/dashboard-view-page.tsx
+++ b/packages/@granit/react-ui-dashboards/src/components/dashboard-view-page.tsx
@@ -1,9 +1,15 @@
-import { DASHBOARD_TIME_WINDOW, resolveTimeWindowToRenderRequest } from '@granit/dashboards';
+import {
+  DASHBOARD_TIME_WINDOW,
+  resolveTimeWindowToRenderRequest,
+  toRefetchInterval,
+} from '@granit/dashboards';
 import {
   DashboardContextProvider,
+  DashboardRefreshToolbar,
   DashboardTimeWindowToolbar,
   RenderedDashboard,
   useDashboardDetail,
+  useDashboardRefreshIntervalState,
   useDashboardTimeWindowState,
 } from '@granit/react-dashboards';
 import { useTranslation } from '@granit/react-localization';
@@ -50,6 +56,13 @@ export function DashboardViewPage() {
     [timeWindow]
   );
 
+  // Auto-refresh cadence, bridged to the bundle query's refetch interval.
+  const [refreshInterval, setRefreshInterval] = useDashboardRefreshIntervalState('auto');
+  const renderOptions = useMemo(
+    () => ({ refetchInterval: toRefetchInterval(refreshInterval ?? 'auto') }),
+    [refreshInterval]
+  );
+
   if (isLoading) {
     return (
       <div className="flex h-64 items-center justify-center">
@@ -87,7 +100,7 @@ export function DashboardViewPage() {
 
   return (
     <DashboardContextProvider
-      value={{ dashboardName: detail.name, timeWindow, setTimeWindow }}
+      value={{ dashboardName: detail.name, timeWindow, setTimeWindow, refreshInterval, setRefreshInterval }}
     >
       <div
         data-slot="dashboard-view-page"
@@ -111,6 +124,7 @@ export function DashboardViewPage() {
           </div>
           <div className="flex items-end gap-3">
             <DashboardTimeWindowToolbar />
+            <DashboardRefreshToolbar />
             <Button
               data-slot="dashboard-view-edit-toggle"
               variant="outline"
@@ -126,6 +140,7 @@ export function DashboardViewPage() {
         <RenderedDashboard
           dashboardId={dashboardId}
           request={renderRequest}
+          options={renderOptions}
           columns={detail.layoutColumns}
           rowHeight={detail.layoutRowHeight}
         />


### PR DESCRIPTION
## Context

Toward Grafana-style dashboard time controls. Adds the **second** top-of-dashboard control alongside the time-window selector: an auto-refresh cadence picker plus a manual "refresh now" button. Liveness is now this dedicated setting rather than a property of the time window's `kind` (companion PR #899 drops `kind: 'Realtime'` from the presets).

## Changes

- **`@granit/dashboards`**: `DashboardRefreshInterval` (`'off' | 'auto' | ms`) + `DASHBOARD_REFRESH_INTERVAL` presets (`Off / Auto / 5s / 10s / 30s / 1m / 5m / 15m / 30m / 1h / 2h / 1d`) + `toRefetchInterval()` mapping to a TanStack Query `refetchInterval` (`'off'`→`false`, `'auto'`→`undefined` = keep the query's own cadence, ms→ms).
- **`DashboardContext`** gains `refreshInterval` + `setRefreshInterval`; `useDashboardRefreshIntervalState` + `useEffectiveRefreshInterval` mirror the time-window hooks.
- **`DashboardRefreshToolbar`**: a cadence `<select>` + a manual refresh button. Manual refresh invalidates **every active query** by default (Grafana re-runs all panels — the query-engine grids use app-configured key prefixes, so there's no single root to scope to); overridable via an `onRefresh` prop.
- **Wired into all three surfaces** next to the period selector — `Dashboard`, `EditableDashboard` (edit mode), `DashboardViewPage` (view mode). Propagation mirrors the time window: definition path via context (`KpiTile` → `useMetric` `refetchInterval`), bundle path bridged to `RenderedDashboard`'s `options.refetchInterval`.

## Verification

- `tsc --noEmit`: clean across dashboards, react-dashboards, react-dashboard-editor, react-ui-dashboards, react-analytics
- Vitest: **3665 passing** (incl. arch-tests) — new `toRefetchInterval` mapping test, `DashboardRefreshToolbar` (select/change/manual-refresh/read-only-null), refresh-toolbar presence across surfaces
- ESLint `--max-warnings 0`: clean

## Notes

- Independent of the tokens PR #899 (different files); either merge order is fine.
- `'auto'` intentionally defers to each source's natural cadence (a metric's `RefreshHint`, the bundle's per-widget hint) — no behavior change unless the user picks a fixed interval or Off.

## Follow-up

- Backend `defaultTimeWindow` projection (granit-business); absolute-range calendar picker; time-shift arrows.