### PR TITLE
feat(dashboards): Grafana-style styled time-range + refresh controls (UI tier)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4930,6 +4930,28 @@
           "signature": "function useEffectiveRefreshInterval( override?: DashboardRefreshInterval ): DashboardRefreshInterval"
         },
         {
+          "name": "TIME_WINDOW_GROUPS",
+          "kind": "const",
+          "signature": "const TIME_WINDOW_GROUPS: readonly TimeWindowGroup[]"
+        },
+        {
+          "name": "TIME_WINDOW_PRESETS",
+          "kind": "const",
+          "signature": "const TIME_WINDOW_PRESETS: readonly TimeWindowPreset[]"
+        },
+        {
+          "name": "TimeWindowGroup",
+          "kind": "interface",
+          "signature": "interface TimeWindowGroup",
+          "members": []
+        },
+        {
+          "name": "TimeWindowPreset",
+          "kind": "interface",
+          "signature": "interface TimeWindowPreset",
+          "members": []
+        },
+        {
           "name": "useWidgetTriggerHandler",
           "kind": "function",
           "signature": "function useWidgetTriggerHandler( trigger: WidgetActionTrigger, actions: readonly WidgetAction[] | null | undefined ): ((data?: Readonly<Record<string, unknown>>) => void) | null"
@@ -8791,6 +8813,28 @@
           "name": "DashboardComposerProps",
           "kind": "interface",
           "signature": "interface DashboardComposerProps",
+          "members": []
+        },
+        {
+          "name": "DashboardTimeRangeControl",
+          "kind": "function",
+          "signature": "function DashboardTimeRangeControl("
+        },
+        {
+          "name": "DashboardTimeRangeControlProps",
+          "kind": "interface",
+          "signature": "interface DashboardTimeRangeControlProps",
+          "members": []
+        },
+        {
+          "name": "DashboardRefreshControl",
+          "kind": "function",
+          "signature": "function DashboardRefreshControl("
+        },
+        {
+          "name": "DashboardRefreshControlProps",
+          "kind": "interface",
+          "signature": "interface DashboardRefreshControlProps",
           "members": []
         },
         {

--- a/packages/@granit/react-dashboard-editor/src/components/editable-dashboard.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/editable-dashboard.tsx
@@ -70,6 +70,13 @@ export interface EditableDashboardProps {
   readonly onEditWidget?: (slug: string) => void;
   readonly onDuplicateWidget?: (slug: string) => void;
   readonly onDeleteWidget?: (slug: string) => void;
+  /**
+   * Time-range / refresh controls rendered above the canvas, inside the
+   * dashboard context. Defaults to the headless `DashboardTimeWindowToolbar` +
+   * `DashboardRefreshToolbar`; a UI-tier parent can pass the styled controls
+   * (they read the same context).
+   */
+  readonly controlsSlot?: ReactNode;
 }
 
 export function EditableDashboard({
@@ -81,6 +88,7 @@ export function EditableDashboard({
   onEditWidget,
   onDuplicateWidget,
   onDeleteWidget,
+  controlsSlot,
 }: EditableDashboardProps) {
   const breakpoint = useDashboardBreakpoint();
 
@@ -153,8 +161,12 @@ export function EditableDashboard({
           data-slot="dashboard-controls"
           className="mb-3 flex flex-wrap items-end justify-end gap-3"
         >
-          <DashboardTimeWindowToolbar />
-          <DashboardRefreshToolbar />
+          {controlsSlot ?? (
+            <>
+              <DashboardTimeWindowToolbar />
+              <DashboardRefreshToolbar />
+            </>
+          )}
         </div>
         <GridLayout
           width={width || FALLBACK_WIDTH_PX}

--- a/packages/@granit/react-dashboards/src/components/dashboard-time-window-toolbar.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-time-window-toolbar.tsx
@@ -1,6 +1,11 @@
-import { DASHBOARD_TIME_WINDOW, shiftTimeWindow, zoomOutTimeWindow } from '@granit/dashboards';
+import { shiftTimeWindow, zoomOutTimeWindow } from '@granit/dashboards';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+
+import {
+  TIME_WINDOW_GROUPS as GROUPS,
+  TIME_WINDOW_PRESETS as ALL_PRESETS,
+} from '../lib/time-window-presets';
 
 import { useDashboardContext } from './dashboard-context';
 import {
@@ -14,114 +19,8 @@ import {
   ZoomOutIcon,
 } from './pill-controls';
 
-import type { DashboardTimeWindow } from '@granit/dashboards';
-
 /** Sentinel `<select>` value that reveals the absolute-range inputs. */
 const CUSTOM_VALUE = '__custom__';
-
-/**
- * One quick-range option. Carries the token that identifies it in
- * {@link DashboardTimeWindow.period} plus a localization key (with an English
- * fallback, mirroring {@link DashboardFilterToolbar} — the package ships no
- * locale files, host translations override via the key).
- */
-interface TimeWindowPreset {
-  readonly token: string;
-  readonly window: DashboardTimeWindow;
-  readonly labelKey: string;
-  readonly defaultLabel: string;
-}
-
-interface TimeWindowGroup {
-  readonly labelKey: string;
-  readonly defaultLabel: string;
-  readonly presets: readonly TimeWindowPreset[];
-}
-
-const W = DASHBOARD_TIME_WINDOW;
-
-function preset(
-  window: DashboardTimeWindow,
-  labelKey: string,
-  defaultLabel: string
-): TimeWindowPreset {
-  const token = 'token' in window.period ? window.period.token : '';
-  return { token, window, labelKey, defaultLabel };
-}
-
-/** Grafana-style quick ranges, grouped for a scannable dropdown. */
-const GROUPS: readonly TimeWindowGroup[] = [
-  {
-    labelKey: 'Dashboard:TimeWindow.Group.MinutesHours',
-    defaultLabel: 'Minutes & hours',
-    presets: [
-      preset(W.Last5Minutes, 'Dashboard:TimeWindow.Last5Minutes', 'Last 5 minutes'),
-      preset(W.Last15Minutes, 'Dashboard:TimeWindow.Last15Minutes', 'Last 15 minutes'),
-      preset(W.Last30Minutes, 'Dashboard:TimeWindow.Last30Minutes', 'Last 30 minutes'),
-      preset(W.Last1Hour, 'Dashboard:TimeWindow.Last1Hour', 'Last 1 hour'),
-      preset(W.Last3Hours, 'Dashboard:TimeWindow.Last3Hours', 'Last 3 hours'),
-      preset(W.Last6Hours, 'Dashboard:TimeWindow.Last6Hours', 'Last 6 hours'),
-      preset(W.Last12Hours, 'Dashboard:TimeWindow.Last12Hours', 'Last 12 hours'),
-      preset(W.Last24Hours, 'Dashboard:TimeWindow.Last24Hours', 'Last 24 hours'),
-    ],
-  },
-  {
-    labelKey: 'Dashboard:TimeWindow.Group.Days',
-    defaultLabel: 'Days',
-    presets: [
-      preset(W.Last2Days, 'Dashboard:TimeWindow.Last2Days', 'Last 2 days'),
-      preset(W.Last7Days, 'Dashboard:TimeWindow.Last7Days', 'Last 7 days'),
-      preset(W.Last30Days, 'Dashboard:TimeWindow.Last30Days', 'Last 30 days'),
-    ],
-  },
-  {
-    labelKey: 'Dashboard:TimeWindow.Group.MonthsYears',
-    defaultLabel: 'Months & years',
-    presets: [
-      preset(W.Last3Months, 'Dashboard:TimeWindow.Last3Months', 'Last 3 months'),
-      preset(W.Last6Months, 'Dashboard:TimeWindow.Last6Months', 'Last 6 months'),
-      preset(W.Last1Year, 'Dashboard:TimeWindow.Last1Year', 'Last 1 year'),
-      preset(W.Last2Years, 'Dashboard:TimeWindow.Last2Years', 'Last 2 years'),
-      preset(W.Last5Years, 'Dashboard:TimeWindow.Last5Years', 'Last 5 years'),
-    ],
-  },
-  {
-    labelKey: 'Dashboard:TimeWindow.Group.RelativeDays',
-    defaultLabel: 'Relative days',
-    presets: [
-      preset(W.Today, 'Dashboard:TimeWindow.Today', 'Today'),
-      preset(W.Yesterday, 'Dashboard:TimeWindow.Yesterday', 'Yesterday'),
-      preset(
-        W.DayBeforeYesterday,
-        'Dashboard:TimeWindow.DayBeforeYesterday',
-        'Day before yesterday'
-      ),
-      preset(W.ThisDayLastWeek, 'Dashboard:TimeWindow.ThisDayLastWeek', 'This day last week'),
-    ],
-  },
-  {
-    labelKey: 'Dashboard:TimeWindow.Group.ToDate',
-    defaultLabel: 'To date',
-    presets: [
-      preset(W.Wtd, 'Dashboard:TimeWindow.Wtd', 'This week (WTD)'),
-      preset(W.Mtd, 'Dashboard:TimeWindow.Mtd', 'This month (MTD)'),
-      preset(W.Qtd, 'Dashboard:TimeWindow.Qtd', 'This quarter (QTD)'),
-      preset(W.Ytd, 'Dashboard:TimeWindow.Ytd', 'This year (YTD)'),
-    ],
-  },
-  {
-    labelKey: 'Dashboard:TimeWindow.Group.Previous',
-    defaultLabel: 'Previous',
-    presets: [
-      preset(W.Pw, 'Dashboard:TimeWindow.Pw', 'Previous week (PW)'),
-      preset(W.Pm, 'Dashboard:TimeWindow.Pm', 'Previous month (PM)'),
-      preset(W.Pq, 'Dashboard:TimeWindow.Pq', 'Previous quarter (PQ)'),
-      preset(W.Py, 'Dashboard:TimeWindow.Py', 'Previous year (PY)'),
-    ],
-  },
-];
-
-const ALL_PRESETS: readonly TimeWindowPreset[] = GROUPS.flatMap((group) => group.presets);
 
 export interface DashboardTimeWindowToolbarProps {
   readonly className?: string;

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -143,6 +143,8 @@ export type {
 } from './lib/widget-action-handler';
 export { useEffectiveTimeWindow } from './hooks/use-effective-time-window';
 export { useEffectiveRefreshInterval } from './hooks/use-effective-refresh-interval';
+export { TIME_WINDOW_GROUPS, TIME_WINDOW_PRESETS } from './lib/time-window-presets';
+export type { TimeWindowGroup, TimeWindowPreset } from './lib/time-window-presets';
 export { useWidgetTriggerHandler } from './hooks/use-widget-trigger-handler';
 export {
   DASHBOARD_BREAKPOINT_MIN_WIDTH,

--- a/packages/@granit/react-dashboards/src/lib/time-window-presets.ts
+++ b/packages/@granit/react-dashboards/src/lib/time-window-presets.ts
@@ -1,0 +1,107 @@
+import { DASHBOARD_TIME_WINDOW } from '@granit/dashboards';
+
+import type { DashboardTimeWindow } from '@granit/dashboards';
+
+/**
+ * One quick-range option: the token identifying it in
+ * {@link DashboardTimeWindow.period}, the window itself, and a localization key
+ * (with an English fallback — packages ship no locale files, host translations
+ * override via the key). Shared by the headless {@link DashboardTimeWindowToolbar}
+ * and the UI-tier styled control so the vocabulary lives in one place.
+ */
+export interface TimeWindowPreset {
+  readonly token: string;
+  readonly window: DashboardTimeWindow;
+  readonly labelKey: string;
+  readonly defaultLabel: string;
+}
+
+export interface TimeWindowGroup {
+  readonly labelKey: string;
+  readonly defaultLabel: string;
+  readonly presets: readonly TimeWindowPreset[];
+}
+
+const W = DASHBOARD_TIME_WINDOW;
+
+function preset(
+  window: DashboardTimeWindow,
+  labelKey: string,
+  defaultLabel: string
+): TimeWindowPreset {
+  const token = 'token' in window.period ? window.period.token : '';
+  return { token, window, labelKey, defaultLabel };
+}
+
+/** Grafana-style quick ranges, grouped for a scannable menu. */
+export const TIME_WINDOW_GROUPS: readonly TimeWindowGroup[] = [
+  {
+    labelKey: 'Dashboard:TimeWindow.Group.MinutesHours',
+    defaultLabel: 'Minutes & hours',
+    presets: [
+      preset(W.Last5Minutes, 'Dashboard:TimeWindow.Last5Minutes', 'Last 5 minutes'),
+      preset(W.Last15Minutes, 'Dashboard:TimeWindow.Last15Minutes', 'Last 15 minutes'),
+      preset(W.Last30Minutes, 'Dashboard:TimeWindow.Last30Minutes', 'Last 30 minutes'),
+      preset(W.Last1Hour, 'Dashboard:TimeWindow.Last1Hour', 'Last 1 hour'),
+      preset(W.Last3Hours, 'Dashboard:TimeWindow.Last3Hours', 'Last 3 hours'),
+      preset(W.Last6Hours, 'Dashboard:TimeWindow.Last6Hours', 'Last 6 hours'),
+      preset(W.Last12Hours, 'Dashboard:TimeWindow.Last12Hours', 'Last 12 hours'),
+      preset(W.Last24Hours, 'Dashboard:TimeWindow.Last24Hours', 'Last 24 hours'),
+    ],
+  },
+  {
+    labelKey: 'Dashboard:TimeWindow.Group.Days',
+    defaultLabel: 'Days',
+    presets: [
+      preset(W.Last2Days, 'Dashboard:TimeWindow.Last2Days', 'Last 2 days'),
+      preset(W.Last7Days, 'Dashboard:TimeWindow.Last7Days', 'Last 7 days'),
+      preset(W.Last30Days, 'Dashboard:TimeWindow.Last30Days', 'Last 30 days'),
+    ],
+  },
+  {
+    labelKey: 'Dashboard:TimeWindow.Group.MonthsYears',
+    defaultLabel: 'Months & years',
+    presets: [
+      preset(W.Last3Months, 'Dashboard:TimeWindow.Last3Months', 'Last 3 months'),
+      preset(W.Last6Months, 'Dashboard:TimeWindow.Last6Months', 'Last 6 months'),
+      preset(W.Last1Year, 'Dashboard:TimeWindow.Last1Year', 'Last 1 year'),
+      preset(W.Last2Years, 'Dashboard:TimeWindow.Last2Years', 'Last 2 years'),
+      preset(W.Last5Years, 'Dashboard:TimeWindow.Last5Years', 'Last 5 years'),
+    ],
+  },
+  {
+    labelKey: 'Dashboard:TimeWindow.Group.RelativeDays',
+    defaultLabel: 'Relative days',
+    presets: [
+      preset(W.Today, 'Dashboard:TimeWindow.Today', 'Today'),
+      preset(W.Yesterday, 'Dashboard:TimeWindow.Yesterday', 'Yesterday'),
+      preset(W.DayBeforeYesterday, 'Dashboard:TimeWindow.DayBeforeYesterday', 'Day before yesterday'),
+      preset(W.ThisDayLastWeek, 'Dashboard:TimeWindow.ThisDayLastWeek', 'This day last week'),
+    ],
+  },
+  {
+    labelKey: 'Dashboard:TimeWindow.Group.ToDate',
+    defaultLabel: 'To date',
+    presets: [
+      preset(W.Wtd, 'Dashboard:TimeWindow.Wtd', 'This week (WTD)'),
+      preset(W.Mtd, 'Dashboard:TimeWindow.Mtd', 'This month (MTD)'),
+      preset(W.Qtd, 'Dashboard:TimeWindow.Qtd', 'This quarter (QTD)'),
+      preset(W.Ytd, 'Dashboard:TimeWindow.Ytd', 'This year (YTD)'),
+    ],
+  },
+  {
+    labelKey: 'Dashboard:TimeWindow.Group.Previous',
+    defaultLabel: 'Previous',
+    presets: [
+      preset(W.Pw, 'Dashboard:TimeWindow.Pw', 'Previous week (PW)'),
+      preset(W.Pm, 'Dashboard:TimeWindow.Pm', 'Previous month (PM)'),
+      preset(W.Pq, 'Dashboard:TimeWindow.Pq', 'Previous quarter (PQ)'),
+      preset(W.Py, 'Dashboard:TimeWindow.Py', 'Previous year (PY)'),
+    ],
+  },
+];
+
+/** Flat list across all groups — for matching the active token. */
+export const TIME_WINDOW_PRESETS: readonly TimeWindowPreset[] = TIME_WINDOW_GROUPS.flatMap(
+  (group) => group.presets
+);

--- a/packages/@granit/react-ui-dashboards/package.json
+++ b/packages/@granit/react-ui-dashboards/package.json
@@ -29,6 +29,7 @@
     "@granit/react-ui": "workspace:*",
     "@granit/react-ui-analytics": "workspace:*",
     "@granit/react-ui-kit": "workspace:*",
+    "@granit/utils": "workspace:*",
     "lucide-react": "^1.21.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -57,6 +58,7 @@
     "@granit/react-ui": "workspace:*",
     "@granit/react-ui-analytics": "workspace:*",
     "@granit/react-ui-kit": "workspace:*",
+    "@granit/utils": "workspace:*",
     "@storybook/react-vite": "^10.4.6",
     "@tanstack/react-query": "^5.0.0",
     "storybook": "^10.4.6"

--- a/packages/@granit/react-ui-dashboards/src/__tests__/dashboard-styled-controls.test.tsx
+++ b/packages/@granit/react-ui-dashboards/src/__tests__/dashboard-styled-controls.test.tsx
@@ -1,0 +1,128 @@
+import { DASHBOARD_TIME_WINDOW } from '@granit/dashboards';
+import { DashboardContextProvider } from '@granit/react-dashboards';
+import { createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import i18n from 'i18next';
+import { useState } from 'react';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DashboardRefreshControl } from '../components/dashboard-refresh-control';
+import { DashboardTimeRangeControl } from '../components/dashboard-time-range-control';
+
+import type { DashboardRefreshInterval, DashboardTimeWindow } from '@granit/dashboards';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: {} } },
+  interpolation: { escapeValue: false },
+});
+
+function wrap(node: ReactNode) {
+  return render(
+    <I18nextProvider i18n={testI18n}>
+      <QueryClientProvider client={createTestQueryClient()}>{node}</QueryClientProvider>
+    </I18nextProvider>
+  );
+}
+
+function TimeHarness({ onChange }: { readonly onChange?: (w: DashboardTimeWindow | undefined) => void }) {
+  const [timeWindow, setLocal] = useState<DashboardTimeWindow | undefined>(
+    DASHBOARD_TIME_WINDOW.Last24Hours
+  );
+  return (
+    <DashboardContextProvider
+      value={{
+        dashboardName: 'Test',
+        timeWindow,
+        setTimeWindow: (next) => {
+          const resolved = typeof next === 'function' ? next(timeWindow) : next;
+          setLocal(resolved);
+          onChange?.(resolved);
+        },
+      }}
+    >
+      <DashboardTimeRangeControl />
+    </DashboardContextProvider>
+  );
+}
+
+describe('DashboardTimeRangeControl', () => {
+  it('renders the pill with the active range label', () => {
+    wrap(<TimeHarness />);
+    expect(document.querySelector('[data-slot="dashboard-time-range-control"]')).toBeInTheDocument();
+    expect(screen.getByText('Last 24 hours')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the window is read-only', () => {
+    wrap(
+      <DashboardContextProvider
+        value={{ dashboardName: 'Test', timeWindow: DASHBOARD_TIME_WINDOW.Last24Hours }}
+      >
+        <DashboardTimeRangeControl />
+      </DashboardContextProvider>
+    );
+    expect(document.querySelector('[data-slot="dashboard-time-range-control"]')).toBeNull();
+  });
+
+  it('shifts the window to an absolute range via the ← control', () => {
+    const onChange = vi.fn();
+    wrap(<TimeHarness onChange={onChange} />);
+    fireEvent.click(document.querySelector('[data-slot="time-range-back"]')!);
+    expect(onChange.mock.calls.at(-1)?.[0].period).toHaveProperty('from');
+  });
+});
+
+function RefreshHarness({ onChange }: { readonly onChange?: (v: DashboardRefreshInterval | undefined) => void }) {
+  const [refreshInterval, setLocal] = useState<DashboardRefreshInterval | undefined>('auto');
+  return (
+    <DashboardContextProvider
+      value={{
+        dashboardName: 'Test',
+        refreshInterval,
+        setRefreshInterval: (next) => {
+          const resolved = typeof next === 'function' ? next(refreshInterval) : next;
+          setLocal(resolved);
+          onChange?.(resolved);
+        },
+      }}
+    >
+      <DashboardRefreshControl />
+    </DashboardContextProvider>
+  );
+}
+
+describe('DashboardRefreshControl', () => {
+  it('renders the pill', () => {
+    wrap(<RefreshHarness />);
+    expect(document.querySelector('[data-slot="dashboard-refresh-control"]')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the cadence is read-only', () => {
+    wrap(
+      <DashboardContextProvider value={{ dashboardName: 'Test', refreshInterval: 'auto' }}>
+        <DashboardRefreshControl />
+      </DashboardContextProvider>
+    );
+    expect(document.querySelector('[data-slot="dashboard-refresh-control"]')).toBeNull();
+  });
+
+  it('fires the manual refresh handler', () => {
+    const onRefresh = vi.fn();
+    wrap(
+      <DashboardContextProvider
+        value={{ dashboardName: 'Test', refreshInterval: 'auto', setRefreshInterval: vi.fn() }}
+      >
+        <DashboardRefreshControl onRefresh={onRefresh} />
+      </DashboardContextProvider>
+    );
+    fireEvent.click(document.querySelector('[data-slot="refresh-now"]')!);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/@granit/react-ui-dashboards/src/__tests__/dashboard-view-page.test.tsx
+++ b/packages/@granit/react-ui-dashboards/src/__tests__/dashboard-view-page.test.tsx
@@ -54,10 +54,16 @@ vi.mock('@granit/react-dashboards', () => ({
   // Context + selectors are covered by their own suites; here they only need to
   // mount so the view page's wiring renders.
   DashboardContextProvider: ({ children }: { readonly children: React.ReactNode }) => children,
-  DashboardTimeWindowToolbar: () => <div data-slot="dashboard-time-window-toolbar" />,
-  DashboardRefreshToolbar: () => <div data-slot="dashboard-refresh-toolbar" />,
   useDashboardTimeWindowState: <T,>(initial: T) => [initial, vi.fn()] as const,
   useDashboardRefreshIntervalState: <T,>(initial: T) => [initial, vi.fn()] as const,
+}));
+
+// The styled controls have their own suites; here they only need to mount.
+vi.mock('../components/dashboard-time-range-control', () => ({
+  DashboardTimeRangeControl: () => <div data-slot="dashboard-time-range-control" />,
+}));
+vi.mock('../components/dashboard-refresh-control', () => ({
+  DashboardRefreshControl: () => <div data-slot="dashboard-refresh-control" />,
 }));
 
 describe('DashboardViewPage', () => {
@@ -75,10 +81,10 @@ describe('DashboardViewPage', () => {
     renderDashboards(<DashboardViewPage />);
 
     expect(
-      document.querySelector('[data-slot="dashboard-time-window-toolbar"]')
+      document.querySelector('[data-slot="dashboard-time-range-control"]')
     ).toBeInTheDocument();
     expect(
-      document.querySelector('[data-slot="dashboard-refresh-toolbar"]')
+      document.querySelector('[data-slot="dashboard-refresh-control"]')
     ).toBeInTheDocument();
     // No declared default → falls back to Last 30 days.
     expect(

--- a/packages/@granit/react-ui-dashboards/src/components/dashboard-composer.tsx
+++ b/packages/@granit/react-ui-dashboards/src/components/dashboard-composer.tsx
@@ -47,6 +47,9 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { logger } from '../logger';
 
+import { DashboardRefreshControl } from './dashboard-refresh-control';
+import { DashboardTimeRangeControl } from './dashboard-time-range-control';
+
 type PendingEditAction = 'delete-widget' | 'discard';
 
 /**
@@ -334,6 +337,12 @@ export function DashboardComposer({
             setSelectedSlug(slug);
             setPendingAction('delete-widget');
           }}
+          controlsSlot={
+            <>
+              <DashboardTimeRangeControl />
+              <DashboardRefreshControl />
+            </>
+          }
         />
       </div>
 

--- a/packages/@granit/react-ui-dashboards/src/components/dashboard-refresh-control.tsx
+++ b/packages/@granit/react-ui-dashboards/src/components/dashboard-refresh-control.tsx
@@ -1,0 +1,103 @@
+import { DASHBOARD_REFRESH_INTERVAL } from '@granit/dashboards';
+import { useDashboardContext } from '@granit/react-dashboards';
+import { useTranslation } from '@granit/react-localization';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@granit/react-ui';
+import { cn } from '@granit/utils';
+import { useQueryClient } from '@tanstack/react-query';
+import { RefreshCw } from 'lucide-react';
+
+import type { DashboardRefreshInterval } from '@granit/dashboards';
+
+const R = DASHBOARD_REFRESH_INTERVAL;
+
+interface RefreshOption {
+  readonly value: DashboardRefreshInterval;
+  readonly labelKey: string;
+  readonly defaultLabel: string;
+}
+
+const OPTIONS: readonly RefreshOption[] = [
+  { value: R.Off, labelKey: 'Dashboard:Refresh.Off', defaultLabel: 'Off' },
+  { value: R.Auto, labelKey: 'Dashboard:Refresh.Auto', defaultLabel: 'Auto' },
+  { value: R.Sec5, labelKey: 'Dashboard:Refresh.Sec5', defaultLabel: '5s' },
+  { value: R.Sec10, labelKey: 'Dashboard:Refresh.Sec10', defaultLabel: '10s' },
+  { value: R.Sec30, labelKey: 'Dashboard:Refresh.Sec30', defaultLabel: '30s' },
+  { value: R.Min1, labelKey: 'Dashboard:Refresh.Min1', defaultLabel: '1m' },
+  { value: R.Min5, labelKey: 'Dashboard:Refresh.Min5', defaultLabel: '5m' },
+  { value: R.Min15, labelKey: 'Dashboard:Refresh.Min15', defaultLabel: '15m' },
+  { value: R.Min30, labelKey: 'Dashboard:Refresh.Min30', defaultLabel: '30m' },
+  { value: R.Hour1, labelKey: 'Dashboard:Refresh.Hour1', defaultLabel: '1h' },
+  { value: R.Hour2, labelKey: 'Dashboard:Refresh.Hour2', defaultLabel: '2h' },
+  { value: R.Day1, labelKey: 'Dashboard:Refresh.Day1', defaultLabel: '1d' },
+];
+
+const PILL =
+  'inline-flex h-9 items-stretch overflow-hidden rounded-md border bg-background text-sm shadow-sm';
+const SEG =
+  'flex items-center gap-1.5 px-2.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:bg-accent';
+
+export interface DashboardRefreshControlProps {
+  readonly className?: string;
+  /** Manual "refresh now" handler. Defaults to invalidating every active query. */
+  readonly onRefresh?: () => void;
+}
+
+/**
+ * UI-tier Grafana-style refresh control: a "↻ Refresh" segment + a styled Radix
+ * {@link Select} cadence menu, one segmented pill matching
+ * {@link DashboardTimeRangeControl}. Reads / writes the surrounding
+ * {@link DashboardContextProvider}. Renders nothing when the cadence is
+ * read-only (`setRefreshInterval` absent).
+ */
+export function DashboardRefreshControl({ className, onRefresh }: DashboardRefreshControlProps) {
+  const { t } = useTranslation();
+  const ctx = useDashboardContext();
+  const queryClient = useQueryClient();
+
+  const refreshNow =
+    onRefresh ??
+    (() => {
+      void queryClient.invalidateQueries();
+    });
+
+  if (!ctx?.setRefreshInterval) return null;
+
+  const { refreshInterval = 'auto', setRefreshInterval } = ctx;
+
+  return (
+    <div
+      data-slot="dashboard-refresh-control"
+      role="toolbar"
+      aria-label="Dashboard refresh"
+      className={cn(PILL, className)}
+    >
+      <button type="button" data-slot="refresh-now" onClick={refreshNow} className={SEG}>
+        <RefreshCw className="h-4 w-4" aria-hidden />
+        <span>{t('Dashboard:Refresh.Label', { defaultValue: 'Refresh' })}</span>
+      </button>
+
+      <Select
+        value={String(refreshInterval)}
+        onValueChange={(next) => {
+          const option = OPTIONS.find((o) => String(o.value) === next);
+          if (option) setRefreshInterval(option.value);
+        }}
+      >
+        <SelectTrigger
+          data-slot="refresh-cadence"
+          aria-label={t('Dashboard:Refresh.Cadence', { defaultValue: 'Refresh cadence' })}
+          className="h-full min-w-[4.5rem] rounded-none border-0 border-l bg-transparent font-medium text-foreground shadow-none focus-visible:ring-0"
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent className="scrollbar-overlay">
+          {OPTIONS.map((option) => (
+            <SelectItem key={String(option.value)} value={String(option.value)}>
+              {t(option.labelKey, { defaultValue: option.defaultLabel })}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/packages/@granit/react-ui-dashboards/src/components/dashboard-time-range-control.tsx
+++ b/packages/@granit/react-ui-dashboards/src/components/dashboard-time-range-control.tsx
@@ -1,0 +1,194 @@
+import { shiftTimeWindow, zoomOutTimeWindow } from '@granit/dashboards';
+import {
+  TIME_WINDOW_GROUPS,
+  TIME_WINDOW_PRESETS,
+  useDashboardContext,
+} from '@granit/react-dashboards';
+import { useTranslation } from '@granit/react-localization';
+import { Popover, PopoverContent, PopoverTrigger } from '@granit/react-ui';
+import { cn } from '@granit/utils';
+import { ChevronDown, ChevronsLeft, ChevronsRight, Clock, ZoomOut } from 'lucide-react';
+import { useState } from 'react';
+
+import type { DashboardTimeWindow } from '@granit/dashboards';
+
+const PILL =
+  'inline-flex h-9 items-stretch overflow-hidden rounded-md border bg-background text-sm shadow-sm';
+const SEG =
+  'flex items-center gap-1.5 px-2.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:bg-accent';
+
+export interface DashboardTimeRangeControlProps {
+  readonly className?: string;
+}
+
+/**
+ * UI-tier Grafana-style time-range picker: a segmented pill (shift « · range
+ * picker ▾ · shift » · zoom ⊖) whose picker opens a styled popover with the
+ * grouped quick ranges (scrollable) and an absolute From/To range. Consumes the
+ * surrounding {@link DashboardContextProvider} from `@granit/react-dashboards`.
+ *
+ * Unlike the headless `DashboardTimeWindowToolbar` (native `<select>`), this uses
+ * the Radix popover for a fully styled menu — same context, so apps swap one for
+ * the other freely. Renders nothing when the window is absent or read-only.
+ */
+export function DashboardTimeRangeControl({ className }: DashboardTimeRangeControlProps) {
+  const { t } = useTranslation();
+  const ctx = useDashboardContext();
+
+  const period = ctx?.timeWindow?.period;
+  const initialAbsolute = period !== undefined && 'from' in period;
+  const [open, setOpen] = useState(false);
+  const [draftFrom, setDraftFrom] = useState(() => (initialAbsolute ? toLocalInput(period.from) : ''));
+  const [draftTo, setDraftTo] = useState(() => (initialAbsolute ? toLocalInput(period.to) : ''));
+
+  if (!ctx?.timeWindow || !ctx.setTimeWindow) return null;
+
+  const { timeWindow, setTimeWindow } = ctx;
+  const shiftOptions = { weekStartsOn: ctx.weekStartsOn, timeZone: ctx.timeZone };
+  const currentToken = 'token' in timeWindow.period ? timeWindow.period.token : '';
+  const activePreset = TIME_WINDOW_PRESETS.find((p) => p.token === currentToken);
+  const label = activePreset
+    ? t(activePreset.labelKey, { defaultValue: activePreset.defaultLabel })
+    : t('Dashboard:TimeWindow.Custom', { defaultValue: 'Custom range' });
+
+  const pickPreset = (window: DashboardTimeWindow) => {
+    setTimeWindow({ ...timeWindow, ...window });
+    setOpen(false);
+  };
+
+  const applyCustom = () => {
+    const from = new Date(draftFrom);
+    const to = new Date(draftTo);
+    if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime()) || from >= to) return;
+    setTimeWindow({ period: { from: from.toISOString(), to: to.toISOString() } });
+    setOpen(false);
+  };
+
+  const customValid = draftFrom !== '' && draftTo !== '' && new Date(draftFrom) < new Date(draftTo);
+
+  return (
+    <div data-slot="dashboard-time-range-control" className={cn(PILL, className)} role="toolbar" aria-label="Dashboard time window">
+      <button
+        type="button"
+        data-slot="time-range-back"
+        aria-label={t('Dashboard:TimeWindow.ShiftBack', { defaultValue: 'Shift earlier' })}
+        onClick={() => setTimeWindow(shiftTimeWindow(timeWindow, 'back', shiftOptions))}
+        className={SEG}
+      >
+        <ChevronsLeft className="h-4 w-4" aria-hidden />
+      </button>
+
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            data-slot="time-range-trigger"
+            className={cn(SEG, 'border-l font-medium text-foreground')}
+          >
+            <Clock className="h-4 w-4 text-muted-foreground" aria-hidden />
+            <span>{label}</span>
+            <ChevronDown className="h-4 w-4 text-muted-foreground" aria-hidden />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="flex w-[36rem] max-w-[calc(100vw-2rem)] gap-4 p-4">
+          {/* Absolute range */}
+          <div className="flex w-1/2 flex-col gap-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              {t('Dashboard:TimeWindow.AbsoluteRange', { defaultValue: 'Absolute time range' })}
+            </p>
+            <label className="flex flex-col gap-1 text-xs">
+              <span className="text-muted-foreground">
+                {t('Dashboard:TimeWindow.From', { defaultValue: 'From' })}
+              </span>
+              <input
+                type="datetime-local"
+                data-slot="time-range-from"
+                value={draftFrom}
+                onChange={(event) => setDraftFrom(event.target.value)}
+                className="rounded-md border bg-background px-2.5 py-1.5 text-sm"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-xs">
+              <span className="text-muted-foreground">
+                {t('Dashboard:TimeWindow.To', { defaultValue: 'To' })}
+              </span>
+              <input
+                type="datetime-local"
+                data-slot="time-range-to"
+                value={draftTo}
+                onChange={(event) => setDraftTo(event.target.value)}
+                className="rounded-md border bg-background px-2.5 py-1.5 text-sm"
+              />
+            </label>
+            <button
+              type="button"
+              data-slot="time-range-apply"
+              disabled={!customValid}
+              onClick={applyCustom}
+              className="mt-1 self-start rounded-md border bg-background px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+            >
+              {t('Dashboard:TimeWindow.Apply', { defaultValue: 'Apply' })}
+            </button>
+          </div>
+
+          {/* Quick ranges — scrollable with the thin overlay scrollbar. */}
+          <div className="scrollbar-overlay max-h-72 w-1/2 overflow-y-auto border-l pl-4">
+            {TIME_WINDOW_GROUPS.map((group) => (
+              <div key={group.labelKey} className="mb-2 last:mb-0">
+                <p className="px-1 py-1 text-[0.7rem] font-medium uppercase tracking-wide text-muted-foreground">
+                  {t(group.labelKey, { defaultValue: group.defaultLabel })}
+                </p>
+                {group.presets.map((p) => {
+                  const active = p.token === currentToken;
+                  return (
+                    <button
+                      key={p.token}
+                      type="button"
+                      data-slot="time-range-preset"
+                      data-token={p.token}
+                      aria-current={active}
+                      onClick={() => pickPreset(p.window)}
+                      className={cn(
+                        'block w-full rounded-md px-2 py-1 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground',
+                        active && 'bg-accent font-medium text-accent-foreground'
+                      )}
+                    >
+                      {t(p.labelKey, { defaultValue: p.defaultLabel })}
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <button
+        type="button"
+        data-slot="time-range-forward"
+        aria-label={t('Dashboard:TimeWindow.ShiftForward', { defaultValue: 'Shift later' })}
+        onClick={() => setTimeWindow(shiftTimeWindow(timeWindow, 'forward', shiftOptions))}
+        className={cn(SEG, 'border-l')}
+      >
+        <ChevronsRight className="h-4 w-4" aria-hidden />
+      </button>
+      <button
+        type="button"
+        data-slot="time-range-zoom-out"
+        aria-label={t('Dashboard:TimeWindow.ZoomOut', { defaultValue: 'Zoom out' })}
+        onClick={() => setTimeWindow(zoomOutTimeWindow(timeWindow, shiftOptions))}
+        className={cn(SEG, 'border-l')}
+      >
+        <ZoomOut className="h-4 w-4" aria-hidden />
+      </button>
+    </div>
+  );
+}
+
+/** ISO 8601 UTC → `datetime-local` value (`YYYY-MM-DDTHH:mm`) in the browser's local zone. */
+function toLocalInput(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}

--- a/packages/@granit/react-ui-dashboards/src/components/dashboard-view-page.tsx
+++ b/packages/@granit/react-ui-dashboards/src/components/dashboard-view-page.tsx
@@ -5,8 +5,6 @@ import {
 } from '@granit/dashboards';
 import {
   DashboardContextProvider,
-  DashboardRefreshToolbar,
-  DashboardTimeWindowToolbar,
   RenderedDashboard,
   useDashboardDetail,
   useDashboardRefreshIntervalState,
@@ -20,7 +18,9 @@ import { useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { DashboardComposer } from './dashboard-composer';
+import { DashboardRefreshControl } from './dashboard-refresh-control';
 import { StatusBadge } from './dashboard-status-badge';
+import { DashboardTimeRangeControl } from './dashboard-time-range-control';
 
 import type { DashboardDetailResponse } from '@granit/dashboards';
 
@@ -164,8 +164,8 @@ function DashboardViewContent({ detail, dashboardId, onEdit }: DashboardViewCont
             </div>
           </div>
           <div className="flex items-end gap-3">
-            <DashboardTimeWindowToolbar />
-            <DashboardRefreshToolbar />
+            <DashboardTimeRangeControl />
+            <DashboardRefreshControl />
             <Button
               data-slot="dashboard-view-edit-toggle"
               variant="outline"

--- a/packages/@granit/react-ui-dashboards/src/index.ts
+++ b/packages/@granit/react-ui-dashboards/src/index.ts
@@ -9,6 +9,10 @@ export { DashboardEditPage } from './components/dashboard-edit-page';
 export { DashboardViewPage } from './components/dashboard-view-page';
 export { DashboardComposer } from './components/dashboard-composer';
 export type { DashboardComposerProps } from './components/dashboard-composer';
+export { DashboardTimeRangeControl } from './components/dashboard-time-range-control';
+export type { DashboardTimeRangeControlProps } from './components/dashboard-time-range-control';
+export { DashboardRefreshControl } from './components/dashboard-refresh-control';
+export type { DashboardRefreshControlProps } from './components/dashboard-refresh-control';
 
 // Public components
 export { StatusBadge } from './components/dashboard-status-badge';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5118,6 +5118,9 @@ importers:
       '@granit/react-ui-map':
         specifier: workspace:*
         version: link:../react-ui-map
+      '@granit/utils':
+        specifier: workspace:*
+        version: link:../utils
       '@storybook/react-vite':
         specifier: ^10.4.6
         version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(yaml@2.9.0))


### PR DESCRIPTION
## Context

The dashboard time controls used native `<select>` elements. The trigger (the pill) is styled, but a native select's **open option list is rendered by the browser and can't be CSS-styled** — so the menus looked basic next to Grafana's. This replaces them with UI-tier controls built on the Radix-based `@granit/react-ui` `Popover` / `Select` → fully styled, accessible menus with the thin `scrollbar-overlay`.

## Changes

- **`@granit/react-dashboards`**: extract `TIME_WINDOW_GROUPS` / `TIME_WINDOW_PRESETS` into a shared `lib/time-window-presets` module (the headless toolbar now consumes it — no more duplication); export them.
- **`@granit/react-ui-dashboards`** (UI tier):
  - **`DashboardTimeRangeControl`** — the segmented pill (« · range picker ▾ · » · ⊖); the picker opens a **Popover** with the grouped quick ranges (scrollable, `scrollbar-overlay`) on one side and an absolute **From / To** range on the other.
  - **`DashboardRefreshControl`** — a styled Radix **`Select`** cadence menu + a "↻ Refresh" segment.
- **`EditableDashboard`** gains a `controlsSlot` prop (defaults to the headless toolbars). **`DashboardComposer`** passes the styled controls and **`DashboardViewPage`** uses them — so **both view and edit modes** get the Grafana look.

The headless native-`<select>` toolbars remain the **portable default** for surfaces that can't depend on the UI tier (playground, or apps composing their own chrome). Both read the same `DashboardContext`, so they're drop-in interchangeable.

## Verification

- `tsc --noEmit`: clean across the three packages · Vitest **3513 passing** (incl. arch + the new `DashboardTimeRangeControl` / `DashboardRefreshControl` suites) · ESLint clean
- `@granit/utils` added to `react-ui-dashboards` peer/devDeps (`cn`); lockfile regenerated in the same commit

## Note

`datetime-local` inputs interpret in the browser timezone; aligning the absolute picker with the user's `TimezoneProvider` (and a full calendar grid) remain optional follow-ups.