### PR TITLE
feat(dashboards): apply the dashboard time window to widget-render tiles

### DIFF
--- a/packages/@granit/react-dashboards/src/__tests__/use-widget-render.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-widget-render.test.tsx
@@ -6,6 +6,9 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
+import { DASHBOARD_TIME_WINDOW } from '@granit/dashboards';
+
+import { DashboardContextProvider } from '../components/dashboard-context';
 import { useWidgetRender, widgetRenderQueryKey } from '../hooks/use-widget-render';
 import { DashboardsProvider } from '../providers/dashboards-provider';
 
@@ -109,6 +112,26 @@ describe('useWidgetRender', () => {
       definition: { slug: 'Banner', type: 'markdown' },
       context: { periodToken: 'mtd' },
     });
+  });
+
+  it('injects the surrounding dashboard time window as the widget period', async () => {
+    const { wrapper: base } = makeWrapper();
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      base({
+        children: (
+          <DashboardContextProvider
+            value={{ dashboardName: 'Test', timeWindow: DASHBOARD_TIME_WINDOW.Last7Days }}
+          >
+            {children}
+          </DashboardContextProvider>
+        ),
+      });
+    const { result } = renderHook(
+      () => useWidgetRender('markdown' as unknown as 'chart', definition),
+      { wrapper }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(lastBody).toMatchObject({ context: { periodToken: 'last_7d' } });
   });
 
   it('returns the DashboardRenderedWidget envelope verbatim', async () => {

--- a/packages/@granit/react-dashboards/src/hooks/use-widget-render.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-widget-render.ts
@@ -1,5 +1,5 @@
 import { HttpError } from '@granit/api-client';
-import { renderWidget } from '@granit/dashboards';
+import { renderWidget, resolveTimeWindowToRenderRequest, toRefetchInterval } from '@granit/dashboards';
 import { useQuery, type Query, type UseQueryResult } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
@@ -8,6 +8,8 @@ import { mergeFilterValuesIntoRequest } from '../lib/merge-filter-values';
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
 import { buildDashboardsQueryKey } from './query-keys';
+import { useEffectiveRefreshInterval } from './use-effective-refresh-interval';
+import { useEffectiveTimeWindow } from './use-effective-time-window';
 
 import type {
   DashboardRenderedWidget,
@@ -116,10 +118,16 @@ export function useWidgetRender<TDefinition extends WidgetDefinitionBase>(
 ): UseQueryResult<DashboardRenderedWidget> {
   const { client } = useDashboardsConfig();
   const filters = useDashboardFilters();
+  const timeWindow = useEffectiveTimeWindow();
+  const refreshInterval = useEffectiveRefreshInterval();
 
   const effectiveContext = useMemo(() => {
-    return mergeFilterValuesIntoRequest(context, filters?.values) as WidgetRenderContext;
-  }, [context, filters?.values]);
+    // The dashboard time window drives the widget's period by default; an
+    // explicit `context` period (rare — ad-hoc previews) overrides it. Filter
+    // values from the surrounding provider merge in on top.
+    const withPeriod = { ...resolveTimeWindowToRenderRequest(timeWindow), ...context };
+    return mergeFilterValuesIntoRequest(withPeriod, filters?.values) as WidgetRenderContext;
+  }, [context, filters?.values, timeWindow]);
 
   const queryKey = useMemo(
     () => widgetRenderQueryKey(kind, definition, effectiveContext),
@@ -139,7 +147,10 @@ export function useWidgetRender<TDefinition extends WidgetDefinitionBase>(
     enabled: options.enabled ?? true,
     retry: shouldRetry,
     staleTime: 60_000,
-    refetchInterval: options.refetchInterval ?? refetchIntervalFromHint,
+    // Explicit option wins; else the dashboard cadence ('auto' → undefined →
+    // the response's refreshHint); 'off' → false.
+    refetchInterval:
+      options.refetchInterval ?? toRefetchInterval(refreshInterval) ?? refetchIntervalFromHint,
   });
 }
 


### PR DESCRIPTION
## Context

Changing the dashboard **time range** left **Table / Chart / Pivot / Map** widgets unchanged — only KPI tiles reacted. Root cause: `WidgetRenderer` invokes each registered tile as `<Renderer widget={widget} />` **without a context**, so those tiles (which fetch via `useWidgetRender`) sent **no period** to `POST /analytics/widgets/{kind}/render`. KPI tiles were unaffected because they use `useMetric` + `useEffectiveTimeWindow` directly.

## Change

`useWidgetRender` now injects the **effective dashboard time window** as the render context's period — exactly the way it already merges dashboard **filters** (`mergeFilterValuesIntoRequest`):

- `resolveTimeWindowToRenderRequest(useEffectiveTimeWindow())` → `periodToken` (or absolute `periodFrom/periodTo`) is spread into the context; an **explicit** `context` period still overrides (ad-hoc previews).
- The dashboard **refresh cadence** is honored too (`useEffectiveRefreshInterval` → `refetchInterval`, explicit option wins).

One change covers **every** widget-render tile (table, chart, pivot, map), on the definition/edit path. The bundle/view path already carries `periodToken` in the render request.

## Verification

- `tsc --noEmit`: clean · Vitest: react-dashboards / react-analytics / react-ui-map **305 passing** + a new test asserting the surrounding time window lands in the render body · ESLint + arch clean

## Note

A widget only visibly changes if its query has a **time dimension** to filter on; period-less queries receive the token and simply don't filter (the backend applies it where relevant, like metrics).