### PR TITLE
feat(dashboards): absolute date range in the time-window selector

### DIFF
--- a/packages/@granit/react-dashboards/src/__tests__/dashboard-time-window-toolbar.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/dashboard-time-window-toolbar.test.tsx
@@ -86,12 +86,58 @@ describe('DashboardTimeWindowToolbar', () => {
     );
   });
 
-  it('shows a disabled Custom entry for an absolute range not in the presets', () => {
+  it('opens the custom-range inputs, seeded, for an absolute-range window', () => {
     render(
       <Harness initial={{ period: { from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' } }} />
     );
-    const select = screen.getByRole('combobox') as HTMLSelectElement;
-    expect(select.value).toBe('');
-    expect(screen.getByRole('option', { name: /custom range/i })).toBeDisabled();
+    expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('__custom__');
+    expect(document.querySelector('[data-slot="dashboard-time-window-custom"]')).toBeInTheDocument();
+    // Seeded from the window (browser-local rendering of the UTC bounds).
+    expect(
+      (document.querySelector('[data-slot="dashboard-time-window-from"]') as HTMLInputElement).value
+    ).not.toBe('');
+  });
+
+  it('reveals the custom inputs when "Custom range" is selected', () => {
+    render(<Harness initial={DASHBOARD_TIME_WINDOW.Last30Days} />);
+    expect(document.querySelector('[data-slot="dashboard-time-window-custom"]')).toBeNull();
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '__custom__' } });
+    expect(document.querySelector('[data-slot="dashboard-time-window-custom"]')).toBeInTheDocument();
+  });
+
+  it('applies a valid absolute range as an absolute-period window', () => {
+    const onChange = vi.fn();
+    render(<Harness initial={DASHBOARD_TIME_WINDOW.Last30Days} setTimeWindow={onChange} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '__custom__' } });
+
+    fireEvent.change(document.querySelector('[data-slot="dashboard-time-window-from"]')!, {
+      target: { value: '2026-01-01T00:00' },
+    });
+    fireEvent.change(document.querySelector('[data-slot="dashboard-time-window-to"]')!, {
+      target: { value: '2026-02-01T00:00' },
+    });
+    fireEvent.click(document.querySelector('[data-slot="dashboard-time-window-apply"]')!);
+
+    const applied = onChange.mock.calls.at(-1)?.[0];
+    expect(applied.period).toHaveProperty('from');
+    expect(applied.period).toHaveProperty('to');
+    expect(new Date(applied.period.from).getTime()).toBeLessThan(
+      new Date(applied.period.to).getTime()
+    );
+  });
+
+  it('disables Apply for an inverted or incomplete range', () => {
+    render(<Harness initial={DASHBOARD_TIME_WINDOW.Last30Days} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '__custom__' } });
+    // Both empty → disabled.
+    expect(document.querySelector('[data-slot="dashboard-time-window-apply"]')).toBeDisabled();
+    fireEvent.change(document.querySelector('[data-slot="dashboard-time-window-from"]')!, {
+      target: { value: '2026-02-01T00:00' },
+    });
+    fireEvent.change(document.querySelector('[data-slot="dashboard-time-window-to"]')!, {
+      target: { value: '2026-01-01T00:00' },
+    });
+    // from > to → still disabled.
+    expect(document.querySelector('[data-slot="dashboard-time-window-apply"]')).toBeDisabled();
   });
 });

--- a/packages/@granit/react-dashboards/src/components/dashboard-time-window-toolbar.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-time-window-toolbar.tsx
@@ -1,9 +1,13 @@
 import { DASHBOARD_TIME_WINDOW } from '@granit/dashboards';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useDashboardContext } from './dashboard-context';
 
 import type { DashboardTimeWindow } from '@granit/dashboards';
+
+/** Sentinel `<select>` value that reveals the absolute-range inputs. */
+const CUSTOM_VALUE = '__custom__';
 
 /**
  * One quick-range option. Carries the token that identifies it in
@@ -131,18 +135,38 @@ export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToo
   const { t } = useTranslation();
   const ctx = useDashboardContext();
 
+  // Hooks run before the early return (rules of hooks). Seed the custom-range
+  // drafts from the active window when it is already an absolute range.
+  const period = ctx?.timeWindow?.period;
+  const initialAbsolute = period !== undefined && 'from' in period;
+  const [customOpen, setCustomOpen] = useState(initialAbsolute);
+  const [draftFrom, setDraftFrom] = useState(() =>
+    initialAbsolute ? toLocalInput(period.from) : ''
+  );
+  const [draftTo, setDraftTo] = useState(() => (initialAbsolute ? toLocalInput(period.to) : ''));
+
   if (!ctx?.timeWindow || !ctx.setTimeWindow) return null;
 
   const { timeWindow, setTimeWindow } = ctx;
   const currentToken = 'token' in timeWindow.period ? timeWindow.period.token : '';
   const matched = ALL_PRESETS.some((p) => p.token === currentToken);
+  const selectValue = customOpen ? CUSTOM_VALUE : matched ? currentToken : '';
+
+  const applyCustom = () => {
+    const from = new Date(draftFrom);
+    const to = new Date(draftTo);
+    if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime()) || from >= to) return;
+    setTimeWindow({ period: { from: from.toISOString(), to: to.toISOString() } });
+  };
+
+  const customValid = draftFrom !== '' && draftTo !== '' && new Date(draftFrom) < new Date(draftTo);
 
   return (
     <div
       data-slot="dashboard-time-window-toolbar"
       role="toolbar"
       aria-label="Dashboard time window"
-      className={joinClasses('flex items-end gap-3', className)}
+      className={joinClasses('flex flex-wrap items-end gap-3', className)}
     >
       <label className="flex flex-col gap-1 text-xs">
         <span data-slot="dashboard-time-window-label" className="text-muted-foreground">
@@ -150,21 +174,32 @@ export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToo
         </span>
         <select
           data-slot="dashboard-time-window-select"
-          value={matched ? currentToken : ''}
+          value={selectValue}
           onChange={(event) => {
-            const next = ALL_PRESETS.find((p) => p.token === event.target.value);
+            const value = event.target.value;
+            if (value === CUSTOM_VALUE) {
+              setCustomOpen(true);
+              return;
+            }
+            const next = ALL_PRESETS.find((p) => p.token === value);
             // Spread over the current window so an app-set `compareTo` /
             // `aggregation` survives a period change; the preset owns `period`
             // and `kind`.
-            if (next) setTimeWindow({ ...timeWindow, ...next.window });
+            if (next) {
+              setCustomOpen(false);
+              setTimeWindow({ ...timeWindow, ...next.window });
+            }
           }}
           className="rounded-md border bg-background px-2.5 py-1.5 text-sm"
         >
-          {!matched && (
+          {!matched && !customOpen && (
             <option value="" disabled>
-              {t('Dashboard:TimeWindow.Custom', { defaultValue: 'Custom range' })}
+              {t('Dashboard:TimeWindow.Placeholder', { defaultValue: 'Select…' })}
             </option>
           )}
+          <option value={CUSTOM_VALUE}>
+            {t('Dashboard:TimeWindow.Custom', { defaultValue: 'Custom range' })}
+          </option>
           {GROUPS.map((group) => (
             <optgroup key={group.labelKey} label={t(group.labelKey, { defaultValue: group.defaultLabel })}>
               {group.presets.map((p) => (
@@ -176,8 +211,54 @@ export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToo
           ))}
         </select>
       </label>
+
+      {customOpen && (
+        <div data-slot="dashboard-time-window-custom" className="flex items-end gap-2">
+          <label className="flex flex-col gap-1 text-xs">
+            <span className="text-muted-foreground">
+              {t('Dashboard:TimeWindow.From', { defaultValue: 'From' })}
+            </span>
+            <input
+              type="datetime-local"
+              data-slot="dashboard-time-window-from"
+              value={draftFrom}
+              onChange={(event) => setDraftFrom(event.target.value)}
+              className="rounded-md border bg-background px-2.5 py-1.5 text-sm"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs">
+            <span className="text-muted-foreground">
+              {t('Dashboard:TimeWindow.To', { defaultValue: 'To' })}
+            </span>
+            <input
+              type="datetime-local"
+              data-slot="dashboard-time-window-to"
+              value={draftTo}
+              onChange={(event) => setDraftTo(event.target.value)}
+              className="rounded-md border bg-background px-2.5 py-1.5 text-sm"
+            />
+          </label>
+          <button
+            type="button"
+            data-slot="dashboard-time-window-apply"
+            disabled={!customValid}
+            onClick={applyCustom}
+            className="rounded-md border bg-background px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50"
+          >
+            {t('Dashboard:TimeWindow.Apply', { defaultValue: 'Apply' })}
+          </button>
+        </div>
+      )}
     </div>
   );
+}
+
+/** ISO 8601 UTC → `datetime-local` value (`YYYY-MM-DDTHH:mm`) in the browser's local zone. */
+function toLocalInput(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 }
 
 function joinClasses(...parts: ReadonlyArray<string | undefined>): string {


### PR DESCRIPTION
## Context

Grafana roadmap (2a). Adds an **absolute date range** to the time-window selector, alongside the quick-range presets (#899).

## Changes

- The headless `DashboardTimeWindowToolbar` gains a **"Custom range"** option that reveals two `datetime-local` inputs (From / To) + an **Apply** button. Applying sets an absolute-period window `{ period: { from, to } }`.
- An absolute window re-opens the inputs **pre-seeded** (UTC bounds rendered in the browser's local zone) and shows "Custom range" selected.
- Apply is disabled until both bounds are set and `from < to`.

The resolver already passes absolute ranges straight through to the render request, so no resolver change is needed.

## Design

Plain HTML `datetime-local` inputs keep the control in the **headless `react-dashboards` tier** — so it works on every surface (`Dashboard`, `EditableDashboard`, `DashboardViewPage`), matching the `DashboardFilterToolbar` idiom. A richer ui-kit calendar (`DatePeriodPicker`) remains an optional UI-tier enhancement an app can compose on the same context.

## Verification

- `tsc --noEmit`: clean · Vitest **3491 passing** (incl. arch) · ESLint clean
- New tests: absolute window opens seeded inputs, "Custom range" reveals inputs, Apply commits an absolute window, Apply disabled for inverted/incomplete ranges

## Note

`datetime-local` interprets values in the **browser** timezone. Aligning with the app's `TimezoneProvider` (user-preferred tz) is a follow-up.

## Follow-up (2b)

Time-shift arrows (← →) + zoom-out, converting the current window to absolute and shifting/expanding it (Grafana).