### PR TITLE
fix(dashboards): locale-aware chart values + correct HorizontalBar data order

### DIFF
--- a/packages/@granit/react-charts/package.json
+++ b/packages/@granit/react-charts/package.json
@@ -18,6 +18,7 @@
     "@granit/charts": "workspace:*",
     "@granit/dashboards": "workspace:*",
     "@granit/react-dashboards": "workspace:*",
+    "@granit/react-localization": "workspace:*",
     "echarts": "^6.0.0",
     "echarts-for-react": "^3.0.6",
     "react": "^19.0.0"
@@ -36,6 +37,7 @@
     "@granit/charts": "workspace:*",
     "@granit/dashboards": "workspace:*",
     "@granit/react-dashboards": "workspace:*",
+    "@granit/react-localization": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*"
   }

--- a/packages/@granit/react-charts/src/__tests__/chart-primitives.test.tsx
+++ b/packages/@granit/react-charts/src/__tests__/chart-primitives.test.tsx
@@ -48,6 +48,21 @@ describe('BarChart', () => {
     expect(opt.xAxis.type).toBe('value');
     expect(opt.yAxis.type).toBe('category');
   });
+
+  it('swaps each data pair to [value, category] when horizontal', () => {
+    const { getByTestId } = render(<BarChart series={SERIES} horizontal />);
+    const opt = optionOf(getByTestId);
+    // Authored as ['2026-01', 10]; horizontal must emit [10, '2026-01'] so the
+    // number lands on the value (x) axis and the label on the category (y) axis.
+    expect(opt.series[0].data[0]).toEqual([10, '2026-01']);
+    expect(opt.series[0].data[1]).toEqual([20, '2026-02']);
+  });
+
+  it('keeps data pairs as [category, value] when vertical', () => {
+    const { getByTestId } = render(<BarChart series={SERIES} />);
+    const opt = optionOf(getByTestId);
+    expect(opt.series[0].data[0]).toEqual(['2026-01', 10]);
+  });
 });
 
 describe('PieChart', () => {
@@ -77,11 +92,7 @@ describe('PieChart', () => {
 });
 
 describe('SparklineChart', () => {
-  const data = [
-    ['2026-01', 1] as const,
-    ['2026-02', 4] as const,
-    ['2026-03', 2] as const,
-  ];
+  const data = [['2026-01', 1] as const, ['2026-02', 4] as const, ['2026-03', 2] as const];
 
   it('renders an axis-less line', () => {
     const { getByTestId } = render(<SparklineChart data={data} />);

--- a/packages/@granit/react-charts/src/components/bar-chart.tsx
+++ b/packages/@granit/react-charts/src/components/bar-chart.tsx
@@ -14,6 +14,8 @@ export interface BarChartProps extends ChartDimensions {
   /** Render bars horizontally (swaps x and y axis roles). */
   readonly horizontal?: boolean;
   readonly showLegend?: boolean;
+  /** Locale-aware formatter for the value axis + tooltip (defaults to raw). */
+  readonly valueFormatter?: (value: number) => string;
   readonly className?: string;
   readonly theme?: string | object;
 }
@@ -30,6 +32,7 @@ export function BarChart({
   stacked = false,
   horizontal = false,
   showLegend,
+  valueFormatter,
   height,
   width,
   className,
@@ -46,9 +49,14 @@ export function BarChart({
       name: yAxis?.label,
       min: yAxis?.min,
       max: yAxis?.max,
+      axisLabel: valueFormatter ? { formatter: (v: number) => valueFormatter(v) } : undefined,
     };
     return {
-      tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'shadow' },
+        valueFormatter: valueFormatter ? (v) => valueFormatter(Number(v)) : undefined,
+      },
       legend: wantLegend ? { data: series.map((s) => s.name), top: 0 } : undefined,
       grid: {
         left: 8,
@@ -66,13 +74,17 @@ export function BarChart({
         id: s.id,
         name: s.name,
         type: 'bar',
-        // ECharts' option types want mutable arrays; spread to drop readonly.
-        data: s.data.map((p) => [...p]) as (number | string)[][],
+        // ECharts maps each tuple as `[xAxis, yAxis]`. Series data is authored
+        // `[category, value]`; when horizontal the value axis is x, so the pair
+        // must be swapped to `[value, category]` — otherwise the category lands
+        // on the numeric axis (NaN) and the value renders as the category label.
+        // Spread also drops the readonly for ECharts' mutable option types.
+        data: s.data.map((p) => (horizontal ? [p[1], p[0]] : [...p])) as (number | string)[][],
         stack: stacked ? 'total' : undefined,
         itemStyle: s.color ? { color: s.color } : undefined,
       })),
     };
-  }, [series, xAxis, yAxis, stacked, horizontal, showLegend]);
+  }, [series, xAxis, yAxis, stacked, horizontal, showLegend, valueFormatter]);
 
   return (
     <Chart options={options} height={height ?? width ?? 320} className={className} theme={theme} />

--- a/packages/@granit/react-charts/src/components/line-chart.tsx
+++ b/packages/@granit/react-charts/src/components/line-chart.tsx
@@ -19,6 +19,8 @@ export interface LineChartProps extends ChartDimensions {
   readonly area?: boolean;
   /** Show the legend above the plot area. Defaults to `true` when >1 series. */
   readonly showLegend?: boolean;
+  /** Locale-aware formatter for the value axis + tooltip (defaults to raw). */
+  readonly valueFormatter?: (value: number) => string;
   readonly className?: string;
   readonly theme?: string | object;
 }
@@ -39,6 +41,7 @@ export function LineChart({
   smooth = false,
   area = false,
   showLegend,
+  valueFormatter,
   height,
   width,
   className,
@@ -47,7 +50,10 @@ export function LineChart({
   const options = useMemo<EChartsOption>(() => {
     const wantLegend = showLegend ?? series.length > 1;
     return {
-      tooltip: { trigger: 'axis' },
+      tooltip: {
+        trigger: 'axis',
+        valueFormatter: valueFormatter ? (v) => valueFormatter(Number(v)) : undefined,
+      },
       legend: wantLegend ? { data: series.map((s) => s.name), top: 0 } : undefined,
       grid: {
         left: 8,
@@ -65,12 +71,16 @@ export function LineChart({
         min: xAxis?.min,
         max: xAxis?.max,
       },
+      // Cast: a numeric `axisLabel.formatter` only type-checks against a value
+      // axis, but `type` is a runtime union here (defaults to 'value' in the
+      // snapshot path). The value axis is always numeric where a formatter is set.
       yAxis: {
         type: yAxis?.type ?? 'value',
         name: yAxis?.label,
         min: yAxis?.min,
         max: yAxis?.max,
-      },
+        axisLabel: valueFormatter ? { formatter: (v: number) => valueFormatter(v) } : undefined,
+      } as EChartsOption['yAxis'],
       series: series.map((s) => ({
         id: s.id,
         name: s.name,
@@ -83,7 +93,7 @@ export function LineChart({
         lineStyle: s.color ? { color: s.color } : undefined,
       })),
     };
-  }, [series, xAxis, yAxis, smooth, area, showLegend]);
+  }, [series, xAxis, yAxis, smooth, area, showLegend, valueFormatter]);
 
   return (
     <Chart options={options} height={height ?? width ?? 320} className={className} theme={theme} />

--- a/packages/@granit/react-charts/src/components/pie-chart.tsx
+++ b/packages/@granit/react-charts/src/components/pie-chart.tsx
@@ -20,6 +20,8 @@ export interface PieChartProps extends ChartDimensions {
    */
   readonly innerRadiusRatio?: number;
   readonly showLegend?: boolean;
+  /** Locale-aware formatter for slice values in the tooltip (defaults to raw). */
+  readonly valueFormatter?: (value: number) => string;
   readonly className?: string;
   readonly theme?: string | object;
 }
@@ -32,6 +34,7 @@ export function PieChart({
   data,
   innerRadiusRatio = 0,
   showLegend = true,
+  valueFormatter,
   height,
   width,
   className,
@@ -41,7 +44,10 @@ export function PieChart({
     const outerRadius = '70%';
     const innerRadius = innerRadiusRatio > 0 ? `${Math.round(innerRadiusRatio * 70)}%` : '0%';
     return {
-      tooltip: { trigger: 'item' },
+      tooltip: {
+        trigger: 'item',
+        valueFormatter: valueFormatter ? (v) => valueFormatter(Number(v)) : undefined,
+      },
       legend: showLegend ? { orient: 'vertical', left: 'left' } : undefined,
       series: [
         {
@@ -59,7 +65,7 @@ export function PieChart({
         },
       ],
     };
-  }, [data, innerRadiusRatio, showLegend]);
+  }, [data, innerRadiusRatio, showLegend, valueFormatter]);
 
   return (
     <Chart options={options} height={height ?? width ?? 320} className={className} theme={theme} />

--- a/packages/@granit/react-charts/src/snapshot/__tests__/format-chart-value.test.ts
+++ b/packages/@granit/react-charts/src/snapshot/__tests__/format-chart-value.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { createChartValueFormatter } from '../format-chart-value';
+
+describe('createChartValueFormatter', () => {
+  it('applies the locale grouping to plain numbers', () => {
+    const fr = createChartValueFormatter('fr-FR', null)(1234567);
+    const en = createChartValueFormatter('en-US', null)(1234567);
+    // fr-FR groups with a (narrow no-break) space, en-US with a comma — the
+    // point is that neither is the raw ECharts default "1234567".
+    expect(fr).not.toBe('1234567');
+    expect(en).toBe('1,234,567');
+    expect(fr).not.toBe(en);
+  });
+
+  it('renders currency buckets with the ISO symbol', () => {
+    const formatted = createChartValueFormatter('en-US', 'EUR')(1234.5);
+    expect(formatted).toContain('€');
+    expect(formatted).toContain('1,234.50');
+  });
+
+  it('falls back to plain number formatting when no currency is set', () => {
+    const formatted = createChartValueFormatter('en-US', undefined)(1234.5);
+    expect(formatted).toBe('1,234.5');
+  });
+});

--- a/packages/@granit/react-charts/src/snapshot/chart-snapshot-widget.tsx
+++ b/packages/@granit/react-charts/src/snapshot/chart-snapshot-widget.tsx
@@ -1,8 +1,12 @@
 import { isChartSnapshotEnvelope } from '@granit/analytics';
+import { useLocale } from '@granit/react-localization';
+import { useMemo } from 'react';
 
 import { BarChart } from '../components/bar-chart';
 import { LineChart } from '../components/line-chart';
 import { PieChart } from '../components/pie-chart';
+
+import { createChartValueFormatter } from './format-chart-value';
 
 import type { ChartWidgetSnapshot } from '@granit/analytics';
 import type { ChartSeries } from '@granit/charts';
@@ -27,6 +31,16 @@ export function ChartSnapshotWidget({ widget }: { readonly widget: DashboardRend
 
 function ChartBody({ snapshot }: { readonly snapshot: ChartWidgetSnapshot }) {
   const { chartType, groupBy, aggregation, field, buckets, currency } = snapshot;
+  const { locale } = useLocale();
+
+  // Locale-aware value formatting for every numeric axis / tooltip. Currency
+  // buckets (B3-8b) render with the ISO symbol; everything else uses the
+  // culture's grouping + decimals. Memoised so ECharts re-renders only when
+  // locale or currency actually changes.
+  const valueFormatter = useMemo(
+    () => createChartValueFormatter(locale, currency),
+    [locale, currency]
+  );
 
   const seriesName = field ? `${aggregation}(${field})` : aggregation;
 
@@ -41,7 +55,12 @@ function ChartBody({ snapshot }: { readonly snapshot: ChartWidgetSnapshot }) {
     }));
     return (
       <div data-slot="chart-snapshot-widget" data-chart-type={chartType} className="h-full w-full">
-        <PieChart data={pieData} innerRadiusRatio={chartType === 'Donut' ? 0.5 : 0} height="100%" />
+        <PieChart
+          data={pieData}
+          innerRadiusRatio={chartType === 'Donut' ? 0.5 : 0}
+          valueFormatter={valueFormatter}
+          height="100%"
+        />
       </div>
     );
   }
@@ -64,6 +83,7 @@ function ChartBody({ snapshot }: { readonly snapshot: ChartWidgetSnapshot }) {
           xAxis={{ label: groupBy }}
           yAxis={{ label: valueAxisLabel }}
           area={chartType === 'Area'}
+          valueFormatter={valueFormatter}
           height="100%"
         />
       </div>
@@ -79,6 +99,7 @@ function ChartBody({ snapshot }: { readonly snapshot: ChartWidgetSnapshot }) {
         xAxis={{ label: horizontal ? valueAxisLabel : groupBy }}
         yAxis={{ label: horizontal ? groupBy : valueAxisLabel }}
         horizontal={horizontal}
+        valueFormatter={valueFormatter}
         height="100%"
       />
     </div>

--- a/packages/@granit/react-charts/src/snapshot/format-chart-value.ts
+++ b/packages/@granit/react-charts/src/snapshot/format-chart-value.ts
@@ -1,0 +1,17 @@
+// Locale-aware value formatting for chart axes + tooltips. Kept as a pure
+// factory (no React) so the number/currency behaviour is unit-testable and the
+// `Intl.NumberFormat` instance can be memoised by the widget across renders.
+
+/**
+ * Builds a value formatter for chart numeric values. When `currency` is set
+ * (a `ColumnBuilder.Currency(...)` field), values render with the ISO 4217
+ * symbol; otherwise they use the culture's grouping + decimals. `locale`
+ * defaults to the host default when `undefined`.
+ */
+export function createChartValueFormatter(
+  locale: string | undefined,
+  currency: string | null | undefined
+): (value: number) => string {
+  const nf = new Intl.NumberFormat(locale, currency ? { style: 'currency', currency } : {});
+  return (value: number) => nf.format(value);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1895,6 +1895,9 @@ importers:
       '@granit/react-dashboards':
         specifier: workspace:*
         version: link:../react-dashboards
+      '@granit/react-localization':
+        specifier: workspace:*
+        version: link:../react-localization
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing


### PR DESCRIPTION
## Two Chart-widget rendering defects (Donut/Bar reported)

### 1. Numbers ignored the user's culture
Chart values went straight to ECharts, so a French user saw `1234567` instead of `1 234 567` (and currency buckets showed a raw number).

**Fix:** thread a locale-aware, currency-aware `valueFormatter` from `ChartSnapshotWidget` — resolved via `useLocale()` (`i18n.language`) — into the pie/bar/line primitives' **tooltip** and **value axis**. Currency buckets (B3-8b) now render with the ISO symbol; everything else uses the culture's grouping + decimals. Extracted as a pure `createChartValueFormatter(locale, currency)` for unit testing.

### 2. HorizontalBar swapped label ↔ value
ECharts reads each tuple as `[xAxis, yAxis]`. Series data is authored `[category, value]`, but a horizontal bar puts the value axis on **x** — so the category landed on the numeric axis (**NaN**) and the value rendered as the category label.

**Fix:** swap each pair to `[value, category]` when `horizontal`.

## Notes
- `@granit/react-localization` added to `react-charts` peer+dev deps (arch-test `no-undeclared-dep`); lockfile regenerated.
- Enum group-by labels are still shown raw (English) — that's a separate cross-stack gap (no enum i18n exists anywhere today), tracked separately.

## Tests
- `createChartValueFormatter`: locale grouping, currency symbol, plain fallback.
- BarChart: horizontal emits `[value, category]`, vertical keeps `[category, value]`.
- All 35 react-charts tests + 3141 arch-tests green; tsc + lint clean.