### PR TITLE
fix(dashboards): honor the timezone in edit-mode time ranges

### DIFF
--- a/packages/@granit/react-dashboard-editor/package.json
+++ b/packages/@granit/react-dashboard-editor/package.json
@@ -16,6 +16,7 @@
   "peerDependencies": {
     "@granit/dashboards": "workspace:*",
     "@granit/react-dashboards": "workspace:*",
+    "@granit/react-localization": "workspace:*",
     "react": "^19.0.0",
     "react-grid-layout": "^2.2.3",
     "react-i18next": "^17.0.0"
@@ -32,6 +33,7 @@
   "devDependencies": {
     "@granit/dashboards": "workspace:*",
     "@granit/react-dashboards": "workspace:*",
+    "@granit/react-localization": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "react-grid-layout": "^2.2.3"

--- a/packages/@granit/react-dashboard-editor/src/components/editable-dashboard.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/editable-dashboard.tsx
@@ -9,6 +9,7 @@ import {
   useDashboardTimeWindowState,
   WidgetRenderer,
 } from '@granit/react-dashboards';
+import { useFirstDayOfWeek, useTimezone } from '@granit/react-localization';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { GridLayout } from 'react-grid-layout';
 
@@ -101,6 +102,10 @@ export function EditableDashboard({
     definition.defaultTimeWindow ?? DASHBOARD_TIME_WINDOW.Last30Days
   );
   const [refreshInterval, setRefreshInterval] = useDashboardRefreshIntervalState('auto');
+  // Same first-day / timezone the read-mode view uses, so calendar tokens
+  // (`wtd`/`pw`) and the shift/zoom/tooltip bounds align between edit and view.
+  const weekStartsOn = useFirstDayOfWeek();
+  const timeZone = useTimezone();
 
   const { layout, widgets: orderedWidgets } = useMemo(
     () => resolveEffectiveLayout(definition.layout, definition.widgets, breakpoint),
@@ -147,6 +152,8 @@ export function EditableDashboard({
         setTimeWindow,
         refreshInterval,
         setRefreshInterval,
+        weekStartsOn,
+        timeZone,
       }}
     >
       <div

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2127,6 +2127,9 @@ importers:
       '@granit/react-dashboards':
         specifier: workspace:*
         version: link:../react-dashboards
+      '@granit/react-localization':
+        specifier: workspace:*
+        version: link:../react-localization
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing


### PR DESCRIPTION
## Bug

In **view** mode the dashboard time range is correct, but in **edit** mode it ignores the timezone — a GMT+2 (Brussels) user sees the range start at `02:00:00` instead of `00:00:00`:

```
2026-06-03 02:00:00
to
2026-07-04 02:00:00
Local browser time  Brussels, GMT+2
```

## Cause

`DashboardViewContent` (view) seeds the dashboard context with `timeZone` (`useTimezone()`) and `weekStartsOn` (`useFirstDayOfWeek()`), so `resolveTimeWindowBounds` day-aligns tokens in the user's zone. **`EditableDashboard` (edit) provided neither** → the resolver fell back to UTC → `00:00 UTC` = `02:00` Brussels. This also affected the shift/zoom controls in edit mode.

## Fix

`EditableDashboard` now reads `useTimezone()` / `useFirstDayOfWeek()` (from `@granit/react-localization`, added as a dep) and puts them on its `DashboardContextProvider` value — mirroring `DashboardViewContent`, so edit and view resolve identical bounds.

## Verification

- `tsc --noEmit`: clean · Vitest: react-dashboard-editor + arch **3284 passing** · ESLint clean
- Dep addition (`@granit/react-localization`) + lockfile regenerated in the same commit (3-line diff)