### PR TITLE
feat(timing): tz- + first-day-aware time windows; server-authoritative render

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -6191,7 +6191,7 @@
         {
           "name": "useTimezone",
           "kind": "function",
-          "signature": "function useTimezone(): string"
+          "signature": "function useTimezone(): TimeZoneId"
         },
         {
           "name": "FirstDayOfWeekProvider",
@@ -6202,11 +6202,6 @@
           "name": "useFirstDayOfWeek",
           "kind": "function",
           "signature": "function useFirstDayOfWeek(): Weekday"
-        },
-        {
-          "name": "Weekday",
-          "kind": "type",
-          "signature": "type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6"
         },
         {
           "name": "useTranslation",
@@ -11986,6 +11981,34 @@
           "name": "toggleReaction",
           "kind": "function",
           "signature": "async function toggleReaction( client: AxiosInstance, basePath: string, entryId: TimelineEntryId, emoji: ReactionEmoji ): Promise<ReactionToggleResponse>"
+        }
+      ]
+    },
+    {
+      "name": "@granit/timing",
+      "description": "Framework-agnostic time vocabulary and calendar-token resolution (mirrors Granit.Timing)",
+      "exports": [
+        {
+          "name": "Weekday",
+          "kind": "type",
+          "signature": "type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6"
+        },
+        {
+          "name": "resolvePeriodToken",
+          "kind": "function",
+          "signature": "function resolvePeriodToken( token: string, options: ResolvePeriodTokenOptions ="
+        },
+        {
+          "name": "PeriodBounds",
+          "kind": "interface",
+          "signature": "interface PeriodBounds",
+          "members": []
+        },
+        {
+          "name": "ResolvePeriodTokenOptions",
+          "kind": "interface",
+          "signature": "interface ResolvePeriodTokenOptions",
+          "members": []
         }
       ]
     },

--- a/packages/@granit/dashboards/package.json
+++ b/packages/@granit/dashboards/package.json
@@ -14,13 +14,22 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@date-fns/tz": "^1.0.0",
     "@granit/api-client": "workspace:*",
     "@granit/logger": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/timing": "workspace:*"
   },
   "peerDependencies": {
+    "@date-fns/tz": "^1.0.0",
     "@granit/api-client": "workspace:*",
-    "@granit/logger": "workspace:*"
+    "@granit/logger": "workspace:*",
+    "@granit/timing": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@date-fns/tz": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/dashboards/src/__tests__/resolve-time-window-bounds.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/resolve-time-window-bounds.test.ts
@@ -1,0 +1,43 @@
+import { toTimeZoneId } from '@granit/timing';
+import { describe, expect, it } from 'vitest';
+
+import { resolveTimeWindowBounds } from '../rendering/resolve-time-window-bounds';
+
+import type { DashboardTimeWindow } from '../types/dashboard-time-window';
+
+const NOW = new Date('2026-07-03T14:30:00.000Z');
+
+function bounds(tw: DashboardTimeWindow, opts?: Parameters<typeof resolveTimeWindowBounds>[1]) {
+  const b = resolveTimeWindowBounds(tw, opts);
+  return b === null ? null : { from: b.from.toISOString(), to: b.to.toISOString() };
+}
+
+describe('resolveTimeWindowBounds', () => {
+  it('returns an absolute range verbatim', () => {
+    expect(
+      bounds({ period: { from: '2026-01-01T00:00:00.000Z', to: '2026-02-01T00:00:00.000Z' } })
+    ).toEqual({ from: '2026-01-01T00:00:00.000Z', to: '2026-02-01T00:00:00.000Z' });
+  });
+
+  it('delegates a token to the timing resolver (UTC by default)', () => {
+    expect(bounds({ period: { token: 'last_7d' } }, { now: NOW })).toEqual({
+      from: '2026-06-26T00:00:00.000Z',
+      to: '2026-07-04T00:00:00.000Z',
+    });
+  });
+
+  it('day-aligns a token in the supplied timezone', () => {
+    // 2026-07-03T14:30Z is still 2026-07-03 in Los Angeles (UTC-7), so "today"
+    // there runs 07:00Z → 07:00Z the next day.
+    expect(
+      bounds(
+        { period: { token: 'today' } },
+        { now: NOW, timeZone: toTimeZoneId('America/Los_Angeles') }
+      )
+    ).toEqual({ from: '2026-07-03T07:00:00.000Z', to: '2026-07-04T07:00:00.000Z' });
+  });
+
+  it('returns null for an unknown token', () => {
+    expect(bounds({ period: { token: 'fortnight' } }, { now: NOW })).toBeNull();
+  });
+});

--- a/packages/@granit/dashboards/src/__tests__/resolve-time-window-request.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/resolve-time-window-request.test.ts
@@ -4,96 +4,31 @@ import { resolveTimeWindowToRenderRequest } from '../rendering/resolve-time-wind
 
 import type { DashboardTimeWindow } from '../types/dashboard-time-window';
 
-// Fixed reference: 2026-07-03T14:30:00Z — a Friday, in Q3, month day 3.
-const NOW = new Date('2026-07-03T14:30:00.000Z');
-const END_OF_TODAY = '2026-07-04T00:00:00.000Z';
-
-function resolve(token: string, opts?: { now?: Date; weekStartsOn?: 0 | 1 }) {
-  const window: DashboardTimeWindow = { period: { token } };
-  return resolveTimeWindowToRenderRequest(window, { now: NOW, ...opts });
-}
-
 describe('resolveTimeWindowToRenderRequest', () => {
-  it('resolves a sub-day token as [now - duration, now)', () => {
-    expect(resolve('last_1h')).toEqual({
-      periodFrom: '2026-07-03T13:30:00.000Z',
-      periodTo: '2026-07-03T14:30:00.000Z',
-      periodToken: 'last_1h',
-    });
+  it('emits a token window as { periodToken } alone (server is authoritative)', () => {
+    // The bundle endpoint resolves the token server-side and ignores any
+    // client-sent from/to, so we deliberately send no bounds — a phone in
+    // another timezone must not pin the window to its own local day.
+    const window: DashboardTimeWindow = { period: { token: 'mtd' } };
+    expect(resolveTimeWindowToRenderRequest(window)).toEqual({ periodToken: 'mtd' });
   });
 
-  it.each([
-    ['last_2d', '2026-07-01T00:00:00.000Z'],
-    ['last_7d', '2026-06-26T00:00:00.000Z'],
-    ['last_30d', '2026-06-03T00:00:00.000Z'],
-    ['last_3mo', '2026-04-03T00:00:00.000Z'],
-    ['last_6mo', '2026-01-03T00:00:00.000Z'],
-    ['last_1y', '2025-07-03T00:00:00.000Z'],
-    ['last_5y', '2021-07-03T00:00:00.000Z'],
-  ])('day-aligns %s through the end of today', (token, from) => {
-    expect(resolve(token)).toEqual({ periodFrom: from, periodTo: END_OF_TODAY, periodToken: token });
-  });
+  it.each(['last_30d', 'wtd', 'today', 'last_1h', 'fortnight'])(
+    'never computes bounds for the token %s',
+    (token) => {
+      expect(resolveTimeWindowToRenderRequest({ period: { token } })).toEqual({
+        periodToken: token,
+      });
+    }
+  );
 
-  it.each([
-    ['today', '2026-07-03T00:00:00.000Z', '2026-07-04T00:00:00.000Z'],
-    ['yesterday', '2026-07-02T00:00:00.000Z', '2026-07-03T00:00:00.000Z'],
-    ['day_before_yesterday', '2026-07-01T00:00:00.000Z', '2026-07-02T00:00:00.000Z'],
-    ['this_day_last_week', '2026-06-26T00:00:00.000Z', '2026-06-27T00:00:00.000Z'],
-  ])('resolves the single day %s', (token, from, to) => {
-    expect(resolve(token)).toEqual({ periodFrom: from, periodTo: to, periodToken: token });
-  });
-
-  it.each([
-    ['mtd', '2026-07-01T00:00:00.000Z'],
-    ['qtd', '2026-07-01T00:00:00.000Z'],
-    ['ytd', '2026-01-01T00:00:00.000Z'],
-  ])('resolves the to-date token %s through the end of today', (token, from) => {
-    expect(resolve(token)).toEqual({ periodFrom: from, periodTo: END_OF_TODAY, periodToken: token });
-  });
-
-  it.each([
-    ['pm', '2026-06-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z'],
-    ['pq', '2026-04-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z'],
-    ['py', '2025-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z'],
-  ])('resolves the previous complete period %s', (token, from, to) => {
-    expect(resolve(token)).toEqual({ periodFrom: from, periodTo: to, periodToken: token });
-  });
-
-  it('resolves wtd / pw against the configured first day of week', () => {
-    // NOW is a Friday. Monday-start week began 2026-06-29; Sunday-start 2026-06-28.
-    expect(resolve('wtd', { weekStartsOn: 1 }).periodFrom).toBe('2026-06-29T00:00:00.000Z');
-    expect(resolve('wtd', { weekStartsOn: 0 }).periodFrom).toBe('2026-06-28T00:00:00.000Z');
-    expect(resolve('pw', { weekStartsOn: 1 })).toEqual({
-      periodFrom: '2026-06-22T00:00:00.000Z',
-      periodTo: '2026-06-29T00:00:00.000Z',
-      periodToken: 'pw',
-    });
-  });
-
-  it('defaults the first day of week to Monday', () => {
-    expect(resolve('wtd').periodFrom).toBe('2026-06-29T00:00:00.000Z');
-  });
-
-  it('clamps month arithmetic to the target month like .NET AddMonths', () => {
-    // From May 31, last_3mo lands on "Feb 31" → clamped to Feb 28 (2026 is not leap).
-    const window: DashboardTimeWindow = { period: { token: 'last_3mo' } };
-    expect(
-      resolveTimeWindowToRenderRequest(window, { now: new Date('2026-05-31T09:00:00.000Z') })
-        .periodFrom
-    ).toBe('2026-02-28T00:00:00.000Z');
-  });
-
-  it('passes an absolute range through unchanged (no token)', () => {
+  it('passes an absolute range through as periodFrom / periodTo', () => {
     const window: DashboardTimeWindow = {
       period: { from: '2026-01-01T00:00:00.000Z', to: '2026-02-01T00:00:00.000Z' },
     };
-    expect(resolveTimeWindowToRenderRequest(window, { now: NOW })).toEqual({
+    expect(resolveTimeWindowToRenderRequest(window)).toEqual({
       periodFrom: '2026-01-01T00:00:00.000Z',
       periodTo: '2026-02-01T00:00:00.000Z',
     });
-  });
-
-  it('degrades an unresolvable token to an echo with no bounds', () => {
-    expect(resolve('fortnight')).toEqual({ periodToken: 'fortnight' });
   });
 });

--- a/packages/@granit/dashboards/src/__tests__/shift-time-window.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/shift-time-window.test.ts
@@ -1,3 +1,4 @@
+import { toTimeZoneId } from '@granit/timing';
 import { describe, expect, it } from 'vitest';
 
 import { shiftTimeWindow, zoomOutTimeWindow } from '../rendering/shift-time-window';
@@ -31,6 +32,20 @@ describe('shiftTimeWindow', () => {
     expect(shifted.period).toEqual({
       from: '2026-06-18T00:00:00.000Z',
       to: '2026-06-26T00:00:00.000Z',
+    });
+  });
+
+  it('resolves a token window in the supplied timezone before shifting', () => {
+    const now = new Date('2026-07-03T14:30:00.000Z');
+    // last_7d in Los Angeles (UTC-7): [2026-06-26T07:00Z, 2026-07-04T07:00Z),
+    // an 8-day span. Back by 8 days.
+    const shifted = shiftTimeWindow({ period: { token: 'last_7d' } }, 'back', {
+      now,
+      timeZone: toTimeZoneId('America/Los_Angeles'),
+    });
+    expect(shifted.period).toEqual({
+      from: '2026-06-18T07:00:00.000Z',
+      to: '2026-06-26T07:00:00.000Z',
     });
   });
 

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -138,10 +138,15 @@ export type {
 } from './types/index';
 
 export {
+  resolveTimeWindowBounds,
   resolveTimeWindowToRenderRequest,
   shiftTimeWindow,
   zoomOutTimeWindow,
 } from './rendering/index';
+
+// `Weekday` is owned by @granit/timing; re-exported so existing
+// `import { Weekday } from '@granit/dashboards'` sites keep resolving.
+export type { Weekday } from '@granit/timing';
 
 export type {
   ShiftDirection,
@@ -151,8 +156,7 @@ export type {
   DashboardRenderRequest,
   DashboardRenderResponse,
   ResolvedRenderPeriod,
-  ResolveTimeWindowOptions,
-  Weekday,
+  ResolveTimeWindowBoundsOptions,
   ImageSnapshotEnvelope,
   ImageWidgetSnapshot,
   MarkdownSnapshotEnvelope,

--- a/packages/@granit/dashboards/src/rendering/index.ts
+++ b/packages/@granit/dashboards/src/rendering/index.ts
@@ -9,13 +9,11 @@
 export type { DashboardDriftStatus } from './dashboard-drift-status';
 export type { DashboardRenderRequest } from './dashboard-render-request';
 export { resolveTimeWindowToRenderRequest } from './resolve-time-window-request';
+export type { ResolvedRenderPeriod } from './resolve-time-window-request';
+export { resolveTimeWindowBounds } from './resolve-time-window-bounds';
+export type { ResolveTimeWindowBoundsOptions } from './resolve-time-window-bounds';
 export { shiftTimeWindow, zoomOutTimeWindow } from './shift-time-window';
 export type { ShiftDirection } from './shift-time-window';
-export type {
-  ResolvedRenderPeriod,
-  ResolveTimeWindowOptions,
-  Weekday,
-} from './resolve-time-window-request';
 export type {
   DashboardRenderedWidget,
   DashboardRenderPeriod,

--- a/packages/@granit/dashboards/src/rendering/resolve-time-window-bounds.ts
+++ b/packages/@granit/dashboards/src/rendering/resolve-time-window-bounds.ts
@@ -1,0 +1,37 @@
+import { resolvePeriodToken } from '@granit/timing';
+
+import type { DashboardTimeWindow } from '../types/dashboard-time-window';
+import type { PeriodBounds, TimeZoneId, Weekday } from '@granit/timing';
+
+export interface ResolveTimeWindowBoundsOptions {
+  /** Reference instant. Injectable for deterministic tests; defaults to now. */
+  readonly now?: Date;
+  /** First day of week for `wtd` / `pw`. Defaults to Monday (`1`). */
+  readonly weekStartsOn?: Weekday;
+  /** IANA timezone the calendar tokens are day-aligned in. Omitted = UTC. */
+  readonly timeZone?: TimeZoneId;
+}
+
+/**
+ * Resolves a {@link DashboardTimeWindow} into absolute `[from, to)` bounds for
+ * **client-side** use — the range label, the custom-range preview, and the
+ * shift / zoom controls. Unlike {@link resolveTimeWindowToRenderRequest}, this
+ * is not sent to the server; it computes the same window the backend would,
+ * timezone- and first-day-aware, by delegating tokens to `@granit/timing`'s
+ * {@link resolvePeriodToken} (a mirror of `Granit.Timing.PeriodResolver`).
+ *
+ * - An absolute-range window returns its parsed `from` / `to`.
+ * - A token window returns the resolved bounds, or `null` for an unknown token.
+ */
+export function resolveTimeWindowBounds(
+  timeWindow: DashboardTimeWindow,
+  options: ResolveTimeWindowBoundsOptions = {}
+): PeriodBounds | null {
+  const { period } = timeWindow;
+
+  if ('from' in period) {
+    return { from: new Date(period.from), to: new Date(period.to) };
+  }
+
+  return resolvePeriodToken(period.token, options);
+}

--- a/packages/@granit/dashboards/src/rendering/resolve-time-window-request.ts
+++ b/packages/@granit/dashboards/src/rendering/resolve-time-window-request.ts
@@ -7,55 +7,26 @@ export type ResolvedRenderPeriod = Pick<
   'periodFrom' | 'periodTo' | 'periodToken'
 >;
 
-/** First day of week: `0` = Sunday … `6` = Saturday (matches `Date.getUTCDay`). */
-export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
-
-export interface ResolveTimeWindowOptions {
-  /** Reference instant. Injectable for deterministic tests; defaults to now. */
-  readonly now?: Date;
-  /** First day of week for `wtd` / `pw`. Defaults to Monday (`1`). */
-  readonly weekStartsOn?: Weekday;
-}
-
-const MINUTE_MS = 60_000;
-const HOUR_MS = 60 * MINUTE_MS;
-
-/** Rolling sub-day tokens, resolved as `[now - duration, now)`. */
-const DURATION_MS: Readonly<Record<string, number>> = {
-  last_60s: MINUTE_MS,
-  last_5m: 5 * MINUTE_MS,
-  last_15m: 15 * MINUTE_MS,
-  last_30m: 30 * MINUTE_MS,
-  last_1h: HOUR_MS,
-  last_3h: 3 * HOUR_MS,
-  last_6h: 6 * HOUR_MS,
-  last_12h: 12 * HOUR_MS,
-  last_24h: 24 * HOUR_MS,
-};
-
 /**
- * Resolves a {@link DashboardTimeWindow} into the absolute `[periodFrom, periodTo)`
- * bounds a {@link DashboardRenderRequest} requires.
+ * Maps a {@link DashboardTimeWindow} to the period fields of a
+ * {@link DashboardRenderRequest}.
  *
- * The bundle render endpoint (`POST /dashboards/{id}/render`) does NOT resolve
- * named tokens server-side — unlike the inline-metric endpoint — so calendar
- * tokens (`last_30d`, `mtd`, `pw`, …) are turned into UTC bounds here. **The
- * semantics mirror `Granit.Analytics` `PeriodResolver` exactly** so a widget
- * bound through either path resolves the same window: sub-day tokens end at
- * `now`; day / calendar tokens are day-aligned and run through the end of today
- * (`todayStart + 1d`, exclusive); month/year arithmetic clamps the day to the
- * target month like .NET `DateTime.AddMonths`.
+ * The bundle render endpoint (`POST /dashboards/{id}/render`) resolves named
+ * tokens **server-side** — timezone- and first-day-aware, via
+ * `Granit.Timing.IPeriodResolver` — and **ignores** any `periodFrom` /
+ * `periodTo` a client sends alongside a token. So this builder is deliberately
+ * thin:
  *
- * - An absolute-range window passes its `from` / `to` through unchanged.
- * - A token with no known resolution degrades to `periodToken` alone — the
- *   endpoint requires the two bounds as a pair, so emitting only one is a 400;
- *   omitting both renders unbounded.
+ * - A **token** window emits `{ periodToken }` alone — the server is
+ *   authoritative, and sending client-computed bounds would only risk a mismatch
+ *   (a phone in a different timezone must not pin the window to its own day).
+ * - An **absolute-range** window passes its `from` / `to` through unchanged.
  *
- * `now` and `weekStartsOn` are injectable via {@link ResolveTimeWindowOptions}.
+ * Client-side token→bounds resolution still exists for display, preview and the
+ * shift / zoom controls — that lives in {@link resolveTimeWindowBounds}, not here.
  */
 export function resolveTimeWindowToRenderRequest(
-  timeWindow: DashboardTimeWindow,
-  options: ResolveTimeWindowOptions = {}
+  timeWindow: DashboardTimeWindow
 ): ResolvedRenderPeriod {
   const { period } = timeWindow;
 
@@ -63,127 +34,5 @@ export function resolveTimeWindowToRenderRequest(
     return { periodFrom: period.from, periodTo: period.to };
   }
 
-  const now = options.now ?? new Date();
-  const weekStartsOn = options.weekStartsOn ?? 1;
-  const bounds = resolveToken(period.token, now, weekStartsOn);
-
-  if (bounds === null) {
-    return { periodToken: period.token };
-  }
-
-  return {
-    periodFrom: bounds.from.toISOString(),
-    periodTo: bounds.to.toISOString(),
-    periodToken: period.token,
-  };
-}
-
-interface Bounds {
-  readonly from: Date;
-  readonly to: Date;
-}
-
-function resolveToken(token: string, now: Date, weekStartsOn: Weekday): Bounds | null {
-  const duration = DURATION_MS[token];
-  if (duration !== undefined) {
-    return { from: new Date(now.getTime() - duration), to: now };
-  }
-
-  const day0 = startOfUtcDay(now);
-  const endOfToday = addUtcDays(day0, 1);
-
-  switch (token) {
-    // Day / month / year rolling — day-aligned, through end of today.
-    case 'last_2d':
-      return { from: addUtcDays(day0, -2), to: endOfToday };
-    case 'last_7d':
-      return { from: addUtcDays(day0, -7), to: endOfToday };
-    case 'last_30d':
-      return { from: addUtcDays(day0, -30), to: endOfToday };
-    case 'last_3mo':
-      return { from: addUtcMonths(day0, -3), to: endOfToday };
-    case 'last_6mo':
-      return { from: addUtcMonths(day0, -6), to: endOfToday };
-    case 'last_1y':
-      return { from: addUtcMonths(day0, -12), to: endOfToday };
-    case 'last_2y':
-      return { from: addUtcMonths(day0, -24), to: endOfToday };
-    case 'last_5y':
-      return { from: addUtcMonths(day0, -60), to: endOfToday };
-
-    // Relative single days.
-    case 'today':
-      return { from: day0, to: endOfToday };
-    case 'yesterday':
-      return { from: addUtcDays(day0, -1), to: day0 };
-    case 'day_before_yesterday':
-      return { from: addUtcDays(day0, -2), to: addUtcDays(day0, -1) };
-    case 'this_day_last_week':
-      return { from: addUtcDays(day0, -7), to: addUtcDays(day0, -6) };
-
-    // To-date ("so far") — start of period through end of today.
-    case 'wtd':
-      return { from: startOfUtcWeek(day0, weekStartsOn), to: endOfToday };
-    case 'mtd':
-      return { from: startOfUtcMonth(day0), to: endOfToday };
-    case 'qtd':
-      return { from: startOfUtcQuarter(day0), to: endOfToday };
-    case 'ytd':
-      return { from: startOfUtcYear(day0), to: endOfToday };
-
-    // Previous complete periods.
-    case 'pw': {
-      const weekStart = startOfUtcWeek(day0, weekStartsOn);
-      return { from: addUtcDays(weekStart, -7), to: weekStart };
-    }
-    case 'pm': {
-      const monthStart = startOfUtcMonth(day0);
-      return { from: addUtcMonths(monthStart, -1), to: monthStart };
-    }
-    case 'pq': {
-      const quarterStart = startOfUtcQuarter(day0);
-      return { from: addUtcMonths(quarterStart, -3), to: quarterStart };
-    }
-    case 'py': {
-      const yearStart = startOfUtcYear(day0);
-      return { from: addUtcMonths(yearStart, -12), to: yearStart };
-    }
-
-    default:
-      return null;
-  }
-}
-
-function startOfUtcDay(d: Date): Date {
-  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
-}
-
-function addUtcDays(d: Date, days: number): Date {
-  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + days));
-}
-
-/** Adds months, clamping the day to the target month's last day (matches .NET `AddMonths`). */
-function addUtcMonths(d: Date, months: number): Date {
-  const total = d.getUTCMonth() + months;
-  const year = d.getUTCFullYear() + Math.floor(total / 12);
-  const month = ((total % 12) + 12) % 12;
-  const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
-  return new Date(Date.UTC(year, month, Math.min(d.getUTCDate(), lastDay)));
-}
-
-function startOfUtcMonth(d: Date): Date {
-  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
-}
-
-function startOfUtcQuarter(d: Date): Date {
-  return new Date(Date.UTC(d.getUTCFullYear(), Math.floor(d.getUTCMonth() / 3) * 3, 1));
-}
-
-function startOfUtcYear(d: Date): Date {
-  return new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-}
-
-function startOfUtcWeek(d: Date, weekStartsOn: Weekday): Date {
-  const diff = (d.getUTCDay() - weekStartsOn + 7) % 7;
-  return addUtcDays(d, -diff);
+  return { periodToken: period.token };
 }

--- a/packages/@granit/dashboards/src/rendering/shift-time-window.ts
+++ b/packages/@granit/dashboards/src/rendering/shift-time-window.ts
@@ -1,6 +1,6 @@
-import { resolveTimeWindowToRenderRequest } from './resolve-time-window-request';
+import { resolveTimeWindowBounds } from './resolve-time-window-bounds';
 
-import type { ResolveTimeWindowOptions } from './resolve-time-window-request';
+import type { ResolveTimeWindowBoundsOptions } from './resolve-time-window-bounds';
 import type { DashboardTimeWindow } from '../types/dashboard-time-window';
 
 /** Direction for {@link shiftTimeWindow}: earlier or later by one window length. */
@@ -18,7 +18,7 @@ export type ShiftDirection = 'back' | 'forward';
 export function shiftTimeWindow(
   timeWindow: DashboardTimeWindow,
   direction: ShiftDirection,
-  options?: ResolveTimeWindowOptions
+  options?: ResolveTimeWindowBoundsOptions
 ): DashboardTimeWindow {
   const bounds = resolveBounds(timeWindow, options);
   if (bounds === null) return timeWindow;
@@ -36,7 +36,7 @@ export function shiftTimeWindow(
  */
 export function zoomOutTimeWindow(
   timeWindow: DashboardTimeWindow,
-  options?: ResolveTimeWindowOptions
+  options?: ResolveTimeWindowBoundsOptions
 ): DashboardTimeWindow {
   const bounds = resolveBounds(timeWindow, options);
   if (bounds === null) return timeWindow;
@@ -49,11 +49,11 @@ export function zoomOutTimeWindow(
 /** Resolves a window to `[fromMs, toMs)`, or `null` when it has no absolute bounds. */
 function resolveBounds(
   timeWindow: DashboardTimeWindow,
-  options?: ResolveTimeWindowOptions
+  options?: ResolveTimeWindowBoundsOptions
 ): readonly [number, number] | null {
-  const { periodFrom, periodTo } = resolveTimeWindowToRenderRequest(timeWindow, options ?? {});
-  if (periodFrom === undefined || periodTo === undefined) return null;
-  return [new Date(periodFrom).getTime(), new Date(periodTo).getTime()];
+  const bounds = resolveTimeWindowBounds(timeWindow, options ?? {});
+  if (bounds === null) return null;
+  return [bounds.from.getTime(), bounds.to.getTime()];
 }
 
 function withAbsolutePeriod(

--- a/packages/@granit/react-dashboards/package.json
+++ b/packages/@granit/react-dashboards/package.json
@@ -19,6 +19,7 @@
     "@granit/dashboards": "workspace:*",
     "@granit/logger": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/timing": "workspace:*",
     "@granit/utils": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "i18next": "^26.0.0",
@@ -51,6 +52,7 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
+    "@granit/timing": "workspace:*",
     "@granit/utils": "workspace:*",
     "msw": "^2.14.6"
   }

--- a/packages/@granit/react-dashboards/src/components/dashboard-context.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-context.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react';
 
 import type { DashboardRefreshInterval, DashboardTimeWindow } from '@granit/dashboards';
+import type { TimeZoneId, Weekday } from '@granit/timing';
 
 /**
  * Read-only ambient context for a rendered dashboard. Surfaces the dashboard
@@ -42,6 +43,20 @@ export interface DashboardContextValue {
    * (no refresh control shown).
    */
   readonly setRefreshInterval?: Dispatch<SetStateAction<DashboardRefreshInterval | undefined>>;
+  /**
+   * First day of week (`wtd` / `pw`) for client-side resolution of the shift /
+   * zoom controls. Fed from the app's `Granit.Timing.PreferredFirstDayOfWeek`
+   * setting (via `useFirstDayOfWeek`); defaults to Monday when omitted. Must
+   * match the backend `Granit.Timing` resolver so a shifted token window lines
+   * up with what the server would render.
+   */
+  readonly weekStartsOn?: Weekday;
+  /**
+   * IANA timezone the shift / zoom controls day-align calendar tokens in. Fed
+   * from the app's `Granit.Timing.PreferredTimezone` setting (via
+   * `useTimezone`); UTC when omitted.
+   */
+  readonly timeZone?: TimeZoneId;
 }
 
 const DashboardContext = createContext<DashboardContextValue | null>(null);
@@ -62,6 +77,8 @@ export function DashboardContextProvider({ value, children }: DashboardContextPr
       value.setTimeWindow,
       value.refreshInterval,
       value.setRefreshInterval,
+      value.weekStartsOn,
+      value.timeZone,
     ]
   );
   return <DashboardContext.Provider value={memoised}>{children}</DashboardContext.Provider>;

--- a/packages/@granit/react-dashboards/src/components/dashboard-time-window-toolbar.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-time-window-toolbar.tsx
@@ -30,7 +30,11 @@ interface TimeWindowGroup {
 
 const W = DASHBOARD_TIME_WINDOW;
 
-function preset(window: DashboardTimeWindow, labelKey: string, defaultLabel: string): TimeWindowPreset {
+function preset(
+  window: DashboardTimeWindow,
+  labelKey: string,
+  defaultLabel: string
+): TimeWindowPreset {
   const token = 'token' in window.period ? window.period.token : '';
   return { token, window, labelKey, defaultLabel };
 }
@@ -148,6 +152,9 @@ export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToo
   if (!ctx?.timeWindow || !ctx.setTimeWindow) return null;
 
   const { timeWindow, setTimeWindow } = ctx;
+  // Shift / zoom resolve token windows to absolute bounds client-side, so they
+  // need the same timezone / first-day the backend resolver uses to stay aligned.
+  const shiftOptions = { weekStartsOn: ctx.weekStartsOn, timeZone: ctx.timeZone };
   const currentToken = 'token' in timeWindow.period ? timeWindow.period.token : '';
   const matched = ALL_PRESETS.some((p) => p.token === currentToken);
   const selectValue = customOpen ? CUSTOM_VALUE : matched ? currentToken : '';
@@ -201,7 +208,10 @@ export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToo
             {t('Dashboard:TimeWindow.Custom', { defaultValue: 'Custom range' })}
           </option>
           {GROUPS.map((group) => (
-            <optgroup key={group.labelKey} label={t(group.labelKey, { defaultValue: group.defaultLabel })}>
+            <optgroup
+              key={group.labelKey}
+              label={t(group.labelKey, { defaultValue: group.defaultLabel })}
+            >
               {group.presets.map((p) => (
                 <option key={p.token} value={p.token}>
                   {t(p.labelKey, { defaultValue: p.defaultLabel })}
@@ -222,7 +232,7 @@ export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToo
           type="button"
           data-slot="dashboard-time-window-back"
           aria-label={t('Dashboard:TimeWindow.ShiftBack', { defaultValue: 'Shift earlier' })}
-          onClick={() => setTimeWindow(shiftTimeWindow(timeWindow, 'back'))}
+          onClick={() => setTimeWindow(shiftTimeWindow(timeWindow, 'back', shiftOptions))}
           className="rounded-md border bg-background px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
         >
           <span aria-hidden>‹</span>
@@ -231,7 +241,7 @@ export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToo
           type="button"
           data-slot="dashboard-time-window-zoom-out"
           aria-label={t('Dashboard:TimeWindow.ZoomOut', { defaultValue: 'Zoom out' })}
-          onClick={() => setTimeWindow(zoomOutTimeWindow(timeWindow))}
+          onClick={() => setTimeWindow(zoomOutTimeWindow(timeWindow, shiftOptions))}
           className="rounded-md border bg-background px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
         >
           <span aria-hidden>⊟</span>
@@ -240,7 +250,7 @@ export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToo
           type="button"
           data-slot="dashboard-time-window-forward"
           aria-label={t('Dashboard:TimeWindow.ShiftForward', { defaultValue: 'Shift later' })}
-          onClick={() => setTimeWindow(shiftTimeWindow(timeWindow, 'forward'))}
+          onClick={() => setTimeWindow(shiftTimeWindow(timeWindow, 'forward', shiftOptions))}
           className="rounded-md border bg-background px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
         >
           <span aria-hidden>›</span>

--- a/packages/@granit/react-localization/package.json
+++ b/packages/@granit/react-localization/package.json
@@ -22,6 +22,7 @@
     "@granit/query-engine": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
     "@granit/storage": "workspace:*",
+    "@granit/timing": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "date-fns": "^4.0.0",
     "i18next": "^26.0.0",
@@ -57,6 +58,7 @@
     "@granit/api-client": "workspace:*",
     "@granit/logger": "workspace:*",
     "@granit/testing": "workspace:*",
+    "@granit/timing": "workspace:*",
     "@granit/types": "workspace:*",
     "@granit/utils": "workspace:*"
   }

--- a/packages/@granit/react-localization/src/index.ts
+++ b/packages/@granit/react-localization/src/index.ts
@@ -26,7 +26,7 @@ export { TimezoneProvider, useTimezone } from './use-timezone';
 
 // Hooks — First day of week (calendar-token resolution parity)
 export { FirstDayOfWeekProvider, useFirstDayOfWeek } from './use-first-day-of-week';
-export type { Weekday } from './use-first-day-of-week';
+export type { Weekday } from '@granit/timing';
 
 // Re-export from react-i18next so apps import everything from @granit/react-localization.
 export { I18nextProvider, Trans } from 'react-i18next';

--- a/packages/@granit/react-localization/src/use-first-day-of-week.ts
+++ b/packages/@granit/react-localization/src/use-first-day-of-week.ts
@@ -1,7 +1,6 @@
 import { createContext, useContext } from 'react';
 
-/** First day of week: `0` = Sunday … `6` = Saturday (matches `Date.getUTCDay`). */
-export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+import type { Weekday } from '@granit/timing';
 
 const DAY_NAME_TO_WEEKDAY: Readonly<Record<string, Weekday>> = {
   sunday: 0,
@@ -43,7 +42,7 @@ const FirstDayOfWeekContext = createContext<string | null>(null);
  * (`wtd` / `pw`) in the subtree.
  *
  * The consuming app feeds the value — typically from the backend setting
- * `Localization:FirstDayOfWeek` via `useSetting`, mirroring
+ * `Granit.Timing.PreferredFirstDayOfWeek` via `useSetting`, mirroring
  * {@link TimezoneProvider}. The value is a `System.DayOfWeek` name (`"Monday"`,
  * `"Sunday"`, …) or `null` to defer to the browser locale.
  *
@@ -66,7 +65,7 @@ export const FirstDayOfWeekProvider = FirstDayOfWeekContext.Provider;
  * 2. Browser locale via `Intl.Locale` week info.
  * 3. Monday.
  *
- * This must match `Granit.Analytics` `PeriodResolver` server-side so `wtd` / `pw`
+ * This must match `Granit.Timing` `PeriodResolver` server-side so `wtd` / `pw`
  * resolve to the same window on the definition and bundle paths.
  */
 export function useFirstDayOfWeek(): Weekday {

--- a/packages/@granit/react-localization/src/use-timezone.ts
+++ b/packages/@granit/react-localization/src/use-timezone.ts
@@ -1,6 +1,9 @@
+import { toTimeZoneId } from '@granit/timing';
 import { createContext, useContext } from 'react';
 
-const BROWSER_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
+import type { TimeZoneId } from '@granit/timing';
+
+const BROWSER_TIMEZONE = toTimeZoneId(Intl.DateTimeFormat().resolvedOptions().timeZone);
 
 const TimezoneContext = createContext<string | null>(null);
 
@@ -23,12 +26,14 @@ const TimezoneContext = createContext<string | null>(null);
 export const TimezoneProvider = TimezoneContext.Provider;
 
 /**
- * Returns the user's preferred timezone (IANA identifier).
+ * Returns the user's preferred timezone as a branded {@link TimeZoneId}
+ * (IANA identifier).
  *
  * Resolution order:
  * 1. Value from the nearest {@link TimezoneProvider} (user setting)
  * 2. Browser timezone via `Intl.DateTimeFormat`
  */
-export function useTimezone(): string {
-  return useContext(TimezoneContext) ?? BROWSER_TIMEZONE;
+export function useTimezone(): TimeZoneId {
+  const value = useContext(TimezoneContext);
+  return value ? toTimeZoneId(value) : BROWSER_TIMEZONE;
 }

--- a/packages/@granit/react-ui-dashboards/src/components/dashboard-view-page.tsx
+++ b/packages/@granit/react-ui-dashboards/src/components/dashboard-view-page.tsx
@@ -12,7 +12,7 @@ import {
   useDashboardRefreshIntervalState,
   useDashboardTimeWindowState,
 } from '@granit/react-dashboards';
-import { useFirstDayOfWeek, useTranslation } from '@granit/react-localization';
+import { useFirstDayOfWeek, useTimezone, useTranslation } from '@granit/react-localization';
 import { Button, Spinner } from '@granit/react-ui';
 import { EmptyState } from '@granit/react-ui-kit';
 import { ArrowLeft, LayoutDashboard, Pencil } from 'lucide-react';
@@ -87,7 +87,11 @@ export function DashboardViewPage() {
   // refresh state can seed from the dashboard's persisted default on first
   // render (a `useState` initialiser cannot pick it up during the loading pass).
   return (
-    <DashboardViewContent detail={detail} dashboardId={dashboardId} onEdit={() => setEditing(true)} />
+    <DashboardViewContent
+      detail={detail}
+      dashboardId={dashboardId}
+      onEdit={() => setEditing(true)}
+    />
   );
 }
 
@@ -102,20 +106,23 @@ function DashboardViewContent({ detail, dashboardId, onEdit }: DashboardViewCont
   const navigate = useNavigate();
 
   // Active render window. Seeded from the dashboard's persisted default,
-  // falling back to Last 30 days. The bundle path needs absolute bounds, so the
-  // window is resolved to `periodFrom` / `periodTo` and fed to the render
-  // request — changing it re-fetches the bundle.
+  // falling back to Last 30 days. A token window is sent to the server as
+  // `{ periodToken }` alone — the bundle endpoint resolves it authoritatively
+  // (timezone- / first-day-aware), so changing the window re-fetches the bundle.
   const [timeWindow, setTimeWindow] = useDashboardTimeWindowState(
     detail.defaultTimeWindow ?? DASHBOARD_TIME_WINDOW.Last30Days
   );
-  // Calendar-token resolution (`wtd` / `pw`) must use the same first day of week
-  // as the backend `PeriodResolver` for the two paths to agree — the app feeds
-  // the `Localization:FirstDayOfWeek` setting into the FirstDayOfWeekProvider.
-  const weekStartsOn = useFirstDayOfWeek();
   const renderRequest = useMemo(
-    () => (timeWindow ? resolveTimeWindowToRenderRequest(timeWindow, { weekStartsOn }) : undefined),
-    [timeWindow, weekStartsOn]
+    () => (timeWindow ? resolveTimeWindowToRenderRequest(timeWindow) : undefined),
+    [timeWindow]
   );
+  // The shift / zoom controls resolve token windows to absolute bounds on the
+  // client, so they need the same first day of week / timezone the backend
+  // `Granit.Timing` resolver uses. The app feeds the
+  // `Granit.Timing.PreferredFirstDayOfWeek` / `Granit.Timing.PreferredTimezone`
+  // settings into the providers these hooks read.
+  const weekStartsOn = useFirstDayOfWeek();
+  const timeZone = useTimezone();
 
   // Auto-refresh cadence, bridged to the bundle query's refetch interval.
   const [refreshInterval, setRefreshInterval] = useDashboardRefreshIntervalState('auto');
@@ -126,7 +133,15 @@ function DashboardViewContent({ detail, dashboardId, onEdit }: DashboardViewCont
 
   return (
     <DashboardContextProvider
-      value={{ dashboardName: detail.name, timeWindow, setTimeWindow, refreshInterval, setRefreshInterval }}
+      value={{
+        dashboardName: detail.name,
+        timeWindow,
+        setTimeWindow,
+        refreshInterval,
+        setRefreshInterval,
+        weekStartsOn,
+        timeZone,
+      }}
     >
       <div
         data-slot="dashboard-view-page"

--- a/packages/@granit/settings/src/constants.ts
+++ b/packages/@granit/settings/src/constants.ts
@@ -3,5 +3,5 @@ export const SETTING_NAMES = {
   PREFERRED_CULTURE: 'Granit.Localization.PreferredCulture',
   PREFERRED_TIMEZONE: 'Granit.Timing.PreferredTimezone',
   /** `System.DayOfWeek` name overriding the culture-derived first day of week (`wtd` / `pw`). */
-  FIRST_DAY_OF_WEEK: 'Localization:FirstDayOfWeek',
+  FIRST_DAY_OF_WEEK: 'Granit.Timing.PreferredFirstDayOfWeek',
 } as const;

--- a/packages/@granit/timing/README.md
+++ b/packages/@granit/timing/README.md
@@ -1,0 +1,49 @@
+# @granit/timing
+
+Framework-agnostic **calendar-token resolution** for the Granit framework — the
+JS/TS counterpart of the backend `Granit.Timing` assembly. Pure TypeScript, no
+React, no DOM, no HTTP.
+
+It owns:
+
+- **`resolvePeriodToken`** — expands a named token (`last_30d`, `mtd`, `pw`,
+  `today`, …) into absolute `[from, to)` bounds, mirroring
+  `Granit.Timing.PeriodResolver` so a window resolved on the client (display,
+  preview, shift arrows) matches what the server resolves for the same token.
+- **`Weekday`** — the `0 = Sunday … 6 = Saturday` index shared by the resolver
+  and the React first-day-of-week hook.
+
+The `TimeZoneId` brand lives in [`@granit/types`](../types) (the shared brand
+vocabulary) and is re-exported here for convenience, since the resolver's API
+speaks it.
+
+## Install
+
+Workspace-internal — inside the monorepo it resolves through the `@granit/*`
+Vite/Vitest aliases like every other package. It depends on `@granit/types` for
+the `TimeZoneId` brand; `@date-fns/tz` is an **optional** peer dependency, only
+pulled in on the timezone-aware code path.
+
+```ts
+import { resolvePeriodToken, toTimeZoneId } from '@granit/timing';
+```
+
+## Timezone semantics
+
+- Sub-day rolling tokens (`last_5m` … `last_24h`) resolve to `[now - duration,
+now)` in absolute instants — timezone-independent.
+- Calendar tokens are day-aligned in the local day of the supplied `timeZone`,
+  then converted back to UTC **DST-correctly** (a "day" spans 23/24/25 h across
+  a transition). `wtd` / `pw` honour `weekStartsOn`; month/year arithmetic
+  clamps to the target month's last day like .NET `AddMonths` / `AddYears`.
+- **Without** a `timeZone` the resolver is pure UTC — byte-for-byte identical to
+  the historical behaviour, so it is safe as a drop-in default.
+
+```ts
+// Local day of Asia/Tokyo, DST-correct, mirroring the backend resolver.
+resolvePeriodToken('today', {
+  now: new Date('2026-07-03T20:00:00Z'),
+  timeZone: toTimeZoneId('Asia/Tokyo'),
+});
+// → { from: 2026-07-03T15:00:00Z, to: 2026-07-04T15:00:00Z }
+```

--- a/packages/@granit/timing/package.json
+++ b/packages/@granit/timing/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@granit/timing",
+  "description": "Framework-agnostic time vocabulary and calendar-token resolution (mirrors Granit.Timing)",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@date-fns/tz": "^1.0.0",
+    "@granit/types": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@date-fns/tz": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@date-fns/tz": "^1.0.0",
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/timing/src/__tests__/resolve-period-token.test.ts
+++ b/packages/@granit/timing/src/__tests__/resolve-period-token.test.ts
@@ -1,0 +1,145 @@
+import { toTimeZoneId } from '@granit/types';
+import { describe, expect, it } from 'vitest';
+
+import { resolvePeriodToken } from '../resolve-period-token';
+
+import type { Weekday } from '../weekday';
+
+// Fixed reference: 2026-07-03T14:30:00Z — a Friday, in Q3, month day 3.
+const NOW = new Date('2026-07-03T14:30:00.000Z');
+const END_OF_TODAY = '2026-07-04T00:00:00.000Z';
+
+function iso(bounds: { from: Date; to: Date } | null) {
+  if (bounds === null) return null;
+  return { from: bounds.from.toISOString(), to: bounds.to.toISOString() };
+}
+
+function resolve(token: string, opts?: { now?: Date; weekStartsOn?: Weekday; timeZone?: string }) {
+  return iso(
+    resolvePeriodToken(token, {
+      now: NOW,
+      ...opts,
+      timeZone: opts?.timeZone ? toTimeZoneId(opts.timeZone) : undefined,
+    })
+  );
+}
+
+describe('resolvePeriodToken — UTC (no timezone, non-regression)', () => {
+  it('resolves sub-day tokens as [now - duration, now)', () => {
+    expect(resolve('last_60s')).toEqual({
+      from: '2026-07-03T14:29:00.000Z',
+      to: '2026-07-03T14:30:00.000Z',
+    });
+    expect(resolve('last_1h')).toEqual({
+      from: '2026-07-03T13:30:00.000Z',
+      to: '2026-07-03T14:30:00.000Z',
+    });
+  });
+
+  it.each([
+    ['last_2d', '2026-07-01T00:00:00.000Z'],
+    ['last_7d', '2026-06-26T00:00:00.000Z'],
+    ['last_30d', '2026-06-03T00:00:00.000Z'],
+    ['last_3mo', '2026-04-03T00:00:00.000Z'],
+    ['last_6mo', '2026-01-03T00:00:00.000Z'],
+    ['last_1y', '2025-07-03T00:00:00.000Z'],
+    ['last_5y', '2021-07-03T00:00:00.000Z'],
+  ])('day-aligns %s through the end of today', (token, from) => {
+    expect(resolve(token)).toEqual({ from, to: END_OF_TODAY });
+  });
+
+  it.each([
+    ['today', '2026-07-03T00:00:00.000Z', '2026-07-04T00:00:00.000Z'],
+    ['yesterday', '2026-07-02T00:00:00.000Z', '2026-07-03T00:00:00.000Z'],
+    ['day_before_yesterday', '2026-07-01T00:00:00.000Z', '2026-07-02T00:00:00.000Z'],
+    ['this_day_last_week', '2026-06-26T00:00:00.000Z', '2026-06-27T00:00:00.000Z'],
+  ])('resolves the single day %s', (token, from, to) => {
+    expect(resolve(token)).toEqual({ from, to });
+  });
+
+  it.each([
+    ['mtd', '2026-07-01T00:00:00.000Z'],
+    ['qtd', '2026-07-01T00:00:00.000Z'],
+    ['ytd', '2026-01-01T00:00:00.000Z'],
+  ])('resolves the to-date token %s through the end of today', (token, from) => {
+    expect(resolve(token)).toEqual({ from, to: END_OF_TODAY });
+  });
+
+  it.each([
+    ['pm', '2026-06-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z'],
+    ['pq', '2026-04-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z'],
+    ['py', '2025-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z'],
+  ])('resolves the previous complete period %s', (token, from, to) => {
+    expect(resolve(token)).toEqual({ from, to });
+  });
+
+  it('returns null for an unknown token', () => {
+    expect(resolve('fortnight')).toBeNull();
+  });
+});
+
+describe('resolvePeriodToken — first day of week', () => {
+  it('resolves wtd / pw against the configured first day of week', () => {
+    // NOW is a Friday. Monday-start week began 2026-06-29; Sunday-start 2026-06-28.
+    expect(resolve('wtd', { weekStartsOn: 1 })?.from).toBe('2026-06-29T00:00:00.000Z');
+    expect(resolve('wtd', { weekStartsOn: 0 })?.from).toBe('2026-06-28T00:00:00.000Z');
+    expect(resolve('pw', { weekStartsOn: 1 })).toEqual({
+      from: '2026-06-22T00:00:00.000Z',
+      to: '2026-06-29T00:00:00.000Z',
+    });
+  });
+
+  it('defaults the first day of week to Monday', () => {
+    expect(resolve('wtd')?.from).toBe('2026-06-29T00:00:00.000Z');
+  });
+});
+
+describe('resolvePeriodToken — .NET AddMonths clamp', () => {
+  it('clamps month arithmetic to the target month last day', () => {
+    // From May 31, last_3mo lands on "Feb 31" → clamped to Feb 28 (2026 is not leap).
+    expect(
+      iso(resolvePeriodToken('last_3mo', { now: new Date('2026-05-31T09:00:00.000Z') }))?.from
+    ).toBe('2026-02-28T00:00:00.000Z');
+  });
+});
+
+describe('resolvePeriodToken — timezone-aware calendar alignment', () => {
+  it('day-aligns in the local timezone, not UTC (Asia/Tokyo, evening UTC)', () => {
+    // 2026-07-03T20:00Z is already 2026-07-04 05:00 in Tokyo (UTC+9), so the
+    // local "today" is the 4th, offset nine hours behind UTC midnight.
+    const now = new Date('2026-07-03T20:00:00.000Z');
+    expect(iso(resolvePeriodToken('today', { now, timeZone: toTimeZoneId('Asia/Tokyo') }))).toEqual(
+      { from: '2026-07-03T15:00:00.000Z', to: '2026-07-04T15:00:00.000Z' }
+    );
+    expect(
+      iso(resolvePeriodToken('last_7d', { now, timeZone: toTimeZoneId('Asia/Tokyo') }))
+    ).toEqual({ from: '2026-06-26T15:00:00.000Z', to: '2026-07-04T15:00:00.000Z' });
+  });
+
+  it('keeps sub-day rolling tokens timezone-independent', () => {
+    const now = new Date('2026-07-03T20:00:00.000Z');
+    expect(
+      iso(resolvePeriodToken('last_1h', { now, timeZone: toTimeZoneId('Asia/Tokyo') }))
+    ).toEqual({ from: '2026-07-03T19:00:00.000Z', to: '2026-07-03T20:00:00.000Z' });
+  });
+});
+
+describe('resolvePeriodToken — DST transitions (Europe/Brussels)', () => {
+  it('spans 23h across the spring-forward day', () => {
+    // 2026-03-29: clocks jump 02:00 → 03:00. Local midnight is CET (+1); the
+    // next local midnight is CEST (+2), so "today" is only 23 hours long.
+    const now = new Date('2026-03-29T12:00:00.000Z');
+    expect(
+      iso(resolvePeriodToken('today', { now, timeZone: toTimeZoneId('Europe/Brussels') }))
+    ).toEqual({ from: '2026-03-28T23:00:00.000Z', to: '2026-03-29T22:00:00.000Z' });
+  });
+
+  it('spans 25h across the fall-back day', () => {
+    // 2026-10-25: clocks fall 03:00 → 02:00. Local midnight is CEST (+2); the
+    // next local midnight is CET (+1), so "today" is 25 hours long.
+    const now = new Date('2026-10-25T12:00:00.000Z');
+    expect(
+      iso(resolvePeriodToken('today', { now, timeZone: toTimeZoneId('Europe/Brussels') }))
+    ).toEqual({ from: '2026-10-24T22:00:00.000Z', to: '2026-10-25T23:00:00.000Z' });
+  });
+});

--- a/packages/@granit/timing/src/index.ts
+++ b/packages/@granit/timing/src/index.ts
@@ -1,0 +1,10 @@
+// The timezone brand lives in @granit/types (the shared brand vocabulary);
+// re-exported here so consumers of the resolver get it from one import.
+export { isTimeZoneId, toTimeZoneId } from '@granit/types';
+export type { TimeZoneId } from '@granit/types';
+
+export type { Weekday } from './weekday';
+
+// Calendar-token resolution — client-side mirror of Granit.Timing.PeriodResolver.
+export { resolvePeriodToken } from './resolve-period-token';
+export type { PeriodBounds, ResolvePeriodTokenOptions } from './resolve-period-token';

--- a/packages/@granit/timing/src/resolve-period-token.ts
+++ b/packages/@granit/timing/src/resolve-period-token.ts
@@ -1,0 +1,176 @@
+import { civilToInstant, localCivilDate } from './time-zone';
+
+import type { Weekday } from './weekday';
+import type { TimeZoneId } from '@granit/types';
+
+/** Absolute, half-open `[from, to)` window — the resolved form of a calendar token. */
+export interface PeriodBounds {
+  readonly from: Date;
+  readonly to: Date;
+}
+
+export interface ResolvePeriodTokenOptions {
+  /** Reference instant. Injectable for deterministic tests; defaults to now. */
+  readonly now?: Date;
+  /** First day of week for `wtd` / `pw`. Defaults to Monday (`1`). */
+  readonly weekStartsOn?: Weekday;
+  /**
+   * IANA timezone the calendar tokens are day-aligned in. Omitted = UTC, which
+   * reproduces the historical bounds exactly (non-regression).
+   */
+  readonly timeZone?: TimeZoneId;
+}
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+
+/** Rolling sub-day tokens, resolved as `[now - duration, now)` — timezone-independent. */
+const DURATION_MS: Readonly<Record<string, number>> = {
+  last_60s: MINUTE_MS,
+  last_5m: 5 * MINUTE_MS,
+  last_15m: 15 * MINUTE_MS,
+  last_30m: 30 * MINUTE_MS,
+  last_1h: HOUR_MS,
+  last_3h: 3 * HOUR_MS,
+  last_6h: 6 * HOUR_MS,
+  last_12h: 12 * HOUR_MS,
+  last_24h: 24 * HOUR_MS,
+};
+
+/**
+ * Resolves a named calendar token (`last_30d`, `mtd`, `pw`, `today`, …) into
+ * absolute `[from, to)` bounds, **mirroring `Granit.Timing.PeriodResolver`
+ * exactly** so a window resolved client-side (display, preview, shift arrows)
+ * matches what the server resolves for the same token:
+ *
+ * - Sub-day rolling tokens end at `now`, in absolute instants (timezone-independent).
+ * - Day / week / month / quarter / year tokens are day-aligned in the local day
+ *   of `timeZone`, then converted back to UTC DST-correctly. `wtd` / `pw` depend
+ *   on `weekStartsOn`; month/year arithmetic clamps the day to the target
+ *   month's last day like .NET `DateTime.AddMonths` / `AddYears`.
+ *
+ * Returns `null` for an unknown token — the caller decides how to degrade.
+ */
+export function resolvePeriodToken(
+  token: string,
+  options: ResolvePeriodTokenOptions = {}
+): PeriodBounds | null {
+  const now = options.now ?? new Date();
+
+  const duration = DURATION_MS[token];
+  if (duration !== undefined) {
+    return { from: new Date(now.getTime() - duration), to: now };
+  }
+
+  const weekStartsOn = options.weekStartsOn ?? 1;
+  const timeZone = options.timeZone;
+
+  const day0 = localCivilDate(now, timeZone);
+  const civil = resolveCivilBounds(token, day0, weekStartsOn);
+  if (civil === null) return null;
+
+  return {
+    from: civilToInstant(civil.from, timeZone),
+    to: civilToInstant(civil.to, timeZone),
+  };
+}
+
+/** Resolves the day-aligned civil `[from, to)` carriers for a calendar token. */
+function resolveCivilBounds(token: string, day0: Date, weekStartsOn: Weekday): PeriodBounds | null {
+  const endOfToday = addDays(day0, 1);
+
+  switch (token) {
+    // Day / month / year rolling — day-aligned, through end of today.
+    case 'last_2d':
+      return { from: addDays(day0, -2), to: endOfToday };
+    case 'last_7d':
+      return { from: addDays(day0, -7), to: endOfToday };
+    case 'last_30d':
+      return { from: addDays(day0, -30), to: endOfToday };
+    case 'last_3mo':
+      return { from: addMonths(day0, -3), to: endOfToday };
+    case 'last_6mo':
+      return { from: addMonths(day0, -6), to: endOfToday };
+    case 'last_1y':
+      return { from: addMonths(day0, -12), to: endOfToday };
+    case 'last_2y':
+      return { from: addMonths(day0, -24), to: endOfToday };
+    case 'last_5y':
+      return { from: addMonths(day0, -60), to: endOfToday };
+
+    // Relative single days.
+    case 'today':
+      return { from: day0, to: endOfToday };
+    case 'yesterday':
+      return { from: addDays(day0, -1), to: day0 };
+    case 'day_before_yesterday':
+      return { from: addDays(day0, -2), to: addDays(day0, -1) };
+    case 'this_day_last_week':
+      return { from: addDays(day0, -7), to: addDays(day0, -6) };
+
+    // To-date ("so far") — start of period through end of today.
+    case 'wtd':
+      return { from: startOfWeek(day0, weekStartsOn), to: endOfToday };
+    case 'mtd':
+      return { from: startOfMonth(day0), to: endOfToday };
+    case 'qtd':
+      return { from: startOfQuarter(day0), to: endOfToday };
+    case 'ytd':
+      return { from: startOfYear(day0), to: endOfToday };
+
+    // Previous complete periods.
+    case 'pw': {
+      const weekStart = startOfWeek(day0, weekStartsOn);
+      return { from: addDays(weekStart, -7), to: weekStart };
+    }
+    case 'pm': {
+      const monthStart = startOfMonth(day0);
+      return { from: addMonths(monthStart, -1), to: monthStart };
+    }
+    case 'pq': {
+      const quarterStart = startOfQuarter(day0);
+      return { from: addMonths(quarterStart, -3), to: quarterStart };
+    }
+    case 'py': {
+      const yearStart = startOfYear(day0);
+      return { from: addMonths(yearStart, -12), to: yearStart };
+    }
+
+    default:
+      return null;
+  }
+}
+
+// --- Civil-date calendar math. Operates on midnight-UTC carriers via `getUTC*`
+// / `Date.UTC` — DST-agnostic and exact; the timezone is applied only later by
+// `civilToInstant`. ---
+
+function addDays(d: Date, days: number): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + days));
+}
+
+/** Adds months, clamping the day to the target month's last day (matches .NET `AddMonths`). */
+function addMonths(d: Date, months: number): Date {
+  const total = d.getUTCMonth() + months;
+  const year = d.getUTCFullYear() + Math.floor(total / 12);
+  const month = ((total % 12) + 12) % 12;
+  const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  return new Date(Date.UTC(year, month, Math.min(d.getUTCDate(), lastDay)));
+}
+
+function startOfMonth(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
+}
+
+function startOfQuarter(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), Math.floor(d.getUTCMonth() / 3) * 3, 1));
+}
+
+function startOfYear(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+}
+
+function startOfWeek(d: Date, weekStartsOn: Weekday): Date {
+  const diff = (d.getUTCDay() - weekStartsOn + 7) % 7;
+  return addDays(d, -diff);
+}

--- a/packages/@granit/timing/src/time-zone.ts
+++ b/packages/@granit/timing/src/time-zone.ts
@@ -1,0 +1,51 @@
+import { TZDate } from '@date-fns/tz';
+
+import type { TimeZoneId } from '@granit/types';
+
+/**
+ * Timezone-aware bridge between a *civil* calendar date and an absolute
+ * instant, mirroring the backend's `IClock.ConvertToUserTime` /
+ * `ToUtcFromUserLocal` pair (`Granit.Timing`).
+ *
+ * A **civil date** is carried as a `Date` pinned to midnight *UTC* — a register
+ * for year/month/day arithmetic, deliberately stripped of any timezone. All
+ * calendar math (add days/months, week/month/quarter/year starts) runs on these
+ * carriers through the `getUTC*` / `Date.UTC` accessors, which are DST-agnostic
+ * and exact. A civil date only becomes a real instant at the very end, via
+ * {@link civilToInstant}.
+ *
+ * Without a `timeZone` every conversion is the identity on UTC, so the whole
+ * pipeline reproduces the historical UTC-only behaviour byte-for-byte.
+ */
+
+/** Midnight-UTC civil carrier for the calendar date of `instant` in `timeZone`. */
+export function localCivilDate(instant: Date, timeZone: TimeZoneId | undefined): Date {
+  if (timeZone === undefined) {
+    return new Date(
+      Date.UTC(instant.getUTCFullYear(), instant.getUTCMonth(), instant.getUTCDate())
+    );
+  }
+  // `TZDate(ms, tz)` reads back its Y/M/D accessors in the target zone.
+  const local = new TZDate(instant.getTime(), timeZone);
+  return new Date(Date.UTC(local.getFullYear(), local.getMonth(), local.getDate()));
+}
+
+/**
+ * Maps a civil midnight to the UTC instant at which that wall-clock midnight
+ * occurs in `timeZone`.
+ *
+ * Without a timezone the civil carrier already *is* the UTC instant (UTC-only
+ * behaviour). With one, `TZDate` resolves the local offset DST-correctly, so a
+ * calendar "day" spans 23/24/25 h across a transition. Nonexistent
+ * (spring-forward) and ambiguous (fall-back) local midnights resolve however
+ * `@date-fns/tz` resolves them — deterministically, toward the post-transition
+ * offset; day boundaries at midnight almost never fall inside a DST gap in
+ * practice.
+ */
+export function civilToInstant(civil: Date, timeZone: TimeZoneId | undefined): Date {
+  if (timeZone === undefined) return civil;
+  // `TZDate(y, m, d, tz)` interprets the fields as a wall-clock time in `tz`.
+  return new Date(
+    new TZDate(civil.getUTCFullYear(), civil.getUTCMonth(), civil.getUTCDate(), timeZone).getTime()
+  );
+}

--- a/packages/@granit/timing/src/weekday.ts
+++ b/packages/@granit/timing/src/weekday.ts
@@ -1,0 +1,8 @@
+/**
+ * First day of week as a numeric index: `0` = Sunday … `6` = Saturday.
+ *
+ * Matches both `Date.getUTCDay()` / `Date.getDay()` and .NET
+ * `System.DayOfWeek` (`Sunday = 0`), so a value crosses the wire to the
+ * `Granit.Timing` backend resolver without remapping.
+ */
+export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;

--- a/packages/@granit/timing/tsconfig.json
+++ b/packages/@granit/timing/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/timing/tsup.config.ts
+++ b/packages/@granit/timing/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -655,6 +655,9 @@ importers:
 
   packages/@granit/dashboards:
     devDependencies:
+      '@date-fns/tz':
+        specifier: ^1.0.0
+        version: 1.5.0
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
@@ -664,6 +667,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/timing':
+        specifier: workspace:*
+        version: link:../timing
 
   packages/@granit/data-exchange:
     devDependencies:
@@ -2173,6 +2179,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/timing':
+        specifier: workspace:*
+        version: link:../timing
       '@granit/utils':
         specifier: workspace:*
         version: link:../utils
@@ -2700,6 +2709,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/timing':
+        specifier: workspace:*
+        version: link:../timing
       '@granit/types':
         specifier: workspace:*
         version: link:../types
@@ -7620,6 +7632,18 @@ importers:
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
+
+  packages/@granit/timing:
+    devDependencies:
+      '@date-fns/tz':
+        specifier: ^1.0.0
+        version: 1.5.0
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing


### PR DESCRIPTION
## Context

Closes the "Grafana-style dashboard time controls" feature. The backend generalised timezone + first-day-of-week into locale settings (granit-dotnet **#2913**) and promoted token resolution into `Granit.Timing.IPeriodResolver` (tz + first-day aware, DST-correct). Business **!193** made the bundle-render path (`POST /dashboards/{id}/render`) resolve `PeriodToken` **server-side** and ignore client `from/to` when a token is present.

## What this does

### New package `@granit/timing`
JS/TS mirror of the backend `Granit.Timing` assembly. Owns:
- **`resolvePeriodToken(token, { now?, weekStartsOn?, timeZone? })`** → absolute `[from, to)` bounds, byte-for-byte matching `Granit.Timing.PeriodResolver`. DST-correct via `@date-fns/tz` (optional peer): sub-day tokens stay timezone-independent; calendar tokens are day-aligned in the local timezone and mapped back to UTC (a "day" spans 23/24/25 h across a transition). **No `timeZone` → pure UTC**, identical to the previous behaviour.
- **`Weekday`** — the shared `0=Sunday … 6=Saturday` index (previously duplicated in dashboards + react-localization).

`TimeZoneId` / `ISODateString` stay in `@granit/types` (the shared brand vocabulary); `@granit/timing` depends on `@granit/types` and re-exports `TimeZoneId` for ergonomics.

### Task 1 — framework setting key
`SETTING_NAMES.FIRST_DAY_OF_WEEK` → `'Granit.Timing.PreferredFirstDayOfWeek'` (canonical key of #2913).

### Task 2 — timezone hook
Reused the existing `useTimezone()` (already provider-based, mirroring `useFirstDayOfWeek`) rather than adding a duplicate; it now returns a branded `TimeZoneId`.

### Task 3 — client-side tz-aware bounds
New `resolveTimeWindowBounds(timeWindow, { now?, weekStartsOn?, timeZone? })` in `@granit/dashboards`, delegating tokens to `@granit/timing`. `shiftTimeWindow` / `zoomOutTimeWindow` rewired onto it. `DashboardContext` now carries `weekStartsOn` + `timeZone` so the shift/zoom controls resolve token windows the way the server would.

### Task 4 — server-authoritative render request
`resolveTimeWindowToRenderRequest` now emits **`{ periodToken }` alone** for token windows (server resolves it, tz-aware) and `{ periodFrom, periodTo }` for absolute ranges. It no longer computes bounds client-side.

### Task 5 — `defaultTimeWindow`
Verified: already present on `DashboardDetailResponse` DTO + `contracts/openapi/dashboards.json`. No wire change (only server behaviour changed), so no vendored-spec update needed.

## Tests / DoD
- New `resolve-period-token` matrix: UTC non-regression, `Asia/Tokyo` (offset day), `Europe/Brussels` DST spring-forward (23h) + fall-back (25h), `weekStartsOn` for `wtd`/`pw`, `AddMonths` clamp.
- Render request → `{ periodToken }` only; `resolveTimeWindowBounds` tz delegation; `shiftTimeWindow` with `timeZone`.
- ✅ `tsc`, ESLint (`--max-warnings 0`), `vitest`, arch-tests (3229), `check:csp`, markdownlint. Lockfile + front-index regenerated.

## Notes for reviewers
- `@granit/dashboards` internal types `ResolveTimeWindowOptions` → `ResolveTimeWindowBoundsOptions` (was internal to the package); `Weekday` now re-exported from `@granit/timing`.
- No showcase-react change is required by this PR; a follow-up MR can feed the `Granit.Timing.Preferred*` settings into the `TimezoneProvider` / `FirstDayOfWeekProvider`.