### PR TITLE
test(dashboards): align widget-bridge fixture with SubscriptionQuery key

### DIFF
--- a/packages/@granit/dashboards/src/types/__tests__/widget-bridge.test.ts
+++ b/packages/@granit/dashboards/src/types/__tests__/widget-bridge.test.ts
@@ -144,9 +144,9 @@ describe('widgetInstanceToDefinition', () => {
       height: 3,
       titleLocalizationKey: `Widget:${DASHBOARD_NAME}.Cancellations`,
       metricName: null,
-      queryName: 'Granit.Subscriptions.SubscriptionsQuery',
+      queryName: 'Granit.Subscriptions.SubscriptionQuery',
       configJson: JSON.stringify({
-        queryName: 'Granit.Subscriptions.SubscriptionsQuery',
+        queryName: 'Granit.Subscriptions.SubscriptionQuery',
         groupBy: 'Week',
         aggregation: 'Count',
         field: null,
@@ -155,7 +155,7 @@ describe('widgetInstanceToDefinition', () => {
       requiredPermission: null,
     };
     const widget = widgetInstanceToDefinition(instance, DASHBOARD_NAME) as ChartWidgetStub;
-    expect(widget.queryName).toBe('Granit.Subscriptions.SubscriptionsQuery');
+    expect(widget.queryName).toBe('Granit.Subscriptions.SubscriptionQuery');
   });
 
   it('falls back to the denormalized queryName column when configJson omits it (legacy dashboard)', () => {
@@ -169,7 +169,7 @@ describe('widgetInstanceToDefinition', () => {
       titleLocalizationKey: `Widget:${DASHBOARD_NAME}.Cancellations`,
       metricName: null,
       // The denormalized column carries the query; the legacy configJson does not.
-      queryName: 'Granit.Subscriptions.SubscriptionsQuery',
+      queryName: 'Granit.Subscriptions.SubscriptionQuery',
       configJson: JSON.stringify({
         groupBy: 'Week',
         aggregation: 'Count',
@@ -179,7 +179,7 @@ describe('widgetInstanceToDefinition', () => {
       requiredPermission: null,
     };
     const widget = widgetInstanceToDefinition(instance, DASHBOARD_NAME) as ChartWidgetStub;
-    expect(widget.queryName).toBe('Granit.Subscriptions.SubscriptionsQuery');
+    expect(widget.queryName).toBe('Granit.Subscriptions.SubscriptionQuery');
   });
 });
 


### PR DESCRIPTION
## What

The backend renamed the Subscriptions query-catalog key `Granit.Subscriptions.SubscriptionsQuery` → `Granit.Subscriptions.SubscriptionQuery` (granit-business MR !196, intra-module singular consistency). This updates the last remaining reference to the old literal — the `widget-bridge.test.ts` fixture.

It is **sample data only** (no runtime dependency on the backend key), so this is a pure test hygiene follow-up.

## Test

`widget-bridge.test.ts` **24/24** green, prettier clean.