### PR TITLE
feat(dashboards): seed the dashboard time window from its persisted default

### DIFF
--- a/contracts/openapi/dashboards.json
+++ b/contracts/openapi/dashboards.json
@@ -1198,6 +1198,7 @@
           "sourceDefinitionVersion",
           "layoutColumns",
           "layoutRowHeight",
+          "defaultTimeWindow",
           "widgets"
         ],
         "type": "object",
@@ -1231,6 +1232,16 @@
           "layoutRowHeight": {
             "type": "integer",
             "format": "int32"
+          },
+          "defaultTimeWindow": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DashboardTimeWindow"
+              }
+            ]
           },
           "widgets": {
             "type": "array",
@@ -1297,6 +1308,16 @@
             "exclusiveMinimum": 0,
             "type": "integer",
             "format": "int32"
+          },
+          "defaultTimeWindow": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DashboardTimeWindow"
+              }
+            ]
           }
         }
       },
@@ -1579,6 +1600,32 @@
           }
         }
       },
+      "DashboardTimeWindow": {
+        "required": ["period"],
+        "type": "object",
+        "properties": {
+          "period": {
+            "$ref": "#/components/schemas/PeriodSpec"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/TimeWindowKind"
+          },
+          "compareTo": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PeriodSpec"
+              }
+            ]
+          },
+          "aggregation": {
+            "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$",
+            "type": ["null", "string"]
+          }
+        }
+      },
       "HttpValidationProblemDetails": {
         "type": "object",
         "properties": {
@@ -1637,6 +1684,22 @@
           }
         }
       },
+      "PeriodSpec": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "to": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "token": {
+            "type": ["null", "string"]
+          }
+        }
+      },
       "ProblemDetails": {
         "type": "object",
         "properties": {
@@ -1664,6 +1727,10 @@
       },
       "RefreshHint": {
         "enum": ["Static", "Dynamic", "Realtime"]
+      },
+      "TimeWindowKind": {
+        "enum": ["History", "Realtime"],
+        "default": "History"
       },
       "UpdateWidgetRequest": {
         "required": ["x", "y", "width", "height", "titleLocalizationKey", "configJson"],
@@ -1710,6 +1777,7 @@
             "$ref": "#/components/schemas/WidgetActionKind"
           },
           "target": {
+            "maxLength": 256,
             "type": "string"
           },
           "params": {

--- a/packages/@granit/dashboards/src/__tests__/dashboards-api.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/dashboards-api.test.ts
@@ -48,6 +48,7 @@ const DETAIL: DashboardDetailResponse = {
   ...SUMMARY,
   layoutColumns: 12,
   layoutRowHeight: 80,
+  defaultTimeWindow: null,
   widgets: [],
 };
 

--- a/packages/@granit/dashboards/src/types/__tests__/widget-bridge.test.ts
+++ b/packages/@granit/dashboards/src/types/__tests__/widget-bridge.test.ts
@@ -195,6 +195,7 @@ describe('dashboardDetailToDefinition', () => {
       sourceDefinitionVersion: '1.2.3',
       layoutColumns: 12,
       layoutRowHeight: 80,
+      defaultTimeWindow: { period: { token: 'last_7d' }, kind: 'History' },
       widgets: [
         {
           id: WIDGET_ID,
@@ -215,6 +216,7 @@ describe('dashboardDetailToDefinition', () => {
     expect(definition.name).toBe(DASHBOARD_NAME);
     expect(definition.version).toBe('1.2.3');
     expect(definition.layout).toEqual({ columns: 12, rowHeight: 80 });
+    expect(definition.defaultTimeWindow).toEqual({ period: { token: 'last_7d' }, kind: 'History' });
     expect(definition.widgets).toHaveLength(1);
     expect(definition.widgets[0]?.slug).toBe('Banner');
   });
@@ -230,6 +232,7 @@ describe('dashboardDetailToDefinition', () => {
       sourceDefinitionVersion: null,
       layoutColumns: 12,
       layoutRowHeight: 80,
+      defaultTimeWindow: null,
       widgets: [],
     };
     expect(dashboardDetailToDefinition(detail).version).toBe('1.0.0');

--- a/packages/@granit/dashboards/src/types/dashboard-detail-response.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-detail-response.ts
@@ -1,4 +1,5 @@
 import type { DashboardStatus } from './dashboard-status';
+import type { DashboardTimeWindow } from './dashboard-time-window';
 import type { WidgetInstanceResponse } from './widget-instance-response';
 import type { DashboardCategory } from '../types/dashboard-category';
 
@@ -21,6 +22,11 @@ export interface DashboardDetailResponse {
   readonly layoutColumns: number;
   /** Grid row height in CSS pixels at the base viewport. */
   readonly layoutRowHeight: number;
+  /**
+   * Default time window seeding the top-of-dashboard time-range control. `null`
+   * leaves the range to the frontend's global default (Last 30 days).
+   */
+  readonly defaultTimeWindow: DashboardTimeWindow | null;
   /** Widgets pinned on the dashboard, ordered by grid coordinate (y, then x). */
   readonly widgets: readonly WidgetInstanceResponse[];
 }

--- a/packages/@granit/dashboards/src/types/widget-bridge.ts
+++ b/packages/@granit/dashboards/src/types/widget-bridge.ts
@@ -234,6 +234,7 @@ export function dashboardDetailToDefinition(detail: DashboardDetailResponse): Da
     isSystem: detail.isSystem,
     version: detail.sourceDefinitionVersion ?? '1.0.0',
     layout: { columns: detail.layoutColumns, rowHeight: detail.layoutRowHeight },
+    defaultTimeWindow: detail.defaultTimeWindow,
     widgets: detail.widgets.map((w) => widgetInstanceToDefinition(w, detail.name)),
   };
 }

--- a/packages/@granit/react-dashboards/src/__tests__/use-dashboard-crud.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-dashboard-crud.test.tsx
@@ -51,6 +51,7 @@ const DETAIL: DashboardDetailResponse = {
   ...SUMMARY,
   layoutColumns: 12,
   layoutRowHeight: 80,
+  defaultTimeWindow: null,
   widgets: [],
 };
 

--- a/packages/@granit/react-dashboards/src/testing/data.ts
+++ b/packages/@granit/react-dashboards/src/testing/data.ts
@@ -489,6 +489,7 @@ function seedStoredDashboard(
     sourceDefinitionVersion: definition.version,
     layoutColumns: definition.layout.columns,
     layoutRowHeight: definition.layout.rowHeight,
+    defaultTimeWindow: definition.defaultTimeWindow ?? null,
     widgets: definition.widgets.map((widget, index) => {
       // Derive the persisted shape through the write-direction bridge so the
       // mock's `configJson` / `metricName` / `queryName` are byte-compatible

--- a/packages/@granit/react-dashboards/src/testing/handlers.ts
+++ b/packages/@granit/react-dashboards/src/testing/handlers.ts
@@ -339,6 +339,7 @@ export function createDashboardsHandlers(baseUrl = DEFAULT_BASE_PATH) {
         sourceDefinitionVersion: entry.version,
         layoutColumns: 12,
         layoutRowHeight: 80,
+        defaultTimeWindow: null,
         widgets: [],
       };
       store.set(id, stored);

--- a/packages/@granit/react-ui-dashboards/src/__tests__/dashboard-edit-page-validation.test.tsx
+++ b/packages/@granit/react-ui-dashboards/src/__tests__/dashboard-edit-page-validation.test.tsx
@@ -35,6 +35,7 @@ vi.mock('@granit/react-dashboards', async (importOriginal) => {
         sourceDefinitionVersion: '1.0.0',
         layoutColumns: 12,
         layoutRowHeight: 80,
+        defaultTimeWindow: null,
         widgets: [
           {
             id: '8c6b1e10-0000-0000-0000-000000000020',

--- a/packages/@granit/react-ui-dashboards/src/__tests__/dashboard-edit-page.test.tsx
+++ b/packages/@granit/react-ui-dashboards/src/__tests__/dashboard-edit-page.test.tsx
@@ -33,6 +33,7 @@ vi.mock('@granit/react-dashboards', async (importOriginal) => {
         sourceDefinitionVersion: '1.0.0',
         layoutColumns: 12,
         layoutRowHeight: 80,
+        defaultTimeWindow: null,
         widgets: [
           {
             id: '8c6b1e10-0000-0000-0000-000000000010',

--- a/packages/@granit/react-ui-dashboards/src/__tests__/dashboard-view-page.test.tsx
+++ b/packages/@granit/react-ui-dashboards/src/__tests__/dashboard-view-page.test.tsx
@@ -30,6 +30,7 @@ const detail = {
   status: 'Published',
   layoutColumns: 12,
   layoutRowHeight: 80,
+  defaultTimeWindow: null,
   widgets: [],
 };
 
@@ -79,10 +80,22 @@ describe('DashboardViewPage', () => {
     expect(
       document.querySelector('[data-slot="dashboard-refresh-toolbar"]')
     ).toBeInTheDocument();
-    // Seeded to Last 30 days → the render request echoes that token.
+    // No declared default → falls back to Last 30 days.
     expect(
       document.querySelector('[data-slot="rendered-dashboard"]')?.getAttribute('data-period-token')
     ).toBe('last_30d');
+  });
+
+  it('seeds the time window from the dashboard\'s persisted default', () => {
+    useDashboardDetail.mockReturnValue({
+      data: { ...detail, defaultTimeWindow: { period: { token: 'last_7d' }, kind: 'History' } },
+      isLoading: false,
+    });
+    renderDashboards(<DashboardViewPage />);
+
+    expect(
+      document.querySelector('[data-slot="rendered-dashboard"]')?.getAttribute('data-period-token')
+    ).toBe('last_7d');
   });
 
   it('shows the status badge for the persisted dashboard', () => {

--- a/packages/@granit/react-ui-dashboards/src/components/dashboard-view-page.tsx
+++ b/packages/@granit/react-ui-dashboards/src/components/dashboard-view-page.tsx
@@ -22,6 +22,8 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { DashboardComposer } from './dashboard-composer';
 import { StatusBadge } from './dashboard-status-badge';
 
+import type { DashboardDetailResponse } from '@granit/dashboards';
+
 /**
  * Single-dashboard page with an **inline edit toggle** (Grafana/luzmo style).
  *
@@ -45,23 +47,6 @@ export function DashboardViewPage() {
 
   const dashboardId = decodeURIComponent(id);
   const { data: detail, isLoading } = useDashboardDetail(dashboardId);
-
-  // Active render window. The bundle path needs absolute bounds, so the chosen
-  // window is resolved to `periodFrom` / `periodTo` and fed to the render
-  // request — changing it re-fetches the bundle. Seeded to Last 30 days until
-  // the backend surfaces the dashboard's declared default on the detail payload.
-  const [timeWindow, setTimeWindow] = useDashboardTimeWindowState(DASHBOARD_TIME_WINDOW.Last30Days);
-  const renderRequest = useMemo(
-    () => (timeWindow ? resolveTimeWindowToRenderRequest(timeWindow) : undefined),
-    [timeWindow]
-  );
-
-  // Auto-refresh cadence, bridged to the bundle query's refetch interval.
-  const [refreshInterval, setRefreshInterval] = useDashboardRefreshIntervalState('auto');
-  const renderOptions = useMemo(
-    () => ({ refetchInterval: toRefetchInterval(refreshInterval ?? 'auto') }),
-    [refreshInterval]
-  );
 
   if (isLoading) {
     return (
@@ -98,6 +83,43 @@ export function DashboardViewPage() {
     );
   }
 
+  // Content is mounted only once `detail` has loaded, so its time-window /
+  // refresh state can seed from the dashboard's persisted default on first
+  // render (a `useState` initialiser cannot pick it up during the loading pass).
+  return (
+    <DashboardViewContent detail={detail} dashboardId={dashboardId} onEdit={() => setEditing(true)} />
+  );
+}
+
+interface DashboardViewContentProps {
+  readonly detail: DashboardDetailResponse;
+  readonly dashboardId: string;
+  readonly onEdit: () => void;
+}
+
+function DashboardViewContent({ detail, dashboardId, onEdit }: DashboardViewContentProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  // Active render window. Seeded from the dashboard's persisted default,
+  // falling back to Last 30 days. The bundle path needs absolute bounds, so the
+  // window is resolved to `periodFrom` / `periodTo` and fed to the render
+  // request — changing it re-fetches the bundle.
+  const [timeWindow, setTimeWindow] = useDashboardTimeWindowState(
+    detail.defaultTimeWindow ?? DASHBOARD_TIME_WINDOW.Last30Days
+  );
+  const renderRequest = useMemo(
+    () => (timeWindow ? resolveTimeWindowToRenderRequest(timeWindow) : undefined),
+    [timeWindow]
+  );
+
+  // Auto-refresh cadence, bridged to the bundle query's refetch interval.
+  const [refreshInterval, setRefreshInterval] = useDashboardRefreshIntervalState('auto');
+  const renderOptions = useMemo(
+    () => ({ refetchInterval: toRefetchInterval(refreshInterval ?? 'auto') }),
+    [refreshInterval]
+  );
+
   return (
     <DashboardContextProvider
       value={{ dashboardName: detail.name, timeWindow, setTimeWindow, refreshInterval, setRefreshInterval }}
@@ -129,7 +151,7 @@ export function DashboardViewPage() {
               data-slot="dashboard-view-edit-toggle"
               variant="outline"
               size="sm"
-              onClick={() => setEditing(true)}
+              onClick={onEdit}
             >
               <Pencil className="mr-2 h-4 w-4" />
               {t('Common.Edit', { defaultValue: 'Edit' })}


### PR DESCRIPTION
## Context

Completes the time-window feature now that granit-business surfaces the dashboard's configured **default time window** on the detail payload. Previously the front always hardcoded `Last30Days`; now it honors the persisted default (falling back to `Last30Days` when none is set).

## Changes

- **`DashboardDetailResponse`** mirrors the backend's new `defaultTimeWindow` (`DashboardTimeWindow | null`). OpenAPI snapshot (`dashboards.json`) resynced from the backend generator — the `@granit/contract-tests` oracle is green.
- **`dashboardDetailToDefinition`** carries `defaultTimeWindow` into the `DashboardDefinition`, so the editor's `EditableDashboard` (which already seeds from `definition.defaultTimeWindow ?? Last30Days`) previews at the configured default.
- **`DashboardViewPage`** — extracted the loaded content into a `DashboardViewContent` child mounted only once `detail` resolves, so its time-window state can seed from `detail.defaultTimeWindow ?? Last30Days` on first render (a `useState` initialiser can't pick it up during the loading pass).

## Verification

- `tsc --noEmit`: clean across dashboards, react-dashboards, react-ui-dashboards, react-dashboard-editor, contract-tests
- Vitest: **981 passing** incl. the contract oracle — new bridge assertion (carries the window) + view-page seeding test (`last_7d` from a persisted default)
- ESLint `--max-warnings 0`: clean

## Follow-up

- **First-day-of-week parity**: the backend resolves `wtd`/`pw` using the `Localization:FirstDayOfWeek` setting; the front bundle-path resolver still defaults to Monday. Wire the setting into `resolveTimeWindowToRenderRequest`'s `weekStartsOn` so both paths agree for non-Monday tenants.
- Absolute-range calendar picker; time-shift arrows.