### PR TITLE
feat(dashboards): map geography-column picker offers only spatial columns

### DIFF
--- a/packages/@granit/react-analytics/src/editor/__tests__/use-query-field-metadata.test.tsx
+++ b/packages/@granit/react-analytics/src/editor/__tests__/use-query-field-metadata.test.tsx
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useQueryFieldMetadata } from '../use-query-field-metadata';
+
+// Mutable column list driving the mocked query metadata.
+const state = vi.hoisted(() => ({ columns: [] as { name: string; type: string }[] }));
+
+vi.mock('@granit/react-query-engine', () => ({
+  useQueryCatalog: () => ({ data: [{ name: 'Q', basePath: '/api/v1/q' }] }),
+  useQueryMetaAt: () => ({
+    data: { columns: state.columns, groupByFields: [], sortableFields: [] },
+  }),
+}));
+
+describe('useQueryFieldMetadata — geographyColumnOptions', () => {
+  it('offers only NetTopologySuite geometry columns', () => {
+    state.columns = [
+      { name: 'Location', type: 'Point' },
+      { name: 'Region', type: 'Polygon' },
+      { name: 'Name', type: 'String' },
+      { name: 'Count', type: 'Int32' },
+    ];
+    const { result } = renderHook(() => useQueryFieldMetadata('Q'));
+    expect(result.current.geographyColumnOptions.map((o) => o.name)).toEqual([
+      'Location',
+      'Region',
+    ]);
+  });
+
+  it('falls back to every column when none are geometry', () => {
+    state.columns = [
+      { name: 'Name', type: 'String' },
+      { name: 'Count', type: 'Int32' },
+    ];
+    const { result } = renderHook(() => useQueryFieldMetadata('Q'));
+    expect(result.current.geographyColumnOptions.map((o) => o.name)).toEqual(['Name', 'Count']);
+  });
+});

--- a/packages/@granit/react-analytics/src/editor/use-query-field-metadata.ts
+++ b/packages/@granit/react-analytics/src/editor/use-query-field-metadata.ts
@@ -14,6 +14,23 @@ import { useQueryCatalog, useQueryMetaAt } from '@granit/react-query-engine';
 
 import type { QueryCatalogEntryResponse } from '@granit/query-engine';
 
+/**
+ * NetTopologySuite geometry CLR type names — a query column bound to a PostGIS
+ * geometry/geography column reports one of these as its `type` (`ClrType.Name`),
+ * so a map's geography-column picker can offer only spatial columns.
+ */
+const GEOMETRY_CLR_TYPES = new Set([
+  'Geometry',
+  'Point',
+  'LineString',
+  'Polygon',
+  'MultiPoint',
+  'MultiLineString',
+  'MultiPolygon',
+  'GeometryCollection',
+  'LinearRing',
+]);
+
 /** CLR type names eligible for numeric aggregation (Sum/Avg/Min/Max). */
 const NUMERIC_CLR_TYPES = new Set([
   'Byte',
@@ -53,6 +70,13 @@ export interface QueryFieldMetadata {
   /** All columns of the selected query (e.g. the table visible-columns picker). */
   readonly columnOptions: readonly FieldOption[];
   /**
+   * Spatial columns only (NetTopologySuite geometry CLR types) — the map's
+   * PostGIS geography-column picker. Falls back to every column when none are
+   * detected (e.g. a nullable geometry the backend reports as `Nullable`1`), so
+   * the picker never goes empty on an unrecognised shape.
+   */
+  readonly geographyColumnOptions: readonly FieldOption[];
+  /**
    * Sortable field options for the selected query: the columns flagged
    * `isSortable` (they carry display labels), falling back to the query's
    * declared `sortableFields` when no column advertises sortability. Empty until
@@ -81,6 +105,9 @@ export function useQueryFieldMetadata(queryName: string): QueryFieldMetadata {
   const numericColumns = (meta?.columns ?? [])
     .filter((column) => NUMERIC_CLR_TYPES.has(column.type))
     .map(toOption);
+  const geometryColumns = (meta?.columns ?? [])
+    .filter((column) => GEOMETRY_CLR_TYPES.has(column.type))
+    .map(toOption);
   const sortableColumns = (meta?.columns ?? []).filter((column) => column.isSortable).map(toOption);
   const sortableDeclared = (meta?.sortableFields ?? []).map(toOption);
 
@@ -90,6 +117,7 @@ export function useQueryFieldMetadata(queryName: string): QueryFieldMetadata {
     groupByOptions: groupByDeclared.length > 0 ? groupByDeclared : columnOptions,
     fieldOptions: numericColumns.length > 0 ? numericColumns : columnOptions,
     columnOptions,
+    geographyColumnOptions: geometryColumns.length > 0 ? geometryColumns : columnOptions,
     sortableFieldOptions: sortableColumns.length > 0 ? sortableColumns : sortableDeclared,
   };
 }

--- a/packages/@granit/react-ui-map/src/editor/map-config-form.tsx
+++ b/packages/@granit/react-ui-map/src/editor/map-config-form.tsx
@@ -41,7 +41,9 @@ type PointSourceKind = (typeof POINT_SOURCE_KINDS)[number]['value'];
 export function MapConfigForm({ widget, onChange }: WidgetConfigFormProps<MapWidgetDefinition>) {
   const { t } = useTranslation();
   const { pointSource } = widget;
-  const { catalogEntries, columnOptions } = useQueryFieldMetadata(widget.queryName);
+  const { catalogEntries, columnOptions, geographyColumnOptions } = useQueryFieldMetadata(
+    widget.queryName
+  );
 
   const handlePointSourceKindChange = (kind: PointSourceKind) => {
     if (kind === 'lat-lng') {
@@ -139,7 +141,7 @@ export function MapConfigForm({ widget, onChange }: WidgetConfigFormProps<MapWid
           <MetaFieldInput
             slot="map-geography-column"
             value={pointSource.geographyColumn}
-            options={columnOptions}
+            options={geographyColumnOptions}
             required
             onChange={(value) =>
               onChange({ ...widget, pointSource: { ...pointSource, geographyColumn: value } })


### PR DESCRIPTION
## What

The map widget's **PostGIS geography column** combobox previously listed *every* query column. It now offers only spatial columns.

## How

- `useQueryFieldMetadata` gains a `geographyColumnOptions` list: query columns whose CLR type is a NetTopologySuite geometry (`Point`, `Polygon`, `MultiPolygon`, …).
- `MapConfigForm` binds the `map-geography-column` input to `geographyColumnOptions` instead of the full `columnOptions`.
- Falls back to every column when none are detected, so the picker never empties on an unrecognised shape.

## Why CLR type (not `ValueKind`)

`ValueKind` is the semantic axis, but its enum has no spatial member today (`Count … Identifier`), so it can't identify geography columns without a cross-stack change (enum + emitter + a spatial cell renderer). NTS geometry types are reference types — never wrapped in `Nullable\`1` — so `column.type` reliably reports `Point`/`Polygon`, making the CLR-type filter robust here.

## Tests

New unit test on `useQueryFieldMetadata` covering the geometry filter + the fallback-to-all-columns path.