### PR TITLE
style(dashboards): thin overlay scrollbar in table + pivot widgets

### DIFF
--- a/packages/@granit/react-analytics/src/components/pivot-snapshot-widget.tsx
+++ b/packages/@granit/react-analytics/src/components/pivot-snapshot-widget.tsx
@@ -98,7 +98,7 @@ function PivotBody({ snapshot }: { readonly snapshot: PivotWidgetSnapshot }) {
           fields: columnFields.join(', ') || '—',
         })}
       </p>
-      <div className="flex-1 overflow-auto">
+      <div className="scrollbar-overlay flex-1 overflow-auto">
         <table className="w-full text-xs">
           <thead>
             <tr className="border-b">

--- a/packages/@granit/react-analytics/src/components/table-snapshot-widget.tsx
+++ b/packages/@granit/react-analytics/src/components/table-snapshot-widget.tsx
@@ -43,7 +43,7 @@ function TableBody({ snapshot }: { readonly snapshot: TableWidgetSnapshot }) {
           total: totalRowCount,
         })}
       </p>
-      <div className="flex-1 overflow-auto">
+      <div className="scrollbar-overlay flex-1 overflow-auto">
         <table className="w-full text-xs">
           <thead>
             <tr className="border-b">


### PR DESCRIPTION
## Change

Apply the app's `scrollbar-overlay` utility — the thin overlay scrollbar the nav menu and AI chat already use — to the **table** and **pivot** widget scroll containers, so their overflow no longer shows the default fat scrollbar.

`scrollbar-overlay` is an app-level CSS utility (per `@granit/ui-theme` `base.css`); framework components opt in by class name (same pattern as `@granit/react-ui-ai-chat`).

## Verification

- `tsc --noEmit`: clean · Vitest: react-analytics **68 passing** · ESLint clean