### PR TITLE
refactor: resolve SonarQube code smells across framework packages

### DIFF
--- a/packages/@granit/react-dashboards/src/components/dashboard-refresh-toolbar.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-refresh-toolbar.tsx
@@ -3,7 +3,13 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 
 import { useDashboardContext } from './dashboard-context';
-import { ChevronDownIcon, joinClasses, PILL_CLASS, RefreshIcon, SEGMENT_BUTTON_CLASS } from './pill-controls';
+import {
+  ChevronDownIcon,
+  joinClasses,
+  PILL_CLASS,
+  RefreshIcon,
+  SEGMENT_BUTTON_CLASS,
+} from './pill-controls';
 
 import type { DashboardRefreshInterval } from '@granit/dashboards';
 
@@ -60,7 +66,7 @@ export function DashboardRefreshToolbar({ className, onRefresh }: DashboardRefre
   const refreshNow =
     onRefresh ??
     (() => {
-      void queryClient.invalidateQueries();
+      queryClient.invalidateQueries();
     });
 
   if (!ctx?.setRefreshInterval) return null;

--- a/packages/@granit/react-dashboards/src/components/dashboard-time-window-toolbar.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-time-window-toolbar.tsx
@@ -66,7 +66,12 @@ export function DashboardTimeWindowToolbar({ className }: DashboardTimeWindowToo
   const shiftOptions = { weekStartsOn: ctx.weekStartsOn, timeZone: ctx.timeZone };
   const currentToken = 'token' in timeWindow.period ? timeWindow.period.token : '';
   const matched = ALL_PRESETS.some((p) => p.token === currentToken);
-  const selectValue = customOpen ? CUSTOM_VALUE : matched ? currentToken : '';
+  let selectValue = '';
+  if (customOpen) {
+    selectValue = CUSTOM_VALUE;
+  } else if (matched) {
+    selectValue = currentToken;
+  }
 
   const applyCustom = () => {
     const from = new Date(draftFrom);

--- a/packages/@granit/react-query-engine/src/cell-formatters.tsx
+++ b/packages/@granit/react-query-engine/src/cell-formatters.tsx
@@ -114,7 +114,12 @@ type LinkKind = 'url' | 'email' | 'phone';
 
 function formatLinkCell(value: unknown, kind: LinkKind): ReactNode {
   if (typeof value !== 'string' || value.length === 0) return null;
-  const href = kind === 'email' ? `mailto:${value}` : kind === 'phone' ? `tel:${value}` : value;
+  let href = value;
+  if (kind === 'email') {
+    href = `mailto:${value}`;
+  } else if (kind === 'phone') {
+    href = `tel:${value}`;
+  }
   const external = kind === 'url';
   return (
     <a
@@ -132,6 +137,17 @@ function renderBoolean(value: boolean): ReactNode {
   return <span data-granit-cell-boolean={String(value)}>{value ? '✓' : '✗'}</span>;
 }
 
+// Identifiers are scalar (string/number ids); anything object-shaped has no
+// meaningful single-cell representation, so it degrades to an em dash rather
+// than the default `[object Object]`.
+function formatIdentifierValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return '—';
+}
+
 /**
  * Cell-level rendering context threaded to every valueKind formatter. A `null`
  * return from a formatter means "cannot render this value" — {@link formatCell}
@@ -145,14 +161,14 @@ export interface CellFormatterContext {
    * it; when absent, the CLR/text path takes over. Currently used to keep the
    * legacy `money` widget working when no `valueKind` is present.
    */
-  readonly component?: string | undefined;
+  readonly component?: string;
   /**
    * Legacy currency resolver for the `money` manifest component. Consulted
    * only on that path (never for `valueKind: 'Currency'`, which resolves its
    * code from the column). Optional — a plain grid without money widgets omits
    * it.
    */
-  readonly currencyResolver?: ((row: Readonly<Record<string, unknown>>) => string) | undefined;
+  readonly currencyResolver?: (row: Readonly<Record<string, unknown>>) => string;
   readonly locale: string;
   readonly formatDate: DateFormatter;
   readonly formatDateTime: DateFormatter;
@@ -197,9 +213,7 @@ export const VALUE_KIND_FORMATTERS: Readonly<Record<string, CellFormatter>> = Ob
   Time: (value, ctx) => formatDateKind(value, ctx, true),
   RelativeTime: (value, ctx) => formatDateKind(value, ctx, true),
   Boolean: (value) => (typeof value === 'boolean' ? renderBoolean(value) : null),
-  Identifier: (value) => (
-    <code className="font-mono text-xs">{typeof value === 'object' ? '—' : String(value)}</code>
-  ),
+  Identifier: (value) => <code className="font-mono text-xs">{formatIdentifierValue(value)}</code>,
 });
 
 /**

--- a/packages/@granit/react-ui-analytics/src/components/chart-config-form.tsx
+++ b/packages/@granit/react-ui-analytics/src/components/chart-config-form.tsx
@@ -258,6 +258,11 @@ export function ChartConfigForm({
             const chartType = value as ChartType;
             const scatter = chartType === 'Scatter';
             const combo = chartType === 'Combo';
+            // Combo needs at least one measure to render — seed one when switching in.
+            let comboSeries: readonly ChartComboSeries[] | null = null;
+            if (combo) {
+              comboSeries = measures.length ? measures : [DEFAULT_COMBO_MEASURE];
+            }
             onChange({
               ...widget,
               chartType,
@@ -265,8 +270,7 @@ export function ChartConfigForm({
               stacked: STACK_CAPABLE.has(chartType) ? widget.stacked : false,
               xField: scatter ? widget.xField : null,
               yField: scatter ? widget.yField : null,
-              // Combo needs at least one measure to render — seed one when switching in.
-              comboSeries: combo ? (measures.length ? measures : [DEFAULT_COMBO_MEASURE]) : null,
+              comboSeries,
             });
           }}
         />

--- a/packages/@granit/react-ui-cms-pages/src/components/page-form-page.tsx
+++ b/packages/@granit/react-ui-cms-pages/src/components/page-form-page.tsx
@@ -16,7 +16,7 @@ import {
 import { createConstraintsResolver } from '@granit/react-validation';
 import { ArrowLeft, ExternalLink } from 'lucide-react';
 import { useEffect, useRef } from 'react';
-import { Controller, useForm, type Resolver } from 'react-hook-form';
+import { Controller, useForm, type Resolver, type UseFormSetValue } from 'react-hook-form';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { buildPageEditorUrl } from '../renderer';
@@ -53,6 +53,27 @@ function buildFormResolver(t: ReturnType<typeof useTranslation>['t']): Resolver<
     }
     return result;
   }) as unknown as Resolver<PageFormValues>;
+}
+
+/**
+ * Pre-selects the site root as the default parent once the page tree loads
+ * (create mode only, and only once — a manual pick must not be overwritten).
+ */
+function useDefaultParentSelection(
+  enabled: boolean,
+  tree: ReturnType<typeof usePageTree>['data'],
+  setValue: UseFormSetValue<PageFormValues>
+): void {
+  const parentInitialized = useRef(false);
+  useEffect(() => {
+    if (!enabled || parentInitialized.current || !tree || tree.length === 0) {
+      return;
+    }
+    const root = tree.find((node) => node.isSiteRoot) ?? tree[0];
+    if (!root) return;
+    setValue('parentId', root.id);
+    parentInitialized.current = true;
+  }, [enabled, tree, setValue]);
 }
 
 /**
@@ -100,17 +121,7 @@ export function PageFormPage() {
     }
   }, [page, reset]);
 
-  // Pre-select the site root as the default parent once the tree loads (create mode only).
-  const parentInitialized = useRef(false);
-  useEffect(() => {
-    if (isEdit || parentInitialized.current || !tree || tree.length === 0) {
-      return;
-    }
-    const root = tree.find((node) => node.isSiteRoot) ?? tree[0];
-    if (!root) return;
-    setValue('parentId', root.id);
-    parentInitialized.current = true;
-  }, [isEdit, tree, setValue]);
+  useDefaultParentSelection(!isEdit, tree, setValue);
 
   function submitEdit(slugSegment: string) {
     if (!pageId || !page) return;

--- a/packages/@granit/react-ui-dashboards/src/components/dashboard-refresh-control.tsx
+++ b/packages/@granit/react-ui-dashboards/src/components/dashboard-refresh-control.tsx
@@ -57,7 +57,7 @@ export function DashboardRefreshControl({ className, onRefresh }: DashboardRefre
   const refreshNow =
     onRefresh ??
     (() => {
-      void queryClient.invalidateQueries();
+      queryClient.invalidateQueries();
     });
 
   if (!ctx?.setRefreshInterval) return null;

--- a/packages/@granit/react-ui-dashboards/src/components/dashboard-time-range-control.tsx
+++ b/packages/@granit/react-ui-dashboards/src/components/dashboard-time-range-control.tsx
@@ -46,7 +46,9 @@ export function DashboardTimeRangeControl({ className }: DashboardTimeRangeContr
   const period = ctx?.timeWindow?.period;
   const initialAbsolute = period !== undefined && 'from' in period;
   const [open, setOpen] = useState(false);
-  const [draftFrom, setDraftFrom] = useState(() => (initialAbsolute ? toLocalInput(period.from) : ''));
+  const [draftFrom, setDraftFrom] = useState(() =>
+    initialAbsolute ? toLocalInput(period.from) : ''
+  );
   const [draftTo, setDraftTo] = useState(() => (initialAbsolute ? toLocalInput(period.to) : ''));
 
   if (!ctx?.timeWindow || !ctx.setTimeWindow) return null;
@@ -89,7 +91,12 @@ export function DashboardTimeRangeControl({ className }: DashboardTimeRangeContr
   const customValid = draftFrom !== '' && draftTo !== '' && new Date(draftFrom) < new Date(draftTo);
 
   return (
-    <div data-slot="dashboard-time-range-control" className={cn(PILL, className)} role="toolbar" aria-label="Dashboard time window">
+    <div
+      data-slot="dashboard-time-range-control"
+      className={cn(PILL, className)}
+      role="toolbar"
+      aria-label="Dashboard time window"
+    >
       <button
         type="button"
         data-slot="time-range-back"
@@ -261,7 +268,7 @@ function formatInZone(date: Date, timeZone: string): string {
 
 /** e.g. `"Brussels, CEST"` — the zone's city + its short name at `at`. */
 function describeZone(timeZone: string, at: Date): string {
-  const city = timeZone.split('/').pop()?.replace(/_/g, ' ') ?? timeZone;
+  const city = timeZone.split('/').pop()?.replaceAll('_', ' ') ?? timeZone;
   const abbrev = new Intl.DateTimeFormat('en', { timeZone, timeZoneName: 'short' })
     .formatToParts(at)
     .find((part) => part.type === 'timeZoneName')?.value;

--- a/packages/@granit/timing/src/time-zone.ts
+++ b/packages/@granit/timing/src/time-zone.ts
@@ -46,6 +46,6 @@ export function civilToInstant(civil: Date, timeZone: TimeZoneId | undefined): D
   if (timeZone === undefined) return civil;
   // `TZDate(y, m, d, tz)` interprets the fields as a wall-clock time in `tz`.
   return new Date(
-    new TZDate(civil.getUTCFullYear(), civil.getUTCMonth(), civil.getUTCDate(), timeZone).getTime()
+    new TZDate(civil.getUTCFullYear(), civil.getUTCMonth(), civil.getUTCDate(), timeZone)
   );
 }


### PR DESCRIPTION
## Context

Maintainability code smells flagged by SonarQube across several framework packages. **No behavioural change** — pure cleanup.

## Changes

| Package | Fix |
|---|---|
| `react-ui-dashboards` | `String#replace` → `replaceAll`; drop redundant `void` on fire-and-forget `invalidateQueries` |
| `react-dashboards` | drop redundant `void`; extract a nested ternary into `if/else` |
| `react-query-engine` | extract nested ternary; drop redundant `\| undefined` on optional props; render identifiers via a primitive-narrowing helper (avoids `[object Object]`) |
| `react-ui-analytics` | hoist the combo `comboSeries` nested ternary out of `onChange` |
| `react-ui-cms-pages` | extract the default-parent effect into `useDefaultParentSelection` to bring cognitive complexity under threshold |
| `timing` | drop unnecessary `.getTime()` when copying a `TZDate` |

## Deliberately skipped

- **6 jsx-a11y "use native element instead of role" findings** — these are intentional ARIA widget patterns (custom listbox/combobox/progressbar/tree-group/presentation); two already carry `// NOSONAR` justification comments. Swapping to native `<select>`/`<progress>`/`<details>` would break the widgets.
- **`chart-config-form` array-index key** — the combo measures are persisted DTOs with no stable id and support add/remove, so content-derived keys collide. A correct fix needs client-side stable ids (a design change), not a mechanical edit.

## Verification

- `eslint --max-warnings 0` clean on all touched files
- `tsc` passes (pre-commit `tsc -r`)