### PR TITLE
feat(dashboards): add radar, funnel and treemap chart widget types

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4165,6 +4165,57 @@
           "members": []
         },
         {
+          "name": "RadarChart",
+          "kind": "function",
+          "signature": "function RadarChart("
+        },
+        {
+          "name": "RadarChartProps",
+          "kind": "interface",
+          "signature": "interface RadarChartProps extends ChartDimensions",
+          "members": []
+        },
+        {
+          "name": "RadarDatum",
+          "kind": "interface",
+          "signature": "interface RadarDatum",
+          "members": []
+        },
+        {
+          "name": "FunnelChart",
+          "kind": "function",
+          "signature": "function FunnelChart("
+        },
+        {
+          "name": "FunnelChartProps",
+          "kind": "interface",
+          "signature": "interface FunnelChartProps extends ChartDimensions",
+          "members": []
+        },
+        {
+          "name": "FunnelDatum",
+          "kind": "interface",
+          "signature": "interface FunnelDatum",
+          "members": []
+        },
+        {
+          "name": "TreemapChart",
+          "kind": "function",
+          "signature": "function TreemapChart("
+        },
+        {
+          "name": "TreemapChartProps",
+          "kind": "interface",
+          "signature": "interface TreemapChartProps extends ChartDimensions",
+          "members": []
+        },
+        {
+          "name": "TreemapDatum",
+          "kind": "interface",
+          "signature": "interface TreemapDatum",
+          "members": []
+        },
+        {
           "name": "useEChartsTheme",
           "kind": "function",
           "signature": "function useEChartsTheme(options: UseEChartsThemeOptions): string"

--- a/contracts/openapi/analytics.json
+++ b/contracts/openapi/analytics.json
@@ -506,7 +506,17 @@
         "enum": ["Count", "Sum", "Avg", "Min", "Max"]
       },
       "ChartType": {
-        "enum": ["Bar", "HorizontalBar", "Line", "Area", "Pie", "Donut"]
+        "enum": [
+          "Bar",
+          "HorizontalBar",
+          "Line",
+          "Area",
+          "Pie",
+          "Donut",
+          "Radar",
+          "Funnel",
+          "Treemap"
+        ]
       },
       "ChartWidgetDefinition": {
         "required": ["queryName", "groupBy", "aggregation", "field", "chartType", "slug"],
@@ -1201,7 +1211,7 @@
             "format": "double"
           },
           "valueKind": {
-            "$ref": "#/components/schemas/MetricValueKind"
+            "$ref": "#/components/schemas/ValueKind"
           },
           "currency": {
             "type": ["null", "string"]
@@ -1223,9 +1233,6 @@
             ]
           }
         }
-      },
-      "MetricValueKind": {
-        "enum": ["Count", "Number", "Currency", "Percentage", "Duration", "Date"]
       },
       "PeriodSpec": {
         "type": "object",
@@ -1427,6 +1434,32 @@
         "enum": ["History", "Realtime"],
         "default": "History"
       },
+      "ValueKind": {
+        "enum": [
+          "Count",
+          "Number",
+          "Currency",
+          "Percentage",
+          "Duration",
+          "Date",
+          "Url",
+          "Email",
+          "Phone",
+          "Bytes",
+          "DateTime",
+          "Boolean",
+          "Enum",
+          "RelativeTime",
+          "Time",
+          "Color",
+          "Image",
+          "Json",
+          "Markdown",
+          "Tags",
+          "Rating",
+          "Identifier"
+        ]
+      },
       "WidgetAction": {
         "required": ["trigger", "kind", "target"],
         "type": "object",
@@ -1438,6 +1471,7 @@
             "$ref": "#/components/schemas/WidgetActionKind"
           },
           "target": {
+            "maxLength": 256,
             "type": "string"
           },
           "params": {

--- a/packages/@granit/analytics/src/__tests__/data-snapshots.test.ts
+++ b/packages/@granit/analytics/src/__tests__/data-snapshots.test.ts
@@ -162,8 +162,18 @@ describe('Type guards — analytics envelope dispatch', () => {
 });
 
 describe('ChartType — exhaustive enum surface (PascalCase, backend-ordered)', () => {
-  it('locks the six backend types in declaration order', () => {
-    const types: readonly ChartType[] = ['Bar', 'HorizontalBar', 'Line', 'Area', 'Pie', 'Donut'];
-    expect(types).toHaveLength(6);
+  it('locks the nine backend types in declaration order', () => {
+    const types: readonly ChartType[] = [
+      'Bar',
+      'HorizontalBar',
+      'Line',
+      'Area',
+      'Pie',
+      'Donut',
+      'Radar',
+      'Funnel',
+      'Treemap',
+    ];
+    expect(types).toHaveLength(9);
   });
 });

--- a/packages/@granit/analytics/src/types/chart-widget.ts
+++ b/packages/@granit/analytics/src/types/chart-widget.ts
@@ -7,7 +7,8 @@ import type { WidgetDefinitionBase } from '@granit/dashboards';
  * values — the framework's host registers a `JsonStringEnumConverter()`
  * with no naming policy. Order matches the backend numeric declaration.
  */
-export type ChartType = 'Bar' | 'HorizontalBar' | 'Line' | 'Area' | 'Pie' | 'Donut';
+export type ChartType =
+  'Bar' | 'HorizontalBar' | 'Line' | 'Area' | 'Pie' | 'Donut' | 'Radar' | 'Funnel' | 'Treemap';
 
 /**
  * Aggregated chart bound to a `QueryDefinition`. Mirrors

--- a/packages/@granit/react-charts/src/__tests__/chart-primitives.test.tsx
+++ b/packages/@granit/react-charts/src/__tests__/chart-primitives.test.tsx
@@ -2,8 +2,11 @@ import { render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { BarChart } from '../components/bar-chart';
+import { FunnelChart } from '../components/funnel-chart';
 import { PieChart } from '../components/pie-chart';
+import { RadarChart } from '../components/radar-chart';
 import { SparklineChart } from '../components/sparkline-chart';
+import { TreemapChart } from '../components/treemap-chart';
 
 import type { ChartSeries } from '@granit/charts';
 
@@ -107,5 +110,82 @@ describe('SparklineChart', () => {
     const opt = optionOf(getByTestId);
     expect(opt.series[0].areaStyle).toEqual({ color: '#123456', opacity: 0.2 });
     expect(opt.series[0].lineStyle).toEqual({ color: '#123456', width: 2 });
+  });
+});
+
+describe('RadarChart', () => {
+  const data = [
+    { label: 'Speed', value: 4 },
+    { label: 'Range', value: 10 },
+    { label: 'Cost', value: 7 },
+  ];
+
+  it('maps each datum to one indicator axis', () => {
+    const { getByTestId } = render(<RadarChart data={data} name="EV" />);
+    const opt = optionOf(getByTestId);
+    expect(opt.series[0].type).toBe('radar');
+    expect(opt.radar.indicator.map((i: { name: string }) => i.name)).toEqual([
+      'Speed',
+      'Range',
+      'Cost',
+    ]);
+  });
+
+  it('shares one scale across every indicator so the axes stay comparable', () => {
+    const { getByTestId } = render(<RadarChart data={data} name="EV" />);
+    const opt = optionOf(getByTestId);
+    // max = Math.max(4, 10, 7) applied to all axes, not a per-axis auto-max.
+    expect(opt.radar.indicator.every((i: { max: number }) => i.max === 10)).toBe(true);
+  });
+
+  it('traces the values as a single series', () => {
+    const { getByTestId } = render(<RadarChart data={data} name="EV" />);
+    const opt = optionOf(getByTestId);
+    expect(opt.series[0].data).toEqual([{ name: 'EV', value: [4, 10, 7] }]);
+  });
+});
+
+describe('FunnelChart', () => {
+  const data = [
+    { label: 'Visited', value: 100 },
+    { label: 'Signed up', value: 40 },
+    { label: 'Paid', value: 12, color: '#0af' },
+  ];
+
+  it('renders a descending-sorted funnel', () => {
+    const { getByTestId } = render(<FunnelChart data={data} />);
+    const opt = optionOf(getByTestId);
+    expect(opt.series[0].type).toBe('funnel');
+    expect(opt.series[0].sort).toBe('descending');
+  });
+
+  it('maps labels to segment names and honours a per-datum color', () => {
+    const { getByTestId } = render(<FunnelChart data={data} />);
+    const opt = optionOf(getByTestId);
+    expect(opt.series[0].data[0]).toMatchObject({ name: 'Visited', value: 100 });
+    expect(opt.series[0].data[2].itemStyle).toEqual({ color: '#0af' });
+  });
+});
+
+describe('TreemapChart', () => {
+  const data = [
+    { label: 'Docs', value: 30 },
+    { label: 'Media', value: 55, color: '#f80' },
+  ];
+
+  it('renders flat, non-interactive leaves', () => {
+    const { getByTestId } = render(<TreemapChart data={data} />);
+    const opt = optionOf(getByTestId);
+    expect(opt.series[0].type).toBe('treemap');
+    expect(opt.series[0].roam).toBe(false);
+    expect(opt.series[0].nodeClick).toBe(false);
+    expect(opt.series[0].breadcrumb.show).toBe(false);
+  });
+
+  it('maps labels to tile names and honours a per-datum color', () => {
+    const { getByTestId } = render(<TreemapChart data={data} />);
+    const opt = optionOf(getByTestId);
+    expect(opt.series[0].data[0]).toMatchObject({ name: 'Docs', value: 30 });
+    expect(opt.series[0].data[1].itemStyle).toEqual({ color: '#f80' });
   });
 });

--- a/packages/@granit/react-charts/src/__tests__/chart-snapshot-widget.test.tsx
+++ b/packages/@granit/react-charts/src/__tests__/chart-snapshot-widget.test.tsx
@@ -24,7 +24,8 @@ const ENVELOPE_BASE = {
 };
 
 function chartEnvelope(
-  chartType: 'Bar' | 'HorizontalBar' | 'Line' | 'Area' | 'Pie' | 'Donut',
+  chartType:
+    'Bar' | 'HorizontalBar' | 'Line' | 'Area' | 'Pie' | 'Donut' | 'Radar' | 'Funnel' | 'Treemap',
   overrides: Partial<{
     field: string | null;
     currency: string | null;
@@ -95,6 +96,35 @@ describe('ChartSnapshotWidget — dispatch by chartType', () => {
     const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
     expect(opt.series[0].type).toBe('pie');
     expect(opt.series[0].radius).toEqual(['35%', '70%']);
+  });
+
+  it('routes Radar to RadarChart, one indicator per bucket', () => {
+    const { container, getByTestId } = render(
+      <ChartSnapshotWidget widget={chartEnvelope('Radar')} />
+    );
+    expect(
+      container
+        .querySelector('[data-slot="chart-snapshot-widget"]')
+        ?.getAttribute('data-chart-type')
+    ).toBe('Radar');
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.series[0].type).toBe('radar');
+    expect(opt.radar.indicator).toHaveLength(3);
+    expect(opt.series[0].data[0].value).toEqual([12500, 18200, 21450]);
+  });
+
+  it('routes Funnel to FunnelChart, descending', () => {
+    const { getByTestId } = render(<ChartSnapshotWidget widget={chartEnvelope('Funnel')} />);
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.series[0].type).toBe('funnel');
+    expect(opt.series[0].sort).toBe('descending');
+  });
+
+  it('routes Treemap to TreemapChart, one leaf per bucket', () => {
+    const { getByTestId } = render(<ChartSnapshotWidget widget={chartEnvelope('Treemap')} />);
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.series[0].type).toBe('treemap');
+    expect(opt.series[0].data).toHaveLength(3);
   });
 
   it('appends the currency code to the value-axis label when set (B3-8b)', () => {

--- a/packages/@granit/react-charts/src/components/funnel-chart.tsx
+++ b/packages/@granit/react-charts/src/components/funnel-chart.tsx
@@ -1,0 +1,64 @@
+import { useMemo } from 'react';
+
+import { Chart } from './chart';
+
+import type { ChartDimensions } from '@granit/charts';
+import type { EChartsOption } from 'echarts';
+
+export interface FunnelDatum {
+  /** Stage label shown on the segment and in the legend / tooltip. */
+  readonly label: string;
+  readonly value: number;
+  readonly color?: string;
+}
+
+export interface FunnelChartProps extends ChartDimensions {
+  readonly data: readonly FunnelDatum[];
+  /** Show the legend beside the plot area. Defaults to `true`. */
+  readonly showLegend?: boolean;
+  /** Locale-aware formatter for segment values in the tooltip (defaults to raw). */
+  readonly valueFormatter?: (value: number) => string;
+  readonly className?: string;
+  readonly theme?: string | object;
+}
+
+/**
+ * Typed funnel chart wrapper. Segments sort descending by value so the widest
+ * band sits at the top — the conventional conversion / pipeline reading —
+ * regardless of the order the buckets arrive in.
+ */
+export function FunnelChart({
+  data,
+  showLegend = true,
+  valueFormatter,
+  height,
+  width,
+  className,
+  theme,
+}: FunnelChartProps) {
+  const options = useMemo<EChartsOption>(
+    () => ({
+      tooltip: {
+        trigger: 'item',
+        valueFormatter: valueFormatter ? (v) => valueFormatter(Number(v)) : undefined,
+      },
+      legend: showLegend ? { orient: 'vertical', left: 'left' } : undefined,
+      series: [
+        {
+          type: 'funnel',
+          sort: 'descending',
+          data: data.map((d) => ({
+            name: d.label,
+            value: d.value,
+            itemStyle: d.color ? { color: d.color } : undefined,
+          })),
+        },
+      ],
+    }),
+    [data, showLegend, valueFormatter]
+  );
+
+  return (
+    <Chart options={options} height={height ?? width ?? 320} className={className} theme={theme} />
+  );
+}

--- a/packages/@granit/react-charts/src/components/radar-chart.tsx
+++ b/packages/@granit/react-charts/src/components/radar-chart.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+
+import { Chart } from './chart';
+
+import type { ChartDimensions } from '@granit/charts';
+import type { EChartsOption } from 'echarts';
+
+export interface RadarDatum {
+  /** Indicator axis name shown around the radar's perimeter. */
+  readonly label: string;
+  /** Value plotted on this axis. */
+  readonly value: number;
+}
+
+export interface RadarChartProps extends ChartDimensions {
+  readonly data: readonly RadarDatum[];
+  /** Series name shown in the tooltip / legend. */
+  readonly name?: string;
+  /** Show the legend above the plot area. Defaults to `false`. */
+  readonly showLegend?: boolean;
+  /** Locale-aware formatter for axis values in the tooltip (defaults to raw). */
+  readonly valueFormatter?: (value: number) => string;
+  readonly className?: string;
+  readonly theme?: string | object;
+}
+
+/**
+ * Typed radar (spider) chart wrapper. Each datum becomes one indicator axis
+ * and the single series traces the values around them.
+ *
+ * All indicators share one scale — the max across the data — so the axes read
+ * as comparable. ECharts' default per-axis auto-max would stretch every point
+ * to the perimeter and flatten the shape the chart exists to show.
+ */
+export function RadarChart({
+  data,
+  name,
+  showLegend = false,
+  valueFormatter,
+  height,
+  width,
+  className,
+  theme,
+}: RadarChartProps) {
+  const options = useMemo<EChartsOption>(() => {
+    const sharedMax = Math.max(0, ...data.map((d) => d.value));
+    return {
+      tooltip: {
+        trigger: 'item',
+        valueFormatter: valueFormatter ? (v) => valueFormatter(Number(v)) : undefined,
+      },
+      legend: showLegend && name ? { data: [name], top: 0 } : undefined,
+      radar: {
+        indicator: data.map((d) => ({ name: d.label, max: sharedMax })),
+      },
+      series: [
+        {
+          type: 'radar',
+          data: [{ name, value: data.map((d) => d.value) }],
+        },
+      ],
+    };
+  }, [data, name, showLegend, valueFormatter]);
+
+  return (
+    <Chart options={options} height={height ?? width ?? 320} className={className} theme={theme} />
+  );
+}

--- a/packages/@granit/react-charts/src/components/treemap-chart.tsx
+++ b/packages/@granit/react-charts/src/components/treemap-chart.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from 'react';
+
+import { Chart } from './chart';
+
+import type { ChartDimensions } from '@granit/charts';
+import type { EChartsOption } from 'echarts';
+
+export interface TreemapDatum {
+  /** Leaf label shown on the tile and in the tooltip. */
+  readonly label: string;
+  readonly value: number;
+  readonly color?: string;
+}
+
+export interface TreemapChartProps extends ChartDimensions {
+  readonly data: readonly TreemapDatum[];
+  /** Locale-aware formatter for tile values in the tooltip (defaults to raw). */
+  readonly valueFormatter?: (value: number) => string;
+  readonly className?: string;
+  readonly theme?: string | object;
+}
+
+/**
+ * Typed treemap wrapper. Each datum is a leaf rectangle sized by its value — a
+ * compact way to show proportions across many categories where a pie would
+ * crowd. Flat (single level) and non-interactive to match the single-series
+ * snapshot contract: no drill-down, roam, or breadcrumb.
+ */
+export function TreemapChart({
+  data,
+  valueFormatter,
+  height,
+  width,
+  className,
+  theme,
+}: TreemapChartProps) {
+  const options = useMemo<EChartsOption>(
+    () => ({
+      tooltip: {
+        trigger: 'item',
+        valueFormatter: valueFormatter ? (v) => valueFormatter(Number(v)) : undefined,
+      },
+      series: [
+        {
+          type: 'treemap',
+          roam: false,
+          nodeClick: false,
+          breadcrumb: { show: false },
+          data: data.map((d) => ({
+            name: d.label,
+            value: d.value,
+            itemStyle: d.color ? { color: d.color } : undefined,
+          })),
+        },
+      ],
+    }),
+    [data, valueFormatter]
+  );
+
+  return (
+    <Chart options={options} height={height ?? width ?? 320} className={className} theme={theme} />
+  );
+}

--- a/packages/@granit/react-charts/src/echarts-instance.ts
+++ b/packages/@granit/react-charts/src/echarts-instance.ts
@@ -8,11 +8,20 @@
  * is paid once, in a single shared module — primitive components import from
  * here, never directly from `echarts/charts` or `echarts/components`.
  */
-import { BarChart, GaugeChart, LineChart, PieChart } from 'echarts/charts';
+import {
+  BarChart,
+  FunnelChart,
+  GaugeChart,
+  LineChart,
+  PieChart,
+  RadarChart,
+  TreemapChart,
+} from 'echarts/charts';
 import {
   DataZoomComponent,
   GridComponent,
   LegendComponent,
+  RadarComponent,
   TitleComponent,
   TooltipComponent,
 } from 'echarts/components';
@@ -25,12 +34,16 @@ echarts.use([
   BarChart,
   PieChart,
   GaugeChart,
+  RadarChart,
+  FunnelChart,
+  TreemapChart,
   // Components
   GridComponent,
   TooltipComponent,
   TitleComponent,
   LegendComponent,
   DataZoomComponent,
+  RadarComponent,
   // Renderer
   CanvasRenderer,
 ]);

--- a/packages/@granit/react-charts/src/index.ts
+++ b/packages/@granit/react-charts/src/index.ts
@@ -15,6 +15,12 @@ export { PieChart } from './components/pie-chart';
 export type { PieChartProps, PieDatum } from './components/pie-chart';
 export { SparklineChart } from './components/sparkline-chart';
 export type { SparklineChartProps } from './components/sparkline-chart';
+export { RadarChart } from './components/radar-chart';
+export type { RadarChartProps, RadarDatum } from './components/radar-chart';
+export { FunnelChart } from './components/funnel-chart';
+export type { FunnelChartProps, FunnelDatum } from './components/funnel-chart';
+export { TreemapChart } from './components/treemap-chart';
+export type { TreemapChartProps, TreemapDatum } from './components/treemap-chart';
 
 // Theming
 export { useEChartsTheme } from './hooks/use-echarts-theme';

--- a/packages/@granit/react-charts/src/snapshot/chart-snapshot-widget.tsx
+++ b/packages/@granit/react-charts/src/snapshot/chart-snapshot-widget.tsx
@@ -3,8 +3,11 @@ import { useLocale } from '@granit/react-localization';
 import { useMemo } from 'react';
 
 import { BarChart } from '../components/bar-chart';
+import { FunnelChart } from '../components/funnel-chart';
 import { LineChart } from '../components/line-chart';
 import { PieChart } from '../components/pie-chart';
+import { RadarChart } from '../components/radar-chart';
+import { TreemapChart } from '../components/treemap-chart';
 
 import { createChartValueFormatter } from './format-chart-value';
 
@@ -61,6 +64,30 @@ function ChartBody({ snapshot }: { readonly snapshot: ChartWidgetSnapshot }) {
           valueFormatter={valueFormatter}
           height="100%"
         />
+      </div>
+    );
+  }
+
+  // Radar / Funnel / Treemap all consume the same flat label-value list as the
+  // pie family — no axis or multi-series shaping — so they share one branch.
+  if (chartType === 'Radar' || chartType === 'Funnel' || chartType === 'Treemap') {
+    const categoryData = buckets.map((b) => ({ label: b.label, value: b.value ?? 0 }));
+    return (
+      <div data-slot="chart-snapshot-widget" data-chart-type={chartType} className="h-full w-full">
+        {chartType === 'Radar' && (
+          <RadarChart
+            data={categoryData}
+            name={seriesName}
+            valueFormatter={valueFormatter}
+            height="100%"
+          />
+        )}
+        {chartType === 'Funnel' && (
+          <FunnelChart data={categoryData} valueFormatter={valueFormatter} height="100%" />
+        )}
+        {chartType === 'Treemap' && (
+          <TreemapChart data={categoryData} valueFormatter={valueFormatter} height="100%" />
+        )}
       </div>
     );
   }

--- a/packages/@granit/react-ui-analytics/src/components/chart-config-form.tsx
+++ b/packages/@granit/react-ui-analytics/src/components/chart-config-form.tsx
@@ -12,7 +12,17 @@ import type { ChartType, ChartWidgetDefinition } from '@granit/analytics';
 import type { AggregateFunction } from '@granit/dashboards';
 import type { WidgetConfigFormProps } from '@granit/react-dashboard-editor';
 
-const CHART_TYPES: readonly ChartType[] = ['Bar', 'HorizontalBar', 'Line', 'Area', 'Pie', 'Donut'];
+const CHART_TYPES: readonly ChartType[] = [
+  'Bar',
+  'HorizontalBar',
+  'Line',
+  'Area',
+  'Pie',
+  'Donut',
+  'Radar',
+  'Funnel',
+  'Treemap',
+];
 const AGGREGATIONS: readonly AggregateFunction[] = ['Count', 'Sum', 'Avg', 'Min', 'Max'];
 
 /**


### PR DESCRIPTION
## What

Extends the dashboard **Chart** widget catalogue from 6 to **9 selectable chart types**, adding **Radar**, **Funnel** and **Treemap**.

These three reuse the existing single-series snapshot contract (`buckets: { label, value }[]`) **unchanged** — no data-contract change. They consume the same shape as the pie family.

## Changes

- **New typed primitives** in `@granit/react-charts`: `RadarChart`, `FunnelChart`, `TreemapChart`, built on modular ECharts imports and registered once in the shared instance (tree-shaking preserved).
- **`ChartType` union** extended in `@granit/analytics` (mirrors the backend enum).
- **OpenAPI contract** (`contracts/openapi/analytics.json`) resynced from `Granit.Business.OpenApi.Generator` — the `ChartType` enum now carries the three values.
- **Snapshot renderer** dispatches the new kinds; **editor picker** offers them.
- Tests: exhaustive-enum surface, snapshot dispatch, and primitive option shapes.

## Cross-stack ordering

Backend enum + openapi are the source of truth and were **merged in granit-business first**. This PR is the front follow-up.

## Verification

- `tsc --noEmit` clean (analytics, react-charts, react-ui-analytics)
- ESLint clean (`--max-warnings 0`)
- `@granit/contract-tests` oracle green (openapi ↔ hand-written DTOs)
- Full vitest suite green (677) + react-charts (45)

## Notes

- The type picker renders the raw enum value (`Radar`, `Funnel`, `Treemap`) — consistent with the pre-existing `HorizontalBar`. i18n labelling of the picker is a separate, optional cleanup.
- Multi-series types (stacked/grouped bars, scatter, heatmap) are **out of scope** — they require a snapshot-contract change and are tracked as the Palier 2 effort.