### PR TITLE
feat(dashboards): server-side sort for the Table widget + row-limit rename

### DIFF
--- a/contracts/openapi/analytics.json
+++ b/contracts/openapi/analytics.json
@@ -1366,6 +1366,13 @@
             "type": "integer",
             "format": "int32"
           },
+          "sortField": {
+            "type": ["null", "string"]
+          },
+          "sortDirection": {
+            "type": ["null", "string"],
+            "default": "asc"
+          },
           "slug": {
             "type": "string"
           },

--- a/packages/@granit/analytics/src/types/table-widget.ts
+++ b/packages/@granit/analytics/src/types/table-widget.ts
@@ -13,4 +13,16 @@ export interface TableWidgetDefinition extends WidgetDefinitionBase {
   /** Subset of the query's columns to surface, in order. Null = render all. */
   readonly visibleColumns: readonly string[] | null;
   readonly pageSize: number;
+  /**
+   * Column to order the rows by — a sortable field name (matches
+   * `QueryMetadata.sortableFields[].name` / `TableWidgetColumn.name`). Null (or
+   * absent) falls back to the query's default sort. Applied server-side before
+   * the `pageSize` truncation, so it genuinely picks the "top N".
+   */
+  readonly sortField?: string | null;
+  /**
+   * Direction for {@link sortField}. Ignored when no sort field is set. Defaults
+   * to `'asc'`. Mirrors `TableWidgetDefinition.SortDirection`.
+   */
+  readonly sortDirection?: 'asc' | 'desc';
 }

--- a/packages/@granit/react-analytics/src/editor/analytics-widget-catalog.ts
+++ b/packages/@granit/react-analytics/src/editor/analytics-widget-catalog.ts
@@ -76,6 +76,9 @@ export const analyticsWidgetCatalog: readonly WidgetCatalogEntry[] = Object.free
       queryName: '',
       visibleColumns: null,
       pageSize: 10,
+      // No explicit sort: the backend falls back to the query's default sort.
+      sortField: null,
+      sortDirection: 'asc',
     }),
   },
   {

--- a/packages/@granit/react-analytics/src/editor/use-query-field-metadata.ts
+++ b/packages/@granit/react-analytics/src/editor/use-query-field-metadata.ts
@@ -52,6 +52,13 @@ export interface QueryFieldMetadata {
   readonly fieldOptions: readonly FieldOption[];
   /** All columns of the selected query (e.g. the table visible-columns picker). */
   readonly columnOptions: readonly FieldOption[];
+  /**
+   * Sortable field options for the selected query: the columns flagged
+   * `isSortable` (they carry display labels), falling back to the query's
+   * declared `sortableFields` when no column advertises sortability. Empty until
+   * metadata resolves.
+   */
+  readonly sortableFieldOptions: readonly FieldOption[];
 }
 
 /**
@@ -74,6 +81,8 @@ export function useQueryFieldMetadata(queryName: string): QueryFieldMetadata {
   const numericColumns = (meta?.columns ?? [])
     .filter((column) => NUMERIC_CLR_TYPES.has(column.type))
     .map(toOption);
+  const sortableColumns = (meta?.columns ?? []).filter((column) => column.isSortable).map(toOption);
+  const sortableDeclared = (meta?.sortableFields ?? []).map(toOption);
 
   return {
     catalogEntries: catalog,
@@ -81,5 +90,6 @@ export function useQueryFieldMetadata(queryName: string): QueryFieldMetadata {
     groupByOptions: groupByDeclared.length > 0 ? groupByDeclared : columnOptions,
     fieldOptions: numericColumns.length > 0 ? numericColumns : columnOptions,
     columnOptions,
+    sortableFieldOptions: sortableColumns.length > 0 ? sortableColumns : sortableDeclared,
   };
 }

--- a/packages/@granit/react-ui-analytics/src/__tests__/table-config-form.test.tsx
+++ b/packages/@granit/react-ui-analytics/src/__tests__/table-config-form.test.tsx
@@ -53,10 +53,11 @@ function mockCatalogClient() {
       return Promise.resolve({
         data: {
           columns: [
-            { name: 'Name', label: 'Name', type: 'String' },
-            { name: 'Amount', label: 'Amount', type: 'Decimal' },
+            { name: 'Name', label: 'Name', type: 'String', isSortable: true },
+            { name: 'Amount', label: 'Amount', type: 'Decimal', isSortable: true },
           ],
           groupByFields: [],
+          sortableFields: [{ name: 'Name' }, { name: 'Amount' }],
         },
       });
     }
@@ -114,5 +115,31 @@ describe('TableConfigForm', () => {
     expect(await screen.findByRole('option', { name: 'Name' })).toBeInTheDocument();
     await user.click(await screen.findByRole('option', { name: 'Amount' }));
     expect(onChange.mock.calls.at(-1)?.[0]?.visibleColumns).toEqual(['Amount']);
+  });
+
+  it('renders the sort-field control but hides the direction control with no sort field', () => {
+    const { container } = wrap(<TableConfigForm widget={baseTable} onChange={vi.fn()} />);
+    expect(container.querySelector('[data-slot="table-sort-field"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="table-sort-direction"]')).toBeNull();
+  });
+
+  it('reveals the direction control once a sort field is set', () => {
+    const { container } = wrap(
+      <TableConfigForm widget={{ ...baseTable, sortField: 'Amount' }} onChange={vi.fn()} />
+    );
+    expect(container.querySelector('[data-slot="table-sort-direction"]')).not.toBeNull();
+  });
+
+  it('emits a sortable field selected from the metadata combobox', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { container } = wrap(
+      <TableConfigForm widget={baseTable} onChange={onChange} />,
+      mockCatalogClient()
+    );
+
+    await user.click(container.querySelector('[data-slot="table-sort-field"]')!);
+    await user.click(await screen.findByRole('option', { name: 'Amount' }));
+    expect(onChange.mock.calls.at(-1)?.[0]?.sortField).toBe('Amount');
   });
 });

--- a/packages/@granit/react-ui-analytics/src/components/table-config-form.tsx
+++ b/packages/@granit/react-ui-analytics/src/components/table-config-form.tsx
@@ -2,27 +2,40 @@ import { useQueryFieldMetadata } from '@granit/react-analytics';
 import { Input } from '@granit/react-ui';
 import { useTranslation } from 'react-i18next';
 
-import { MetaMultiFieldInput, QueryNameCombobox, RequiredMark } from './query-field-controls';
+import {
+  EnumSelect,
+  MetaFieldInput,
+  MetaMultiFieldInput,
+  QueryNameCombobox,
+  RequiredMark,
+} from './query-field-controls';
 
 import type { TableWidgetDefinition } from '@granit/analytics';
 import type { WidgetConfigFormProps } from '@granit/react-dashboard-editor';
 
 /**
  * Built-in config form for {@link TableWidgetDefinition}. Edits the
- * query binding, visible columns + page size.
+ * query binding, visible columns, sort (server-side) + row limit.
+ *
+ * The table renders a single page (top N) — the row limit caps the rows the
+ * backend returns; there is no pagination. The sort field / direction are
+ * applied server-side before that truncation, so they choose which N rows show;
+ * leaving the sort field empty falls back to the query's default sort.
  *
  * Under a `<QueryCatalogProvider>` the query field is a catalogue-backed
- * combobox and the visible-columns picker is a multi-select sourced from the
- * query's columns; otherwise both degrade to free-text (comma-separated for
- * columns). Apps wanting a richer column-picker dialog register their own form
- * via `composeWidgetConfigFormRegistries`.
+ * combobox and the column / sort pickers are sourced from the query's metadata;
+ * otherwise they degrade to free-text (comma-separated for columns). Apps
+ * wanting a richer column-picker dialog register their own form via
+ * `composeWidgetConfigFormRegistries`.
  */
 export function TableConfigForm({
   widget,
   onChange,
 }: WidgetConfigFormProps<TableWidgetDefinition>) {
   const { t } = useTranslation();
-  const { catalogEntries, columnOptions } = useQueryFieldMetadata(widget.queryName);
+  const { catalogEntries, columnOptions, sortableFieldOptions } = useQueryFieldMetadata(
+    widget.queryName
+  );
 
   return (
     <div data-slot="table-config-form" className="space-y-3">
@@ -55,7 +68,37 @@ export function TableConfigForm({
       </label>
       <label className="block text-sm">
         <span className="mb-1 block text-muted-foreground">
-          {t('Dashboard:Widget.Table.PageSize.Label')}
+          {t('Dashboard:Widget.Table.SortField.Label')}
+        </span>
+        <MetaFieldInput
+          slot="table-sort-field"
+          value={widget.sortField ?? ''}
+          options={sortableFieldOptions}
+          allowEmpty
+          onChange={(value) => onChange({ ...widget, sortField: value.length > 0 ? value : null })}
+        />
+      </label>
+      {widget.sortField ? (
+        <label className="block text-sm">
+          <span className="mb-1 block text-muted-foreground">
+            {t('Dashboard:Widget.Table.SortDirection.Label')}
+          </span>
+          <EnumSelect
+            slot="table-sort-direction"
+            value={widget.sortDirection ?? 'asc'}
+            options={[
+              { value: 'asc', label: t('Dashboard:Widget.Table.SortDirection.Asc') },
+              { value: 'desc', label: t('Dashboard:Widget.Table.SortDirection.Desc') },
+            ]}
+            onChange={(value) =>
+              onChange({ ...widget, sortDirection: value === 'desc' ? 'desc' : 'asc' })
+            }
+          />
+        </label>
+      ) : null}
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Table.RowLimit.Label')}
         </span>
         <Input
           type="number"


### PR DESCRIPTION
## Context

As a dashboard author, the Table widget gave no control over row ordering: rows fell back to the backing query's default sort, so the "first pageSize rows" were an arbitrary top-N. There was also no way to choose which column to sort by.

Pairs with the granit-business backend change (sort threaded into `QueryRequest.Sort`, applied before the page-size truncation).

## Changes

- **Contract** (`@granit/analytics`): add optional `sortField: string | null` + `sortDirection: 'asc' | 'desc'` to `TableWidgetDefinition`. Null `sortField` preserves current behaviour (query default sort). Mirrors the backend DTO; `contracts/openapi/analytics.json` synced (2 properties).
- **Editor** (`@granit/react-ui-analytics`): sortable-field combobox sourced from the query metadata's sortable columns (`sortableFieldOptions`, new on `useQueryFieldMetadata`) + an asc/desc toggle shown once a field is picked.
- **Row limit rename**: the "Page Size" editor label now uses a `RowLimit.Label` i18n key — the widget renders a single page (top N), not paginated results, so the old term was misleading. The `pageSize` field name is unchanged (no data migration).

## Why single-page / top-N (no pagination)

A dashboard tile is glanceable, not an exploration surface; pagination state doesn't survive auto-refresh and Grafana's table panel follows the same top-N + limit model. Sort is server-side (applied before truncation) so it genuinely selects the top N — client header sort would only reorder the visible slice.

## Verification

- `pnpm tsc` (workspace) — clean
- ESLint (changed files, `--max-warnings 0`) — clean
- `table-config-form` tests — 6/6 (sort-field emit, direction gating, existing)

## Follow-up (separate)

Host (showcase) translations for the new keys: `Dashboard:Widget.Table.SortField.Label`, `SortDirection.Label/Asc/Desc`, and renaming `PageSize.Label` → `RowLimit.Label`.