### PR TITLE
feat(dashboards): drag-and-drop reorder of Table widget columns

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -12,7 +12,7 @@ Last updated: 2026-06-30
 
 | License    | Package count |
 | ---------- | ------------- |
-| MIT        | 50            |
+| MIT        | 53            |
 | Apache-2.0 | 15            |
 
 ---
@@ -32,6 +32,9 @@ Last updated: 2026-06-30
 | @commitlint/cli                 | 21.1.0  | commitlint Contributors                    |
 | @commitlint/config-conventional | 21.1.0  | commitlint Contributors                    |
 | @date-fns/tz                    | 1.5.0   | Copyright (c) Sasha Koss                   |
+| @dnd-kit/core                   | 6.3.1   | Copyright (c) Claudéric Demers             |
+| @dnd-kit/sortable               | 10.0.0  | Copyright (c) Claudéric Demers             |
+| @dnd-kit/utilities              | 3.2.2   | Copyright (c) Claudéric Demers             |
 | @eslint/js                      | 10.0.1  | OpenJS Foundation                          |
 | @puckeditor/core                | 0.21.3  | Copyright (c) Measured Corp                |
 | @microsoft/fetch-event-source   | 2.0.1   | Copyright (c) Microsoft Corporation        |

--- a/packages/@granit/react-dashboard-editor/package.json
+++ b/packages/@granit/react-dashboard-editor/package.json
@@ -14,9 +14,6 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "@dnd-kit/core": "^6.3.0",
-    "@dnd-kit/sortable": "^10.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
     "@granit/dashboards": "workspace:*",
     "@granit/react-dashboards": "workspace:*",
     "react": "^19.0.0",
@@ -33,9 +30,6 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
     "@granit/dashboards": "workspace:*",
     "@granit/react-dashboards": "workspace:*",
     "@granit/react-testing": "workspace:*",

--- a/packages/@granit/react-dashboard-editor/src/components/widget-palette.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/widget-palette.tsx
@@ -10,9 +10,9 @@ import type { WidgetCatalogEntry } from '../lib/widget-catalog';
  *
  * Drag-from-palette (drop a button into the grid to insert at a specific
  * position) is deferred — keeps the v1 surface tight and avoids a second
- * round of dnd-kit choreography. Apps wanting drag-to-add wrap their own
- * `<DndContext>` around `<EditableDashboard>` + `<WidgetPalette>` and
- * register palette items as additional sortable sources.
+ * drag-and-drop layer on top of the grid. Apps wanting drag-to-add wrap
+ * `<EditableDashboard>` + `<WidgetPalette>` in their own drag-and-drop
+ * context and register palette items as additional drag sources.
  *
  * Labels resolve through `useTranslation()` — when the localization key
  * is missing from the bundle, i18next falls back to the key itself, so

--- a/packages/@granit/react-ui-analytics/src/__tests__/table-config-form.test.tsx
+++ b/packages/@granit/react-ui-analytics/src/__tests__/table-config-form.test.tsx
@@ -103,7 +103,7 @@ describe('TableConfigForm', () => {
     expect(onChange.mock.calls.at(-1)?.[0]?.pageSize).toBe(50);
   });
 
-  it('toggles a visible column from the metadata multi-select', async () => {
+  it('adds a visible column from the metadata combobox', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     const { container } = wrap(
@@ -115,6 +115,24 @@ describe('TableConfigForm', () => {
     expect(await screen.findByRole('option', { name: 'Name' })).toBeInTheDocument();
     await user.click(await screen.findByRole('option', { name: 'Amount' }));
     expect(onChange.mock.calls.at(-1)?.[0]?.visibleColumns).toEqual(['Amount']);
+  });
+
+  it('lists the chosen columns in order and removes one, preserving order', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { container } = wrap(
+      <TableConfigForm
+        widget={{ ...baseTable, visibleColumns: ['Amount', 'Name'] }}
+        onChange={onChange}
+      />
+    );
+
+    const rows = container.querySelectorAll('[data-slot="sortable-item"]');
+    expect([...rows].map((row) => row.textContent)).toEqual(['Amount', 'Name']);
+
+    const removeButtons = container.querySelectorAll('[data-slot="sortable-remove"]');
+    await user.click(removeButtons[0]!);
+    expect(onChange.mock.calls.at(-1)?.[0]?.visibleColumns).toEqual(['Name']);
   });
 
   it('renders the sort-field control but hides the direction control with no sort field', () => {

--- a/packages/@granit/react-ui-analytics/src/components/query-field-controls.tsx
+++ b/packages/@granit/react-ui-analytics/src/components/query-field-controls.tsx
@@ -18,6 +18,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  SortableList,
   type ComboboxOption,
 } from '@granit/react-ui';
 import { useTranslation } from 'react-i18next';
@@ -268,5 +269,55 @@ export function EnumSelect({
         })}
       </SelectContent>
     </Select>
+  );
+}
+
+/**
+ * Ordered multi-field picker: a combobox to add a column plus a drag-and-drop
+ * (and keyboard-reorderable) list of the chosen columns. The emitted array's
+ * order is meaningful — table widgets render columns in exactly this order — so
+ * unlike {@link MetaMultiFieldInput} it lets the author control the sequence and
+ * remove individual entries. Falls back to free-text add when no metadata is
+ * loaded (`allowCustomValue`).
+ */
+export function ColumnOrderInput({
+  slot,
+  values,
+  options,
+  onChange,
+  placeholder,
+}: {
+  readonly slot: string;
+  readonly values: readonly string[];
+  readonly options: readonly FieldOption[];
+  readonly onChange: (values: string[]) => void;
+  readonly placeholder?: string;
+}) {
+  const labelFor = (name: string): string =>
+    options.find((option) => option.name === name)?.label ?? name;
+  const available = options.filter((option) => !values.includes(option.name));
+
+  return (
+    <div className="space-y-2">
+      <Combobox
+        slot={slot}
+        value=""
+        onValueChange={(value) => {
+          if (value.length > 0 && !values.includes(value)) {
+            onChange([...values, value]);
+          }
+        }}
+        options={toComboboxOptions(available)}
+        allowCustomValue
+        allowEmpty
+        placeholder={placeholder ?? 'Add a column…'}
+        searchPlaceholder="Search or type a column…"
+      />
+      <SortableList
+        items={values.map((name) => ({ id: name, label: labelFor(name) }))}
+        onReorder={onChange}
+        onRemove={(id) => onChange(values.filter((value) => value !== id))}
+      />
+    </div>
   );
 }

--- a/packages/@granit/react-ui-analytics/src/components/table-config-form.tsx
+++ b/packages/@granit/react-ui-analytics/src/components/table-config-form.tsx
@@ -3,9 +3,9 @@ import { Input } from '@granit/react-ui';
 import { useTranslation } from 'react-i18next';
 
 import {
+  ColumnOrderInput,
   EnumSelect,
   MetaFieldInput,
-  MetaMultiFieldInput,
   QueryNameCombobox,
   RequiredMark,
 } from './query-field-controls';
@@ -24,7 +24,8 @@ import type { WidgetConfigFormProps } from '@granit/react-dashboard-editor';
  *
  * Under a `<QueryCatalogProvider>` the query field is a catalogue-backed
  * combobox and the column / sort pickers are sourced from the query's metadata;
- * otherwise they degrade to free-text (comma-separated for columns). Apps
+ * otherwise they degrade to free-text (type a column name to add). The visible
+ * columns render in the order chosen — drag or keyboard-reorder them. Apps
  * wanting a richer column-picker dialog register their own form via
  * `composeWidgetConfigFormRegistries`.
  */
@@ -56,11 +57,11 @@ export function TableConfigForm({
         <span className="mb-1 block text-muted-foreground">
           {t('Dashboard:Widget.Table.VisibleColumns.Label')}
         </span>
-        <MetaMultiFieldInput
+        <ColumnOrderInput
           slot="table-visible-columns"
           values={widget.visibleColumns ?? []}
           options={columnOptions}
-          placeholder="leave empty for all columns"
+          placeholder="add a column (empty = all, drag to reorder)"
           onChange={(values) =>
             onChange({ ...widget, visibleColumns: values.length > 0 ? values : null })
           }

--- a/packages/@granit/react-ui/package.json
+++ b/packages/@granit/react-ui/package.json
@@ -14,6 +14,9 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@dnd-kit/core": "^6.3.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@granit/utils": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "cmdk": "^1.1.1",
@@ -35,6 +38,9 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@granit/utils": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "cmdk": "^1.1.1",

--- a/packages/@granit/react-ui/src/__tests__/sortable-list.test.tsx
+++ b/packages/@granit/react-ui/src/__tests__/sortable-list.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { SortableList, reorderIds } from '../sortable-list.js';
+
+describe('reorderIds', () => {
+  it('moves an item from its old position to the target position', () => {
+    expect(reorderIds(['a', 'b', 'c'], 'a', 'c')).toEqual(['b', 'c', 'a']);
+    expect(reorderIds(['a', 'b', 'c'], 'c', 'a')).toEqual(['c', 'a', 'b']);
+  });
+
+  it('returns an unchanged copy when either id is absent', () => {
+    expect(reorderIds(['a', 'b'], 'a', 'z')).toEqual(['a', 'b']);
+    expect(reorderIds(['a', 'b'], 'z', 'b')).toEqual(['a', 'b']);
+  });
+});
+
+describe('SortableList', () => {
+  const items = [
+    { id: 'Amount', label: 'Amount' },
+    { id: 'Name', label: 'Name' },
+  ];
+
+  it('renders nothing when there are no items', () => {
+    const { container } = render(<SortableList items={[]} onReorder={vi.fn()} />);
+    expect(container.querySelector('[data-slot="sortable-list"]')).toBeNull();
+  });
+
+  it('renders one row per item in order, each with a drag handle', () => {
+    render(<SortableList items={items} onReorder={vi.fn()} />);
+    const rows = screen.getAllByRole('listitem');
+    expect(rows.map((row) => row.textContent)).toEqual(['Amount', 'Name']);
+    expect(screen.getAllByRole('button', { name: 'Reorder' })).toHaveLength(2);
+  });
+
+  it('invokes onRemove with the row id when its remove button is clicked', async () => {
+    const user = userEvent.setup();
+    const onRemove = vi.fn();
+    render(<SortableList items={items} onReorder={vi.fn()} onRemove={onRemove} />);
+    await user.click(screen.getAllByRole('button', { name: 'Remove' })[0]!);
+    expect(onRemove).toHaveBeenCalledWith('Amount');
+  });
+
+  it('omits remove buttons when onRemove is not provided', () => {
+    render(<SortableList items={items} onReorder={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: 'Remove' })).toBeNull();
+  });
+});

--- a/packages/@granit/react-ui/src/index.ts
+++ b/packages/@granit/react-ui/src/index.ts
@@ -25,6 +25,7 @@ export * from './sheet.js';
 export * from './sidebar.js';
 export * from './skeleton.js';
 export * from './sonner.js';
+export * from './sortable-list.js';
 export * from './spinner.js';
 export * from './status-badge.js';
 export * from './switch.js';

--- a/packages/@granit/react-ui/src/sortable-list.tsx
+++ b/packages/@granit/react-ui/src/sortable-list.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { cn } from '@granit/utils';
+import { GripVerticalIcon, XIcon } from 'lucide-react';
+
+import type { ReactNode } from 'react';
+
+export interface SortableListItem {
+  /** Stable identity — used for drag tracking and emitted as the order token. */
+  readonly id: string;
+  /** Row content (label, badges, …). */
+  readonly label: ReactNode;
+}
+
+export interface SortableListProps {
+  readonly items: readonly SortableListItem[];
+  /** Emitted with the full id list in its new order after a drag or keyboard move. */
+  readonly onReorder: (orderedIds: string[]) => void;
+  /** When set, each row shows a remove button invoking this with the row id. */
+  readonly onRemove?: (id: string) => void;
+  readonly className?: string;
+  /** Accessible label for the drag handle. */
+  readonly dragHandleLabel?: string;
+  /** Accessible label for the remove button. */
+  readonly removeLabel?: string;
+}
+
+/**
+ * Pure reorder applied on drag end — exported for direct unit testing, since
+ * pointer/keyboard drags are not reliably reproducible under jsdom.
+ */
+export function reorderIds(ids: readonly string[], activeId: string, overId: string): string[] {
+  const oldIndex = ids.indexOf(activeId);
+  const newIndex = ids.indexOf(overId);
+  if (oldIndex < 0 || newIndex < 0) {
+    return [...ids];
+  }
+  return arrayMove([...ids], oldIndex, newIndex);
+}
+
+/**
+ * Vertical drag-and-drop reorderable list built on `@dnd-kit`. Keyboard-operable
+ * (focus a handle, Space to pick up, ↑/↓ to move, Space to drop) for WCAG parity
+ * with pointer dragging. Purely controlled: the caller owns the ordered id list
+ * and re-renders `items` after `onReorder`.
+ */
+export function SortableList({
+  items,
+  onReorder,
+  onRemove,
+  className,
+  dragHandleLabel = 'Reorder',
+  removeLabel = 'Remove',
+}: SortableListProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+  const ids = items.map((item) => item.id);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      onReorder(reorderIds(ids, String(active.id), String(over.id)));
+    }
+  };
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+        <ul data-slot="sortable-list" className={cn('flex flex-col gap-1', className)}>
+          {items.map((item) => (
+            <SortableRow
+              key={item.id}
+              item={item}
+              onRemove={onRemove}
+              dragHandleLabel={dragHandleLabel}
+              removeLabel={removeLabel}
+            />
+          ))}
+        </ul>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+function SortableRow({
+  item,
+  onRemove,
+  dragHandleLabel,
+  removeLabel,
+}: {
+  readonly item: SortableListItem;
+  readonly onRemove?: (id: string) => void;
+  readonly dragHandleLabel: string;
+  readonly removeLabel: string;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: item.id,
+  });
+
+  return (
+    <li
+      ref={setNodeRef}
+      data-slot="sortable-item"
+      data-dragging={isDragging || undefined}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        'flex items-center gap-2 rounded-md border bg-background px-2 py-1 text-sm',
+        isDragging && 'opacity-70 shadow-sm'
+      )}
+    >
+      <button
+        type="button"
+        data-slot="sortable-drag-handle"
+        aria-label={dragHandleLabel}
+        className="cursor-grab touch-none text-muted-foreground focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-1"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVerticalIcon className="size-4 shrink-0 opacity-50" />
+      </button>
+      <span className="min-w-0 flex-1 truncate">{item.label}</span>
+      {onRemove ? (
+        <button
+          type="button"
+          data-slot="sortable-remove"
+          aria-label={removeLabel}
+          className="text-muted-foreground hover:text-foreground focus-visible:ring-ring shrink-0 focus-visible:outline-none focus-visible:ring-1"
+          onClick={() => onRemove(item.id)}
+        >
+          <XIcon className="size-4 opacity-50" />
+        </button>
+      ) : null}
+    </li>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2121,15 +2121,6 @@ importers:
         specifier: ^17.0.0
         version: 17.0.8(i18next@26.3.3(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
     devDependencies:
-      '@dnd-kit/core':
-        specifier: ^6.3.1
-        version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@dnd-kit/sortable':
-        specifier: ^10.0.0
-        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
-      '@dnd-kit/utilities':
-        specifier: ^3.2.2
-        version: 3.2.2(react@19.2.7)
       '@granit/dashboards':
         specifier: workspace:*
         version: link:../dashboards
@@ -3574,6 +3565,15 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
     devDependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.7)
       '@granit/utils':
         specifier: workspace:*
         version: link:../utils


### PR DESCRIPTION
Follows #909 (server-side sort), now merged. This adds column-order control on top.

## Context

The Table widget renders columns in the order of `visibleColumns`, but the editor's multi-select only toggled membership — reordering meant clearing and re-picking columns in sequence. This gives real control over the order, with **no backend change** (the backend already renders `visibleColumns` in array order).

## Changes

- **`SortableList`** (new `@granit/react-ui` primitive): a vertical drag-and-drop list built on `@dnd-kit`, **keyboard-operable** (focus a handle, Space to pick up, ↑/↓ to move, Space to drop) for WCAG parity, with an optional per-row remove. The reorder math (`reorderIds`) is a pure exported function — pointer/keyboard drags aren't reproducible under jsdom, so it's unit-tested directly.
- **`ColumnOrderInput`** (new in `@granit/react-ui-analytics`): a combobox to add a column + a `SortableList` of the chosen columns. Replaces the visible-columns multi-select in the Table config form. Emitted order → `visibleColumns`.
- **Move `@dnd-kit`** (core / sortable / utilities): from `@granit/react-dashboard-editor` — where it was **declared but never imported** (leftover from a dropped drag-from-palette design; the grid uses `react-grid-layout`) — to `@granit/react-ui`, its first real consumer. Lockfile + `THIRD-PARTY-NOTICES.md` updated.

## Note for consumers

`@granit/react-ui` now declares `@dnd-kit/{core,sortable,utilities}` as **peer dependencies**. Apps consuming it source-direct via the workspace resolve them transparently; a published-package consumer must install the peers.

## Verification

- `pnpm tsc` (workspace) — clean
- ESLint (changed files, `--max-warnings 0`) — clean
- Tests — 68 passing: 7 `SortableList` (incl. `reorderIds` both branches, render, remove), 8 Table config form (add / order / remove + existing sort), 55 `react-dashboard-editor` unaffected by the dep move
- `.mcp-front-index.json` regenerates with no diff (react-ui exports aren't indexed)