### PR TITLE
feat(dashboards): restyle the refresh control as a Grafana-style pill

### DIFF
--- a/packages/@granit/react-dashboards/src/components/dashboard-refresh-toolbar.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-refresh-toolbar.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 
 import { useDashboardContext } from './dashboard-context';
+import { ChevronDownIcon, joinClasses, PILL_CLASS, RefreshIcon, SEGMENT_BUTTON_CLASS } from './pill-controls';
 
 import type { DashboardRefreshInterval } from '@granit/dashboards';
 
@@ -71,29 +72,31 @@ export function DashboardRefreshToolbar({ className, onRefresh }: DashboardRefre
       data-slot="dashboard-refresh-toolbar"
       role="toolbar"
       aria-label="Dashboard refresh"
-      className={joinClasses('flex items-end gap-2', className)}
+      className={joinClasses(PILL_CLASS, className)}
     >
+      {/* Manual "refresh now" + the cadence picker, one segmented pill matching
+          the time-window toolbar. */}
       <button
         type="button"
         data-slot="dashboard-refresh-now"
         aria-label={t('Dashboard:Refresh.Now', { defaultValue: 'Refresh now' })}
         onClick={refreshNow}
-        className="rounded-md border bg-background px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+        className={SEGMENT_BUTTON_CLASS}
       >
-        <span aria-hidden>↻</span>
+        <RefreshIcon />
+        <span>{t('Dashboard:Refresh.Label', { defaultValue: 'Refresh' })}</span>
       </button>
-      <label className="flex flex-col gap-1 text-xs">
-        <span data-slot="dashboard-refresh-label" className="text-muted-foreground">
-          {t('Dashboard:Refresh.Label', { defaultValue: 'Refresh' })}
-        </span>
+
+      <div className="relative flex items-center border-l">
         <select
           data-slot="dashboard-refresh-select"
+          aria-label={t('Dashboard:Refresh.Cadence', { defaultValue: 'Refresh cadence' })}
           value={String(refreshInterval)}
           onChange={(event) => {
             const option = OPTIONS.find((o) => String(o.value) === event.target.value);
             if (option) setRefreshInterval(option.value);
           }}
-          className="rounded-md border bg-background px-2.5 py-1.5 text-sm"
+          className="h-full cursor-pointer appearance-none bg-transparent py-1.5 pl-3 pr-8 font-medium text-foreground focus:outline-none focus-visible:bg-accent"
         >
           {OPTIONS.map((option) => (
             <option key={String(option.value)} value={String(option.value)}>
@@ -101,11 +104,8 @@ export function DashboardRefreshToolbar({ className, onRefresh }: DashboardRefre
             </option>
           ))}
         </select>
-      </label>
+        <ChevronDownIcon className="pointer-events-none absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+      </div>
     </div>
   );
-}
-
-function joinClasses(...parts: ReadonlyArray<string | undefined>): string {
-  return parts.filter(Boolean).join(' ');
 }

--- a/packages/@granit/react-dashboards/src/components/dashboard-time-window-toolbar.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-time-window-toolbar.tsx
@@ -1,8 +1,18 @@
 import { DASHBOARD_TIME_WINDOW, shiftTimeWindow, zoomOutTimeWindow } from '@granit/dashboards';
-import { useState, type ReactNode } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useDashboardContext } from './dashboard-context';
+import {
+  ChevronDownIcon,
+  ChevronsLeftIcon,
+  ChevronsRightIcon,
+  ClockIcon,
+  joinClasses,
+  PILL_CLASS,
+  SEGMENT_BUTTON_CLASS,
+  ZoomOutIcon,
+} from './pill-controls';
 
 import type { DashboardTimeWindow } from '@granit/dashboards';
 
@@ -175,11 +185,7 @@ export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToo
     >
       {/* Grafana-style segmented pill: shift back « · clock + range picker ▾ ·
           shift forward » · zoom out ⊖. */}
-      <div
-        role="toolbar"
-        aria-label="Dashboard time window"
-        className="inline-flex h-9 items-stretch overflow-hidden rounded-md border bg-background text-sm shadow-sm"
-      >
+      <div role="toolbar" aria-label="Dashboard time window" className={PILL_CLASS}>
         <button
           type="button"
           data-slot="dashboard-time-window-back"
@@ -301,87 +307,10 @@ export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToo
   );
 }
 
-/** Shared styling for the flanking icon buttons of the segmented pill. */
-const SEGMENT_BUTTON_CLASS =
-  'flex items-center px-2.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground';
-
-/** Line-icon wrapper (lucide-style geometry) — keeps the package icon-lib-free. */
-function Icon({
-  children,
-  className,
-}: {
-  readonly children: ReactNode;
-  readonly className?: string;
-}) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden
-      className={className ?? 'h-4 w-4'}
-    >
-      {children}
-    </svg>
-  );
-}
-
-function ClockIcon({ className }: { readonly className?: string }) {
-  return (
-    <Icon className={className}>
-      <circle cx="12" cy="12" r="10" />
-      <polyline points="12 6 12 12 16 14" />
-    </Icon>
-  );
-}
-
-function ChevronDownIcon({ className }: { readonly className?: string }) {
-  return (
-    <Icon className={className}>
-      <path d="m6 9 6 6 6-6" />
-    </Icon>
-  );
-}
-
-function ChevronsLeftIcon() {
-  return (
-    <Icon>
-      <path d="m11 17-5-5 5-5" />
-      <path d="m18 17-5-5 5-5" />
-    </Icon>
-  );
-}
-
-function ChevronsRightIcon() {
-  return (
-    <Icon>
-      <path d="m6 17 5-5-5-5" />
-      <path d="m13 17 5-5-5-5" />
-    </Icon>
-  );
-}
-
-function ZoomOutIcon() {
-  return (
-    <Icon>
-      <circle cx="11" cy="11" r="8" />
-      <path d="m21 21-4.3-4.3" />
-      <path d="M8 11h6" />
-    </Icon>
-  );
-}
-
 /** ISO 8601 UTC → `datetime-local` value (`YYYY-MM-DDTHH:mm`) in the browser's local zone. */
 function toLocalInput(iso: string): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return '';
   const pad = (n: number) => String(n).padStart(2, '0');
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
-}
-
-function joinClasses(...parts: ReadonlyArray<string | undefined>): string {
-  return parts.filter(Boolean).join(' ');
 }

--- a/packages/@granit/react-dashboards/src/components/pill-controls.tsx
+++ b/packages/@granit/react-dashboards/src/components/pill-controls.tsx
@@ -1,0 +1,95 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Shared vocabulary for the Grafana-style segmented "pill" toolbars
+ * (time-window + refresh): the container / segment classes and the line-icon
+ * set. Kept icon-library-free (inline lucide-geometry SVGs) so the headless
+ * `@granit/react-dashboards` tier stays dependency-light and usable on every
+ * dashboard surface.
+ */
+
+/** Rounded, bordered pill that groups segments separated by `border-l`. */
+export const PILL_CLASS =
+  'inline-flex h-9 items-stretch overflow-hidden rounded-md border bg-background text-sm shadow-sm';
+
+/** A flanking icon/text segment of the pill. */
+export const SEGMENT_BUTTON_CLASS =
+  'flex items-center gap-1.5 px-2.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground';
+
+export function joinClasses(...parts: ReadonlyArray<string | undefined>): string {
+  return parts.filter(Boolean).join(' ');
+}
+
+/** Line-icon wrapper (lucide-style geometry). */
+function Icon({ children, className }: { readonly children: ReactNode; readonly className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className={className ?? 'h-4 w-4'}
+    >
+      {children}
+    </svg>
+  );
+}
+
+export function ClockIcon({ className }: { readonly className?: string }) {
+  return (
+    <Icon className={className}>
+      <circle cx="12" cy="12" r="10" />
+      <polyline points="12 6 12 12 16 14" />
+    </Icon>
+  );
+}
+
+export function ChevronDownIcon({ className }: { readonly className?: string }) {
+  return (
+    <Icon className={className}>
+      <path d="m6 9 6 6 6-6" />
+    </Icon>
+  );
+}
+
+export function ChevronsLeftIcon() {
+  return (
+    <Icon>
+      <path d="m11 17-5-5 5-5" />
+      <path d="m18 17-5-5 5-5" />
+    </Icon>
+  );
+}
+
+export function ChevronsRightIcon() {
+  return (
+    <Icon>
+      <path d="m6 17 5-5-5-5" />
+      <path d="m13 17 5-5-5-5" />
+    </Icon>
+  );
+}
+
+export function ZoomOutIcon() {
+  return (
+    <Icon>
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.3-4.3" />
+      <path d="M8 11h6" />
+    </Icon>
+  );
+}
+
+export function RefreshIcon({ className }: { readonly className?: string }) {
+  return (
+    <Icon className={className}>
+      <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+      <path d="M21 3v5h-5" />
+      <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+      <path d="M3 21v-5h5" />
+    </Icon>
+  );
+}


### PR DESCRIPTION
## Context

The time-window toolbar already renders the Grafana-style **segmented pill** (shift « · clock + range picker ▾ · shift » · zoom ⊖, with the custom-range popover) — matching the reference artifact. The **refresh control** was still a bare native `<select>` with a stacked label. This aligns it to the same pill aesthetic.

## Changes

- **`pill-controls.tsx`** (new, shared): extracts the pill vocabulary both toolbars use — `PILL_CLASS`, `SEGMENT_BUTTON_CLASS`, the inline line-icon set (lucide geometry, no icon-lib dependency — keeps the tier headless), `joinClasses` — and adds `RefreshIcon`. The time-window toolbar now imports from it instead of duplicating the icons.
- **`DashboardRefreshToolbar`**: a "↻ Refresh" button segment + the cadence `<select>` (native, keyboard/SR intact) overlaid with a caret, in one rounded/bordered pill matching the time-window control. Cadence propagation + manual-refresh wiring unchanged.

## Verification

- `tsc --noEmit`: clean · Vitest: react-dashboards **200**, editor + ui-dashboards + arch **3307** passing · ESLint clean
- Existing refresh + time-window toolbar tests unchanged and green (data-slots preserved)

## Note

Both controls stay in the **headless `@granit/react-dashboards` tier** (native `<select>` + inline SVG), so they render identically on every surface (view, edit, playground) with no ui-kit dependency.