### PR TITLE
feat(dashboards): resolve wtd/pw with the configured first day of week

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -6194,6 +6194,21 @@
           "signature": "function useTimezone(): string"
         },
         {
+          "name": "FirstDayOfWeekProvider",
+          "kind": "const",
+          "signature": "const FirstDayOfWeekProvider"
+        },
+        {
+          "name": "useFirstDayOfWeek",
+          "kind": "function",
+          "signature": "function useFirstDayOfWeek(): Weekday"
+        },
+        {
+          "name": "Weekday",
+          "kind": "type",
+          "signature": "type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6"
+        },
+        {
           "name": "useTranslation",
           "kind": "function",
           "signature": "function useTranslation< Ns extends FlatNamespace | readonly [FlatNamespace?, ...FlatNamespace[]] = 'translation', KPrefix extends KeyPrefix<FallbackNs<Ns>> = undefined, >( ns?: Ns, options?: UseTranslationOptions<KPrefix> ): UseTranslationResponse<FallbackNs<Ns>, KPrefix>"

--- a/packages/@granit/react-localization/src/__tests__/use-first-day-of-week.test.tsx
+++ b/packages/@granit/react-localization/src/__tests__/use-first-day-of-week.test.tsx
@@ -1,0 +1,38 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { FirstDayOfWeekProvider, useFirstDayOfWeek } from '../use-first-day-of-week';
+
+import type { ReactNode } from 'react';
+
+function withProvider(value: string | null) {
+  return ({ children }: { readonly children: ReactNode }) => (
+    <FirstDayOfWeekProvider value={value}>{children}</FirstDayOfWeekProvider>
+  );
+}
+
+describe('useFirstDayOfWeek', () => {
+  it('parses a DayOfWeek name from the provider', () => {
+    expect(renderHook(() => useFirstDayOfWeek(), { wrapper: withProvider('Sunday') }).result.current).toBe(0);
+    expect(renderHook(() => useFirstDayOfWeek(), { wrapper: withProvider('Monday') }).result.current).toBe(1);
+    expect(renderHook(() => useFirstDayOfWeek(), { wrapper: withProvider('Saturday') }).result.current).toBe(6);
+  });
+
+  it('is case-insensitive', () => {
+    expect(renderHook(() => useFirstDayOfWeek(), { wrapper: withProvider('monday') }).result.current).toBe(1);
+  });
+
+  it('falls back to a valid browser-derived weekday outside a provider', () => {
+    // Locale-dependent (Intl week info), so only assert it is a valid Weekday.
+    const day = renderHook(() => useFirstDayOfWeek()).result.current;
+    expect(day).toBeGreaterThanOrEqual(0);
+    expect(day).toBeLessThanOrEqual(6);
+  });
+
+  it('falls back to the same browser default for an unrecognised value', () => {
+    const fallback = renderHook(() => useFirstDayOfWeek()).result.current;
+    expect(
+      renderHook(() => useFirstDayOfWeek(), { wrapper: withProvider('Someday') }).result.current
+    ).toBe(fallback);
+  });
+});

--- a/packages/@granit/react-localization/src/index.ts
+++ b/packages/@granit/react-localization/src/index.ts
@@ -24,6 +24,10 @@ export { useDateFormatter } from './use-date-formatter';
 // Hooks — Timezone
 export { TimezoneProvider, useTimezone } from './use-timezone';
 
+// Hooks — First day of week (calendar-token resolution parity)
+export { FirstDayOfWeekProvider, useFirstDayOfWeek } from './use-first-day-of-week';
+export type { Weekday } from './use-first-day-of-week';
+
 // Re-export from react-i18next so apps import everything from @granit/react-localization.
 export { I18nextProvider, Trans } from 'react-i18next';
 

--- a/packages/@granit/react-localization/src/use-first-day-of-week.ts
+++ b/packages/@granit/react-localization/src/use-first-day-of-week.ts
@@ -1,0 +1,79 @@
+import { createContext, useContext } from 'react';
+
+/** First day of week: `0` = Sunday … `6` = Saturday (matches `Date.getUTCDay`). */
+export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+const DAY_NAME_TO_WEEKDAY: Readonly<Record<string, Weekday>> = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+};
+
+/**
+ * Browser-locale first day of week, resolved once. `Intl.Locale.getWeekInfo()`
+ * reports `firstDay` as `1` = Monday … `7` = Sunday (ISO); `% 7` maps it to the
+ * `0` = Sunday convention. Falls back to Monday where the API is unavailable
+ * (older engines, JSDOM) — the same neutral default the framework assumes.
+ */
+const BROWSER_FIRST_DAY: Weekday = resolveBrowserFirstDay();
+
+function resolveBrowserFirstDay(): Weekday {
+  try {
+    const locale = new Intl.Locale(Intl.DateTimeFormat().resolvedOptions().locale);
+    const weekInfo =
+      (locale as { getWeekInfo?: () => { firstDay?: number } }).getWeekInfo?.() ??
+      (locale as { weekInfo?: { firstDay?: number } }).weekInfo;
+    const firstDay = weekInfo?.firstDay;
+    if (typeof firstDay === 'number') return (firstDay % 7) as Weekday;
+  } catch {
+    // `Intl.Locale` week info is not universally supported — use the default.
+    return 1;
+  }
+  return 1;
+}
+
+const FirstDayOfWeekContext = createContext<string | null>(null);
+
+/**
+ * Provider that sets the first day of week for calendar-token resolution
+ * (`wtd` / `pw`) in the subtree.
+ *
+ * The consuming app feeds the value — typically from the backend setting
+ * `Localization:FirstDayOfWeek` via `useSetting`, mirroring
+ * {@link TimezoneProvider}. The value is a `System.DayOfWeek` name (`"Monday"`,
+ * `"Sunday"`, …) or `null` to defer to the browser locale.
+ *
+ * @example
+ * ```tsx
+ * const { data } = useSetting('user', SETTING_NAMES.FIRST_DAY_OF_WEEK);
+ *
+ * <FirstDayOfWeekProvider value={data?.value ?? null}>
+ *   <App />
+ * </FirstDayOfWeekProvider>
+ * ```
+ */
+export const FirstDayOfWeekProvider = FirstDayOfWeekContext.Provider;
+
+/**
+ * Returns the effective first day of week as a {@link Weekday}.
+ *
+ * Resolution order:
+ * 1. Value from the nearest {@link FirstDayOfWeekProvider} (backend setting).
+ * 2. Browser locale via `Intl.Locale` week info.
+ * 3. Monday.
+ *
+ * This must match `Granit.Analytics` `PeriodResolver` server-side so `wtd` / `pw`
+ * resolve to the same window on the definition and bundle paths.
+ */
+export function useFirstDayOfWeek(): Weekday {
+  const value = useContext(FirstDayOfWeekContext);
+  if (value) {
+    const parsed = DAY_NAME_TO_WEEKDAY[value.toLowerCase()];
+    if (parsed !== undefined) return parsed;
+  }
+  return BROWSER_FIRST_DAY;
+}

--- a/packages/@granit/react-ui-dashboards/src/components/dashboard-view-page.tsx
+++ b/packages/@granit/react-ui-dashboards/src/components/dashboard-view-page.tsx
@@ -12,7 +12,7 @@ import {
   useDashboardRefreshIntervalState,
   useDashboardTimeWindowState,
 } from '@granit/react-dashboards';
-import { useTranslation } from '@granit/react-localization';
+import { useFirstDayOfWeek, useTranslation } from '@granit/react-localization';
 import { Button, Spinner } from '@granit/react-ui';
 import { EmptyState } from '@granit/react-ui-kit';
 import { ArrowLeft, LayoutDashboard, Pencil } from 'lucide-react';
@@ -108,9 +108,13 @@ function DashboardViewContent({ detail, dashboardId, onEdit }: DashboardViewCont
   const [timeWindow, setTimeWindow] = useDashboardTimeWindowState(
     detail.defaultTimeWindow ?? DASHBOARD_TIME_WINDOW.Last30Days
   );
+  // Calendar-token resolution (`wtd` / `pw`) must use the same first day of week
+  // as the backend `PeriodResolver` for the two paths to agree — the app feeds
+  // the `Localization:FirstDayOfWeek` setting into the FirstDayOfWeekProvider.
+  const weekStartsOn = useFirstDayOfWeek();
   const renderRequest = useMemo(
-    () => (timeWindow ? resolveTimeWindowToRenderRequest(timeWindow) : undefined),
-    [timeWindow]
+    () => (timeWindow ? resolveTimeWindowToRenderRequest(timeWindow, { weekStartsOn }) : undefined),
+    [timeWindow, weekStartsOn]
   );
 
   // Auto-refresh cadence, bridged to the bundle query's refetch interval.

--- a/packages/@granit/settings/src/constants.ts
+++ b/packages/@granit/settings/src/constants.ts
@@ -2,4 +2,6 @@
 export const SETTING_NAMES = {
   PREFERRED_CULTURE: 'Granit.Localization.PreferredCulture',
   PREFERRED_TIMEZONE: 'Granit.Timing.PreferredTimezone',
+  /** `System.DayOfWeek` name overriding the culture-derived first day of week (`wtd` / `pw`). */
+  FIRST_DAY_OF_WEEK: 'Localization:FirstDayOfWeek',
 } as const;


### PR DESCRIPTION
## Context

Closes the last correctness gap in the Grafana time-controls work. The bundle-path resolver (`resolveTimeWindowToRenderRequest`) hardcoded Monday for `wtd` / `pw`, so those tokens could diverge from the backend `PeriodResolver` — which honours the `Localization:FirstDayOfWeek` setting — on the definition path, for a non-Monday tenant.

> Stacked on #901. Base will retarget to `develop` once #901 merges.

## Changes

- **`@granit/react-localization`**: `FirstDayOfWeekProvider` + `useFirstDayOfWeek()`, mirroring the existing `TimezoneProvider` pattern. The context value is a `System.DayOfWeek` name (from the setting); the hook resolves it to a `Weekday` (0=Sun…6=Sat), falling back to the **browser locale** (`Intl.Locale` week info) then Monday.
- **`@granit/settings`**: `SETTING_NAMES.FIRST_DAY_OF_WEEK = 'Localization:FirstDayOfWeek'`.
- **`DashboardViewPage`** feeds `useFirstDayOfWeek()` into the resolver's `weekStartsOn`, so the bundle path agrees with the backend.

The **definition path already honours the setting** (tiles send tokens to the metric endpoint, resolved server-side) — this only fixes the bundle path.

## App wiring (follow-up showcase MR)

The app feeds the setting into the provider, exactly like the existing `TimezoneSettingProvider`:

```tsx
const { data } = useSetting('user', SETTING_NAMES.FIRST_DAY_OF_WEEK, { enabled: authenticated });
<FirstDayOfWeekProvider value={data?.value ?? null}>…</FirstDayOfWeekProvider>
```

Until wired, the framework degrades to the browser locale (a good match for the backend's culture default).

## Verification

- `tsc --noEmit`: clean (react-localization, settings, react-ui-dashboards)
- Vitest: **3871 passing** incl. arch + contract oracle; new `useFirstDayOfWeek` tests (provider parse, case-insensitive, locale fallback)
- ESLint `--max-warnings 0`: clean

## Residual note

When no explicit override is set, the front uses the browser locale's first day of week and the backend uses its request-culture default — these match in the overwhelming majority of cases. Exact parity for the override case flows through the `FirstDayOfWeekProvider` once the app wires it.