### PR TITLE
feat(dashboards): time-shift and zoom-out controls

### DIFF
--- a/packages/@granit/dashboards/src/__tests__/shift-time-window.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/shift-time-window.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { shiftTimeWindow, zoomOutTimeWindow } from '../rendering/shift-time-window';
+
+import type { DashboardTimeWindow } from '../types/dashboard-time-window';
+
+// A 7-day absolute window — deterministic, no `now` dependency.
+const WEEK: DashboardTimeWindow = {
+  period: { from: '2026-01-08T00:00:00.000Z', to: '2026-01-15T00:00:00.000Z' },
+};
+
+describe('shiftTimeWindow', () => {
+  it('shifts back by one window length', () => {
+    expect(shiftTimeWindow(WEEK, 'back').period).toEqual({
+      from: '2026-01-01T00:00:00.000Z',
+      to: '2026-01-08T00:00:00.000Z',
+    });
+  });
+
+  it('shifts forward by one window length', () => {
+    expect(shiftTimeWindow(WEEK, 'forward').period).toEqual({
+      from: '2026-01-15T00:00:00.000Z',
+      to: '2026-01-22T00:00:00.000Z',
+    });
+  });
+
+  it('resolves a token window to absolute bounds before shifting', () => {
+    const now = new Date('2026-07-03T14:30:00.000Z');
+    // last_7d → [2026-06-26, 2026-07-04) (day-aligned). Back by 8 days.
+    const shifted = shiftTimeWindow({ period: { token: 'last_7d' } }, 'back', { now });
+    expect(shifted.period).toEqual({
+      from: '2026-06-18T00:00:00.000Z',
+      to: '2026-06-26T00:00:00.000Z',
+    });
+  });
+
+  it('preserves compareTo / kind', () => {
+    const shifted = shiftTimeWindow(
+      { ...WEEK, kind: 'History', compareTo: { token: 'previous_period' } },
+      'forward'
+    );
+    expect(shifted.kind).toBe('History');
+    expect(shifted.compareTo).toEqual({ token: 'previous_period' });
+  });
+
+  it('returns the window unchanged for an unresolvable token', () => {
+    const window: DashboardTimeWindow = { period: { token: 'fortnight' } };
+    expect(shiftTimeWindow(window, 'back')).toBe(window);
+  });
+});
+
+describe('zoomOutTimeWindow', () => {
+  it('doubles the span around the centre', () => {
+    // 7-day window → expand by 3.5 days each side.
+    expect(zoomOutTimeWindow(WEEK).period).toEqual({
+      from: '2026-01-04T12:00:00.000Z',
+      to: '2026-01-18T12:00:00.000Z',
+    });
+  });
+
+  it('returns the window unchanged for an unresolvable token', () => {
+    const window: DashboardTimeWindow = { period: { token: 'fortnight' } };
+    expect(zoomOutTimeWindow(window)).toBe(window);
+  });
+});

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -137,9 +137,14 @@ export type {
   WidgetRenderKind,
 } from './types/index';
 
-export { resolveTimeWindowToRenderRequest } from './rendering/index';
+export {
+  resolveTimeWindowToRenderRequest,
+  shiftTimeWindow,
+  zoomOutTimeWindow,
+} from './rendering/index';
 
 export type {
+  ShiftDirection,
   DashboardDriftStatus,
   DashboardRenderedWidget,
   DashboardRenderPeriod,

--- a/packages/@granit/dashboards/src/rendering/index.ts
+++ b/packages/@granit/dashboards/src/rendering/index.ts
@@ -9,6 +9,8 @@
 export type { DashboardDriftStatus } from './dashboard-drift-status';
 export type { DashboardRenderRequest } from './dashboard-render-request';
 export { resolveTimeWindowToRenderRequest } from './resolve-time-window-request';
+export { shiftTimeWindow, zoomOutTimeWindow } from './shift-time-window';
+export type { ShiftDirection } from './shift-time-window';
 export type {
   ResolvedRenderPeriod,
   ResolveTimeWindowOptions,

--- a/packages/@granit/dashboards/src/rendering/shift-time-window.ts
+++ b/packages/@granit/dashboards/src/rendering/shift-time-window.ts
@@ -1,0 +1,68 @@
+import { resolveTimeWindowToRenderRequest } from './resolve-time-window-request';
+
+import type { ResolveTimeWindowOptions } from './resolve-time-window-request';
+import type { DashboardTimeWindow } from '../types/dashboard-time-window';
+
+/** Direction for {@link shiftTimeWindow}: earlier or later by one window length. */
+export type ShiftDirection = 'back' | 'forward';
+
+/**
+ * Shifts a {@link DashboardTimeWindow} earlier or later by its own length
+ * (Grafana's ← / → controls). The window is first resolved to absolute bounds —
+ * a token window (`last_7d`, `mtd`, …) becomes an absolute range anchored to the
+ * shifted period, since "the previous 7 days" is no longer a rolling token.
+ *
+ * Returns the window unchanged when it cannot be resolved to bounds (an unknown
+ * token). `compareTo` / `aggregation` / `kind` are preserved.
+ */
+export function shiftTimeWindow(
+  timeWindow: DashboardTimeWindow,
+  direction: ShiftDirection,
+  options?: ResolveTimeWindowOptions
+): DashboardTimeWindow {
+  const bounds = resolveBounds(timeWindow, options);
+  if (bounds === null) return timeWindow;
+
+  const [from, to] = bounds;
+  const length = to - from;
+  const delta = direction === 'back' ? -length : length;
+  return withAbsolutePeriod(timeWindow, from + delta, to + delta);
+}
+
+/**
+ * Doubles a {@link DashboardTimeWindow}'s span around its centre (Grafana's
+ * zoom-out). Resolves to absolute bounds first, then expands by half the length
+ * on each side. Returns the window unchanged when it cannot be resolved.
+ */
+export function zoomOutTimeWindow(
+  timeWindow: DashboardTimeWindow,
+  options?: ResolveTimeWindowOptions
+): DashboardTimeWindow {
+  const bounds = resolveBounds(timeWindow, options);
+  if (bounds === null) return timeWindow;
+
+  const [from, to] = bounds;
+  const half = (to - from) / 2;
+  return withAbsolutePeriod(timeWindow, from - half, to + half);
+}
+
+/** Resolves a window to `[fromMs, toMs)`, or `null` when it has no absolute bounds. */
+function resolveBounds(
+  timeWindow: DashboardTimeWindow,
+  options?: ResolveTimeWindowOptions
+): readonly [number, number] | null {
+  const { periodFrom, periodTo } = resolveTimeWindowToRenderRequest(timeWindow, options ?? {});
+  if (periodFrom === undefined || periodTo === undefined) return null;
+  return [new Date(periodFrom).getTime(), new Date(periodTo).getTime()];
+}
+
+function withAbsolutePeriod(
+  timeWindow: DashboardTimeWindow,
+  fromMs: number,
+  toMs: number
+): DashboardTimeWindow {
+  return {
+    ...timeWindow,
+    period: { from: new Date(fromMs).toISOString(), to: new Date(toMs).toISOString() },
+  };
+}

--- a/packages/@granit/react-dashboards/src/__tests__/dashboard-time-window-toolbar.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/dashboard-time-window-toolbar.test.tsx
@@ -126,6 +126,34 @@ describe('DashboardTimeWindowToolbar', () => {
     );
   });
 
+  it('shifts the window to an absolute range via the ← / → controls', () => {
+    const onChange = vi.fn();
+    render(<Harness initial={DASHBOARD_TIME_WINDOW.Last7Days} setTimeWindow={onChange} />);
+
+    fireEvent.click(document.querySelector('[data-slot="dashboard-time-window-back"]')!);
+    const shifted = onChange.mock.calls.at(-1)?.[0];
+    expect(shifted.period).toHaveProperty('from');
+    expect(shifted.period).toHaveProperty('to');
+  });
+
+  it('zooms out to a wider absolute range', () => {
+    const onChange = vi.fn();
+    render(
+      <Harness
+        initial={{ period: { from: '2026-01-08T00:00:00Z', to: '2026-01-15T00:00:00Z' } }}
+        setTimeWindow={onChange}
+      />
+    );
+    fireEvent.click(document.querySelector('[data-slot="dashboard-time-window-zoom-out"]')!);
+    const zoomed = onChange.mock.calls.at(-1)?.[0];
+    expect(new Date(zoomed.period.from).getTime()).toBeLessThan(
+      new Date('2026-01-08T00:00:00Z').getTime()
+    );
+    expect(new Date(zoomed.period.to).getTime()).toBeGreaterThan(
+      new Date('2026-01-15T00:00:00Z').getTime()
+    );
+  });
+
   it('disables Apply for an inverted or incomplete range', () => {
     render(<Harness initial={DASHBOARD_TIME_WINDOW.Last30Days} />);
     fireEvent.change(screen.getByRole('combobox'), { target: { value: '__custom__' } });

--- a/packages/@granit/react-dashboards/src/components/dashboard-time-window-toolbar.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-time-window-toolbar.tsx
@@ -1,4 +1,4 @@
-import { DASHBOARD_TIME_WINDOW } from '@granit/dashboards';
+import { DASHBOARD_TIME_WINDOW, shiftTimeWindow, zoomOutTimeWindow } from '@granit/dashboards';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -211,6 +211,41 @@ export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToo
           ))}
         </select>
       </label>
+
+      <div
+        data-slot="dashboard-time-window-shift"
+        role="group"
+        aria-label="Shift time range"
+        className="flex items-end gap-1"
+      >
+        <button
+          type="button"
+          data-slot="dashboard-time-window-back"
+          aria-label={t('Dashboard:TimeWindow.ShiftBack', { defaultValue: 'Shift earlier' })}
+          onClick={() => setTimeWindow(shiftTimeWindow(timeWindow, 'back'))}
+          className="rounded-md border bg-background px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <span aria-hidden>‹</span>
+        </button>
+        <button
+          type="button"
+          data-slot="dashboard-time-window-zoom-out"
+          aria-label={t('Dashboard:TimeWindow.ZoomOut', { defaultValue: 'Zoom out' })}
+          onClick={() => setTimeWindow(zoomOutTimeWindow(timeWindow))}
+          className="rounded-md border bg-background px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <span aria-hidden>⊟</span>
+        </button>
+        <button
+          type="button"
+          data-slot="dashboard-time-window-forward"
+          aria-label={t('Dashboard:TimeWindow.ShiftForward', { defaultValue: 'Shift later' })}
+          onClick={() => setTimeWindow(shiftTimeWindow(timeWindow, 'forward'))}
+          className="rounded-md border bg-background px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <span aria-hidden>›</span>
+        </button>
+      </div>
 
       {customOpen && (
         <div data-slot="dashboard-time-window-custom" className="flex items-end gap-2">


### PR DESCRIPTION
## Context

Grafana roadmap (2b), completing the time-controls set. Adds **← / ⊟ / →** controls next to the time-window selector.

> Stacked on #903 (both touch the toolbar). Base retargets to `develop` once #903 merges.

## Changes

- **`@granit/dashboards`**: `shiftTimeWindow(tw, 'back' | 'forward')` and `zoomOutTimeWindow(tw)`. Both resolve the current window to absolute bounds first (a rolling token like `last_7d` becomes an absolute range once shifted — "the previous 7 days" is no longer a rolling token), then shift by one window length or expand to double around the centre. `compareTo` / `kind` preserved; an unresolvable token returns the window unchanged.
- **Toolbar**: back / zoom-out / forward buttons wired to `setTimeWindow`.

## Verification

- `tsc --noEmit`: clean · Vitest **3549 passing** (incl. arch) · ESLint clean
- New tests: shift back/forward (absolute + token windows), zoom-out doubles the span, compareTo/kind preserved, unresolvable-token no-op; toolbar button wiring

## Roadmap status

This closes the Grafana time-controls set: quick ranges (#899), refresh (#900), default seeding (#901), first-day-of-week parity (#902), absolute range (#903), shift/zoom (this). Remaining nice-to-haves: a ui-kit calendar for the absolute picker; timezone-aware `datetime-local`.