### PR TITLE
feat(dashboards): add scatter chart widget type

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4233,6 +4233,17 @@
           "members": []
         },
         {
+          "name": "ScatterChart",
+          "kind": "function",
+          "signature": "function ScatterChart("
+        },
+        {
+          "name": "ScatterChartProps",
+          "kind": "interface",
+          "signature": "interface ScatterChartProps extends ChartDimensions",
+          "members": []
+        },
+        {
           "name": "useEChartsTheme",
           "kind": "function",
           "signature": "function useEChartsTheme(options: UseEChartsThemeOptions): string"

--- a/contracts/openapi/analytics.json
+++ b/contracts/openapi/analytics.json
@@ -516,7 +516,8 @@
           "Radar",
           "Funnel",
           "Treemap",
-          "Heatmap"
+          "Heatmap",
+          "Scatter"
         ]
       },
       "ChartWidgetDefinition": {
@@ -544,6 +545,12 @@
           "stacked": {
             "type": "boolean",
             "default": false
+          },
+          "xField": {
+            "type": ["null", "string"]
+          },
+          "yField": {
+            "type": ["null", "string"]
           },
           "slug": {
             "type": "string"

--- a/packages/@granit/analytics/src/__tests__/data-snapshots.test.ts
+++ b/packages/@granit/analytics/src/__tests__/data-snapshots.test.ts
@@ -162,7 +162,7 @@ describe('Type guards — analytics envelope dispatch', () => {
 });
 
 describe('ChartType — exhaustive enum surface (PascalCase, backend-ordered)', () => {
-  it('locks the ten backend types in declaration order', () => {
+  it('locks the eleven backend types in declaration order', () => {
     const types: readonly ChartType[] = [
       'Bar',
       'HorizontalBar',
@@ -174,7 +174,8 @@ describe('ChartType — exhaustive enum surface (PascalCase, backend-ordered)', 
       'Funnel',
       'Treemap',
       'Heatmap',
+      'Scatter',
     ];
-    expect(types).toHaveLength(10);
+    expect(types).toHaveLength(11);
   });
 });

--- a/packages/@granit/analytics/src/index.ts
+++ b/packages/@granit/analytics/src/index.ts
@@ -46,6 +46,7 @@ export type {
   PivotSnapshotEnvelope,
   PivotWidgetDefinition,
   PivotWidgetSnapshot,
+  ScatterPoint,
   TableSnapshotEnvelope,
   TableWidgetColumn,
   TableWidgetDefinition,

--- a/packages/@granit/analytics/src/types/chart-snapshot.ts
+++ b/packages/@granit/analytics/src/types/chart-snapshot.ts
@@ -28,6 +28,22 @@ export interface ChartBucket {
 }
 
 /**
+ * One point of a scatter plot. Mirrors
+ * `Granit.Analytics.Endpoints.Rendering.ScatterPoint`.
+ */
+export interface ScatterPoint {
+  /** X-axis value (the numeric x column). */
+  readonly x: number;
+  /** Y-axis value (the numeric y column). */
+  readonly y: number;
+  /**
+   * Series key colouring the point; `null`/absent when no series column was
+   * requested. Null series values surface as `'(null)'`.
+   */
+  readonly series?: string | null;
+}
+
+/**
  * Snapshot payload for the `'Chart'` widget kind. Mirrors
  * `Granit.Analytics.Endpoints.Rendering.ChartWidgetSnapshot` (B3-5, ADR-039).
  *
@@ -77,6 +93,16 @@ export interface ChartWidgetSnapshot {
    * .NET `ValueKind` enum member names verbatim.
    */
   readonly valueKind?: string | null;
+  /** Numeric x-axis field echoed for the scatter axis label; `null` unless `Scatter`. */
+  readonly xField?: string | null;
+  /** Numeric y-axis field echoed for the scatter axis label; `null` unless `Scatter`. */
+  readonly yField?: string | null;
+  /**
+   * Scatter point cloud — one point per entity. Populated only for `'Scatter'`;
+   * `null`/absent for every other chart type (which ship their series in
+   * {@link buckets} instead).
+   */
+  readonly points?: readonly ScatterPoint[] | null;
 }
 
 /** Narrowed `WidgetSnapshotEnvelope` for the `'Chart'` widget kind. */

--- a/packages/@granit/analytics/src/types/chart-widget.ts
+++ b/packages/@granit/analytics/src/types/chart-widget.ts
@@ -17,7 +17,8 @@ export type ChartType =
   | 'Radar'
   | 'Funnel'
   | 'Treemap'
-  | 'Heatmap';
+  | 'Heatmap'
+  | 'Scatter';
 
 /**
  * Aggregated chart bound to a `QueryDefinition`. Mirrors
@@ -50,4 +51,12 @@ export interface ChartWidgetDefinition extends WidgetDefinitionBase {
    * zeroes it out for every other chart type.
    */
   readonly stacked?: boolean;
+  /**
+   * Numeric x-axis field. Used only by `Scatter` (which ignores
+   * `groupBy`/`aggregation`/`field` and plots raw points); required for that
+   * type, `null` otherwise.
+   */
+  readonly xField?: string | null;
+  /** Numeric y-axis field for `Scatter`. Required for that type, `null` otherwise. */
+  readonly yField?: string | null;
 }

--- a/packages/@granit/analytics/src/types/index.ts
+++ b/packages/@granit/analytics/src/types/index.ts
@@ -38,7 +38,12 @@ export type { PivotWidgetDefinition } from './pivot-widget';
 export type { TableWidgetDefinition } from './table-widget';
 
 // Widgets — snapshot envelopes consumed by @granit/dashboards
-export type { ChartBucket, ChartSnapshotEnvelope, ChartWidgetSnapshot } from './chart-snapshot';
+export type {
+  ChartBucket,
+  ChartSnapshotEnvelope,
+  ChartWidgetSnapshot,
+  ScatterPoint,
+} from './chart-snapshot';
 export type { KpiSnapshot, KpiSnapshotEnvelope } from './kpi-snapshot';
 export type {
   MapCenterPayload,

--- a/packages/@granit/react-analytics/src/editor/analytics-widget-catalog.ts
+++ b/packages/@granit/react-analytics/src/editor/analytics-widget-catalog.ts
@@ -63,6 +63,8 @@ export const analyticsWidgetCatalog: readonly WidgetCatalogEntry[] = Object.free
       chartType: 'Bar',
       seriesBy: null,
       stacked: false,
+      xField: null,
+      yField: null,
     }),
   },
   {

--- a/packages/@granit/react-charts/src/__tests__/chart-primitives.test.tsx
+++ b/packages/@granit/react-charts/src/__tests__/chart-primitives.test.tsx
@@ -7,6 +7,7 @@ import { HeatmapChart } from '../components/heatmap-chart';
 import { LineChart } from '../components/line-chart';
 import { PieChart } from '../components/pie-chart';
 import { RadarChart } from '../components/radar-chart';
+import { ScatterChart } from '../components/scatter-chart';
 import { SparklineChart } from '../components/sparkline-chart';
 import { TreemapChart } from '../components/treemap-chart';
 
@@ -181,6 +182,31 @@ describe('LineChart', () => {
     const { getByTestId } = render(<LineChart series={SERIES} />);
     const opt = optionOf(getByTestId);
     expect(opt.series[0].stack).toBeUndefined();
+  });
+});
+
+describe('ScatterChart', () => {
+  const series: readonly ChartSeries<number, number>[] = [
+    { id: 'a', name: 'A', data: [[1, 10] as const, [2, 20] as const] },
+    { id: 'b', name: 'B', data: [[3, 5] as const] },
+  ];
+
+  it('renders scatter series over two value axes', () => {
+    const { getByTestId } = render(<ScatterChart series={series} />);
+    const opt = optionOf(getByTestId);
+    expect(opt.series[0].type).toBe('scatter');
+    expect(opt.xAxis.type).toBe('value');
+    expect(opt.yAxis.type).toBe('value');
+    expect(opt.series).toHaveLength(2);
+  });
+
+  it('keeps each series numeric [x, y] pairs', () => {
+    const { getByTestId } = render(<ScatterChart series={series} />);
+    const opt = optionOf(getByTestId);
+    expect(opt.series[0].data).toEqual([
+      [1, 10],
+      [2, 20],
+    ]);
   });
 });
 

--- a/packages/@granit/react-charts/src/__tests__/chart-snapshot-widget.test.tsx
+++ b/packages/@granit/react-charts/src/__tests__/chart-snapshot-widget.test.tsx
@@ -151,6 +151,38 @@ describe('ChartSnapshotWidget — dispatch by chartType', () => {
     expect(opt.series[0].data).toHaveLength(3);
   });
 
+  it('routes Scatter to scatter series built from points, grouped by series key', () => {
+    const widget: DashboardRenderedWidget = {
+      ...ENVELOPE_BASE,
+      widgetType: 'Chart',
+      snapshot: {
+        chartType: 'Scatter',
+        groupBy: '',
+        aggregation: 'Sum',
+        field: null,
+        buckets: [],
+        xField: 'Amount',
+        yField: 'Score',
+        points: [
+          { x: 10, y: 1, series: 'EUR' },
+          { x: 20, y: 2, series: 'USD' },
+          { x: 30, y: 3, series: 'EUR' },
+        ],
+      },
+    };
+    const { getByTestId } = render(<ChartSnapshotWidget widget={widget} />);
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.series[0].type).toBe('scatter');
+    expect(opt.series.map((s: { name: string }) => s.name)).toEqual(['EUR', 'USD']);
+    // EUR groups both its points as numeric [x, y] pairs.
+    expect(opt.series[0].data).toEqual([
+      [10, 1],
+      [30, 3],
+    ]);
+    expect(opt.xAxis.name).toBe('Amount');
+    expect(opt.yAxis.name).toBe('Score');
+  });
+
   it('builds one series per distinct series-by value for a grouped bar', () => {
     const { getByTestId } = render(
       <ChartSnapshotWidget

--- a/packages/@granit/react-charts/src/components/scatter-chart.tsx
+++ b/packages/@granit/react-charts/src/components/scatter-chart.tsx
@@ -1,0 +1,70 @@
+import { useMemo } from 'react';
+
+import { Chart } from './chart';
+
+import type { ChartAxis, ChartDimensions, ChartSeries } from '@granit/charts';
+import type { EChartsOption } from 'echarts';
+
+export interface ScatterChartProps extends ChartDimensions {
+  /** One series per colour group; each point is a numeric `[x, y]` pair. */
+  readonly series: readonly ChartSeries<number, number>[];
+  readonly xAxis?: ChartAxis;
+  readonly yAxis?: ChartAxis;
+  /** Show the legend above the plot area. Defaults to `true` when >1 series. */
+  readonly showLegend?: boolean;
+  /** Locale-aware formatter for both value axes + tooltip (defaults to raw). */
+  readonly valueFormatter?: (value: number) => string;
+  readonly className?: string;
+  readonly theme?: string | object;
+}
+
+/**
+ * Typed scatter (point cloud) chart wrapper. Both axes are numeric value axes;
+ * each {@link ChartSeries} is a colour group (from the widget's series-by
+ * dimension). Unlike the aggregating primitives, scatter plots raw points.
+ */
+export function ScatterChart({
+  series,
+  xAxis,
+  yAxis,
+  showLegend,
+  valueFormatter,
+  height,
+  width,
+  className,
+  theme,
+}: ScatterChartProps) {
+  const options = useMemo<EChartsOption>(() => {
+    const wantLegend = showLegend ?? series.length > 1;
+    const axisLabel = valueFormatter ? { formatter: (v: number) => valueFormatter(v) } : undefined;
+    return {
+      tooltip: {
+        trigger: 'item',
+        valueFormatter: valueFormatter ? (v) => valueFormatter(Number(v)) : undefined,
+      },
+      legend: wantLegend ? { data: series.map((s) => s.name), top: 0 } : undefined,
+      grid: {
+        left: 8,
+        right: 16,
+        top: wantLegend ? 32 : 8,
+        bottom: 8,
+        outerBoundsMode: 'same',
+        outerBoundsContain: 'axisLabel',
+      },
+      xAxis: { type: 'value', name: xAxis?.label, min: xAxis?.min, max: xAxis?.max, axisLabel },
+      yAxis: { type: 'value', name: yAxis?.label, min: yAxis?.min, max: yAxis?.max, axisLabel },
+      series: series.map((s) => ({
+        id: s.id,
+        name: s.name,
+        type: 'scatter',
+        // Spread drops the readonly for ECharts' mutable option types.
+        data: s.data.map((p) => [...p]) as number[][],
+        itemStyle: s.color ? { color: s.color } : undefined,
+      })),
+    };
+  }, [series, xAxis, yAxis, showLegend, valueFormatter]);
+
+  return (
+    <Chart options={options} height={height ?? width ?? 320} className={className} theme={theme} />
+  );
+}

--- a/packages/@granit/react-charts/src/echarts-instance.ts
+++ b/packages/@granit/react-charts/src/echarts-instance.ts
@@ -16,6 +16,7 @@ import {
   LineChart,
   PieChart,
   RadarChart,
+  ScatterChart,
   TreemapChart,
 } from 'echarts/charts';
 import {
@@ -40,6 +41,7 @@ echarts.use([
   FunnelChart,
   TreemapChart,
   HeatmapChart,
+  ScatterChart,
   // Components
   GridComponent,
   TooltipComponent,

--- a/packages/@granit/react-charts/src/index.ts
+++ b/packages/@granit/react-charts/src/index.ts
@@ -23,6 +23,8 @@ export { TreemapChart } from './components/treemap-chart';
 export type { TreemapChartProps, TreemapDatum } from './components/treemap-chart';
 export { HeatmapChart } from './components/heatmap-chart';
 export type { HeatmapChartProps, HeatmapDatum } from './components/heatmap-chart';
+export { ScatterChart } from './components/scatter-chart';
+export type { ScatterChartProps } from './components/scatter-chart';
 
 // Theming
 export { useEChartsTheme } from './hooks/use-echarts-theme';

--- a/packages/@granit/react-charts/src/snapshot/chart-snapshot-widget.tsx
+++ b/packages/@granit/react-charts/src/snapshot/chart-snapshot-widget.tsx
@@ -8,11 +8,12 @@ import { HeatmapChart } from '../components/heatmap-chart';
 import { LineChart } from '../components/line-chart';
 import { PieChart } from '../components/pie-chart';
 import { RadarChart } from '../components/radar-chart';
+import { ScatterChart } from '../components/scatter-chart';
 import { TreemapChart } from '../components/treemap-chart';
 
 import { createChartValueFormatter } from './format-chart-value';
 
-import type { ChartBucket, ChartWidgetSnapshot } from '@granit/analytics';
+import type { ChartBucket, ChartWidgetSnapshot, ScatterPoint } from '@granit/analytics';
 import type { ChartSeries } from '@granit/charts';
 import type { DashboardRenderedWidget } from '@granit/dashboards';
 
@@ -60,6 +61,39 @@ function buildChartSeries(
 }
 
 /**
+ * Group scatter points into one numeric `[x, y]` series per distinct `series`
+ * key. When no point carries a `series` key the plot is a single cloud named
+ * `singleName`.
+ */
+function buildScatterSeries(
+  points: readonly ScatterPoint[],
+  singleName: string
+): readonly ChartSeries<number, number>[] {
+  if (!points.some((p) => p.series != null)) {
+    return [{ id: 'series', name: singleName, data: points.map((p) => [p.x, p.y]) }];
+  }
+
+  const seriesKeys: string[] = [];
+  const byKey = new Map<string, [number, number][]>();
+  for (const p of points) {
+    const seriesKey = p.series ?? '(null)';
+    let group = byKey.get(seriesKey);
+    if (group === undefined) {
+      group = [];
+      byKey.set(seriesKey, group);
+      seriesKeys.push(seriesKey);
+    }
+    group.push([p.x, p.y]);
+  }
+
+  return seriesKeys.map((seriesKey) => ({
+    id: seriesKey,
+    name: seriesKey,
+    data: byKey.get(seriesKey)!,
+  }));
+}
+
+/**
  * Snapshot-driven renderer for the `'Chart'` widget kind. Mirrors the
  * declarative `<Chart>` definition path: dispatches by `chartType` to the
  * right typed primitive (`<BarChart>` / `<LineChart>` / `<PieChart>`) with
@@ -78,6 +112,7 @@ export function ChartSnapshotWidget({ widget }: { readonly widget: DashboardRend
 
 function ChartBody({ snapshot }: { readonly snapshot: ChartWidgetSnapshot }) {
   const { chartType, groupBy, aggregation, field, buckets, currency, seriesBy, stacked } = snapshot;
+  const { xField, yField, points } = snapshot;
   const { locale } = useLocale();
 
   // Locale-aware value formatting for every numeric axis / tooltip. Currency
@@ -132,6 +167,24 @@ function ChartBody({ snapshot }: { readonly snapshot: ChartWidgetSnapshot }) {
         {chartType === 'Treemap' && (
           <TreemapChart data={categoryData} valueFormatter={valueFormatter} height="100%" />
         )}
+      </div>
+    );
+  }
+
+  // Scatter is the one non-aggregating type: it plots raw (x, y) points from
+  // `snapshot.points` (not `buckets`), one series per series-by colour group.
+  if (chartType === 'Scatter') {
+    const scatterName = xField && yField ? `${yField} / ${xField}` : seriesName;
+    const scatterSeries = buildScatterSeries(points ?? [], scatterName);
+    return (
+      <div data-slot="chart-snapshot-widget" data-chart-type={chartType} className="h-full w-full">
+        <ScatterChart
+          series={scatterSeries}
+          xAxis={{ label: xField ?? '' }}
+          yAxis={{ label: yField ?? '' }}
+          valueFormatter={valueFormatter}
+          height="100%"
+        />
       </div>
     );
   }

--- a/packages/@granit/react-ui-analytics/src/components/chart-config-form.tsx
+++ b/packages/@granit/react-ui-analytics/src/components/chart-config-form.tsx
@@ -24,16 +24,18 @@ const CHART_TYPES: readonly ChartType[] = [
   'Funnel',
   'Treemap',
   'Heatmap',
+  'Scatter',
 ];
 const AGGREGATIONS: readonly AggregateFunction[] = ['Count', 'Sum', 'Avg', 'Min', 'Max'];
 
-/** Chart types that accept a second `seriesBy` dimension (multi-series). */
+/** Chart types that accept a second `seriesBy` dimension (multi-series / point colour). */
 const SERIES_CAPABLE: ReadonlySet<ChartType> = new Set([
   'Bar',
   'HorizontalBar',
   'Line',
   'Area',
   'Heatmap',
+  'Scatter',
 ]);
 /** Chart types where `stacked` (vs grouped) is meaningful. */
 const STACK_CAPABLE: ReadonlySet<ChartType> = new Set(['Bar', 'HorizontalBar', 'Line', 'Area']);
@@ -58,6 +60,7 @@ export function ChartConfigForm({
   const { catalogEntries, groupByOptions, fieldOptions } = useQueryFieldMetadata(widget.queryName);
 
   const isCount = widget.aggregation === 'Count';
+  const isScatter = widget.chartType === 'Scatter';
   const supportsSeries = SERIES_CAPABLE.has(widget.chartType);
   const supportsStacking = STACK_CAPABLE.has(widget.chartType);
   const seriesRequired = widget.chartType === 'Heatmap';
@@ -78,46 +81,84 @@ export function ChartConfigForm({
           required
         />
       </label>
-      <label className="block text-sm">
-        <span className="mb-1 block text-muted-foreground">
-          {t('Dashboard:Widget.Chart.GroupBy.Label')}
-          <RequiredMark />
-        </span>
-        <MetaFieldInput
-          slot="chart-group-by"
-          value={widget.groupBy}
-          options={groupByOptions}
-          onChange={(value) => onChange({ ...widget, groupBy: value })}
-          required
-        />
-      </label>
-      <label className="block text-sm">
-        <span className="mb-1 block text-muted-foreground">
-          {t('Dashboard:Widget.Chart.Aggregation.Label')}
-        </span>
-        <EnumSelect
-          slot="chart-aggregation"
-          value={widget.aggregation}
-          options={AGGREGATIONS}
-          onChange={(value) => onChange({ ...widget, aggregation: value as AggregateFunction })}
-        />
-      </label>
-      {/* Field is required for everything except Count (then it must be empty). */}
-      <label className="block text-sm">
-        <span className="mb-1 block text-muted-foreground">
-          {t('Dashboard:Widget.Chart.Field.Label')}
-          {!isCount && <RequiredMark />}
-        </span>
-        <MetaFieldInput
-          slot="chart-field"
-          value={widget.field ?? ''}
-          options={fieldOptions}
-          disabled={isCount}
-          allowEmpty
-          required={!isCount}
-          onChange={(value) => onChange({ ...widget, field: value === '' ? null : value })}
-        />
-      </label>
+      {/* Scatter ignores the aggregation-centric fields — it plots raw x/y points instead. */}
+      {!isScatter && (
+        <>
+          <label className="block text-sm">
+            <span className="mb-1 block text-muted-foreground">
+              {t('Dashboard:Widget.Chart.GroupBy.Label')}
+              <RequiredMark />
+            </span>
+            <MetaFieldInput
+              slot="chart-group-by"
+              value={widget.groupBy}
+              options={groupByOptions}
+              onChange={(value) => onChange({ ...widget, groupBy: value })}
+              required
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="mb-1 block text-muted-foreground">
+              {t('Dashboard:Widget.Chart.Aggregation.Label')}
+            </span>
+            <EnumSelect
+              slot="chart-aggregation"
+              value={widget.aggregation}
+              options={AGGREGATIONS}
+              onChange={(value) => onChange({ ...widget, aggregation: value as AggregateFunction })}
+            />
+          </label>
+          {/* Field is required for everything except Count (then it must be empty). */}
+          <label className="block text-sm">
+            <span className="mb-1 block text-muted-foreground">
+              {t('Dashboard:Widget.Chart.Field.Label')}
+              {!isCount && <RequiredMark />}
+            </span>
+            <MetaFieldInput
+              slot="chart-field"
+              value={widget.field ?? ''}
+              options={fieldOptions}
+              disabled={isCount}
+              allowEmpty
+              required={!isCount}
+              onChange={(value) => onChange({ ...widget, field: value === '' ? null : value })}
+            />
+          </label>
+        </>
+      )}
+      {/* Scatter's two numeric axes — raw point coordinates, sourced from the numeric fields. */}
+      {isScatter && (
+        <>
+          <label className="block text-sm">
+            <span className="mb-1 block text-muted-foreground">
+              {t('Dashboard:Widget.Chart.XField.Label')}
+              <RequiredMark />
+            </span>
+            <MetaFieldInput
+              slot="chart-x-field"
+              value={widget.xField ?? ''}
+              options={fieldOptions}
+              allowEmpty
+              required
+              onChange={(value) => onChange({ ...widget, xField: value === '' ? null : value })}
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="mb-1 block text-muted-foreground">
+              {t('Dashboard:Widget.Chart.YField.Label')}
+              <RequiredMark />
+            </span>
+            <MetaFieldInput
+              slot="chart-y-field"
+              value={widget.yField ?? ''}
+              options={fieldOptions}
+              allowEmpty
+              required
+              onChange={(value) => onChange({ ...widget, yField: value === '' ? null : value })}
+            />
+          </label>
+        </>
+      )}
       <label className="block text-sm">
         <span className="mb-1 block text-muted-foreground">
           {t('Dashboard:Widget.Chart.ChartType.Label')}
@@ -131,11 +172,14 @@ export function ChartConfigForm({
             // them, so a switched-away config never persists a stale seriesBy /
             // stacked (the backend also zeroes stacked, but keep the DTO clean).
             const chartType = value as ChartType;
+            const scatter = chartType === 'Scatter';
             onChange({
               ...widget,
               chartType,
               seriesBy: SERIES_CAPABLE.has(chartType) ? widget.seriesBy : null,
               stacked: STACK_CAPABLE.has(chartType) ? widget.stacked : false,
+              xField: scatter ? widget.xField : null,
+              yField: scatter ? widget.yField : null,
             });
           }}
         />


### PR DESCRIPTION
## What

**Palier 2b** — adds the **Scatter** chart type: a non-aggregating point cloud that plots raw `(x, y)` numeric pairs, optionally coloured by a `seriesBy` dimension. Front follow-up to the merged granit-business backend.

## How

Scatter is the one chart type that doesn't aggregate — the backend streams entities and projects `(xField, yField)` points (whitelist-gated, `MaxStreamSize`-capped with graceful `Unavailable` degradation). It ships those in a dedicated `points` snapshot channel rather than `buckets`.

## Changes

- **Contract**: `ChartType` gains `Scatter`; `ChartWidgetDefinition` gains `xField`/`yField`; `ChartWidgetSnapshot` gains `points: ScatterPoint[]` (+ echoed `xField`/`yField`). `contracts/openapi/analytics.json` resynced from the generator.
- **Primitive**: new `ScatterChart` (registers the ECharts `scatter` series; two numeric value axes, one series per colour group).
- **Renderer** (`chart-snapshot-widget.tsx`): a `Scatter` branch reads `snapshot.points` and groups them into one numeric `[x, y]` series per `series` key.
- **Editor** (`chart-config-form.tsx`): selecting `Scatter` swaps the aggregation fields (`groupBy`/`aggregation`/`field`) for `xField`/`yField`, keeps `seriesBy` as the point-colour dimension, and sanitises `xField`/`yField` when the type changes.
- **Catalog**: seeds `xField: null` / `yField: null`.

## Design decision (validated)

- **No new endpoint/runner/DI** on the backend: scatter is a method on the existing `IChartRunner`, resolved by `ChartService` — stays under `POST /widgets/chart/render`.

## Verification

- `tsc --noEmit` clean (analytics, react-charts, react-ui-analytics, react-analytics)
- ESLint clean; `@granit/arch-tests` green (ADR-010 layering)
- `@granit/contract-tests` oracle green; full affected + contract + arch suites green (3990 tests)

## Notes

- `ScatterPoint` mirrors the backend snapshot record (the snapshot is emitted as an opaque `JsonElement`, so it isn't in the OpenAPI schema — same as the other widget snapshots).
- `Dashboard:Widget.Chart.XField.Label` / `.YField.Label` follow the host-provided i18n pattern; showcase supplies translations.

## Follow-up

- **2c — Combo** (bar + line, multi-measure) closes Palier 2.