### PR TITLE
fix(dashboards): correct import order in use-widget-render test

### DIFF
--- a/packages/@granit/react-dashboards/src/__tests__/use-widget-render.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-widget-render.test.tsx
@@ -1,3 +1,4 @@
+import { DASHBOARD_TIME_WINDOW } from '@granit/dashboards';
 import { GranitClientProvider } from '@granit/react-api-client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
@@ -5,8 +6,6 @@ import axios from 'axios';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
-
-import { DASHBOARD_TIME_WINDOW } from '@granit/dashboards';
 
 import { DashboardContextProvider } from '../components/dashboard-context';
 import { useWidgetRender, widgetRenderQueryKey } from '../hooks/use-widget-render';


### PR DESCRIPTION
## Summary

Fixes the ESLint failure introduced with the radar/funnel/treemap widget types (#920): the `@granit/dashboards` import in `use-widget-render.test.tsx` sat in its own import group, breaking `import-x/order`.

- Merged the stray import into the top group, ordered before `@granit/react-api-client` (via `eslint --fix`).

## Verification

- `pnpm exec eslint … --max-warnings 0` → clean
- Pre-commit hook (gitleaks + prettier + workspace `tsc -r --noEmit`) passed

Follow-up to squash-merged #920.