### PR TITLE
fix(dashboards): theme-aware colors on the time-range hover tooltip

### DIFF
--- a/packages/@granit/react-ui-dashboards/src/components/dashboard-time-range-control.tsx
+++ b/packages/@granit/react-ui-dashboards/src/components/dashboard-time-range-control.tsx
@@ -117,7 +117,16 @@ export function DashboardTimeRangeControl({ className }: DashboardTimeRangeContr
               </PopoverTrigger>
             </TooltipTrigger>
             {bounds && (
-              <TooltipContent side="bottom" align="start" data-slot="time-range-tooltip">
+              <TooltipContent
+                side="bottom"
+                align="start"
+                data-slot="time-range-tooltip"
+                // Use the standard popover surface (like the dropdowns) instead of
+                // the default inverted `bg-foreground` tooltip, so the muted /
+                // primary tokens read correctly and the whole thing flips with the
+                // light / dark theme. `[&_svg]` recolors the arrow to match.
+                className="border bg-popover text-sm text-popover-foreground [&_svg]:bg-popover [&_svg]:fill-popover"
+              >
                 <div className="text-center">
                   <div className="font-medium">{formatInZone(bounds.from, zone)}</div>
                   <div className="text-muted-foreground">


### PR DESCRIPTION
## Context

Follow-up to the hover summary (#912). react-ui's default `TooltipContent` uses an **inverted** surface (`bg-foreground` / `text-background`) — a dark-in-light / light-in-dark tooltip. The summary's inner tokens (`text-muted-foreground`, `text-primary`) are meant for the **normal** surface, so on the inverted background they read with the wrong contrast and don't flip cleanly with the theme.

## Change

Style the tooltip with the **standard popover surface** (`bg-popover` / `text-popover-foreground` / `border`) — the same surface the dropdown menus use. Now the muted / primary tokens read correctly and the whole summary adapts to the light / dark theme like the rest of the app. The arrow is recolored to match.

## Verification

- `tsc --noEmit`: clean · Vitest: react-ui-dashboards styled-controls **7 passing** · ESLint clean