### PR TITLE
feat(dashboards): add multi-series chart widgets (grouped/stacked/heatmap)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4216,6 +4216,23 @@
           "members": []
         },
         {
+          "name": "HeatmapChart",
+          "kind": "function",
+          "signature": "function HeatmapChart("
+        },
+        {
+          "name": "HeatmapChartProps",
+          "kind": "interface",
+          "signature": "interface HeatmapChartProps extends ChartDimensions",
+          "members": []
+        },
+        {
+          "name": "HeatmapDatum",
+          "kind": "interface",
+          "signature": "interface HeatmapDatum",
+          "members": []
+        },
+        {
           "name": "useEChartsTheme",
           "kind": "function",
           "signature": "function useEChartsTheme(options: UseEChartsThemeOptions): string"

--- a/contracts/openapi/analytics.json
+++ b/contracts/openapi/analytics.json
@@ -515,7 +515,8 @@
           "Donut",
           "Radar",
           "Funnel",
-          "Treemap"
+          "Treemap",
+          "Heatmap"
         ]
       },
       "ChartWidgetDefinition": {
@@ -536,6 +537,13 @@
           },
           "chartType": {
             "$ref": "#/components/schemas/ChartType"
+          },
+          "seriesBy": {
+            "type": ["null", "string"]
+          },
+          "stacked": {
+            "type": "boolean",
+            "default": false
           },
           "slug": {
             "type": "string"

--- a/packages/@granit/analytics/src/__tests__/data-snapshots.test.ts
+++ b/packages/@granit/analytics/src/__tests__/data-snapshots.test.ts
@@ -162,7 +162,7 @@ describe('Type guards — analytics envelope dispatch', () => {
 });
 
 describe('ChartType — exhaustive enum surface (PascalCase, backend-ordered)', () => {
-  it('locks the nine backend types in declaration order', () => {
+  it('locks the ten backend types in declaration order', () => {
     const types: readonly ChartType[] = [
       'Bar',
       'HorizontalBar',
@@ -173,7 +173,8 @@ describe('ChartType — exhaustive enum surface (PascalCase, backend-ordered)', 
       'Radar',
       'Funnel',
       'Treemap',
+      'Heatmap',
     ];
-    expect(types).toHaveLength(9);
+    expect(types).toHaveLength(10);
   });
 });

--- a/packages/@granit/analytics/src/types/chart-snapshot.ts
+++ b/packages/@granit/analytics/src/types/chart-snapshot.ts
@@ -19,6 +19,12 @@ export interface ChartBucket {
    * carry a non-null value (zero for empty groups).
    */
   readonly value: number | null;
+  /**
+   * Series (series-by) key for a multi-series chart — one bucket per
+   * (category × series) pair. `null`/absent for a single-series chart. Null
+   * series values surface as `'(null)'`.
+   */
+  readonly series?: string | null;
 }
 
 /**
@@ -52,6 +58,25 @@ export interface ChartWidgetSnapshot {
    * formats every bucket value with the matching currency symbol + locale.
    */
   readonly currency?: string | null;
+  /**
+   * Second categorical dimension echoed from the definition. When set, the
+   * chart is multi-series — each {@link ChartBucket.series} is a value of this
+   * dimension. `null`/absent for a single-series chart.
+   */
+  readonly seriesBy?: string | null;
+  /**
+   * Whether a multi-series chart stacks its series (vs grouping them). Only
+   * ever `true` for `Bar` / `HorizontalBar` / `Line` / `Area` with a
+   * `seriesBy` — the backend zeroes it out for every other chart type.
+   */
+  readonly stacked?: boolean;
+  /**
+   * Semantic display-type shared by every bucket (`'Count'`, `'Currency'`,
+   * `'Percentage'`, `'Bytes'`, …), or `null`. Drives the shared cell formatter
+   * so chart values format like the query grids and pivot. Wire values are the
+   * .NET `ValueKind` enum member names verbatim.
+   */
+  readonly valueKind?: string | null;
 }
 
 /** Narrowed `WidgetSnapshotEnvelope` for the `'Chart'` widget kind. */

--- a/packages/@granit/analytics/src/types/chart-widget.ts
+++ b/packages/@granit/analytics/src/types/chart-widget.ts
@@ -8,7 +8,16 @@ import type { WidgetDefinitionBase } from '@granit/dashboards';
  * with no naming policy. Order matches the backend numeric declaration.
  */
 export type ChartType =
-  'Bar' | 'HorizontalBar' | 'Line' | 'Area' | 'Pie' | 'Donut' | 'Radar' | 'Funnel' | 'Treemap';
+  | 'Bar'
+  | 'HorizontalBar'
+  | 'Line'
+  | 'Area'
+  | 'Pie'
+  | 'Donut'
+  | 'Radar'
+  | 'Funnel'
+  | 'Treemap'
+  | 'Heatmap';
 
 /**
  * Aggregated chart bound to a `QueryDefinition`. Mirrors
@@ -27,4 +36,18 @@ export interface ChartWidgetDefinition extends WidgetDefinitionBase {
   /** Field aggregated. Null when `aggregation === 'Count'`. */
   readonly field: string | null;
   readonly chartType: ChartType;
+  /**
+   * Optional second categorical dimension. When set, the chart becomes
+   * multi-series — one series per distinct `seriesBy` value (grouped/stacked
+   * bars, multi-line, stacked area, heatmap). Absent/`null` for a single-series
+   * chart. `Heatmap` requires it; the pie family / radar / funnel / treemap
+   * ignore it.
+   */
+  readonly seriesBy?: string | null;
+  /**
+   * Stack the series instead of grouping them side-by-side. Only meaningful for
+   * `Bar` / `HorizontalBar` / `Line` / `Area` with a `seriesBy` set; the backend
+   * zeroes it out for every other chart type.
+   */
+  readonly stacked?: boolean;
 }

--- a/packages/@granit/react-analytics/src/editor/analytics-widget-catalog.ts
+++ b/packages/@granit/react-analytics/src/editor/analytics-widget-catalog.ts
@@ -61,6 +61,8 @@ export const analyticsWidgetCatalog: readonly WidgetCatalogEntry[] = Object.free
       aggregation: 'Sum',
       field: null,
       chartType: 'Bar',
+      seriesBy: null,
+      stacked: false,
     }),
   },
   {

--- a/packages/@granit/react-charts/src/__tests__/chart-primitives.test.tsx
+++ b/packages/@granit/react-charts/src/__tests__/chart-primitives.test.tsx
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { BarChart } from '../components/bar-chart';
 import { FunnelChart } from '../components/funnel-chart';
+import { HeatmapChart } from '../components/heatmap-chart';
+import { LineChart } from '../components/line-chart';
 import { PieChart } from '../components/pie-chart';
 import { RadarChart } from '../components/radar-chart';
 import { SparklineChart } from '../components/sparkline-chart';
@@ -164,6 +166,56 @@ describe('FunnelChart', () => {
     const opt = optionOf(getByTestId);
     expect(opt.series[0].data[0]).toMatchObject({ name: 'Visited', value: 100 });
     expect(opt.series[0].data[2].itemStyle).toEqual({ color: '#0af' });
+  });
+});
+
+describe('LineChart', () => {
+  it('stacks the series on a shared baseline when stacked', () => {
+    const { getByTestId } = render(<LineChart series={SERIES} stacked />);
+    const opt = optionOf(getByTestId);
+    expect(opt.series[0].stack).toBe('total');
+    expect(opt.series[1].stack).toBe('total');
+  });
+
+  it('keeps each series independent by default', () => {
+    const { getByTestId } = render(<LineChart series={SERIES} />);
+    const opt = optionOf(getByTestId);
+    expect(opt.series[0].stack).toBeUndefined();
+  });
+});
+
+describe('HeatmapChart', () => {
+  const data = [
+    { x: 'Mon', y: 'AM', value: 3 },
+    { x: 'Mon', y: 'PM', value: 8 },
+    { x: 'Tue', y: 'AM', value: 5 },
+  ];
+
+  it('renders a heatmap series over two category axes with a visualMap', () => {
+    const { getByTestId } = render(<HeatmapChart data={data} />);
+    const opt = optionOf(getByTestId);
+    expect(opt.series[0].type).toBe('heatmap');
+    expect(opt.xAxis.type).toBe('category');
+    expect(opt.yAxis.type).toBe('category');
+    expect(opt.xAxis.data).toEqual(['Mon', 'Tue']);
+    expect(opt.yAxis.data).toEqual(['AM', 'PM']);
+  });
+
+  it('maps each datum to an [xIndex, yIndex, value] triple', () => {
+    const { getByTestId } = render(<HeatmapChart data={data} />);
+    const opt = optionOf(getByTestId);
+    expect(opt.series[0].data).toEqual([
+      [0, 0, 3],
+      [0, 1, 8],
+      [1, 0, 5],
+    ]);
+  });
+
+  it('spans the visualMap over the value range', () => {
+    const { getByTestId } = render(<HeatmapChart data={data} />);
+    const opt = optionOf(getByTestId);
+    expect(opt.visualMap.min).toBe(3);
+    expect(opt.visualMap.max).toBe(8);
   });
 });
 

--- a/packages/@granit/react-charts/src/__tests__/chart-snapshot-widget.test.tsx
+++ b/packages/@granit/react-charts/src/__tests__/chart-snapshot-widget.test.tsx
@@ -23,13 +23,27 @@ const ENVELOPE_BASE = {
   reasonLocalizationKey: null,
 };
 
+type TestChartType =
+  | 'Bar'
+  | 'HorizontalBar'
+  | 'Line'
+  | 'Area'
+  | 'Pie'
+  | 'Donut'
+  | 'Radar'
+  | 'Funnel'
+  | 'Treemap'
+  | 'Heatmap';
+
 function chartEnvelope(
-  chartType:
-    'Bar' | 'HorizontalBar' | 'Line' | 'Area' | 'Pie' | 'Donut' | 'Radar' | 'Funnel' | 'Treemap',
+  chartType: TestChartType,
   overrides: Partial<{
     field: string | null;
     currency: string | null;
     aggregation: string;
+    seriesBy: string | null;
+    stacked: boolean;
+    buckets: readonly { label: string; value: number | null; series?: string | null }[];
   }> = {}
 ): DashboardRenderedWidget {
   return {
@@ -40,15 +54,25 @@ function chartEnvelope(
       groupBy: 'IssuedAtMonth',
       aggregation: overrides.aggregation ?? 'Sum',
       field: 'field' in overrides ? overrides.field! : 'Total',
-      buckets: [
+      buckets: overrides.buckets ?? [
         { label: '2026-02', value: 12500 },
         { label: '2026-03', value: 18200 },
         { label: '2026-04', value: 21450 },
       ],
       currency: overrides.currency ?? null,
+      seriesBy: overrides.seriesBy ?? null,
+      stacked: overrides.stacked ?? false,
     },
   };
 }
+
+// Two categories × two series — the shape a multi-series (grouped/stacked) or
+// heatmap chart ships. Sparse: ('2026-03', 'EUR') is intentionally omitted.
+const MULTI_SERIES_BUCKETS = [
+  { label: '2026-02', value: 100, series: 'EUR' },
+  { label: '2026-02', value: 40, series: 'USD' },
+  { label: '2026-03', value: 55, series: 'USD' },
+] as const;
 
 describe('ChartSnapshotWidget — dispatch by chartType', () => {
   it('routes Bar to BarChart with vertical axes', () => {
@@ -125,6 +149,54 @@ describe('ChartSnapshotWidget — dispatch by chartType', () => {
     const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
     expect(opt.series[0].type).toBe('treemap');
     expect(opt.series[0].data).toHaveLength(3);
+  });
+
+  it('builds one series per distinct series-by value for a grouped bar', () => {
+    const { getByTestId } = render(
+      <ChartSnapshotWidget
+        widget={chartEnvelope('Bar', { seriesBy: 'Currency', buckets: MULTI_SERIES_BUCKETS })}
+      />
+    );
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    // Two series (EUR, USD), grouped (no stack), aligned on both categories —
+    // the missing ('2026-03','EUR') cell fills with 0.
+    expect(opt.series).toHaveLength(2);
+    expect(opt.series.map((s: { name: string }) => s.name)).toEqual(['EUR', 'USD']);
+    expect(opt.series[0].stack).toBeUndefined();
+    expect(opt.series[0].data).toEqual([
+      ['2026-02', 100],
+      ['2026-03', 0],
+    ]);
+  });
+
+  it('stacks the series when stacked is set', () => {
+    const { getByTestId } = render(
+      <ChartSnapshotWidget
+        widget={chartEnvelope('Bar', {
+          seriesBy: 'Currency',
+          stacked: true,
+          buckets: MULTI_SERIES_BUCKETS,
+        })}
+      />
+    );
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.series[0].stack).toBe('total');
+    expect(opt.series[1].stack).toBe('total');
+  });
+
+  it('routes Heatmap to a heatmap series with a visualMap and category axes', () => {
+    const { getByTestId } = render(
+      <ChartSnapshotWidget
+        widget={chartEnvelope('Heatmap', { seriesBy: 'Currency', buckets: MULTI_SERIES_BUCKETS })}
+      />
+    );
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.series[0].type).toBe('heatmap');
+    expect(opt.visualMap).toBeDefined();
+    expect(opt.xAxis.type).toBe('category');
+    expect(opt.yAxis.type).toBe('category');
+    // [xIndex, yIndex, value] triples over the distinct category/series axes.
+    expect(opt.series[0].data[0]).toEqual([0, 0, 100]);
   });
 
   it('appends the currency code to the value-axis label when set (B3-8b)', () => {

--- a/packages/@granit/react-charts/src/components/heatmap-chart.tsx
+++ b/packages/@granit/react-charts/src/components/heatmap-chart.tsx
@@ -1,0 +1,109 @@
+import { useMemo } from 'react';
+
+import { Chart } from './chart';
+
+import type { ChartAxis, ChartDimensions } from '@granit/charts';
+import type { EChartsOption } from 'echarts';
+
+export interface HeatmapDatum {
+  /** Category-axis (x) key. */
+  readonly x: string;
+  /** Series-axis (y) key. */
+  readonly y: string;
+  readonly value: number;
+}
+
+export interface HeatmapChartProps extends ChartDimensions {
+  readonly data: readonly HeatmapDatum[];
+  readonly xAxis?: ChartAxis;
+  readonly yAxis?: ChartAxis;
+  /** Locale-aware formatter for cell values in the tooltip + legend (defaults to raw). */
+  readonly valueFormatter?: (value: number) => string;
+  readonly className?: string;
+  readonly theme?: string | object;
+}
+
+/**
+ * Typed heatmap wrapper. Each datum colours the cell at (`x`, `y`) by its
+ * value through a continuous `visualMap` scale. Both axes are categorical —
+ * category order is first-seen in `data`.
+ *
+ * NOTE: the shared ECharts instance must register `HeatmapChart` AND
+ * `VisualMapComponent` (see `echarts-instance.ts`). Without the visual map the
+ * cells render colourless and the legend is absent — a silent failure.
+ */
+export function HeatmapChart({
+  data,
+  xAxis,
+  yAxis,
+  valueFormatter,
+  height,
+  width,
+  className,
+  theme,
+}: HeatmapChartProps) {
+  const options = useMemo<EChartsOption>(() => {
+    // Distinct axis categories in first-seen order, and each datum mapped to
+    // its [xIndex, yIndex, value] triple — the shape ECharts' heatmap series
+    // consumes against two category axes.
+    const xCategories: string[] = [];
+    const yCategories: string[] = [];
+    const xIndex = new Map<string, number>();
+    const yIndex = new Map<string, number>();
+    for (const d of data) {
+      if (!xIndex.has(d.x)) {
+        xIndex.set(d.x, xCategories.length);
+        xCategories.push(d.x);
+      }
+      if (!yIndex.has(d.y)) {
+        yIndex.set(d.y, yCategories.length);
+        yCategories.push(d.y);
+      }
+    }
+
+    const points = data.map((d) => [xIndex.get(d.x)!, yIndex.get(d.y)!, d.value]);
+    const values = data.map((d) => d.value);
+    const min = values.length ? Math.min(...values) : 0;
+    const max = values.length ? Math.max(...values) : 0;
+
+    return {
+      tooltip: {
+        position: 'top',
+        valueFormatter: valueFormatter ? (v) => valueFormatter(Number(v)) : undefined,
+      },
+      grid: {
+        left: 8,
+        right: 16,
+        top: 8,
+        bottom: 48,
+        outerBoundsMode: 'same',
+        outerBoundsContain: 'axisLabel',
+      },
+      xAxis: { type: 'category', data: xCategories, name: xAxis?.label },
+      yAxis: { type: 'category', data: yCategories, name: yAxis?.label },
+      visualMap: {
+        min,
+        max,
+        calculable: true,
+        orient: 'horizontal',
+        left: 'center',
+        bottom: 0,
+        formatter: valueFormatter ? (v) => valueFormatter(Number(v)) : undefined,
+      },
+      series: [
+        {
+          type: 'heatmap',
+          data: points,
+          label: { show: false },
+          emphasis: {
+            itemStyle: { shadowBlur: 10, shadowColor: 'rgba(0, 0, 0, 0.3)' },
+          },
+        },
+      ],
+    };
+  }, [data, xAxis, yAxis, valueFormatter]);
+
+  return (
+    <Chart options={options} height={height ?? width ?? 320} className={className} theme={theme} />
+  );
+}

--- a/packages/@granit/react-charts/src/components/line-chart.tsx
+++ b/packages/@granit/react-charts/src/components/line-chart.tsx
@@ -17,6 +17,12 @@ export interface LineChartProps extends ChartDimensions {
    * pipeline.
    */
   readonly area?: boolean;
+  /**
+   * Stack the series on a shared baseline. Defaults to `false`. Combined with
+   * {@link area}, produces a stacked-area chart from the multi-series render
+   * pipeline.
+   */
+  readonly stacked?: boolean;
   /** Show the legend above the plot area. Defaults to `true` when >1 series. */
   readonly showLegend?: boolean;
   /** Locale-aware formatter for the value axis + tooltip (defaults to raw). */
@@ -40,6 +46,7 @@ export function LineChart({
   yAxis,
   smooth = false,
   area = false,
+  stacked = false,
   showLegend,
   valueFormatter,
   height,
@@ -88,12 +95,13 @@ export function LineChart({
         // ECharts' option types want mutable arrays; spread to drop readonly.
         data: s.data.map((p) => [...p]) as (number | string)[][],
         smooth,
+        stack: stacked ? 'total' : undefined,
         areaStyle: area ? {} : undefined,
         itemStyle: s.color ? { color: s.color } : undefined,
         lineStyle: s.color ? { color: s.color } : undefined,
       })),
     };
-  }, [series, xAxis, yAxis, smooth, area, showLegend, valueFormatter]);
+  }, [series, xAxis, yAxis, smooth, area, stacked, showLegend, valueFormatter]);
 
   return (
     <Chart options={options} height={height ?? width ?? 320} className={className} theme={theme} />

--- a/packages/@granit/react-charts/src/echarts-instance.ts
+++ b/packages/@granit/react-charts/src/echarts-instance.ts
@@ -12,6 +12,7 @@ import {
   BarChart,
   FunnelChart,
   GaugeChart,
+  HeatmapChart,
   LineChart,
   PieChart,
   RadarChart,
@@ -24,6 +25,7 @@ import {
   RadarComponent,
   TitleComponent,
   TooltipComponent,
+  VisualMapComponent,
 } from 'echarts/components';
 import * as echarts from 'echarts/core';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -37,6 +39,7 @@ echarts.use([
   RadarChart,
   FunnelChart,
   TreemapChart,
+  HeatmapChart,
   // Components
   GridComponent,
   TooltipComponent,
@@ -44,6 +47,7 @@ echarts.use([
   LegendComponent,
   DataZoomComponent,
   RadarComponent,
+  VisualMapComponent,
   // Renderer
   CanvasRenderer,
 ]);

--- a/packages/@granit/react-charts/src/index.ts
+++ b/packages/@granit/react-charts/src/index.ts
@@ -21,6 +21,8 @@ export { FunnelChart } from './components/funnel-chart';
 export type { FunnelChartProps, FunnelDatum } from './components/funnel-chart';
 export { TreemapChart } from './components/treemap-chart';
 export type { TreemapChartProps, TreemapDatum } from './components/treemap-chart';
+export { HeatmapChart } from './components/heatmap-chart';
+export type { HeatmapChartProps, HeatmapDatum } from './components/heatmap-chart';
 
 // Theming
 export { useEChartsTheme } from './hooks/use-echarts-theme';

--- a/packages/@granit/react-charts/src/snapshot/chart-snapshot-widget.tsx
+++ b/packages/@granit/react-charts/src/snapshot/chart-snapshot-widget.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 
 import { BarChart } from '../components/bar-chart';
 import { FunnelChart } from '../components/funnel-chart';
+import { HeatmapChart } from '../components/heatmap-chart';
 import { LineChart } from '../components/line-chart';
 import { PieChart } from '../components/pie-chart';
 import { RadarChart } from '../components/radar-chart';
@@ -11,9 +12,52 @@ import { TreemapChart } from '../components/treemap-chart';
 
 import { createChartValueFormatter } from './format-chart-value';
 
-import type { ChartWidgetSnapshot } from '@granit/analytics';
+import type { ChartBucket, ChartWidgetSnapshot } from '@granit/analytics';
 import type { ChartSeries } from '@granit/charts';
 import type { DashboardRenderedWidget } from '@granit/dashboards';
+
+/**
+ * Reshape the flat bucket list into one {@link ChartSeries} per distinct
+ * `series` key — the multi-series transform mirrors the pivot renderer's
+ * `(category × series)` pivot. When no bucket carries a `series` key the chart
+ * is single-series and collapses to one series named `singleName`.
+ *
+ * Categories and series keys keep first-seen order (the order the backend
+ * streamed them). Sparse `(category × series)` combinations the backend never
+ * emitted fill with `0` so grouped/stacked bars keep aligned categories.
+ */
+function buildChartSeries(
+  buckets: readonly ChartBucket[],
+  singleName: string
+): readonly ChartSeries[] {
+  if (!buckets.some((b) => b.series != null)) {
+    return [{ id: 'series', name: singleName, data: buckets.map((b) => [b.label, b.value ?? 0]) }];
+  }
+
+  const categories: string[] = [];
+  const seenCategory = new Set<string>();
+  const seriesKeys: string[] = [];
+  const seenSeries = new Set<string>();
+  const byKey = new Map<string, number>();
+  for (const b of buckets) {
+    const seriesKey = b.series ?? '(null)';
+    if (!seenCategory.has(b.label)) {
+      seenCategory.add(b.label);
+      categories.push(b.label);
+    }
+    if (!seenSeries.has(seriesKey)) {
+      seenSeries.add(seriesKey);
+      seriesKeys.push(seriesKey);
+    }
+    byKey.set(`${b.label}\u0000${seriesKey}`, b.value ?? 0);
+  }
+
+  return seriesKeys.map((seriesKey) => ({
+    id: seriesKey,
+    name: seriesKey,
+    data: categories.map((category) => [category, byKey.get(`${category}\u0000${seriesKey}`) ?? 0]),
+  }));
+}
 
 /**
  * Snapshot-driven renderer for the `'Chart'` widget kind. Mirrors the
@@ -33,7 +77,7 @@ export function ChartSnapshotWidget({ widget }: { readonly widget: DashboardRend
 }
 
 function ChartBody({ snapshot }: { readonly snapshot: ChartWidgetSnapshot }) {
-  const { chartType, groupBy, aggregation, field, buckets, currency } = snapshot;
+  const { chartType, groupBy, aggregation, field, buckets, currency, seriesBy, stacked } = snapshot;
   const { locale } = useLocale();
 
   // Locale-aware value formatting for every numeric axis / tooltip. Currency
@@ -92,14 +136,31 @@ function ChartBody({ snapshot }: { readonly snapshot: ChartWidgetSnapshot }) {
     );
   }
 
-  const series: readonly ChartSeries[] = [
-    {
-      id: 'series',
-      name: seriesName,
-      data: buckets.map((b) => [b.label, b.value ?? 0]),
-    },
-  ];
+  // Heatmap needs both axes categorical: category (group-by) × series (series-by)
+  // coloured by value. Single-series buckets carry no `series`, so the y-axis
+  // collapses to one row named after the aggregation.
+  if (chartType === 'Heatmap') {
+    const heatmapData = buckets.map((b) => ({
+      x: b.label,
+      y: b.series ?? seriesName,
+      value: b.value ?? 0,
+    }));
+    return (
+      <div data-slot="chart-snapshot-widget" data-chart-type={chartType} className="h-full w-full">
+        <HeatmapChart
+          data={heatmapData}
+          xAxis={{ label: groupBy }}
+          yAxis={{ label: seriesBy ?? '' }}
+          valueFormatter={valueFormatter}
+          height="100%"
+        />
+      </div>
+    );
+  }
 
+  // Bar / HorizontalBar / Line / Area — single-series when no bucket carries a
+  // `series` key, else one series per distinct series-by value (grouped/stacked).
+  const series: readonly ChartSeries[] = buildChartSeries(buckets, seriesName);
   const valueAxisLabel = currency ? `${seriesName} (${currency})` : seriesName;
 
   if (chartType === 'Line' || chartType === 'Area') {
@@ -110,6 +171,7 @@ function ChartBody({ snapshot }: { readonly snapshot: ChartWidgetSnapshot }) {
           xAxis={{ label: groupBy }}
           yAxis={{ label: valueAxisLabel }}
           area={chartType === 'Area'}
+          stacked={stacked ?? false}
           valueFormatter={valueFormatter}
           height="100%"
         />
@@ -126,6 +188,7 @@ function ChartBody({ snapshot }: { readonly snapshot: ChartWidgetSnapshot }) {
         xAxis={{ label: horizontal ? valueAxisLabel : groupBy }}
         yAxis={{ label: horizontal ? groupBy : valueAxisLabel }}
         horizontal={horizontal}
+        stacked={stacked ?? false}
         valueFormatter={valueFormatter}
         height="100%"
       />

--- a/packages/@granit/react-ui-analytics/src/components/chart-config-form.tsx
+++ b/packages/@granit/react-ui-analytics/src/components/chart-config-form.tsx
@@ -1,4 +1,5 @@
 import { useQueryFieldMetadata } from '@granit/react-analytics';
+import { Checkbox } from '@granit/react-ui';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -22,8 +23,20 @@ const CHART_TYPES: readonly ChartType[] = [
   'Radar',
   'Funnel',
   'Treemap',
+  'Heatmap',
 ];
 const AGGREGATIONS: readonly AggregateFunction[] = ['Count', 'Sum', 'Avg', 'Min', 'Max'];
+
+/** Chart types that accept a second `seriesBy` dimension (multi-series). */
+const SERIES_CAPABLE: ReadonlySet<ChartType> = new Set([
+  'Bar',
+  'HorizontalBar',
+  'Line',
+  'Area',
+  'Heatmap',
+]);
+/** Chart types where `stacked` (vs grouped) is meaningful. */
+const STACK_CAPABLE: ReadonlySet<ChartType> = new Set(['Bar', 'HorizontalBar', 'Line', 'Area']);
 
 /**
  * Built-in config form for {@link ChartWidgetDefinition}. Edits the
@@ -45,6 +58,10 @@ export function ChartConfigForm({
   const { catalogEntries, groupByOptions, fieldOptions } = useQueryFieldMetadata(widget.queryName);
 
   const isCount = widget.aggregation === 'Count';
+  const supportsSeries = SERIES_CAPABLE.has(widget.chartType);
+  const supportsStacking = STACK_CAPABLE.has(widget.chartType);
+  const seriesRequired = widget.chartType === 'Heatmap';
+  const hasSeriesBy = widget.seriesBy != null && widget.seriesBy !== '';
 
   return (
     <div data-slot="chart-config-form" className="space-y-3">
@@ -109,9 +126,47 @@ export function ChartConfigForm({
           slot="chart-type"
           value={widget.chartType}
           options={CHART_TYPES}
-          onChange={(value) => onChange({ ...widget, chartType: value as ChartType })}
+          onChange={(value) => {
+            // Sanitise the second-dimension fields when the new type can't use
+            // them, so a switched-away config never persists a stale seriesBy /
+            // stacked (the backend also zeroes stacked, but keep the DTO clean).
+            const chartType = value as ChartType;
+            onChange({
+              ...widget,
+              chartType,
+              seriesBy: SERIES_CAPABLE.has(chartType) ? widget.seriesBy : null,
+              stacked: STACK_CAPABLE.has(chartType) ? widget.stacked : false,
+            });
+          }}
         />
       </label>
+      {/* Optional second dimension — grouped/stacked/multi-line/heatmap. Required for Heatmap. */}
+      {supportsSeries && (
+        <label className="block text-sm">
+          <span className="mb-1 block text-muted-foreground">
+            {t('Dashboard:Widget.Chart.SeriesBy.Label')}
+            {seriesRequired && <RequiredMark />}
+          </span>
+          <MetaFieldInput
+            slot="chart-series-by"
+            value={widget.seriesBy ?? ''}
+            options={groupByOptions}
+            allowEmpty
+            required={seriesRequired}
+            onChange={(value) => onChange({ ...widget, seriesBy: value === '' ? null : value })}
+          />
+        </label>
+      )}
+      {/* Stacking is only meaningful once a series dimension is chosen, and only for bar/line/area. */}
+      {supportsStacking && hasSeriesBy && (
+        <label className="flex items-center gap-2 text-sm" data-slot="chart-stacked">
+          <Checkbox
+            checked={widget.stacked ?? false}
+            onCheckedChange={(checked) => onChange({ ...widget, stacked: checked === true })}
+          />
+          <span className="text-muted-foreground">{t('Dashboard:Widget.Chart.Stacked.Label')}</span>
+        </label>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What

**Palier 2a** — extends the dashboard **Chart** widget from single-series to a **second categorical dimension** (`seriesBy`), unlocking grouped bars, stacked bars, multi-line, stacked area, and **heatmap**. Front follow-up to the merged granit-business backend.

## How

The backend reuses the pivot's proven 2D aggregation (`TwoKeyGroupAggregator`, in-memory streaming, whitelist-gated). The front reshapes the flat bucket list into one `ChartSeries` per distinct `series` key — the same transform the pivot renderer uses.

## Changes

- **Contract**: `ChartType` gains `Heatmap`; `ChartWidgetDefinition` gains `seriesBy` + `stacked`; `ChartWidgetSnapshot`/`ChartBucket` gain `series` + echoed `seriesBy`/`stacked`/`valueKind`. `contracts/openapi/analytics.json` resynced from `Granit.Business.OpenApi.Generator`.
- **Renderer** (`chart-snapshot-widget.tsx`): buckets → multi-series (`buildChartSeries`), passes `stacked` to `<BarChart>`/`<LineChart>`, adds a `Heatmap` branch.
- **Primitives**: new `HeatmapChart` (registers `HeatmapChart` **+ `VisualMapComponent`** — the silent-failure trap); `LineChart` gains `stacked` for stacked-area.
- **Editor** (`chart-config-form.tsx`): `seriesBy` field + a `stacked` checkbox, **gated** to `Bar`/`HorizontalBar`/`Line`/`Area` (required for `Heatmap`), sanitising both when the type can't use them.
- **Catalog**: seeds `seriesBy: null` / `stacked: false`.

## Design decisions (validated)

- **Flags over enum explosion**: `seriesBy` + `stacked` reuse Bar/Line/Area; only `Heatmap` is a new enum member (Scatter/Combo land in 2b/2c).
- **In-memory shared aggregator** (backend): reuses the pivot path, capped by `MaxStreamSize` — the runner degrades to `Unavailable` (`Widget:Unavailable.ChartResultTooLarge`) on truncation, never a silently-partial chart. SQL tuple-key pushdown is a documented shared follow-up.

## Verification

- `tsc --noEmit` clean (analytics, react-charts, react-ui-analytics, react-analytics, react-dashboards)
- ESLint clean; `@granit/arch-tests` green (ADR-010 layering — `react-ui-analytics` is UI-tier, may import `@granit/react-ui`)
- `@granit/contract-tests` oracle green (openapi ↔ DTOs); full suites green (758 analytics/charts + 201 dashboards)

## Notes

- `Dashboard:Widget.Chart.SeriesBy.Label` / `.Stacked.Label` and `Widget:Unavailable.ChartResultTooLarge` follow the existing **host-provided** i18n pattern (like `QueryNotFound`) — no package bundle change; showcase supplies translations.
- Contract-oracle coverage of the chart snapshot (currently excluded in `manifest.ts`) is deferred.

## Follow-ups

- **2b — Scatter**: XField/YField roles, new ScatterRunner, `Scatter` type.
- **2c — Combo**: multi-measure series (bar + line), `Combo` type.