### PR TITLE
test(entities,timeline): cover react-ui-entities & react-ui-timeline views

### DIFF
--- a/packages/@granit/react-ui-entities/src/action-drawer.test.tsx
+++ b/packages/@granit/react-ui-entities/src/action-drawer.test.tsx
@@ -1,0 +1,305 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import {
+  EntityActionDrawerHost,
+  EntityRendererProvider,
+  useEntityActionDrawer,
+} from '@granit/react-entities';
+import {
+  ENTITIES_BASE_PATH,
+  SAMPLE_ENTITY_NAME,
+  createEntitiesHandlers,
+  mockEntityManifest,
+} from '@granit/react-entities/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { ActionDrawer } from './action-drawer';
+import { EntityActionScopeProvider, useEntityActionScope } from './entity-action-scope';
+
+import type { EntityActionManifest } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+// The Granit Axios client is created with `baseURL: 'http://localhost'`, so
+// requests are fully-qualified — the MSW handlers must be too.
+const ORIGIN = 'http://localhost';
+// The overlay reads hang off `/api/v1/{entityName}` (not the discovery
+// `/api/v1/entities/{name}` manifest route), so the row handler is keyed on
+// the literal entity name to avoid colliding with the manifest handlers.
+const ROW_PATH = `${ORIGIN}/api/v1/${SAMPLE_ENTITY_NAME}/:id`;
+const MANIFEST_PATH = `${ORIGIN}${ENTITIES_BASE_PATH}/:name`;
+const DEFAULT_ROW = { number: 'P-001', kind: 'Person' };
+
+function rowHandler(body: unknown = DEFAULT_ROW) {
+  return http.get(ROW_PATH, () => HttpResponse.json(body));
+}
+
+// Entities handlers cover the `/api/v1/entities/{name}` manifest route; the
+// row handler covers the overlay read at `/api/v1/{entityName}/{id}`.
+const server = setupServer(
+  ...createEntitiesHandlers(`${ORIGIN}${ENTITIES_BASE_PATH}`),
+  rowHandler()
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function makeAction(overrides: Partial<EntityActionManifest> = {}): EntityActionManifest {
+  return {
+    name: 'view',
+    kind: 'OpenDrawer',
+    displayKey: null,
+    icon: null,
+    order: 0,
+    urlTemplate: null,
+    httpMethod: null,
+    confirmationKey: null,
+    workflowTransitionName: null,
+    contributorAssemblyName: null,
+    ...overrides,
+  };
+}
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <GranitClientProvider client={apiClient}>
+          <EntityRendererProvider>
+            <EntityActionScopeProvider>
+              <EntityActionDrawerHost>{children}</EntityActionDrawerHost>
+            </EntityActionScopeProvider>
+          </EntityRendererProvider>
+        </GranitClientProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+interface HarnessProps {
+  readonly action: EntityActionManifest;
+  readonly rowId: string | null;
+  readonly entityName: string | null;
+}
+
+function DrawerHarness({ action, rowId, entityName }: HarnessProps) {
+  const drawer = useEntityActionDrawer();
+  const scope = useEntityActionScope();
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="open"
+        onClick={() => {
+          scope.setEntityName(entityName);
+          drawer.open({ action, rowId, row: null });
+        }}
+      >
+        open
+      </button>
+      <ActionDrawer />
+    </>
+  );
+}
+
+function renderClosed(props: HarnessProps) {
+  const Wrapper = makeWrapper();
+  return render(
+    <Wrapper>
+      <DrawerHarness {...props} />
+    </Wrapper>
+  );
+}
+
+function renderOpen(props: HarnessProps) {
+  const utils = renderClosed(props);
+  fireEvent.click(utils.getByTestId('open'));
+  return utils;
+}
+
+const title = () => document.body.querySelector('[data-slot="sheet-title"]')?.textContent;
+const sheetContent = () => document.body.querySelector('[data-slot="sheet-content"]');
+const frame = () =>
+  document.body.querySelector<HTMLIFrameElement>('[data-granit-action-drawer-url-frame]');
+
+describe('ActionDrawer', () => {
+  it('keeps the sheet body unmounted while the drawer is closed', () => {
+    renderClosed({ action: makeAction(), rowId: 'r1', entityName: SAMPLE_ENTITY_NAME });
+    expect(sheetContent()).toBeNull();
+  });
+
+  it('opens the sheet with the action name as title when no displayKey is set', () => {
+    renderOpen({
+      action: makeAction({ displayKey: null, name: 'View details', urlTemplate: 'https://x/y' }),
+      rowId: 'r1',
+      entityName: null,
+    });
+    expect(sheetContent()).not.toBeNull();
+    expect(title()).toBe('View details');
+    // sr-only description branch is always emitted for a11y.
+    expect(document.body.querySelector('[data-slot="sheet-description"]')).not.toBeNull();
+  });
+
+  it('closes the drawer (via onOpenChange) when the sheet is dismissed', async () => {
+    renderOpen({
+      action: makeAction({ urlTemplate: 'https://x/y' }),
+      rowId: 'r1',
+      entityName: null,
+    });
+    expect(sheetContent()).not.toBeNull();
+    // Escape drives Radix's onOpenChange(false) → drawer.close() → unmount.
+    fireEvent.keyDown(document.body, { key: 'Escape', code: 'Escape' });
+    await waitFor(() => expect(sheetContent()).toBeNull());
+  });
+
+  it('resolves the translated displayKey (falling back to the action name)', () => {
+    renderOpen({
+      action: makeAction({ displayKey: 'Actions.View', name: 'view', urlTemplate: 'https://x/y' }),
+      rowId: 'r1',
+      entityName: null,
+    });
+    // Without an i18n provider the no-op `t` returns its string fallback (name).
+    expect(title()).toBe('view');
+  });
+
+  it('falls back to the generic Drawer title when neither displayKey nor name is set', () => {
+    renderOpen({
+      action: makeAction({
+        displayKey: null,
+        // Defensive `?? t('Common.Drawer')` branch — the wire type is
+        // non-nullable but the runtime guards against a missing name.
+        name: null as unknown as string,
+        urlTemplate: 'https://x/y',
+      }),
+      rowId: 'r1',
+      entityName: null,
+    });
+    expect(title()).toBe('Drawer');
+  });
+
+  it('renders a sandboxed iframe with the row id substituted for {id}', () => {
+    renderOpen({
+      action: makeAction({ urlTemplate: 'https://example.com/wizard?id={id}' }),
+      rowId: 'row 1',
+      entityName: null,
+    });
+    const iframe = frame();
+    expect(iframe).not.toBeNull();
+    // replaceAll + encodeURIComponent: the space becomes %20.
+    expect(iframe?.getAttribute('src')).toBe('https://example.com/wizard?id=row%201');
+    expect(iframe?.getAttribute('sandbox')).toBe('allow-forms allow-same-origin allow-scripts');
+    expect(iframe?.getAttribute('title')).toBe('Drawer content');
+  });
+
+  it('uses the raw template unchanged when the row id is null', () => {
+    renderOpen({
+      action: makeAction({ urlTemplate: 'https://example.com/plain' }),
+      rowId: null,
+      entityName: null,
+    });
+    expect(frame()?.getAttribute('src')).toBe('https://example.com/plain');
+  });
+
+  it('shows the no-row message when the scope has no active entity', () => {
+    renderOpen({
+      action: makeAction({ urlTemplate: null }),
+      rowId: 'r1',
+      entityName: null,
+    });
+    expect(sheetContent()?.textContent).toContain('No row context.');
+  });
+
+  it('shows the no-row message when the row id is null (detail branch)', () => {
+    renderOpen({
+      action: makeAction({ urlTemplate: null }),
+      rowId: null,
+      entityName: SAMPLE_ENTITY_NAME,
+    });
+    expect(sheetContent()?.textContent).toContain('No row context.');
+  });
+
+  it('shows a loading skeleton then renders the entity detail once data lands', async () => {
+    renderOpen({
+      action: makeAction({ urlTemplate: null }),
+      rowId: 'row-001',
+      entityName: SAMPLE_ENTITY_NAME,
+    });
+    // Both the manifest and the row query are in-flight → skeleton branch.
+    expect(document.body.querySelector('[data-slot="skeleton"]')).not.toBeNull();
+    await waitFor(() =>
+      expect(document.body.querySelector('[data-granit-detail-row]')).not.toBeNull()
+    );
+    const numberRow = document.body.querySelector(
+      '[data-granit-detail-row][data-property="Number"]'
+    );
+    expect(numberRow?.querySelector('dd')?.textContent).toBe('P-001');
+  });
+
+  it('renders the detail with an empty form-variant list when the manifest omits forms', async () => {
+    server.use(
+      http.get(MANIFEST_PATH, () =>
+        HttpResponse.json({
+          ...mockEntityManifest,
+          forms: null,
+          details: [
+            {
+              name: 'default',
+              sections: [
+                {
+                  key: 'main',
+                  labelKey: null,
+                  order: 0,
+                  inheritsFromFormVariant: null,
+                  fields: ['Number'],
+                },
+              ],
+              sidePanels: [],
+            },
+          ],
+        })
+      )
+    );
+    renderOpen({
+      action: makeAction({ urlTemplate: null }),
+      rowId: 'row-001',
+      entityName: SAMPLE_ENTITY_NAME,
+    });
+    await waitFor(() =>
+      expect(document.body.querySelector('[data-granit-detail-row]')).not.toBeNull()
+    );
+    const numberRow = document.body.querySelector(
+      '[data-granit-detail-row][data-property="Number"]'
+    );
+    expect(numberRow?.querySelector('dd')?.textContent).toBe('P-001');
+  });
+
+  it('shows the no-detail message when the manifest declares no detail variant', async () => {
+    server.use(
+      http.get(MANIFEST_PATH, () => HttpResponse.json({ ...mockEntityManifest, details: [] }))
+    );
+    renderOpen({
+      action: makeAction({ urlTemplate: null }),
+      rowId: 'row-001',
+      entityName: SAMPLE_ENTITY_NAME,
+    });
+    await waitFor(() => expect(sheetContent()?.textContent).toContain('No details available.'));
+  });
+
+  it('shows the no-detail message when the manifest request fails', async () => {
+    server.use(
+      http.get(MANIFEST_PATH, () => HttpResponse.json({ error: 'boom' }, { status: 500 }))
+    );
+    renderOpen({
+      action: makeAction({ urlTemplate: null }),
+      rowId: 'row-001',
+      entityName: SAMPLE_ENTITY_NAME,
+    });
+    await waitFor(() => expect(sheetContent()?.textContent).toContain('No details available.'));
+  });
+});

--- a/packages/@granit/react-ui-entities/src/action-modal.test.tsx
+++ b/packages/@granit/react-ui-entities/src/action-modal.test.tsx
@@ -1,0 +1,275 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import {
+  EntityActionModalContext,
+  EntityRendererProvider,
+  SelectionProvider,
+} from '@granit/react-entities';
+import {
+  ENTITIES_BASE_PATH,
+  SAMPLE_ENTITY_NAME,
+  createEntitiesHandlers,
+  mockEntityManifest,
+} from '@granit/react-entities/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { delay, http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { useEffect } from 'react';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { ActionModal } from './action-modal';
+import { EntityActionScopeProvider, useEntityActionScope } from './entity-action-scope';
+
+import type { EntityActionManifest, EntityManifestResponse } from '@granit/entities';
+import type {
+  EntityActionOverlayContextValue,
+  EntityActionOverlayState,
+} from '@granit/react-entities';
+import type { ReactNode } from 'react';
+
+const ORIGIN = 'http://localhost';
+const MANIFEST_BASE = `${ORIGIN}${ENTITIES_BASE_PATH}`;
+const ROW_PATH = `${ORIGIN}/api/v1/${SAMPLE_ENTITY_NAME}/:id`;
+
+function baseHandlers() {
+  return [
+    ...createEntitiesHandlers(MANIFEST_BASE),
+    http.get(ROW_PATH, () => HttpResponse.json({ number: 'ACME-001', kind: 'Person' })),
+  ];
+}
+
+const server = setupServer(...baseHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers(...baseHandlers()));
+afterAll(() => server.close());
+
+function makeAction(overrides: Partial<EntityActionManifest> = {}): EntityActionManifest {
+  return {
+    name: 'edit',
+    kind: 'OpenModal',
+    displayKey: null,
+    icon: null,
+    order: 0,
+    urlTemplate: null,
+    httpMethod: null,
+    confirmationKey: null,
+    workflowTransitionName: null,
+    contributorAssemblyName: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Sets the action scope entity name and gates the children until the
+ * scope reflects that name, so the modal body reads a stable
+ * `scope.entityName` on first mount (no null → name flicker).
+ */
+function ScopeGate({ name, children }: { name: string | null; children: ReactNode }) {
+  const scope = useEntityActionScope();
+  useEffect(() => {
+    scope.setEntityName(name);
+  }, [scope, name]);
+  if (scope.entityName !== name) return null;
+  return children;
+}
+
+interface RenderOptions {
+  readonly current: EntityActionOverlayState | null;
+  readonly entityName?: string | null;
+  readonly selectedIds?: readonly string[];
+}
+
+function renderModal({ current, entityName = null, selectedIds = [] }: RenderOptions) {
+  const close = vi.fn();
+  const modalValue: EntityActionOverlayContextValue = {
+    current,
+    open: vi.fn(),
+    close,
+  };
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: ORIGIN });
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>
+        <EntityRendererProvider>
+          <SelectionProvider initialSelectedIds={selectedIds}>
+            <EntityActionScopeProvider>
+              <ScopeGate name={entityName}>
+                <EntityActionModalContext.Provider value={modalValue}>
+                  <ActionModal />
+                </EntityActionModalContext.Provider>
+              </ScopeGate>
+            </EntityActionScopeProvider>
+          </SelectionProvider>
+        </EntityRendererProvider>
+      </GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { ...result, close };
+}
+
+function state(
+  action: EntityActionManifest,
+  rowId: string | null = null
+): EntityActionOverlayState {
+  return { action, rowId, row: null };
+}
+
+describe('ActionModal', () => {
+  it('renders no dialog content when the modal has no current action', () => {
+    renderModal({ current: null });
+    expect(document.body.querySelector('[data-slot="dialog-content"]')).toBeNull();
+  });
+
+  it('renders the title from displayKey and a confirmation description when both are set', () => {
+    renderModal({
+      current: state(
+        makeAction({ displayKey: 'Action.Edit.Label', confirmationKey: 'Action.Edit.Confirm' })
+      ),
+    });
+    const title = document.body.querySelector('[data-slot="dialog-title"]');
+    // t(displayKey, name) resolves to the fallback name without an i18n bundle,
+    // but the displayKey branch of the title ternary is exercised.
+    expect(title?.textContent).toBe('edit');
+    expect(document.body.querySelector('[data-slot="dialog-description"]')).not.toBeNull();
+  });
+
+  it('falls back to the action name for the title and omits the description when unset', () => {
+    renderModal({ current: state(makeAction({ displayKey: null, name: 'archive' })) });
+    expect(document.body.querySelector('[data-slot="dialog-title"]')?.textContent).toBe('archive');
+    expect(document.body.querySelector('[data-slot="dialog-description"]')).toBeNull();
+  });
+
+  it('invokes close() when the footer Close button is clicked', () => {
+    const { close } = renderModal({ current: state(makeAction()) });
+    const footer = document.body.querySelector('[data-slot="dialog-footer"]') as HTMLElement;
+    const closeButton = footer.querySelector('button') as HTMLButtonElement;
+    fireEvent.click(closeButton);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes close() when the dialog dismisses itself (Escape)', () => {
+    const { close } = renderModal({ current: state(makeAction()) });
+    const content = document.body.querySelector('[data-slot="dialog-content"]') as HTMLElement;
+    fireEvent.keyDown(content, { key: 'Escape', code: 'Escape' });
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  describe('urlTemplate === null → embedded entity form', () => {
+    it('shows the no-entity fallback when the scope has no entity name', () => {
+      renderModal({ current: state(makeAction({ urlTemplate: null }), 'row-1'), entityName: null });
+      const body = document.body.querySelector('.overflow-y-auto') as HTMLElement;
+      expect(body.textContent).toContain('No entity scope available.');
+    });
+
+    it('shows a skeleton while the manifest is loading', () => {
+      server.use(
+        http.get(`${MANIFEST_BASE}/:name`, async () => {
+          await delay('infinite');
+          return HttpResponse.json(mockEntityManifest);
+        }),
+        http.get(ROW_PATH, async () => {
+          await delay('infinite');
+          return HttpResponse.json({});
+        })
+      );
+      renderModal({
+        current: state(makeAction({ urlTemplate: null }), 'row-1'),
+        entityName: SAMPLE_ENTITY_NAME,
+      });
+      expect(document.body.querySelector('[data-slot="skeleton"]')).not.toBeNull();
+    });
+
+    it('shows the no-form fallback when the manifest exposes no form variant', async () => {
+      const noForms: EntityManifestResponse = { ...mockEntityManifest, forms: [] };
+      server.use(http.get(`${MANIFEST_BASE}/:name`, () => HttpResponse.json(noForms)));
+      renderModal({
+        current: state(makeAction({ urlTemplate: null }), 'row-1'),
+        entityName: SAMPLE_ENTITY_NAME,
+      });
+      await waitFor(() =>
+        expect(document.body.textContent).toContain('No form variant available.')
+      );
+    });
+
+    it('renders the entity form once the manifest and row values land', async () => {
+      renderModal({
+        current: state(makeAction({ urlTemplate: null }), 'row-1'),
+        entityName: SAMPLE_ENTITY_NAME,
+      });
+      await waitFor(() =>
+        expect(document.body.querySelector('[data-granit-entity-form]')).not.toBeNull()
+      );
+    });
+
+    it('renders a blank form for a header/bulk action with no row id', async () => {
+      // rowId === null exercises the `rowId ?? 'new'` key fallback and the
+      // `initial ?? {}` fallback (useEntity is disabled with no id, so the
+      // form seeds from an empty object).
+      renderModal({
+        current: state(makeAction({ urlTemplate: null }), null),
+        entityName: SAMPLE_ENTITY_NAME,
+      });
+      await waitFor(() =>
+        expect(document.body.querySelector('[data-granit-entity-form]')).not.toBeNull()
+      );
+    });
+  });
+
+  describe('urlTemplate present → sandboxed iframe / no-url fallback', () => {
+    it('substitutes {id} from the row id and encodes it into the frame src', () => {
+      renderModal({
+        current: state(makeAction({ urlTemplate: '/entities/{id}/edit' }), 'a/b'),
+      });
+      const frame = document.body.querySelector(
+        '[data-granit-action-modal-url-frame]'
+      ) as HTMLIFrameElement;
+      expect(frame).not.toBeNull();
+      expect(frame.getAttribute('src')).toBe('/entities/a%2Fb/edit');
+      expect(frame.getAttribute('sandbox')).toBe('allow-forms allow-same-origin allow-scripts');
+    });
+
+    it('shows the no-url fallback when the template needs an id but the row id is null', () => {
+      renderModal({
+        current: state(makeAction({ urlTemplate: '/entities/{id}/edit' }), null),
+      });
+      expect(document.body.querySelector('[data-granit-action-modal-url-frame]')).toBeNull();
+      expect(document.body.textContent).toContain('No URL available.');
+    });
+
+    it('uses the template verbatim in bulk mode when nothing is selected', () => {
+      renderModal({
+        current: state(makeAction({ urlTemplate: '/static/page' }), null),
+        selectedIds: [],
+      });
+      const frame = document.body.querySelector(
+        '[data-granit-action-modal-url-frame]'
+      ) as HTMLIFrameElement;
+      expect(frame.getAttribute('src')).toBe('/static/page');
+    });
+
+    it('appends the selection ids as a new query string (? separator)', () => {
+      renderModal({
+        current: state(makeAction({ urlTemplate: '/bulk' }), null),
+        selectedIds: ['x', 'y'],
+      });
+      const frame = document.body.querySelector(
+        '[data-granit-action-modal-url-frame]'
+      ) as HTMLIFrameElement;
+      expect(frame.getAttribute('src')).toBe('/bulk?ids=x%2Cy');
+    });
+
+    it('appends the selection ids with an & separator when the template already has a query', () => {
+      renderModal({
+        current: state(makeAction({ urlTemplate: '/bulk?tab=1' }), null),
+        selectedIds: ['x'],
+      });
+      const frame = document.body.querySelector(
+        '[data-granit-action-modal-url-frame]'
+      ) as HTMLIFrameElement;
+      expect(frame.getAttribute('src')).toBe('/bulk?tab=1&ids=x');
+    });
+  });
+});

--- a/packages/@granit/react-ui-entities/src/collection-section-card.test.tsx
+++ b/packages/@granit/react-ui-entities/src/collection-section-card.test.tsx
@@ -1,0 +1,336 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { CollectionSectionCard } from './collection-section-card';
+
+import type {
+  CollectionColumnManifest,
+  EntityCollectionSectionManifest,
+} from './manifest-extensions';
+
+function section(
+  overrides: Partial<EntityCollectionSectionManifest> = {}
+): EntityCollectionSectionManifest {
+  return {
+    key: 'lineItems',
+    labelKey: null,
+    order: 0,
+    propertyName: 'lineItems',
+    columns: [{ propertyName: 'description', labelKey: null, align: 'left' }],
+    ...overrides,
+  };
+}
+
+const MONEY_COLUMNS: readonly CollectionColumnManifest[] = [
+  { propertyName: 'description', labelKey: null, align: 'left' },
+  { propertyName: 'quantity', labelKey: null, align: 'right' },
+  { propertyName: 'total', labelKey: null, component: 'money', align: 'right' },
+];
+
+describe('CollectionSectionCard', () => {
+  it('renders the empty placeholder when the source property is absent', () => {
+    const { container } = render(
+      <CollectionSectionCard section={section()} values={{}} locale="en-GB" />
+    );
+    const card = container.querySelector('[data-slot="collection-section-card"]');
+    expect(card).not.toBeNull();
+    expect(card?.getAttribute('data-section-key')).toBe('lineItems');
+    // No table rendered in the empty branch.
+    expect(container.querySelector('table')).toBeNull();
+    expect(container.querySelector('p')).not.toBeNull();
+  });
+
+  it('renders the empty placeholder when the source array is empty', () => {
+    const { container } = render(
+      <CollectionSectionCard section={section()} values={{ lineItems: [] }} locale="en-GB" />
+    );
+    expect(container.querySelector('[data-slot="collection-section-card"]')).not.toBeNull();
+    expect(container.querySelector('table')).toBeNull();
+  });
+
+  it('renders a populated table with a Sum footer and formats money via the currency property', () => {
+    const s = section({
+      currencyProperty: 'currency',
+      columns: MONEY_COLUMNS,
+      footer: { aggregate: 'Sum', propertyName: 'total', component: 'money', labelKey: null },
+    });
+    const values = {
+      currency: 'EUR',
+      lineItems: [
+        { id: '1', description: 'A', quantity: 2, total: 12000 },
+        { id: '2', description: 'B', quantity: 1, total: 8000 },
+      ],
+    };
+    const { container } = render(
+      <CollectionSectionCard section={s} values={values} locale="en-GB" />
+    );
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(2);
+    const bodyCells = container.querySelectorAll('tbody tr:first-child td');
+    // money column: 12000 minor units / 100 → 120.00 in EUR
+    expect(bodyCells[2]?.textContent).toContain('120');
+    const footer = container.querySelector('tfoot');
+    expect(footer).not.toBeNull();
+    // colSpan spans all but the last column.
+    expect(footer?.querySelector('td')?.getAttribute('colspan')).toBe('2');
+    // Sum of 12000 + 8000 = 20000 → 200.00
+    expect(footer?.querySelectorAll('td')[1]?.textContent).toContain('200');
+  });
+
+  it('resolves the footer label key to its last segment and falls back to EUR without a currency property', () => {
+    const s = section({
+      columns: MONEY_COLUMNS,
+      footer: {
+        aggregate: 'Sum',
+        propertyName: 'total',
+        component: 'money',
+        labelKey: 'Invoice:Footer.Grand',
+      },
+    });
+    const values = { lineItems: [{ id: '1', description: 'A', quantity: 1, total: 10000 }] };
+    const { container } = render(
+      <CollectionSectionCard section={s} values={values} locale="en-GB" />
+    );
+    const footerLabel = container.querySelector('tfoot td');
+    expect(footerLabel?.textContent).toBe('Grand');
+    // No currencyProperty → EUR symbol.
+    expect(container.querySelector('tfoot')?.textContent).toContain('€');
+  });
+
+  it('falls back to EUR when the currency property is declared but missing from values', () => {
+    const s = section({
+      currencyProperty: 'currency',
+      columns: MONEY_COLUMNS,
+    });
+    const values = { lineItems: [{ id: '1', description: 'A', quantity: 1, total: 10000 }] };
+    const { container } = render(
+      <CollectionSectionCard section={s} values={values} locale="en-GB" />
+    );
+    expect(container.querySelector('tbody')?.textContent).toContain('€');
+  });
+
+  it('omits the footer when the section declares none', () => {
+    const s = section({ columns: MONEY_COLUMNS });
+    const values = { lineItems: [{ id: '1', description: 'A', quantity: 1, total: 10000 }] };
+    const { container } = render(
+      <CollectionSectionCard section={s} values={values} locale="en-GB" />
+    );
+    expect(container.querySelector('tfoot')).toBeNull();
+  });
+
+  it('treats non-numeric footer values as zero when summing', () => {
+    const s = section({
+      columns: MONEY_COLUMNS,
+      footer: { aggregate: 'Sum', propertyName: 'total', labelKey: null },
+    });
+    const values = {
+      lineItems: [
+        { id: '1', description: 'A', quantity: 1, total: 5000 },
+        { id: '2', description: 'B', quantity: 1, total: 'n/a' },
+      ],
+    };
+    const { container } = render(
+      <CollectionSectionCard section={s} values={values} locale="en-GB" />
+    );
+    // No money component on the footer → plain String() of the raw sum 5000.
+    const footerCells = container.querySelectorAll('tfoot td');
+    expect(footerCells[1]?.textContent).toBe('5000');
+  });
+
+  it('renders email / tel / url link cells and rejects unsafe URL schemes', () => {
+    const s = section({
+      propertyName: 'contacts',
+      columns: [
+        { propertyName: 'email', labelKey: null, component: 'email' },
+        { propertyName: 'phone', labelKey: null, component: 'tel' },
+        { propertyName: 'external', labelKey: null, component: 'url' },
+        { propertyName: 'internal', labelKey: null, component: 'url' },
+        { propertyName: 'unsafe', labelKey: null, component: 'url' },
+      ],
+    });
+    const values = {
+      contacts: [
+        {
+          id: 'c1',
+          email: 'ada@example.com',
+          phone: '+32 (2) 555-0123',
+          external: 'https://example.com',
+          internal: '/parties/c1',
+          unsafe: 'javascript:alert(1)',
+        },
+      ],
+    };
+    const { container } = render(
+      <CollectionSectionCard section={s} values={values} locale="en-GB" />
+    );
+    const cells = container.querySelectorAll('tbody td');
+    expect(cells[0]?.querySelector('a')?.getAttribute('href')).toBe('mailto:ada@example.com');
+    // tel strips non-dial characters.
+    expect(cells[1]?.querySelector('a')?.getAttribute('href')).toBe('tel:+3225550123');
+    const external = cells[2]?.querySelector('a');
+    expect(external?.getAttribute('href')).toBe('https://example.com');
+    expect(external?.getAttribute('target')).toBe('_blank');
+    expect(external?.getAttribute('rel')).toBe('noreferrer');
+    const internal = cells[3]?.querySelector('a');
+    expect(internal?.getAttribute('href')).toBe('/parties/c1');
+    expect(internal?.hasAttribute('target')).toBe(false);
+    // Unsafe scheme rendered as plain text, no anchor.
+    expect(cells[4]?.querySelector('a')).toBeNull();
+    expect(cells[4]?.textContent).toBe('javascript:alert(1)');
+  });
+
+  it('rejects protocol-relative URLs (leading //) as unsafe', () => {
+    const s = section({
+      propertyName: 'contacts',
+      columns: [{ propertyName: 'site', labelKey: null, component: 'url' }],
+    });
+    const values = { contacts: [{ id: 'c1', site: '//evil.example.com' }] };
+    const { container } = render(
+      <CollectionSectionCard section={s} values={values} locale="en-GB" />
+    );
+    const cell = container.querySelector('tbody td');
+    expect(cell?.querySelector('a')).toBeNull();
+    expect(cell?.textContent).toBe('//evil.example.com');
+  });
+
+  it('formats scalar cell kinds: null, boolean, object, number and empty link value', () => {
+    const s = section({
+      propertyName: 'rows',
+      columns: [
+        { propertyName: 'missing', labelKey: null },
+        { propertyName: 'flagTrue', labelKey: null },
+        { propertyName: 'flagFalse', labelKey: null },
+        { propertyName: 'meta', labelKey: null },
+        { propertyName: 'count', labelKey: null },
+        { propertyName: 'blankMail', labelKey: null, component: 'email' },
+      ],
+    });
+    const values = {
+      rows: [
+        {
+          id: 'r1',
+          missing: null,
+          flagTrue: true,
+          flagFalse: false,
+          meta: { a: 1 },
+          count: 42,
+          blankMail: '',
+        },
+      ],
+    };
+    const { container } = render(
+      <CollectionSectionCard section={s} values={values} locale="en-GB" />
+    );
+    const cells = container.querySelectorAll('tbody td');
+    expect(cells[0]?.textContent).toBe('—');
+    expect(cells[1]?.textContent).toBe('✓');
+    expect(cells[2]?.textContent).toBe('✗');
+    expect(cells[3]?.textContent).toBe('{"a":1}');
+    expect(cells[4]?.textContent).toBe('42');
+    // Empty string with a link component falls through to String('').
+    expect(cells[5]?.querySelector('a')).toBeNull();
+    expect(cells[5]?.textContent).toBe('');
+  });
+
+  it('formats date and datetime components and auto-detects ISO strings without a component', () => {
+    const s = section({
+      propertyName: 'rows',
+      columns: [
+        { propertyName: 'd', labelKey: null, component: 'date' },
+        { propertyName: 'dt', labelKey: null, component: 'datetime' },
+        { propertyName: 'auto', labelKey: null },
+        { propertyName: 'plain', labelKey: null },
+      ],
+    });
+    const values = {
+      rows: [
+        {
+          id: 'r1',
+          d: '2024-03-12T09:00:00Z',
+          dt: '2024-05-30T14:30:00Z',
+          auto: '2024-07-01T00:00:00Z',
+          plain: 'hello',
+        },
+      ],
+    };
+    const { container } = render(
+      <CollectionSectionCard section={s} values={values} locale="en-GB" />
+    );
+    const cells = container.querySelectorAll('tbody td');
+    // date-fns PPP format includes the year; raw ISO 'T' marker must be gone.
+    expect(cells[0]?.textContent).toContain('2024');
+    expect(cells[0]?.textContent).not.toContain('T09:00');
+    expect(cells[1]?.textContent).toContain('2024');
+    expect(cells[1]?.textContent).toContain(':');
+    expect(cells[2]?.textContent).toContain('2024');
+    expect(cells[2]?.textContent).not.toContain('T00:00');
+    // A non-ISO plain string is passed through verbatim.
+    expect(cells[3]?.textContent).toBe('hello');
+  });
+
+  it('returns the raw value when a date component receives an unparseable string', () => {
+    const s = section({
+      propertyName: 'rows',
+      columns: [{ propertyName: 'when', labelKey: null, component: 'date' }],
+    });
+    const values = { rows: [{ id: 'r1', when: 'not-a-date' }] };
+    const { container } = render(
+      <CollectionSectionCard section={s} values={values} locale="en-GB" />
+    );
+    expect(container.querySelector('tbody td')?.textContent).toBe('not-a-date');
+  });
+
+  it('applies alignment classes and resolves column + section labels', () => {
+    const s = section({
+      key: 'contacts',
+      labelKey: 'Party:Section.Contacts',
+      propertyName: 'rows',
+      columns: [
+        { propertyName: 'left', labelKey: null, align: 'left' },
+        { propertyName: 'center', labelKey: 'Col:Center', align: 'center' },
+        { propertyName: 'right', labelKey: null, align: 'right' },
+        { propertyName: 'default', labelKey: null },
+      ],
+    });
+    const values = { rows: [{ id: 'r1', left: 'a', center: 'b', right: 'c', default: 'd' }] };
+    const { container } = render(
+      <CollectionSectionCard section={s} values={values} locale="en-GB" />
+    );
+    const heads = container.querySelectorAll('thead th');
+    expect(heads[0]?.className).toContain('text-left');
+    expect(heads[1]?.className).toContain('text-center');
+    expect(heads[1]?.textContent).toBe('Center');
+    expect(heads[2]?.className).toContain('text-right');
+    // Undefined align → default left.
+    expect(heads[3]?.className).toContain('text-left');
+    // Section label resolved from its key path last segment.
+    expect(container.querySelector('[data-slot="collection-section-card"]')?.textContent).toContain(
+      'Contacts'
+    );
+  });
+
+  it('falls back to the row index for the key when a row carries no id', () => {
+    const s = section({
+      propertyName: 'rows',
+      columns: [{ propertyName: 'name', labelKey: null }],
+    });
+    const values = { rows: [{ name: 'first' }, { name: 'second' }] };
+    const { container } = render(
+      <CollectionSectionCard section={s} values={values} locale="en-GB" />
+    );
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(2);
+    expect(container.querySelector('tbody')?.textContent).toContain('first');
+  });
+
+  it('uses the section key as the title when no label key is provided', () => {
+    const { container } = render(
+      <CollectionSectionCard
+        section={section({ key: 'lineItems', labelKey: null })}
+        values={{ lineItems: [] }}
+        locale="en-GB"
+      />
+    );
+    expect(container.querySelector('[data-slot="collection-section-card"]')?.textContent).toContain(
+      'lineItems'
+    );
+  });
+});

--- a/packages/@granit/react-ui-entities/src/entity-action-button.test.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-action-button.test.tsx
@@ -1,0 +1,148 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { EntityRendererProvider, type EntityActionHandlers } from '@granit/react-entities';
+import { mockEntityManifest, SAMPLE_ENTITY_ID } from '@granit/react-entities/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { EntityActionButton } from './entity-action-button';
+import { logger } from './logger';
+
+import type { EntityActionManifest } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+function makeAction(overrides: Partial<EntityActionManifest> = {}): EntityActionManifest {
+  // Reuse the shared manifest fixture's action as the base descriptor and
+  // override only the axes under test (kind / confirmationKey / labels).
+  return { ...mockEntityManifest.actions![0]!, ...overrides };
+}
+
+function withProviders(children: ReactNode) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>
+        <EntityRendererProvider>{children}</EntityRendererProvider>
+      </GranitClientProvider>
+    </QueryClientProvider>
+  );
+}
+
+function renderButton(action: EntityActionManifest, actionHandlers?: EntityActionHandlers) {
+  const result = render(
+    withProviders(
+      <EntityActionButton
+        action={action}
+        entityId={SAMPLE_ENTITY_ID}
+        actionHandlers={actionHandlers}
+      />
+    )
+  );
+  const button = result.container.querySelector(
+    '[data-slot="entity-action-button"]'
+  ) as HTMLButtonElement;
+  return { ...result, button };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('EntityActionButton', () => {
+  it.each([
+    ['Download', 'outline', true],
+    ['Navigate', 'outline', true],
+    ['WorkflowTransition', 'default', true],
+    ['OpenDrawer', 'outline', true],
+    ['OpenModal', 'outline', true],
+  ] as const)('maps kind %s to variant %s with an icon', (kind, variant, hasIcon) => {
+    const { button } = renderButton(makeAction({ kind }));
+    expect(button.getAttribute('data-variant')).toBe(variant);
+    expect(button.getAttribute('data-action-kind')).toBe(kind);
+    expect(button.querySelector('svg') !== null).toBe(hasIcon);
+  });
+
+  it('maps ApiCall with a confirmationKey to the destructive delete visual', () => {
+    const { button } = renderButton(
+      makeAction({ kind: 'ApiCall', confirmationKey: 'Confirm.Key' })
+    );
+    expect(button.getAttribute('data-variant')).toBe('destructive');
+    expect(button.querySelector('svg')).not.toBeNull();
+  });
+
+  it('maps ApiCall without a confirmationKey to the default variant and no icon', () => {
+    const { button } = renderButton(makeAction({ kind: 'ApiCall', confirmationKey: null }));
+    expect(button.getAttribute('data-variant')).toBe('default');
+    expect(button.querySelector('svg')).toBeNull();
+  });
+
+  it('exposes the action name as a data attribute', () => {
+    const { button } = renderButton(makeAction({ name: 'Approve' }));
+    expect(button.getAttribute('data-action-name')).toBe('Approve');
+  });
+
+  it('resolves the label to the last segment of a dotted displayKey', () => {
+    const { button } = renderButton(
+      makeAction({ displayKey: 'Granit.Parties.Party.Action.Publish', name: 'Publish' })
+    );
+    expect(button.getAttribute('aria-label')).toBe('Publish');
+    expect(button.getAttribute('title')).toBe('Publish');
+    expect(button.textContent).toContain('Publish');
+  });
+
+  it('falls back to the action name when displayKey is null', () => {
+    const { button } = renderButton(makeAction({ displayKey: null, name: 'Archive' }));
+    expect(button.getAttribute('aria-label')).toBe('Archive');
+    expect(button.textContent).toContain('Archive');
+  });
+
+  it('renders a default label when both displayKey and name are empty', () => {
+    const { button } = renderButton(makeAction({ displayKey: null, name: '' }));
+    // resolveLabel returns the empty name, so the `label || t(...)` fallback fires.
+    expect(button.getAttribute('aria-label')).toBe('');
+    expect(button.textContent?.length).toBeGreaterThan(0);
+  });
+
+  it('dispatches through the matching handler with the entity id on click', async () => {
+    const apiCall = vi.fn().mockResolvedValue(undefined);
+    const action = makeAction({ kind: 'ApiCall', confirmationKey: null });
+    const { button } = renderButton(action, { apiCall });
+    fireEvent.click(button);
+    await waitFor(() => expect(apiCall).toHaveBeenCalledTimes(1));
+    expect(apiCall).toHaveBeenCalledWith(action, SAMPLE_ENTITY_ID, null, expect.anything());
+  });
+
+  it('disables the button while the dispatch is pending and re-enables it after', async () => {
+    let release = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const apiCall = vi.fn(() => gate);
+    const { button } = renderButton(makeAction({ kind: 'ApiCall', confirmationKey: null }), {
+      apiCall,
+    });
+    expect(button.disabled).toBe(false);
+    fireEvent.click(button);
+    await waitFor(() => expect(button.disabled).toBe(true));
+    release();
+    await waitFor(() => expect(button.disabled).toBe(false));
+  });
+
+  it('logs the error and re-enables the button when the dispatch rejects', async () => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const failure = new Error('boom');
+    const apiCall = vi.fn().mockRejectedValue(failure);
+    const { button } = renderButton(
+      makeAction({ kind: 'ApiCall', confirmationKey: null, name: 'Delete' }),
+      {
+        apiCall,
+      }
+    );
+    fireEvent.click(button);
+    await waitFor(() => expect(errorSpy).toHaveBeenCalledTimes(1));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Delete'), failure);
+    await waitFor(() => expect(button.disabled).toBe(false));
+  });
+});

--- a/packages/@granit/react-ui-entities/src/entity-calendar-view.test.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-calendar-view.test.tsx
@@ -1,0 +1,514 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import {
+  ENTITIES_BASE_PATH,
+  SAMPLE_ENTITY_ID,
+  SAMPLE_ENTITY_NAME,
+  createEntitiesHandlers,
+  mockCalendarItems,
+} from '@granit/react-entities/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntityCalendarView } from './entity-calendar-view';
+
+import type { ExtendedEntityManifest } from './manifest-extensions';
+import type { CalendarItemResponse, EntityCalendarLayoutManifest } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+// Fully-qualified base so the MSW handlers match the axios `http://localhost`
+// baseURL (the calendar hook hits `/api/v1/entities/{name}/calendar`).
+const BASE = `http://localhost${ENTITIES_BASE_PATH}`;
+const CALENDAR_PATH = `${BASE}/:name/calendar`;
+
+// mockCalendarItems are dated 2026-05-04 (INV-001, colour Blue) and
+// 2026-05-12 (INV-002, colour null). Pin "now" to 2026-05-04 so the
+// default month cursor lands on May and the default day cursor lands on
+// a day that actually has an event.
+const FIXED_NOW = new Date('2026-05-04T12:00:00Z');
+
+const LAYOUT: EntityCalendarLayoutManifest = {
+  startPropertyName: 'StartDate',
+  endPropertyName: 'EndDate',
+  titlePropertyName: 'Number',
+  colorByPropertyName: 'Status',
+  actions: [],
+};
+
+const MANIFEST = {
+  schemaVersion: 1,
+  identity: null,
+  permissions: null,
+  forms: null,
+  details: null,
+  collections: null,
+  relations: null,
+  actions: [],
+  activities: null,
+} as unknown as ExtendedEntityManifest;
+
+const JOIN_ACTION = {
+  name: 'join',
+  displayKey: 'Calendar.Action.Join',
+  icon: 'video',
+  contributorAssemblyName: null,
+} as const;
+
+const LAYOUT_WITH_ACTION: EntityCalendarLayoutManifest = {
+  ...LAYOUT,
+  actions: [JOIN_ACTION],
+};
+
+const MANIFEST_WITH_ACTIONS = {
+  ...MANIFEST,
+  actions: [
+    {
+      name: 'join',
+      kind: 'Navigate' as const,
+      displayKey: 'Calendar.Action.Join',
+      icon: 'video',
+      order: 0,
+      urlTemplate: '/meetings/{id}/join',
+      httpMethod: null,
+      confirmationKey: null,
+      workflowTransitionName: null,
+      contributorAssemblyName: null,
+    },
+  ],
+} as unknown as ExtendedEntityManifest;
+
+const server = setupServer(...createEntitiesHandlers(BASE));
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers(...createEntitiesHandlers(BASE)));
+afterAll(() => server.close());
+
+beforeEach(() => {
+  // Fake only `Date` so MSW / React Query async timers stay real and
+  // `waitFor` still resolves.
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(FIXED_NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper };
+}
+
+interface RenderOptions {
+  readonly layout?: EntityCalendarLayoutManifest;
+  readonly manifest?: ExtendedEntityManifest;
+  readonly onItemClick?: (id: string) => void;
+  readonly actionHandlers?: Parameters<typeof EntityCalendarView>[0]['actionHandlers'];
+}
+
+function renderView(opts: RenderOptions = {}) {
+  const { wrapper: Wrapper } = makeWrapper();
+  return render(
+    <Wrapper>
+      <EntityCalendarView
+        entityName={SAMPLE_ENTITY_NAME}
+        manifest={opts.manifest ?? MANIFEST}
+        layout={opts.layout ?? LAYOUT}
+        onItemClick={opts.onItemClick}
+        actionHandlers={opts.actionHandlers}
+      />
+    </Wrapper>
+  );
+}
+
+function tabs(container: HTMLElement): HTMLButtonElement[] {
+  return Array.from(container.querySelectorAll('[role="tab"]'));
+}
+
+// day / week / month / year, in VIEW_MODES order.
+function selectMode(container: HTMLElement, index: 0 | 1 | 2 | 3) {
+  fireEvent.click(tabs(container)[index]!);
+}
+
+function events(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll('[data-slot="calendar-event"]'));
+}
+
+function navButtons(container: HTMLElement): HTMLButtonElement[] {
+  const toolbar = container.querySelector('[data-slot="entity-calendar-toolbar"]') as HTMLElement;
+  const group = toolbar.querySelector('div') as HTMLElement;
+  return Array.from(group.querySelectorAll('button'));
+}
+
+describe('EntityCalendarView', () => {
+  it('renders the toolbar and defaults to the month grid with layout data attrs', async () => {
+    const { container } = renderView();
+    const grid = container.querySelector('[data-slot="entity-calendar-grid"]') as HTMLElement;
+    expect(container.querySelector('[data-slot="entity-calendar-toolbar"]')).not.toBeNull();
+    expect(grid.getAttribute('data-mode')).toBe('month');
+    expect(grid.getAttribute('data-start-property')).toBe('StartDate');
+    expect(grid.getAttribute('data-end-property')).toBe('EndDate');
+    expect(grid.getAttribute('data-color-property')).toBe('Status');
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-month"]')).not.toBeNull()
+    );
+  });
+
+  it('omits optional layout data attrs when the manifest leaves them null', async () => {
+    const slim: EntityCalendarLayoutManifest = {
+      startPropertyName: 'StartDate',
+      endPropertyName: null,
+      titlePropertyName: null,
+      colorByPropertyName: null,
+      actions: [],
+    };
+    const { container } = renderView({ layout: slim });
+    const grid = container.querySelector('[data-slot="entity-calendar-grid"]') as HTMLElement;
+    expect(grid.getAttribute('data-start-property')).toBe('StartDate');
+    expect(grid.hasAttribute('data-end-property')).toBe(false);
+    expect(grid.hasAttribute('data-color-property')).toBe(false);
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-month"]')).not.toBeNull()
+    );
+  });
+
+  it('marks the grid as loading before the range response lands', () => {
+    const { container } = renderView();
+    const grid = container.querySelector('[data-slot="entity-calendar-grid"]') as HTMLElement;
+    expect(grid.getAttribute('data-loading')).toBe('true');
+  });
+
+  it('renders an error alert when the range endpoint returns 500', async () => {
+    server.use(http.get(CALENDAR_PATH, () => new HttpResponse(null, { status: 500 })));
+    const { container } = renderView();
+    await waitFor(() => expect(container.querySelector('[role="alert"]')).not.toBeNull());
+    const grid = container.querySelector('[data-slot="entity-calendar-grid"]') as HTMLElement;
+    expect(grid.getAttribute('data-error')).toBe('true');
+    // The grid short-circuits to the alert and never paints a sub-view.
+    expect(container.querySelector('[data-slot="calendar-month"]')).toBeNull();
+  });
+
+  it('paints one tile per event and forwards the colour attr (null omitted)', async () => {
+    const { container } = renderView();
+    await waitFor(() => expect(events(container)).toHaveLength(2));
+    const inv001 = container.querySelector(`[data-event-id="${SAMPLE_ENTITY_ID}"]`) as HTMLElement;
+    expect(inv001.getAttribute('data-color')).toBe('Blue');
+    const inv002 = container.querySelector(
+      '[data-event-id="8c6b1e10-0000-4000-8000-000000000002"]'
+    ) as HTMLElement;
+    expect(inv002.hasAttribute('data-color')).toBe(false);
+  });
+
+  it('renders no tiles when the endpoint returns an empty range', async () => {
+    server.use(http.get(CALENDAR_PATH, () => HttpResponse.json([])));
+    const { container } = renderView();
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-month"]')).not.toBeNull()
+    );
+    expect(events(container)).toHaveLength(0);
+  });
+
+  it('switches to the day view and shows the event on the cursor day', async () => {
+    const { container } = renderView();
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-month"]')).not.toBeNull()
+    );
+    selectMode(container, 0);
+    const grid = container.querySelector('[data-slot="entity-calendar-grid"]') as HTMLElement;
+    expect(grid.getAttribute('data-mode')).toBe('day');
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-day"]')).not.toBeNull()
+    );
+    expect(events(container)).toHaveLength(1);
+  });
+
+  it('renders the day-view empty state when the cursor day has no events', async () => {
+    const { container } = renderView();
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-month"]')).not.toBeNull()
+    );
+    selectMode(container, 0);
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-day"]')).not.toBeNull()
+    );
+    // Advance one day (05-05) — no events there.
+    fireEvent.click(navButtons(container)[2]!);
+    await waitFor(() => expect(events(container)).toHaveLength(0));
+    expect(container.querySelector('[data-slot="calendar-day"] p')).not.toBeNull();
+  });
+
+  it('switches to the week view and renders the week grid', async () => {
+    const { container } = renderView();
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-month"]')).not.toBeNull()
+    );
+    selectMode(container, 1);
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-week"]')).not.toBeNull()
+    );
+    expect(events(container)).toHaveLength(1);
+  });
+
+  it('switches to the year view and renders twelve month minis', async () => {
+    const { container } = renderView();
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-month"]')).not.toBeNull()
+    );
+    selectMode(container, 3);
+    const year = await waitFor(() => {
+      const node = container.querySelector('[data-slot="calendar-year"]');
+      expect(node).not.toBeNull();
+      return node as HTMLElement;
+    });
+    expect(year.children).toHaveLength(12);
+  });
+
+  it('navigates forward and back and resets to today across the month view', async () => {
+    const { container } = renderView();
+    await waitFor(() => expect(events(container)).toHaveLength(2));
+    // June 2026 grid holds no May events.
+    fireEvent.click(navButtons(container)[2]!);
+    await waitFor(() => expect(events(container)).toHaveLength(0));
+    // Today resets the cursor back to May.
+    fireEvent.click(navButtons(container)[1]!);
+    await waitFor(() => expect(events(container)).toHaveLength(2));
+    // Prev steps to April (no May events).
+    fireEvent.click(navButtons(container)[0]!);
+    await waitFor(() => expect(events(container)).toHaveLength(0));
+  });
+
+  it.each([
+    ['day', 0],
+    ['week', 1],
+    ['month', 2],
+    ['year', 3],
+  ] as const)('steps the cursor forward and back in the %s view', async (mode, index) => {
+    const { container } = renderView();
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-month"]')).not.toBeNull()
+    );
+    selectMode(container, index);
+    await waitFor(() =>
+      expect(container.querySelector(`[data-slot="calendar-${mode}"]`)).not.toBeNull()
+    );
+    fireEvent.click(navButtons(container)[2]!);
+    fireEvent.click(navButtons(container)[0]!);
+    await waitFor(() =>
+      expect(container.querySelector(`[data-slot="calendar-${mode}"]`)).not.toBeNull()
+    );
+  });
+
+  it('hides weekend columns when the show-weekends switch is toggled off', async () => {
+    const { container } = renderView();
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-month"]')).not.toBeNull()
+    );
+    const grid = container.querySelector('[data-slot="entity-calendar-grid"]') as HTMLElement;
+    expect(grid.getAttribute('data-show-weekends')).toBe('true');
+    const header = container.querySelector('[data-slot="calendar-month-header"]') as HTMLElement;
+    expect(header.children).toHaveLength(7);
+
+    fireEvent.click(container.querySelector('[role="switch"]') as HTMLElement);
+
+    expect(grid.hasAttribute('data-show-weekends')).toBe(false);
+    await waitFor(() =>
+      expect(
+        (container.querySelector('[data-slot="calendar-month-header"]') as HTMLElement).children
+      ).toHaveLength(5)
+    );
+  });
+
+  it('renders event tiles as buttons and fires onItemClick with the row id (compact month tile)', async () => {
+    const onItemClick = vi.fn();
+    const { container } = renderView({ onItemClick });
+    await waitFor(() => expect(events(container)).toHaveLength(2));
+    const chip = container.querySelector(`[data-event-id="${SAMPLE_ENTITY_ID}"]`) as HTMLElement;
+    expect(chip.tagName).toBe('BUTTON');
+    fireEvent.click(chip);
+    expect(onItemClick).toHaveBeenCalledWith(SAMPLE_ENTITY_ID);
+  });
+
+  it('renders a non-interactive chip (div) when no onItemClick is supplied', async () => {
+    const { container } = renderView();
+    await waitFor(() => expect(events(container)).toHaveLength(2));
+    const chip = container.querySelector(`[data-event-id="${SAMPLE_ENTITY_ID}"]`) as HTMLElement;
+    expect(chip.tagName).toBe('DIV');
+  });
+
+  it('paints resolved tile actions in the day view and dispatches via the navigate handler', async () => {
+    const navigate = vi.fn();
+    const onItemClick = vi.fn();
+    const { container } = renderView({
+      layout: LAYOUT_WITH_ACTION,
+      manifest: MANIFEST_WITH_ACTIONS,
+      onItemClick,
+      actionHandlers: { navigate },
+    });
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-month"]')).not.toBeNull()
+    );
+    // Month tiles are compact → no inline actions there.
+    expect(container.querySelector('[data-granit-entity-action]')).toBeNull();
+    // Day tiles are full-size → actions surface next to the chip body.
+    selectMode(container, 0);
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-entity-action]')).not.toBeNull()
+    );
+    // Chip is a wrapper div with an inner button for row activation.
+    const chip = container.querySelector(`[data-event-id="${SAMPLE_ENTITY_ID}"]`) as HTMLElement;
+    expect(chip.tagName).toBe('DIV');
+    fireEvent.click(chip.querySelector('button:not([data-granit-entity-action])') as HTMLElement);
+    expect(onItemClick).toHaveBeenCalledWith(SAMPLE_ENTITY_ID);
+
+    fireEvent.click(container.querySelector('[data-granit-entity-action]') as HTMLElement);
+    expect(navigate).toHaveBeenCalledOnce();
+  });
+
+  it('renders tile actions with no onItemClick (chip stays a div, actions only)', async () => {
+    const { container } = renderView({
+      layout: LAYOUT_WITH_ACTION,
+      manifest: MANIFEST_WITH_ACTIONS,
+    });
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-month"]')).not.toBeNull()
+    );
+    selectMode(container, 0);
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-entity-action]')).not.toBeNull()
+    );
+    const chip = container.querySelector(`[data-event-id="${SAMPLE_ENTITY_ID}"]`) as HTMLElement;
+    expect(chip.tagName).toBe('DIV');
+    // No row-activation button, only the action button.
+    const bodyButtons = Array.from(chip.querySelectorAll('button')).filter(
+      (b) => !b.hasAttribute('data-granit-entity-action')
+    );
+    expect(bodyButtons).toHaveLength(0);
+  });
+
+  it('renders no action bar when layout declares actions but the manifest omits them', async () => {
+    const manifestNoActions = { ...MANIFEST, actions: null } as unknown as ExtendedEntityManifest;
+    const { container } = renderView({
+      layout: LAYOUT_WITH_ACTION,
+      manifest: manifestNoActions,
+    });
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-month"]')).not.toBeNull()
+    );
+    selectMode(container, 0);
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-day"]')).not.toBeNull()
+    );
+    expect(container.querySelector('[data-granit-entity-action]')).toBeNull();
+  });
+
+  it('drops weekend columns in the week view when show-weekends is toggled off', async () => {
+    const { container } = renderView();
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-month"]')).not.toBeNull()
+    );
+    selectMode(container, 1);
+    const week = await waitFor(() => {
+      const node = container.querySelector('[data-slot="calendar-week"]');
+      expect(node).not.toBeNull();
+      return node as HTMLElement;
+    });
+    expect(week.children).toHaveLength(7);
+
+    fireEvent.click(container.querySelector('[role="switch"]') as HTMLElement);
+
+    await waitFor(() =>
+      expect(
+        (container.querySelector('[data-slot="calendar-week"]') as HTMLElement).children
+      ).toHaveLength(5)
+    );
+    // No Saturday/Sunday columns remain once weekends are hidden.
+    expect(container.querySelector('[data-slot="calendar-week"] [data-weekend]')).toBeNull();
+  });
+
+  it('drops weekend cells in the year-view month minis when show-weekends is toggled off', async () => {
+    const { container } = renderView();
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-month"]')).not.toBeNull()
+    );
+    selectMode(container, 3);
+    const year = await waitFor(() => {
+      const node = container.querySelector('[data-slot="calendar-year"]');
+      expect(node).not.toBeNull();
+      return node as HTMLElement;
+    });
+    const cellsBefore = year.querySelectorAll('.aspect-square').length;
+
+    fireEvent.click(container.querySelector('[role="switch"]') as HTMLElement);
+
+    // The 5-column minis render strictly fewer day cells than the 7-column ones.
+    await waitFor(() => {
+      const cellsAfter = (
+        container.querySelector('[data-slot="calendar-year"]') as HTMLElement
+      ).querySelectorAll('.aspect-square').length;
+      expect(cellsAfter).toBeLessThan(cellsBefore);
+    });
+    expect(
+      (container.querySelector('[data-slot="calendar-year"]') as HTMLElement).children
+    ).toHaveLength(12);
+  });
+
+  it('renders a null-colour event as a full-size clickable chip with tile actions', async () => {
+    const nullColorEvent: CalendarItemResponse = {
+      ...(mockCalendarItems[1] as CalendarItemResponse),
+      start: '2026-05-04T09:00:00Z',
+    };
+    server.use(http.get(CALENDAR_PATH, () => HttpResponse.json([nullColorEvent])));
+    const onItemClick = vi.fn();
+    const { container } = renderView({
+      layout: LAYOUT_WITH_ACTION,
+      manifest: MANIFEST_WITH_ACTIONS,
+      onItemClick,
+    });
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="calendar-month"]')).not.toBeNull()
+    );
+    selectMode(container, 0);
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-entity-action]')).not.toBeNull()
+    );
+    const chip = container.querySelector('[data-slot="calendar-event"]') as HTMLElement;
+    // showActions + onItemClick path: wrapper div, null colour attr omitted.
+    expect(chip.tagName).toBe('DIV');
+    expect(chip.hasAttribute('data-color')).toBe(false);
+    fireEvent.click(chip.querySelector('button:not([data-granit-entity-action])') as HTMLElement);
+    expect(onItemClick).toHaveBeenCalledWith(nullColorEvent.id);
+  });
+
+  it('caps month-cell tiles at three and shows a "+N" overflow marker, sorting the day view', async () => {
+    const day = '2026-05-04';
+    const fourEvents: readonly CalendarItemResponse[] = [
+      { id: 'evt-1', start: `${day}T11:00:00Z`, end: null, title: 'D', color: 'Blue' },
+      { id: 'evt-2', start: `${day}T08:00:00Z`, end: null, title: 'A', color: 'Green' },
+      { id: 'evt-3', start: `${day}T10:00:00Z`, end: null, title: 'C', color: null },
+      { id: 'evt-4', start: `${day}T09:00:00Z`, end: null, title: 'B', color: 'Red' },
+    ];
+    server.use(http.get(CALENDAR_PATH, () => HttpResponse.json([...fourEvents])));
+    const { container } = renderView();
+    // Month cells cap at 3 tiles; the fourth collapses into a "+1" marker.
+    await waitFor(() => expect(events(container)).toHaveLength(3));
+    const cell = container.querySelector(`[data-day="${day}"]`) as HTMLElement;
+    expect(cell.textContent).toContain('+1');
+
+    // Day view lists all four, sorted ascending by start (comparator runs).
+    selectMode(container, 0);
+    await waitFor(() => expect(events(container)).toHaveLength(4));
+    const titles = Array.from(container.querySelectorAll('[data-slot="calendar-event"]')).map(
+      (chip) => (chip.querySelector('.flex-1') as HTMLElement).textContent
+    );
+    expect(titles).toEqual(['A', 'B', 'C', 'D']);
+  });
+});

--- a/packages/@granit/react-ui-entities/src/entity-detail-content.test.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-detail-content.test.tsx
@@ -1,0 +1,428 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { EntityRendererProvider } from '@granit/react-entities';
+import {
+  ENTITIES_BASE_PATH,
+  SAMPLE_ENTITY_ID,
+  SAMPLE_ENTITY_NAME,
+  createEntitiesHandlers,
+  mockEntityManifest,
+} from '@granit/react-entities/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { EntityDetailContent } from './entity-detail-content';
+
+import type {
+  EntityCollectionSectionManifest,
+  ExtendedEntityManifest,
+} from './manifest-extensions';
+import type {
+  EntityActionManifest,
+  EntityFormFieldManifest,
+  EntityFormManifest,
+  EntityIdentitySection,
+} from '@granit/entities';
+import type { ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// Fixtures — the entity row (opaque camelCase wire record, no static DTO) plus
+// manifest builders layered over the shared `mockEntityManifest` fixture.
+// ---------------------------------------------------------------------------
+
+const ORIGIN = 'http://localhost';
+const ROW_BASE_PATH = '/api/v1/parties';
+
+/** Raw camelCase wire row returned by `GET /api/v1/parties/{id}`. */
+const RICH_ROW: Record<string, unknown> = {
+  number: 'P-001',
+  kind: 'Company',
+  amount: 12345,
+  currency: 'USD',
+  dueDate: '2026-03-04T00:00:00Z',
+  createdAt: '2026-01-02T10:30:00Z',
+  badDate: 'not-a-date',
+  timestamp: '2026-05-06T08:00:00Z',
+  meta: { nested: true },
+  lines: [
+    { id: 'l1', description: 'Widget', total: 1000 },
+    { id: 'l2', description: 'Gadget', total: 500 },
+  ],
+};
+
+function field(
+  propertyName: string,
+  order: number,
+  component: string,
+  overrides: Partial<EntityFormFieldManifest> = {}
+): EntityFormFieldManifest {
+  return {
+    propertyName,
+    clrTypeName: 'String',
+    component,
+    config: null,
+    labelKey: `Field.${propertyName}.Label`,
+    helpKey: null,
+    order,
+    readOnly: false,
+    visibleIf: null,
+    lookup: null,
+    provenance: null,
+    ...overrides,
+  };
+}
+
+const RICH_FORMS: EntityFormManifest[] = [
+  {
+    name: 'default',
+    customizable: true,
+    sections: [
+      {
+        key: 'identity',
+        labelKey: 'Section.Identity',
+        order: 0,
+        collapsedByDefault: false,
+        ownedCollection: null,
+        fields: [
+          field('Number', 0, 'text'),
+          field('Amount', 1, 'money'),
+          field('DueDate', 2, 'date'),
+          field('CreatedAt', 3, 'datetime'),
+          field('BadDate', 4, 'date'),
+        ],
+      },
+    ],
+    hiddenByOverride: null,
+  },
+];
+
+const RICH_ACTIONS: EntityActionManifest[] = [
+  {
+    name: 'Edit',
+    kind: 'Navigate',
+    displayKey: 'Action.Edit',
+    icon: 'pencil',
+    order: 5,
+    urlTemplate: '/parties/{id}/edit',
+    httpMethod: null,
+    confirmationKey: null,
+    workflowTransitionName: null,
+    contributorAssemblyName: null,
+  },
+  {
+    name: 'Blank',
+    kind: 'Navigate',
+    displayKey: null,
+    icon: null,
+    order: 1,
+    urlTemplate: null,
+    httpMethod: null,
+    confirmationKey: null,
+    workflowTransitionName: null,
+    contributorAssemblyName: null,
+  },
+];
+
+const RICH_COLLECTION_SECTIONS: EntityCollectionSectionManifest[] = [
+  {
+    key: 'lines',
+    labelKey: 'Section.Lines',
+    order: 10,
+    propertyName: 'lines',
+    currencyProperty: 'currency',
+    columns: [
+      { propertyName: 'description', labelKey: null },
+      { propertyName: 'total', labelKey: null, component: 'money', align: 'right' },
+    ],
+    footer: { aggregate: 'Sum', propertyName: 'total', component: 'money', labelKey: null },
+  },
+  {
+    key: 'empty',
+    labelKey: null,
+    order: 0,
+    propertyName: 'nothingHere',
+    columns: [{ propertyName: 'x', labelKey: null }],
+  },
+];
+
+const RICH_IDENTITY: EntityIdentitySection = {
+  name: SAMPLE_ENTITY_NAME,
+  entityClrType: 'Granit.Parties.Domain.Party',
+  displayKey: 'Granit.Parties.Party.DisplayName',
+  icon: 'users',
+  permissionGroup: 'Parties.Parties',
+  displayProperty: 'Number',
+  subtitleProperty: 'Kind',
+};
+
+/** Manifest exercising money/date/datetime pre-formatting, actions, collections. */
+const richManifest: ExtendedEntityManifest = {
+  ...mockEntityManifest,
+  identity: RICH_IDENTITY,
+  forms: RICH_FORMS,
+  actions: RICH_ACTIONS,
+  collectionSections: RICH_COLLECTION_SECTIONS,
+};
+
+// ---------------------------------------------------------------------------
+// MSW — discovery + manifest + relation aggregates from the shared handlers,
+// plus the single-row read the detail body drives off `links.list`.
+// ---------------------------------------------------------------------------
+
+function rowHandler(row: Record<string, unknown> = RICH_ROW) {
+  return http.get(`${ORIGIN}${ROW_BASE_PATH}/:id`, () => HttpResponse.json(row));
+}
+
+function baseHandlers() {
+  return [...createEntitiesHandlers(`${ORIGIN}${ENTITIES_BASE_PATH}`), rowHandler()];
+}
+
+const server = setupServer(...baseHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers(...baseHandlers()));
+afterAll(() => server.close());
+
+// ---------------------------------------------------------------------------
+// Render harness — QueryClient + Granit axios client + entity renderer +
+// router (the body calls `useNavigate`).
+// ---------------------------------------------------------------------------
+
+let lastLocation = '';
+function LocationProbe() {
+  lastLocation = useLocation().pathname;
+  return null;
+}
+
+function renderContent(ui: ReactNode) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: ORIGIN });
+  return render(
+    <MemoryRouter initialEntries={['/start']}>
+      <QueryClientProvider client={queryClient}>
+        <GranitClientProvider client={apiClient}>
+          <EntityRendererProvider>
+            {ui}
+            <LocationProbe />
+          </EntityRendererProvider>
+        </GranitClientProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('EntityDetailContent', () => {
+  it('renders the skeleton while manifest / entity / discovery load', () => {
+    const { container } = renderContent(
+      <EntityDetailContent entityName={SAMPLE_ENTITY_NAME} entityId={SAMPLE_ENTITY_ID} />
+    );
+    expect(container.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+    expect(container.querySelector('[data-slot="entity-detail-content"]')).toBeNull();
+  });
+
+  it('renders the not-found error slot when the entity is absent from discovery', async () => {
+    // Unknown name => no `links.list` => useEntity stays disabled => no row =>
+    // `!entityData` error branch (the row endpoint is never hit).
+    renderContent(<EntityDetailContent entityName="Granit.Unknown.Thing" entityId="x-1" />);
+    await waitFor(() =>
+      expect(document.querySelector('[data-slot="entity-detail-content-error"]')).not.toBeNull()
+    );
+  });
+
+  it('renders the not-found error slot when the row request fails', async () => {
+    server.use(
+      http.get(`${ORIGIN}${ROW_BASE_PATH}/:id`, () => new HttpResponse(null, { status: 500 }))
+    );
+    renderContent(
+      <EntityDetailContent entityName={SAMPLE_ENTITY_NAME} entityId={SAMPLE_ENTITY_ID} />
+    );
+    await waitFor(() =>
+      expect(document.querySelector('[data-slot="entity-detail-content-error"]')).not.toBeNull()
+    );
+  });
+
+  it('renders the no-variant slot when the manifest declares no detail variant', async () => {
+    server.use(
+      http.get(`${ORIGIN}${ENTITIES_BASE_PATH}/:name`, () =>
+        HttpResponse.json({ ...mockEntityManifest, details: [] })
+      )
+    );
+    renderContent(
+      <EntityDetailContent entityName={SAMPLE_ENTITY_NAME} entityId={SAMPLE_ENTITY_ID} />
+    );
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-slot="entity-detail-content-no-variant"]')
+      ).not.toBeNull()
+    );
+  });
+
+  it('renders the populated body: header, actions, formatted values and collections', async () => {
+    server.use(
+      http.get(`${ORIGIN}${ENTITIES_BASE_PATH}/:name`, () => HttpResponse.json(richManifest))
+    );
+    const { container } = renderContent(
+      <EntityDetailContent
+        entityName={SAMPLE_ENTITY_NAME}
+        entityId={SAMPLE_ENTITY_ID}
+        workspace="acme"
+      />
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="entity-detail-content"]')).not.toBeNull()
+    );
+
+    // Header label (displayProperty=Number) is rendered in the <h1>.
+    expect(container.querySelector('h1')?.textContent).toBe('P-001');
+    // Subtitle uses subtitleProperty=Kind.
+    expect(container.querySelector('header p')?.textContent).toBe('Company');
+
+    // Two Navigate actions render as action buttons.
+    const actionButtons = container.querySelectorAll('[data-slot="entity-action-button"]');
+    expect(actionButtons.length).toBe(2);
+
+    // Money pre-formatting (component=money) reaches the detail rows.
+    expect(container.textContent).toContain('$123.45');
+
+    // Collection section with rows renders a table; the empty one shows a placeholder.
+    const cards = container.querySelectorAll('[data-slot="collection-section-card"]');
+    expect(cards.length).toBe(2);
+    const linesCard = container.querySelector('[data-section-key="lines"]');
+    expect(linesCard?.querySelectorAll('tbody tr').length).toBe(2);
+
+    // The reserved workspace context is written to the hidden span.
+    expect(container.querySelector('[data-workspace-context="acme"]')).not.toBeNull();
+  });
+
+  it('routes in-app when a Navigate action with a urlTemplate is clicked', async () => {
+    server.use(
+      http.get(`${ORIGIN}${ENTITIES_BASE_PATH}/:name`, () => HttpResponse.json(richManifest))
+    );
+    const user = userEvent.setup();
+    const { container } = renderContent(
+      <EntityDetailContent entityName={SAMPLE_ENTITY_NAME} entityId={SAMPLE_ENTITY_ID} />
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="entity-detail-content"]')).not.toBeNull()
+    );
+
+    // The action whose urlTemplate carries {id} => navigate with the id substituted.
+    const editButton = container.querySelector('[data-action-name="Edit"]');
+    expect(editButton).not.toBeNull();
+    await user.click(editButton as Element);
+    await waitFor(() =>
+      expect(lastLocation).toBe(`/parties/${encodeURIComponent(SAMPLE_ENTITY_ID)}/edit`)
+    );
+
+    // The action with a null urlTemplate is a no-op (early return in the handler).
+    await user.click(container.querySelector('[data-action-name="Blank"]') as Element);
+    expect(lastLocation).toBe(`/parties/${encodeURIComponent(SAMPLE_ENTITY_ID)}/edit`);
+  });
+
+  it('omits the header actions and h1 when identity + actions are absent', async () => {
+    server.use(
+      http.get(`${ORIGIN}${ENTITIES_BASE_PATH}/:name`, () =>
+        HttpResponse.json({
+          ...mockEntityManifest,
+          identity: null,
+          actions: null,
+        })
+      )
+    );
+    const { container } = renderContent(
+      <EntityDetailContent entityName={SAMPLE_ENTITY_NAME} entityId={SAMPLE_ENTITY_ID} />
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="entity-detail-content"]')).not.toBeNull()
+    );
+    // No displayProperty => no header label.
+    expect(container.querySelector('h1')).toBeNull();
+    // No actions => no action buttons.
+    expect(container.querySelector('[data-slot="entity-action-button"]')).toBeNull();
+    // subtitleProperty absent => subtitle falls back to the resolved identity label.
+    expect(container.querySelector('header p')?.textContent).toBeTruthy();
+    // Absent workspace prop => empty context marker.
+    expect(container.querySelector('[data-workspace-context=""]')).not.toBeNull();
+  });
+
+  it('stringifies an object header, defaults currency to EUR and skips invalid ISO strings', async () => {
+    // Row with NO `currency` key => `values.Currency ?? 'EUR'` takes the EUR
+    // fallback. `weird` is a no-component string matching the ISO date regex
+    // but parsing to an invalid Date => the `!Number.isNaN` guard is skipped.
+    // `displayProperty` points at an object value => `toDisplayString` walks
+    // its `JSON.stringify` branch.
+    const objectRow: Record<string, unknown> = {
+      number: 'P-777',
+      amount: 5000,
+      weird: '2026-13-45T99:00',
+      meta: { nested: true },
+    };
+    const objectHeaderManifest: ExtendedEntityManifest = {
+      ...mockEntityManifest,
+      identity: { ...RICH_IDENTITY, displayProperty: 'Meta', subtitleProperty: 'Number' },
+      forms: [
+        {
+          name: 'default',
+          customizable: true,
+          sections: [
+            {
+              key: 'identity',
+              labelKey: 'Section.Identity',
+              order: 0,
+              collapsedByDefault: false,
+              ownedCollection: null,
+              // The empty-string component exercises the `if (field.component)`
+              // false branch of the property→component map builder.
+              fields: [field('Amount', 0, 'money'), field('Number', 1, '')],
+            },
+          ],
+          hiddenByOverride: null,
+        },
+      ],
+      actions: null,
+      collectionSections: null,
+    };
+    server.use(
+      http.get(`${ORIGIN}${ENTITIES_BASE_PATH}/:name`, () =>
+        HttpResponse.json(objectHeaderManifest)
+      ),
+      http.get(`${ORIGIN}${ROW_BASE_PATH}/:id`, () => HttpResponse.json(objectRow))
+    );
+    const { container } = renderContent(
+      <EntityDetailContent entityName={SAMPLE_ENTITY_NAME} entityId={SAMPLE_ENTITY_ID} />
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="entity-detail-content"]')).not.toBeNull()
+    );
+    // Object header value stringified into the <h1>.
+    expect(container.querySelector('h1')?.textContent).toBe('{"nested":true}');
+    // Subtitle resolves from the string `Number` property.
+    expect(container.querySelector('header p')?.textContent).toBe('P-777');
+    // EUR default currency reaches the money-formatted amount (5000 / 100).
+    expect(container.textContent).toContain('€');
+  });
+
+  it('renders when the manifest omits forms and relations entirely', async () => {
+    // `forms: null` and `relations: null` drive the `?? []` / `?? undefined`
+    // nullish fallbacks feeding the component map builder and `<EntityDetail />`.
+    server.use(
+      http.get(`${ORIGIN}${ENTITIES_BASE_PATH}/:name`, () =>
+        HttpResponse.json({ ...mockEntityManifest, forms: null, relations: null })
+      )
+    );
+    const { container } = renderContent(
+      <EntityDetailContent entityName={SAMPLE_ENTITY_NAME} entityId={SAMPLE_ENTITY_ID} />
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="entity-detail-content"]')).not.toBeNull()
+    );
+    // displayProperty=Number still resolves the header from the row.
+    expect(container.querySelector('h1')?.textContent).toBe('P-001');
+  });
+});

--- a/packages/@granit/react-ui-entities/src/entity-gallery-view.test.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-gallery-view.test.tsx
@@ -1,0 +1,656 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { mockEntityManifest } from '@granit/react-entities/testing';
+import { QueryEndpointStateProvider, QueryProvider } from '@granit/react-query-engine';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { delay, http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntityGalleryView, type GalleryRenderImage } from './entity-gallery-view';
+import { asExtended, type ExtendedEntityManifest } from './manifest-extensions';
+
+import type { EntityManifestResponse } from '@granit/entities';
+import type { EntityGalleryLayoutManifest } from '@granit/entities';
+import type { QueryRequest } from '@granit/query-engine';
+import type { ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// Coverage suite for the host `<EntityGalleryView />` wrapper. Drives both
+// modes: the flat delegation to the framework `<EntityGallery>` (params has no
+// groupBy) and the manually-rendered grouped path (ambient groupBy set), which
+// owns its own infinite-query, sentinel, section headers and card markup.
+// Grouped-path branches exercised: loading / error / empty / populated,
+// single vs multi group (header patching), title from layout vs identity
+// fallback vs absent, subtitle present vs absent, scalar / non-scalar / missing
+// field values, camelCase field fallback, card-click handler (string id fires,
+// numeric id skipped, `Id` fallback, no-handler no-op), IntersectionObserver
+// pagination (hasMore path, totalCount fallback, neither), non-intersecting and
+// absent-observer guards.
+// ---------------------------------------------------------------------------
+
+const BASE_PATH = '/api/v1/parties';
+
+// --- IntersectionObserver test double ---------------------------------------
+
+interface FakeObserver {
+  readonly observed: Element[];
+  trigger(intersecting?: boolean): void;
+}
+const observers: FakeObserver[] = [];
+class MockIntersectionObserver implements FakeObserver {
+  readonly observed: Element[] = [];
+  constructor(private readonly cb: IntersectionObserverCallback) {
+    observers.push(this);
+  }
+  observe(node: Element): void {
+    this.observed.push(node);
+  }
+  unobserve(node: Element): void {
+    const idx = this.observed.indexOf(node);
+    if (idx >= 0) this.observed.splice(idx, 1);
+  }
+  disconnect(): void {
+    this.observed.length = 0;
+    const idx = observers.indexOf(this);
+    if (idx >= 0) observers.splice(idx, 1);
+  }
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+  trigger(intersecting = true): void {
+    const entries = this.observed.map(
+      (target) =>
+        ({
+          target,
+          isIntersecting: intersecting,
+          intersectionRatio: intersecting ? 1 : 0,
+          time: Date.now(),
+          rootBounds: null,
+          boundingClientRect: target.getBoundingClientRect(),
+          intersectionRect: target.getBoundingClientRect(),
+        }) as IntersectionObserverEntry
+    );
+    this.cb(entries, this as unknown as IntersectionObserver);
+  }
+}
+
+function triggerLastObserver(intersecting = true): void {
+  const last = observers[observers.length - 1];
+  if (last) last.trigger(intersecting);
+}
+
+beforeAll(() => vi.stubGlobal('IntersectionObserver', MockIntersectionObserver));
+beforeEach(() => {
+  observers.length = 0;
+});
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// --- fixtures ---------------------------------------------------------------
+
+const renderImage: GalleryRenderImage = (blobId) => (
+  <div data-testid="gallery-image" data-blob={blobId ?? undefined} />
+);
+
+function galleryLayout(
+  overrides: Partial<EntityGalleryLayoutManifest> = {}
+): EntityGalleryLayoutManifest {
+  return {
+    imagePropertyName: 'avatarBlobId',
+    titlePropertyName: 'name',
+    subtitlePropertyName: 'kind',
+    groupByPropertyName: null,
+    cardSize: 'Medium',
+    actions: [],
+    ...overrides,
+  };
+}
+
+function extManifest(identityPatch: Record<string, unknown> = {}): ExtendedEntityManifest {
+  const clone = structuredClone(mockEntityManifest) as EntityManifestResponse;
+  if (clone.identity) Object.assign(clone.identity, identityPatch);
+  return asExtended(clone);
+}
+
+function makeWrapper(initialParams: QueryRequest) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>
+        <QueryProvider config={{ basePath: BASE_PATH }}>
+          <QueryEndpointStateProvider initialParams={initialParams}>
+            {children}
+          </QueryEndpointStateProvider>
+        </QueryProvider>
+      </GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return Wrapper;
+}
+
+function respondItems(items: readonly Record<string, unknown>[]): void {
+  server.use(
+    http.get(`http://localhost${BASE_PATH}`, () =>
+      HttpResponse.json({ items, totalCount: items.length, hasMore: false })
+    )
+  );
+}
+
+// ===========================================================================
+// Flat mode — no ambient groupBy → delegate to the framework <EntityGallery>.
+// ===========================================================================
+
+describe('EntityGalleryView — flat mode (no groupBy)', () => {
+  it('wraps the framework gallery in the view slot and forwards renderImage + card clicks', async () => {
+    respondItems([{ id: 'a', name: 'ACME', kind: 'Customer', avatarBlobId: 'blob-a' }]);
+    const onCardClick = vi.fn<(id: string) => void>();
+    const Wrapper = makeWrapper({ page: 1, pageSize: 50 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout()}
+          onCardClick={onCardClick}
+          actionHandlers={{}}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+
+    expect(container.querySelector('[data-slot="entity-gallery-view"]')).not.toBeNull();
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-entity-gallery]')).not.toBeNull()
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-card]')).not.toBeNull()
+    );
+
+    // The framework card forwards the row to our wrapped handler → onCardClick(id).
+    const button = container.querySelector<HTMLElement>('[data-granit-gallery-card-button]');
+    if (button) {
+      fireEvent.click(button);
+      expect(onCardClick).toHaveBeenCalledWith('a');
+    }
+  });
+});
+
+// ===========================================================================
+// Grouped mode — ambient groupBy → the wrapper renders sections itself.
+// ===========================================================================
+
+describe('EntityGalleryView — grouped mode status branches', () => {
+  it('shows the loading marker while the first page is in flight', () => {
+    respondItems([{ id: '1', name: 'A', kind: 'Customer', avatarBlobId: null }]);
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 50 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout({ groupByPropertyName: 'kind' })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    expect(container.querySelector('[data-granit-gallery-loading]')).not.toBeNull();
+  });
+
+  it('shows the error marker with a role=alert when the query rejects', async () => {
+    server.use(
+      http.get(`http://localhost${BASE_PATH}`, () => new HttpResponse(null, { status: 500 }))
+    );
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 50 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout({ groupByPropertyName: 'kind' })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    await waitFor(() => {
+      const error = container.querySelector('[data-granit-gallery-error]');
+      expect(error).not.toBeNull();
+      expect(error?.getAttribute('role')).toBe('alert');
+      expect((error?.textContent ?? '').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('shows the empty marker when the grouped query returns no items', async () => {
+    respondItems([]);
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 50 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout({ groupByPropertyName: 'kind' })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-empty]')).not.toBeNull()
+    );
+    expect(container.querySelector('[data-granit-gallery-card]')).toBeNull();
+  });
+});
+
+describe('EntityGalleryView — grouped rendering with section headers', () => {
+  it('emits a header per group with the running count and populates card slots', async () => {
+    respondItems([
+      { id: '1', name: 'ACME', kind: 'Customer', avatarBlobId: 'blob-1' },
+      { id: '2', name: 'Globex', kind: 'Customer', avatarBlobId: 'blob-2' },
+      { id: '3', name: 'Initech', kind: 'Supplier', avatarBlobId: null },
+    ]);
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 50 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout({ groupByPropertyName: 'kind' })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(3)
+    );
+
+    const root = container.querySelector('[data-granit-entity-gallery]') as HTMLElement;
+    expect(root.getAttribute('data-entity')).toBe('Granit.Parties.Party');
+    expect(root.getAttribute('data-card-size')).toBe('Medium');
+    expect(root.hasAttribute('data-granit-gallery-grouped')).toBe(true);
+
+    const headers = container.querySelectorAll('[data-granit-gallery-group-header]');
+    expect(headers.length).toBe(2);
+    const labels = [...container.querySelectorAll('[data-granit-gallery-group-label]')].map(
+      (n) => n.textContent
+    );
+    expect(labels).toEqual(['Customer', 'Supplier']);
+    const counts = [...container.querySelectorAll('[data-granit-gallery-group-count]')].map(
+      (n) => n.textContent
+    );
+    expect(counts).toEqual(['2', '1']);
+
+    // Title / subtitle / image slots resolve from the layout property names.
+    expect(container.querySelector('[data-granit-gallery-card-title]')?.textContent).toBe('ACME');
+    expect(container.querySelector('[data-granit-gallery-card-subtitle]')?.textContent).toBe(
+      'Customer'
+    );
+    const firstCard = container.querySelector('[data-granit-gallery-card]') as HTMLElement;
+    expect(firstCard.getAttribute('data-row-id')).toBe('1');
+    expect(firstCard.getAttribute('data-image-blob-id')).toBe('blob-1');
+  });
+
+  it('falls back to identity.displayProperty for the title and reads camelCased fields', async () => {
+    // No layout title → identity.displayProperty ('Number') supplies the title.
+    // The row carries only the camelCase key `number`, exercising readRowField's fallback.
+    respondItems([{ id: '1', number: 'P-001', kind: 'Customer', avatarBlobId: null }]);
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 50 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout({ titlePropertyName: null, groupByPropertyName: 'kind' })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-card]')).not.toBeNull()
+    );
+    expect(container.querySelector('[data-granit-gallery-card-title]')?.textContent).toBe('P-001');
+  });
+
+  it('omits the title / subtitle / id / image attrs for non-scalar and missing fields', async () => {
+    // identity.displayProperty null AND layout title null → titleProperty null → no title slot.
+    // subtitle null, no id/Id key, object-valued image → readScalar → null.
+    respondItems([{ name: 'ignored', kind: 'Customer', avatarBlobId: { nested: true } }]);
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 50 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest({ displayProperty: null })}
+          layout={galleryLayout({ titlePropertyName: null, subtitlePropertyName: null })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-card]')).not.toBeNull()
+    );
+    const card = container.querySelector('[data-granit-gallery-card]') as HTMLElement;
+    expect(card.hasAttribute('data-row-id')).toBe(false);
+    expect(card.hasAttribute('data-image-blob-id')).toBe(false);
+    expect(container.querySelector('[data-granit-gallery-card-title]')).toBeNull();
+    expect(container.querySelector('[data-granit-gallery-card-subtitle]')).toBeNull();
+  });
+
+  it('stringifies null and object group values (— and JSON) and keys rows by fallback index', async () => {
+    respondItems([
+      { name: 'A', kind: null },
+      { name: 'B', kind: null },
+      { name: 'C', kind: { tier: 'gold' } },
+    ]);
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 50 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout({ subtitlePropertyName: null, groupByPropertyName: 'kind' })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(3)
+    );
+    const labels = [...container.querySelectorAll('[data-granit-gallery-group-label]')].map(
+      (n) => n.textContent
+    );
+    expect(labels).toEqual(['—', '{"tier":"gold"}']);
+    const counts = [...container.querySelectorAll('[data-granit-gallery-group-count]')].map(
+      (n) => n.textContent
+    );
+    expect(counts).toEqual(['2', '1']);
+  });
+});
+
+describe('EntityGalleryView — grouped card click handler', () => {
+  it('fires onCardClick with the string id, skips numeric ids, and reads the `Id` fallback', async () => {
+    respondItems([
+      { id: 'a', name: 'ACME', kind: 'Customer', avatarBlobId: null },
+      { id: 7, name: 'Numeric', kind: 'Customer', avatarBlobId: null },
+      { Id: 'b', name: 'Capital', kind: 'Customer', avatarBlobId: null },
+    ]);
+    const onCardClick = vi.fn<(id: string) => void>();
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 50 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout({ groupByPropertyName: 'kind' })}
+          onCardClick={onCardClick}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card-button]').length).toBe(3)
+    );
+    const buttons = container.querySelectorAll<HTMLElement>('[data-granit-gallery-card-button]');
+    fireEvent.click(buttons[0]!); // string id → fires with 'a'
+    fireEvent.click(buttons[1]!); // numeric id → typeof !== 'string' → no call
+    fireEvent.click(buttons[2]!); // `Id` fallback → fires with 'b'
+    expect(onCardClick.mock.calls).toEqual([['a'], ['b']]);
+  });
+
+  it('still renders a card button and no-ops on click when no onCardClick is provided', async () => {
+    respondItems([{ id: 'a', name: 'ACME', kind: 'Customer', avatarBlobId: null }]);
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 50 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout({ groupByPropertyName: 'kind' })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-card-button]')).not.toBeNull()
+    );
+    const button = container.querySelector<HTMLElement>('[data-granit-gallery-card-button]');
+    expect(() => fireEvent.click(button!)).not.toThrow();
+  });
+});
+
+describe('EntityGalleryView — grouped pagination', () => {
+  // GroupedGallery hardcodes pageSize=50 on the request, so paginate with our
+  // own fixed page size (2) driven purely by the `page` cursor.
+  const PAGE = 2;
+  function paginatedHandler(
+    rows: readonly Record<string, unknown>[],
+    mode: 'hasMore' | 'totalCount' | 'none'
+  ): void {
+    server.use(
+      http.get(`http://localhost${BASE_PATH}`, ({ request }) => {
+        const url = new URL(request.url);
+        const page = Number(url.searchParams.get('page') ?? '1');
+        const start = (page - 1) * PAGE;
+        const slice = rows.slice(start, start + PAGE);
+        if (mode === 'hasMore') {
+          return HttpResponse.json({ items: slice, hasMore: start + slice.length < rows.length });
+        }
+        if (mode === 'totalCount') {
+          return HttpResponse.json({ items: slice, totalCount: rows.length });
+        }
+        return HttpResponse.json({ items: slice });
+      })
+    );
+  }
+
+  const rows = [
+    { id: '1', name: 'A', kind: 'Customer', avatarBlobId: null },
+    { id: '2', name: 'B', kind: 'Customer', avatarBlobId: null },
+    { id: '3', name: 'C', kind: 'Customer', avatarBlobId: null },
+  ];
+
+  it('advances pages via the hasMore flag when the sentinel intersects', async () => {
+    paginatedHandler(rows, 'hasMore');
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 2 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout({ groupByPropertyName: 'kind' })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(2)
+    );
+    const sentinel = container.querySelector('[data-granit-gallery-sentinel]') as HTMLElement;
+    expect(sentinel.hasAttribute('data-exhausted')).toBe(false);
+
+    triggerLastObserver(true);
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(3)
+    );
+    const after = container.querySelector('[data-granit-gallery-sentinel]') as HTMLElement;
+    expect(after.hasAttribute('data-exhausted')).toBe(true);
+  });
+
+  it('advances pages via the totalCount fallback when hasMore is omitted', async () => {
+    paginatedHandler(rows, 'totalCount');
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 2 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout({ groupByPropertyName: 'kind' })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(2)
+    );
+    triggerLastObserver(true);
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(3)
+    );
+    const sentinel = container.querySelector('[data-granit-gallery-sentinel]') as HTMLElement;
+    expect(sentinel.hasAttribute('data-exhausted')).toBe(true);
+  });
+
+  it('stops after one page when the server sends neither hasMore nor totalCount', async () => {
+    paginatedHandler(rows, 'none');
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 2 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout({ groupByPropertyName: 'kind' })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(2)
+    );
+    const sentinel = container.querySelector('[data-granit-gallery-sentinel]') as HTMLElement;
+    expect(sentinel.hasAttribute('data-exhausted')).toBe(true);
+  });
+
+  it('does not fetch further pages when the sentinel reports no intersection', async () => {
+    paginatedHandler(rows, 'hasMore');
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 2 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout({ groupByPropertyName: 'kind' })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(2)
+    );
+    triggerLastObserver(false); // .some() arm false → no fetchNextPage
+    await Promise.resolve();
+    expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(2);
+  });
+
+  it('renders cards without arming an observer when IntersectionObserver is absent', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined);
+    paginatedHandler(rows, 'hasMore');
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 2 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout({ groupByPropertyName: 'kind' })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(2)
+    );
+    expect(observers.length).toBe(0);
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  });
+});
+
+// ===========================================================================
+// Residual branch coverage — the untaken sides left after the suites above.
+// ===========================================================================
+
+describe('EntityGalleryView — residual branch coverage', () => {
+  it('omits the data-entity attr when the manifest identity has no name', async () => {
+    // `manifest.identity?.name ?? undefined` → nullish-left side (line 244).
+    respondItems([{ id: '1', name: 'ACME', kind: 'Customer', avatarBlobId: null }]);
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 50 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest({ name: null })}
+          layout={galleryLayout({ groupByPropertyName: 'kind' })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-card]')).not.toBeNull()
+    );
+    const root = container.querySelector('[data-granit-entity-gallery]') as HTMLElement;
+    expect(root.hasAttribute('data-entity')).toBe(false);
+  });
+
+  it('groups a null value together with a missing (undefined) value under one header', async () => {
+    // isSameGroup(undefined, null): a !== b yet both == null → same group (line 343).
+    respondItems([
+      { id: '1', name: 'A', kind: null, avatarBlobId: null },
+      { id: '2', name: 'B', avatarBlobId: null }, // `kind` absent → readRowField → undefined
+    ]);
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 50 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout({ subtitlePropertyName: null, groupByPropertyName: 'kind' })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(2)
+    );
+    expect(container.querySelectorAll('[data-granit-gallery-group-header]').length).toBe(1);
+    expect(container.querySelector('[data-granit-gallery-group-count]')?.textContent).toBe('2');
+    expect(container.querySelector('[data-granit-gallery-group-label]')?.textContent).toBe('—');
+  });
+
+  it('tolerates a page that omits its items array (totalCount only)', async () => {
+    // flattenPages skips the item-less page (line 389) and nextPageParam's
+    // reduce falls back to 0 for its length (line 377) → empty marker.
+    server.use(
+      http.get(`http://localhost${BASE_PATH}`, () => HttpResponse.json({ totalCount: 0 }))
+    );
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 50 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout({ groupByPropertyName: 'kind' })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-empty]')).not.toBeNull()
+    );
+    expect(container.querySelector('[data-granit-gallery-card]')).toBeNull();
+  });
+
+  it('marks the sentinel as fetching while the next page is in flight', async () => {
+    server.use(
+      http.get(`http://localhost${BASE_PATH}`, async ({ request }) => {
+        const page = Number(new URL(request.url).searchParams.get('page') ?? '1');
+        if (page > 1) await delay('infinite'); // keep page 2 pending → isFetchingNextPage stays true
+        return HttpResponse.json({
+          items: [{ id: '1', name: 'A', kind: 'Customer', avatarBlobId: null }],
+          hasMore: true,
+        });
+      })
+    );
+    const Wrapper = makeWrapper({ groupBy: 'kind', pageSize: 2 });
+    const { container } = render(
+      <Wrapper>
+        <EntityGalleryView
+          manifest={extManifest()}
+          layout={galleryLayout({ groupByPropertyName: 'kind' })}
+          renderImage={renderImage}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-sentinel]')).not.toBeNull()
+    );
+    triggerLastObserver(true);
+    await waitFor(() => {
+      const sentinel = container.querySelector('[data-granit-gallery-sentinel]') as HTMLElement;
+      expect(sentinel.hasAttribute('data-fetching')).toBe(true);
+    });
+  });
+});

--- a/packages/@granit/react-ui-entities/src/entity-kanban-view.test.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-kanban-view.test.tsx
@@ -1,0 +1,683 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryProvider } from '@granit/react-query-engine';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import {
+  EntityKanbanView,
+  fieldToColumnDefinition,
+  makeCurrencyResolver,
+} from './entity-kanban-view';
+
+import type { ExtendedEntityManifest } from './manifest-extensions';
+import type {
+  EntityActionKind,
+  EntityActionManifest,
+  EntityFormFieldManifest,
+  EntityKanbanCardActionManifest,
+  EntityKanbanColumnManifest,
+  EntityKanbanLayoutManifest,
+  KanbanColor,
+  KanbanColumnState,
+} from '@granit/entities';
+import type { EntityActionHandlers } from '@granit/react-entities';
+import type { ReactNode } from 'react';
+
+const BASE_PATH = '/api/v1/tasks';
+const ENTITY_NAME = 'Granit.Tasks.Task';
+
+const patchedIds: string[] = [];
+
+const server = setupServer(
+  http.patch(`http://localhost${BASE_PATH}/:id`, ({ params }) => {
+    patchedIds.push(String(params.id));
+    return HttpResponse.json({ id: params.id });
+  })
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers();
+  patchedIds.length = 0;
+});
+afterAll(() => server.close());
+
+function field(
+  propertyName: string,
+  overrides: Partial<EntityFormFieldManifest> = {}
+): EntityFormFieldManifest {
+  return {
+    propertyName,
+    clrTypeName: 'String',
+    component: 'text',
+    config: null,
+    labelKey: null,
+    helpKey: null,
+    order: 0,
+    readOnly: false,
+    visibleIf: null,
+    lookup: null,
+    provenance: null,
+    ...overrides,
+  };
+}
+
+function action(
+  name: string,
+  kind: EntityActionKind,
+  overrides: Partial<EntityActionManifest> = {}
+): EntityActionManifest {
+  return {
+    name,
+    kind,
+    displayKey: null,
+    icon: null,
+    order: 0,
+    urlTemplate: null,
+    httpMethod: null,
+    confirmationKey: null,
+    workflowTransitionName: null,
+    contributorAssemblyName: null,
+    ...overrides,
+  };
+}
+
+function cardActionRef(name: string): EntityKanbanCardActionManifest {
+  return { name, displayKey: null, icon: null, contributorAssemblyName: null };
+}
+
+function column(
+  value: string,
+  color: EntityKanbanColumnManifest['color'] = null,
+  defaultState: KanbanColumnState = 'Open'
+): EntityKanbanColumnManifest {
+  return { value, color, defaultState };
+}
+
+interface LayoutOverrides {
+  readonly titleProperty?: string | null;
+  readonly fields?: readonly EntityFormFieldManifest[];
+  readonly actions?: readonly EntityKanbanCardActionManifest[];
+  readonly columns?: readonly EntityKanbanColumnManifest[];
+  readonly groupByPropertyName?: string;
+}
+
+function makeLayout(overrides: LayoutOverrides = {}): EntityKanbanLayoutManifest {
+  return {
+    groupByPropertyName: overrides.groupByPropertyName ?? 'Status',
+    groupByClrTypeName: 'String',
+    card: {
+      titleProperty: overrides.titleProperty === undefined ? 'Title' : overrides.titleProperty,
+      fields: overrides.fields ?? [],
+      relations: [],
+      actions: overrides.actions ?? [],
+    },
+    columns: overrides.columns ?? [
+      column('Todo', 'Gray'),
+      column('InProgress', 'Blue'),
+      column('Done', 'Green'),
+    ],
+  };
+}
+
+function makeManifest(options: {
+  displayProperty?: string | null;
+  identity?: boolean;
+  actions?: readonly EntityActionManifest[];
+}): ExtendedEntityManifest {
+  const { displayProperty = 'Title', identity = true, actions = [] } = options;
+  return {
+    schemaVersion: 1,
+    identity: identity
+      ? {
+          name: ENTITY_NAME,
+          entityClrType: ENTITY_NAME,
+          displayKey: null,
+          icon: null,
+          permissionGroup: 'Tasks.Tasks',
+          displayProperty,
+          subtitleProperty: null,
+        }
+      : null,
+    permissions: null,
+    forms: null,
+    details: null,
+    collections: null,
+    relations: null,
+    actions: [...actions],
+  } as unknown as ExtendedEntityManifest;
+}
+
+const ROWS: readonly Readonly<Record<string, unknown>>[] = [
+  { id: '1', title: 'Draft proposal', status: 'Todo', assignee: 'Ada' },
+  { id: '2', title: 'Review designs', status: 'Todo', assignee: 'Alan' },
+  { id: '3', title: 'Build prototype', status: 'InProgress', assignee: 'Grace' },
+  { id: '4', title: 'Ship release', status: 'Done', assignee: 'Linus' },
+];
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>
+        <QueryProvider config={{ basePath: BASE_PATH }}>{children}</QueryProvider>
+      </GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return wrapper;
+}
+
+interface RenderOptions {
+  readonly rows?: readonly Readonly<Record<string, unknown>>[];
+  readonly canUpdate?: boolean;
+  readonly layout?: EntityKanbanLayoutManifest;
+  readonly manifest?: ExtendedEntityManifest;
+  readonly locale?: string;
+  readonly onCardClick?: (id: string) => void;
+  readonly actionHandlers?: EntityActionHandlers;
+}
+
+function renderView(options: RenderOptions = {}) {
+  const Wrapper = makeWrapper();
+  const layout = options.layout ?? makeLayout();
+  const manifest = options.manifest ?? makeManifest({});
+  return render(
+    <Wrapper>
+      <EntityKanbanView
+        entityName={ENTITY_NAME}
+        manifest={manifest}
+        layout={layout}
+        rows={options.rows ?? ROWS}
+        canUpdate={options.canUpdate ?? false}
+        locale={options.locale ?? 'en-GB'}
+        onCardClick={options.onCardClick}
+        actionHandlers={options.actionHandlers}
+      />
+    </Wrapper>
+  );
+}
+
+describe('EntityKanbanView', () => {
+  it('renders the board with a column per declared value and bucketed cards', () => {
+    const { container } = renderView();
+    const board = container.querySelector('[data-slot="entity-kanban-view"]');
+    expect(board).not.toBeNull();
+    expect(board?.getAttribute('data-entity')).toBe(ENTITY_NAME);
+    expect(board?.getAttribute('data-group-by')).toBe('Status');
+    expect(board?.getAttribute('data-can-update')).toBeNull();
+
+    const columns = Array.from(container.querySelectorAll('[data-slot="kanban-column"]'));
+    expect(columns.map((c) => c.getAttribute('data-column-value'))).toEqual([
+      'Todo',
+      'InProgress',
+      'Done',
+    ]);
+    const cards = container.querySelectorAll('[data-slot="kanban-card"]');
+    expect(cards).toHaveLength(4);
+  });
+
+  it('carries the color token attribute and falls back for a colourless column', () => {
+    const layout = makeLayout({ columns: [column('Todo', 'Blue'), column('Done', null)] });
+    const { container } = renderView({ layout });
+    const [colored, plain] = Array.from(container.querySelectorAll('[data-slot="kanban-column"]'));
+    expect(colored?.getAttribute('data-color')).toBe('Blue');
+    expect(colored?.className).toContain('bg-primary/10');
+    expect(plain?.getAttribute('data-color')).toBeNull();
+    expect(plain?.className).toContain('bg-muted/40');
+  });
+
+  it('synthesises columns for unknown group values and buckets nulls into ∅', () => {
+    const rows = [
+      { id: '1', title: 'A', status: 'Todo' },
+      { id: '2', title: 'B', status: 'Archived' },
+      { id: '3', title: 'C', status: null },
+      { id: '4', title: 'D', status: 7 },
+      // object group value coerces to the same ∅ fallback bucket as null
+      { id: '5', title: 'E', status: { weird: true } },
+    ];
+    const { container } = renderView({ rows });
+    const values = Array.from(container.querySelectorAll('[data-slot="kanban-column"]')).map((c) =>
+      c.getAttribute('data-column-value')
+    );
+    // declared first, then synthesised (Archived, ∅, and numeric coerced to "7")
+    expect(values).toEqual(['Todo', 'InProgress', 'Done', 'Archived', '∅', '7']);
+    const emptyBucket = container.querySelector('[data-column-value="∅"]');
+    expect(emptyBucket?.querySelectorAll('[data-slot="kanban-card"]')).toHaveLength(2);
+  });
+
+  it('sets data-can-update and makes cards draggable when canUpdate is true', () => {
+    const { container } = renderView({ canUpdate: true });
+    expect(
+      container.querySelector('[data-slot="entity-kanban-view"]')?.getAttribute('data-can-update')
+    ).toBe('true');
+    const card = container.querySelector('[data-slot="kanban-card"]');
+    expect(card?.getAttribute('draggable')).toBe('true');
+    expect(card?.className).toContain('cursor-grab');
+  });
+
+  it('renders a column collapsed by default and toggles it open then closed', () => {
+    const layout = makeLayout({
+      columns: [column('Todo', 'Gray', 'Collapsed'), column('Done', 'Green')],
+    });
+    const { container } = renderView({ layout });
+    const todo = () =>
+      container.querySelector('[data-slot="kanban-column"][data-column-value="Todo"]');
+    expect(todo()?.getAttribute('data-collapsed')).toBe('true');
+
+    // collapsed body button expands (toggleColumn delete path)
+    fireEvent.click(todo()?.querySelector('button') as HTMLButtonElement);
+    expect(todo()?.getAttribute('data-collapsed')).toBeNull();
+    expect(todo()?.querySelector('[data-slot="kanban-column-header"]')).not.toBeNull();
+
+    // clicking the header button collapses again (toggleColumn add path)
+    fireEvent.click(
+      todo()?.querySelector('[data-slot="kanban-column-header"] button') as HTMLButtonElement
+    );
+    expect(todo()?.getAttribute('data-collapsed')).toBe('true');
+  });
+
+  it('drops Hidden columns from the board entirely', () => {
+    const layout = makeLayout({
+      columns: [column('Todo', 'Gray'), column('Secret', 'Red', 'Hidden'), column('Done', 'Green')],
+    });
+    const rows = [
+      { id: '1', title: 'A', status: 'Todo' },
+      { id: '2', title: 'B', status: 'Done' },
+    ];
+    const { container } = renderView({ layout, rows });
+    const values = Array.from(container.querySelectorAll('[data-slot="kanban-column"]')).map((c) =>
+      c.getAttribute('data-column-value')
+    );
+    expect(values).toEqual(['Todo', 'Done']);
+  });
+
+  it('uses the explicit card titleProperty for the card title', () => {
+    const { container } = renderView({ layout: makeLayout({ titleProperty: 'Title' }) });
+    const first = container.querySelector('[data-slot="kanban-card"]');
+    expect(first?.textContent).toContain('Draft proposal');
+  });
+
+  it('falls back to identity.displayProperty when titleProperty is null', () => {
+    const layout = makeLayout({ titleProperty: null });
+    const manifest = makeManifest({ displayProperty: 'Assignee' });
+    const { container } = renderView({ layout, manifest });
+    const first = container.querySelector('[data-slot="kanban-card"]');
+    expect(first?.textContent).toContain('Ada');
+  });
+
+  it('falls back to the "name" property when there is no identity', () => {
+    const layout = makeLayout({ titleProperty: null });
+    const manifest = makeManifest({ identity: false });
+    const rows = [{ id: '9', name: 'Named row', status: 'Todo' }];
+    const { container } = renderView({ layout, manifest, rows });
+    expect(container.querySelector('[data-slot="kanban-card"]')?.textContent).toContain(
+      'Named row'
+    );
+  });
+
+  it('falls back to the row id when the title value is an object or missing', () => {
+    const layout = makeLayout({ titleProperty: 'Title' });
+    const rows = [
+      { id: 'obj', title: { nested: true }, status: 'Todo' },
+      { id: 'none', status: 'Todo' },
+    ];
+    const { container } = renderView({ layout, rows });
+    const cards = Array.from(container.querySelectorAll('[data-slot="kanban-card"]'));
+    expect(cards.map((c) => c.getAttribute('data-card-id'))).toEqual(['obj', 'none']);
+    expect(cards[0]?.textContent).toContain('obj');
+    expect(cards[1]?.textContent).toContain('none');
+  });
+
+  it('renders manifest body fields as a definition list, and none when empty', () => {
+    const withFields = renderView({ layout: makeLayout({ fields: [field('Assignee')] }) });
+    expect(withFields.container.querySelector('[data-slot="kanban-card"] dl')).not.toBeNull();
+    expect(withFields.container.querySelector('[data-slot="kanban-card"] dd')?.textContent).toBe(
+      'Ada'
+    );
+
+    const noFields = renderView({ layout: makeLayout({ fields: [] }) });
+    expect(noFields.container.querySelector('[data-slot="kanban-card"] dl')).toBeNull();
+  });
+
+  it('renders a clickable card body button and fires onCardClick with the id', () => {
+    const onCardClick = vi.fn();
+    const { container } = renderView({ onCardClick });
+    const body = container.querySelector(
+      '[data-slot="kanban-card"] [data-slot="kanban-card-body"]'
+    ) as HTMLButtonElement;
+    expect(body.tagName).toBe('BUTTON');
+    fireEvent.click(body);
+    expect(onCardClick).toHaveBeenCalledWith('1');
+  });
+
+  it('renders a non-interactive body when no onCardClick is supplied', () => {
+    const { container } = renderView({ onCardClick: undefined });
+    expect(
+      container.querySelector('[data-slot="kanban-card"] [data-slot="kanban-card-body"]')
+    ).toBeNull();
+  });
+
+  it('handles drag start / over / drop to PATCH a moved card', async () => {
+    const { container } = renderView({ canUpdate: true });
+    const todoCard = container.querySelector('[data-card-id="1"]') as HTMLElement;
+    const doneColumn = container.querySelector('[data-column-value="Done"]') as HTMLElement;
+
+    const store: Record<string, string> = {};
+    const dataTransfer = {
+      setData: (type: string, val: string) => {
+        store[type] = val;
+      },
+      getData: (type: string) => store[type] ?? '',
+      effectAllowed: '',
+      dropEffect: '',
+    };
+
+    fireEvent.dragStart(todoCard, { dataTransfer });
+    expect(store['text/plain']).toBe('1');
+
+    fireEvent.dragOver(doneColumn, { dataTransfer });
+    expect(dataTransfer.dropEffect).toBe('move');
+
+    fireEvent.drop(doneColumn, { dataTransfer });
+    await waitFor(() => expect(patchedIds).toContain('1'));
+  });
+
+  it('ignores a drop with no dragged id and a drop back onto the same column', async () => {
+    const { container } = renderView({ canUpdate: true });
+    const todoColumn = container.querySelector('[data-column-value="Todo"]') as HTMLElement;
+    const doneColumn = container.querySelector('[data-column-value="Done"]') as HTMLElement;
+
+    // no id → early return
+    fireEvent.drop(doneColumn, { dataTransfer: { getData: () => '' } });
+    // drop card '1' (already Todo) back onto Todo → current === newValue → no-op
+    fireEvent.drop(todoColumn, { dataTransfer: { getData: () => '1' } });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(patchedIds).toHaveLength(0);
+  });
+
+  it('does not enable drop handlers or preventDefault on dragover when read-only', () => {
+    const { container } = renderView({ canUpdate: false });
+    const doneColumn = container.querySelector('[data-column-value="Done"]') as HTMLElement;
+    const dataTransfer = { getData: () => '1', dropEffect: '' };
+    // canUpdate false: handleDragOver returns before touching dropEffect
+    fireEvent.dragOver(doneColumn, { dataTransfer });
+    expect(dataTransfer.dropEffect).toBe('');
+    // and onDrop is undefined, so a drop never mutates
+    fireEvent.drop(doneColumn, { dataTransfer });
+    expect(patchedIds).toHaveLength(0);
+  });
+
+  it('does not carry drag data when the card is not draggable', () => {
+    const { container } = renderView({ canUpdate: false });
+    const card = container.querySelector('[data-card-id="1"]') as HTMLElement;
+    expect(card.getAttribute('draggable')).toBe('false');
+    const store: Record<string, string> = {};
+    fireEvent.dragStart(card, {
+      dataTransfer: {
+        setData: (t: string, v: string) => {
+          store[t] = v;
+        },
+      },
+    });
+    expect(store['text/plain']).toBeUndefined();
+  });
+
+  it('renders one action button per resolved card action with the right icon per kind', () => {
+    const actions = [
+      action('dl', 'Download'),
+      action('go', 'Navigate'),
+      action('flow', 'WorkflowTransition'),
+      action('drawer', 'OpenDrawer'),
+      action('modal', 'OpenModal'),
+      action('call', 'ApiCall'),
+      action('del', 'ApiCall', { confirmationKey: 'Confirm.Delete' }),
+      // referenced by name but NOT declared on manifest → filtered out
+    ];
+    const layout = makeLayout({
+      actions: [
+        cardActionRef('dl'),
+        cardActionRef('go'),
+        cardActionRef('flow'),
+        cardActionRef('drawer'),
+        cardActionRef('modal'),
+        cardActionRef('call'),
+        cardActionRef('del'),
+        cardActionRef('missing'),
+      ],
+    });
+    const manifest = makeManifest({ actions });
+    const rows = [{ id: '1', title: 'Only', status: 'Todo' }];
+    const { container } = renderView({ layout, manifest, rows });
+    const buttons = Array.from(
+      container.querySelectorAll('[data-slot="kanban-card-action"]')
+    ) as HTMLElement[];
+    expect(buttons.map((b) => b.getAttribute('data-action-kind'))).toEqual([
+      'Download',
+      'Navigate',
+      'WorkflowTransition',
+      'OpenDrawer',
+      'OpenModal',
+      'ApiCall',
+      'ApiCall',
+    ]);
+    // confirmation ApiCall uses the trash icon; plain ApiCall the play icon
+    const call = buttons.find((b) => b.getAttribute('data-action-name') === 'call');
+    const del = buttons.find((b) => b.getAttribute('data-action-name') === 'del');
+    expect(call?.querySelector('.lucide-play')).not.toBeNull();
+    expect(del?.querySelector('.lucide-trash2')).not.toBeNull();
+  });
+
+  it('dispatches an action via the provided handler without triggering onCardClick', async () => {
+    const navigate = vi.fn();
+    const onCardClick = vi.fn();
+    const layout = makeLayout({ actions: [cardActionRef('go')] });
+    const manifest = makeManifest({ actions: [action('go', 'Navigate')] });
+    const rows = [{ id: '42', title: 'Row', status: 'Todo' }];
+    const { container } = renderView({
+      layout,
+      manifest,
+      rows,
+      onCardClick,
+      actionHandlers: { navigate },
+    });
+    const btn = container.querySelector('[data-slot="kanban-card-action"]') as HTMLButtonElement;
+    fireEvent.click(btn);
+    await waitFor(() => expect(navigate).toHaveBeenCalledTimes(1));
+    expect(navigate).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'go' }),
+      '42',
+      rows[0],
+      expect.anything()
+    );
+    expect(onCardClick).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a toast and re-enables the button when the action handler throws', async () => {
+    const navigate = vi.fn().mockRejectedValue(new Error('boom'));
+    const layout = makeLayout({ actions: [cardActionRef('go')] });
+    const manifest = makeManifest({ actions: [action('go', 'Navigate')] });
+    const rows = [{ id: '5', title: 'Row', status: 'Todo' }];
+    const { container } = renderView({
+      layout,
+      manifest,
+      rows,
+      actionHandlers: { navigate },
+    });
+    const btn = container.querySelector('[data-slot="kanban-card-action"]') as HTMLButtonElement;
+    fireEvent.click(btn);
+    await waitFor(() => expect(navigate).toHaveBeenCalled());
+    // finally { setPending(false) } re-enables the button
+    await waitFor(() => expect(btn.disabled).toBe(false));
+  });
+
+  it('renders an empty board (columns with zero counts) when there are no rows', () => {
+    const { container } = renderView({ rows: [] });
+    expect(container.querySelectorAll('[data-slot="kanban-column"]')).toHaveLength(3);
+    expect(container.querySelectorAll('[data-slot="kanban-card"]')).toHaveLength(0);
+  });
+
+  it('tolerates a manifest with no actions array at all', () => {
+    // `manifest.actions ?? []` — undefined actions must not throw.
+    const manifest = {
+      ...makeManifest({}),
+      actions: undefined,
+    } as unknown as ExtendedEntityManifest;
+    const { container } = renderView({ manifest });
+    expect(container.querySelectorAll('[data-slot="kanban-column"]')).toHaveLength(3);
+    expect(container.querySelectorAll('[data-slot="kanban-card"]')).toHaveLength(4);
+  });
+
+  it('falls back to the neutral tint for a colour outside the token map', () => {
+    // `COLUMN_COLOR_CLASS[color] ?? FALLBACK_COLUMN_CLASS` — unknown colour value.
+    const layout = makeLayout({ columns: [column('Todo', 'Magenta' as KanbanColor)] });
+    const { container } = renderView({ layout });
+    const col = container.querySelector('[data-column-value="Todo"]');
+    expect(col?.getAttribute('data-color')).toBe('Magenta');
+    expect(col?.className).toContain('bg-muted/40');
+  });
+
+  it('resolves the dragged card by its PascalCase Id key when lowercase id is absent', async () => {
+    // `row.id ?? row.Id` on the card (id/key) AND in the drop lookup.
+    const rows = [{ Id: 'cap-1', title: 'Capitalised', status: 'Todo' }];
+    const { container } = renderView({ rows, canUpdate: true });
+    const card = container.querySelector('[data-card-id="cap-1"]') as HTMLElement;
+    expect(card).not.toBeNull();
+    const doneColumn = container.querySelector('[data-column-value="Done"]') as HTMLElement;
+
+    const store: Record<string, string> = {};
+    const dataTransfer = {
+      setData: (type: string, val: string) => {
+        store[type] = val;
+      },
+      getData: (type: string) => store[type] ?? '',
+      effectAllowed: '',
+      dropEffect: '',
+    };
+    fireEvent.dragStart(card, { dataTransfer });
+    expect(store['text/plain']).toBe('cap-1');
+    fireEvent.drop(doneColumn, { dataTransfer });
+    await waitFor(() => expect(patchedIds).toContain('cap-1'));
+  });
+
+  it('patches an unknown dragged id (row not in the current rows) as a move from no column', async () => {
+    // handleDrop: `row ? toScalarString(row[groupByJsonKey]) : ''` — the else branch.
+    const { container } = renderView({ canUpdate: true });
+    const doneColumn = container.querySelector('[data-column-value="Done"]') as HTMLElement;
+    // id is present but matches no row → current resolves to '' → '' !== 'Done' → mutate
+    fireEvent.drop(doneColumn, { dataTransfer: { getData: () => 'ghost' } });
+    await waitFor(() => expect(patchedIds).toContain('ghost'));
+  });
+
+  it('optimistically patches the seeded list cache, touching only the matching row', async () => {
+    // Drives the `optimistic.patchRow` closure: `r.id ?? r.Id` and the
+    // matched/unmatched sides of the row-id ternary against the cached list.
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const listKey = ['api', 'v1', 'tasks', 'list'];
+    queryClient.setQueryData(listKey, {
+      items: [
+        { id: 'match', title: 'Matches', status: 'Todo' },
+        { Id: 'other', title: 'Untouched', status: 'Todo' },
+      ],
+    });
+    const apiClient = axios.create({ baseURL: 'http://localhost' });
+    const rows = [{ id: 'match', title: 'Matches', status: 'Todo' }];
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <GranitClientProvider client={apiClient}>
+          <QueryProvider config={{ basePath: BASE_PATH }}>
+            <EntityKanbanView
+              entityName={ENTITY_NAME}
+              manifest={makeManifest({})}
+              layout={makeLayout()}
+              rows={rows}
+              canUpdate
+              locale="en-GB"
+            />
+          </QueryProvider>
+        </GranitClientProvider>
+      </QueryClientProvider>
+    );
+
+    const card = container.querySelector('[data-card-id="match"]') as HTMLElement;
+    const doneColumn = container.querySelector('[data-column-value="Done"]') as HTMLElement;
+    const store: Record<string, string> = {};
+    const dataTransfer = {
+      setData: (type: string, val: string) => {
+        store[type] = val;
+      },
+      getData: (type: string) => store[type] ?? '',
+      effectAllowed: '',
+      dropEffect: '',
+    };
+    fireEvent.dragStart(card, { dataTransfer });
+    fireEvent.drop(doneColumn, { dataTransfer });
+
+    await waitFor(() => expect(patchedIds).toContain('match'));
+    const patched = queryClient.getQueryData(listKey) as {
+      readonly items: readonly Readonly<Record<string, unknown>>[];
+    };
+    expect(patched.items[0]?.status).toBe('Done');
+    expect(patched.items[1]?.status).toBe('Todo');
+  });
+
+  it('ignores a second action click while the first dispatch is still pending', async () => {
+    // `if (pending) return` guard in the action button handler.
+    let release!: () => void;
+    const navigate = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        })
+    );
+    const layout = makeLayout({ actions: [cardActionRef('go')] });
+    const manifest = makeManifest({ actions: [action('go', 'Navigate')] });
+    const rows = [{ id: '7', title: 'Row', status: 'Todo' }];
+    const { container } = renderView({ layout, manifest, rows, actionHandlers: { navigate } });
+    const btn = container.querySelector('[data-slot="kanban-card-action"]') as HTMLButtonElement;
+
+    fireEvent.click(btn);
+    await waitFor(() => expect(btn.disabled).toBe(true));
+    // second click while pending must not dispatch again
+    fireEvent.click(btn);
+    release();
+    await waitFor(() => expect(btn.disabled).toBe(false));
+    expect(navigate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('fieldToColumnDefinition', () => {
+  it('camelizes the property name and forwards the valueKind for non-money components', () => {
+    const def = fieldToColumnDefinition(field('DueDate', { valueKind: 'Date' }));
+    expect(def.name).toBe('dueDate');
+    expect(def.valueKind).toBe('Date');
+  });
+
+  it('keeps an empty property name empty and suppresses valueKind for the money component', () => {
+    const def = fieldToColumnDefinition(field('', { component: 'money', valueKind: 'Currency' }));
+    expect(def.name).toBe('');
+    expect(def.valueKind).toBeUndefined();
+  });
+});
+
+describe('makeCurrencyResolver', () => {
+  it('prefers the configured currency property, then the row currency, then EUR', () => {
+    const withProperty = makeCurrencyResolver(
+      field('Amount', { config: { currencyProperty: 'CurrencyCode' } })
+    );
+    expect(withProperty({ currencyCode: 'USD', currency: 'GBP' })).toBe('USD');
+
+    const withoutProperty = makeCurrencyResolver(field('Amount'));
+    expect(withoutProperty({ currency: 'GBP' })).toBe('GBP');
+    expect(withoutProperty({})).toBe('EUR');
+  });
+});

--- a/packages/@granit/react-ui-entities/src/entity-page-layout.test.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-page-layout.test.tsx
@@ -1,0 +1,162 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { EntityPageLayout } from './entity-page-layout';
+
+describe('EntityPageLayout', () => {
+  it('renders only the body when no optional slots are supplied', () => {
+    const { container } = render(
+      <EntityPageLayout>
+        <span data-testid="body">content</span>
+      </EntityPageLayout>
+    );
+    const root = container.querySelector('[data-slot="entity-page-layout"]') as HTMLElement;
+    expect(root).not.toBeNull();
+    // Default width is `full` → padding classes applied on the shell root.
+    expect(root.getAttribute('data-content-width')).toBe('full');
+    expect(root.className).toContain('px-4');
+    // No optional slots.
+    expect(container.querySelector('[data-slot="entity-page-back"]')).toBeNull();
+    expect(container.querySelector('[data-slot="entity-page-header"]')).toBeNull();
+    expect(container.querySelector('[data-slot="entity-page-view-switcher"]')).toBeNull();
+    expect(container.querySelector('[data-slot="entity-page-query-controls"]')).toBeNull();
+    expect(container.querySelector('[data-slot="entity-page-pagination"]')).toBeNull();
+    // Body always present.
+    const body = container.querySelector('[data-slot="entity-page-body"]') as HTMLElement;
+    expect(body).not.toBeNull();
+    expect(body.textContent).toBe('content');
+  });
+
+  it('renders a string title as an <h1> and a string subtitle as a <p>', () => {
+    const { container } = render(
+      <EntityPageLayout title="Parties" subtitle="All records">
+        <span>body</span>
+      </EntityPageLayout>
+    );
+    const header = container.querySelector('[data-slot="entity-page-header"]') as HTMLElement;
+    expect(header).not.toBeNull();
+    const h1 = header.querySelector('h1');
+    expect(h1?.textContent).toBe('Parties');
+    const p = header.querySelector('p');
+    expect(p?.textContent).toBe('All records');
+  });
+
+  it('renders a ReactNode title and ReactNode subtitle verbatim (no wrapping h1/p)', () => {
+    const { container } = render(
+      <EntityPageLayout
+        title={<span data-testid="custom-title">T</span>}
+        subtitle={<em data-testid="custom-subtitle">S</em>}
+      >
+        <span>body</span>
+      </EntityPageLayout>
+    );
+    const header = container.querySelector('[data-slot="entity-page-header"]') as HTMLElement;
+    expect(header.querySelector('h1')).toBeNull();
+    expect(header.querySelector('[data-testid="custom-title"]')).not.toBeNull();
+    expect(header.querySelector('p')).toBeNull();
+    expect(header.querySelector('[data-testid="custom-subtitle"]')).not.toBeNull();
+  });
+
+  it('renders the header when only actions are supplied (no title / subtitle)', () => {
+    const { container } = render(
+      <EntityPageLayout actions={<button type="button">Create</button>}>
+        <span>body</span>
+      </EntityPageLayout>
+    );
+    expect(container.querySelector('[data-slot="entity-page-header"]')).not.toBeNull();
+    const actions = container.querySelector('[data-slot="entity-page-actions"]') as HTMLElement;
+    expect(actions).not.toBeNull();
+    expect(actions.querySelector('button')?.textContent).toBe('Create');
+    // No title / subtitle content.
+    expect(container.querySelector('h1')).toBeNull();
+  });
+
+  it('renders the header when only a subtitle is supplied but omits the actions slot', () => {
+    const { container } = render(
+      <EntityPageLayout subtitle="hint">
+        <span>body</span>
+      </EntityPageLayout>
+    );
+    expect(container.querySelector('[data-slot="entity-page-header"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="entity-page-actions"]')).toBeNull();
+  });
+
+  it('renders the back slot when provided', () => {
+    const { container } = render(
+      <EntityPageLayout back={<button type="button">Back</button>}>
+        <span>body</span>
+      </EntityPageLayout>
+    );
+    const back = container.querySelector('[data-slot="entity-page-back"]') as HTMLElement;
+    expect(back).not.toBeNull();
+    expect(back.querySelector('button')?.textContent).toBe('Back');
+  });
+
+  it('renders the view switcher and query controls slots when provided', () => {
+    const { container } = render(
+      <EntityPageLayout
+        viewSwitcher={<div data-testid="switcher" />}
+        queryControls={<div data-testid="controls" />}
+      >
+        <span>body</span>
+      </EntityPageLayout>
+    );
+    const switcher = container.querySelector(
+      '[data-slot="entity-page-view-switcher"]'
+    ) as HTMLElement;
+    expect(switcher).not.toBeNull();
+    expect(switcher.querySelector('[data-testid="switcher"]')).not.toBeNull();
+    const controls = container.querySelector(
+      '[data-slot="entity-page-query-controls"]'
+    ) as HTMLElement;
+    expect(controls).not.toBeNull();
+    expect(controls.querySelector('[data-testid="controls"]')).not.toBeNull();
+  });
+
+  it('renders the pagination footer when provided', () => {
+    const { container } = render(
+      <EntityPageLayout pagination={<nav data-testid="pager" />}>
+        <span>body</span>
+      </EntityPageLayout>
+    );
+    const pagination = container.querySelector(
+      '[data-slot="entity-page-pagination"]'
+    ) as HTMLElement;
+    expect(pagination).not.toBeNull();
+    expect(pagination.querySelector('[data-testid="pager"]')).not.toBeNull();
+  });
+
+  it('applies no extra padding classes for the comfortable width', () => {
+    const { container } = render(
+      <EntityPageLayout contentWidth="comfortable">
+        <span>body</span>
+      </EntityPageLayout>
+    );
+    const root = container.querySelector('[data-slot="entity-page-layout"]') as HTMLElement;
+    expect(root.getAttribute('data-content-width')).toBe('comfortable');
+    expect(root.className).not.toContain('px-4');
+  });
+
+  it('applies no extra padding classes for the narrow width', () => {
+    const { container } = render(
+      <EntityPageLayout contentWidth="narrow">
+        <span>body</span>
+      </EntityPageLayout>
+    );
+    const root = container.querySelector('[data-slot="entity-page-layout"]') as HTMLElement;
+    expect(root.getAttribute('data-content-width')).toBe('narrow');
+    expect(root.className).not.toContain('px-4');
+  });
+
+  it('merges a custom className and honours a dataSlot override', () => {
+    const { container } = render(
+      <EntityPageLayout className="my-custom-class" dataSlot="custom-shell">
+        <span>body</span>
+      </EntityPageLayout>
+    );
+    expect(container.querySelector('[data-slot="entity-page-layout"]')).toBeNull();
+    const root = container.querySelector('[data-slot="custom-shell"]') as HTMLElement;
+    expect(root).not.toBeNull();
+    expect(root.className).toContain('my-custom-class');
+  });
+});

--- a/packages/@granit/react-ui-entities/src/entity-view-switcher.test.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-view-switcher.test.tsx
@@ -1,0 +1,131 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EntityViewSwitcher } from './entity-view-switcher';
+
+import type { EntityListLayoutKind, EntityListLayoutManifest } from '@granit/entities';
+
+function layout(kind: EntityListLayoutKind): EntityListLayoutManifest {
+  return {
+    kind,
+    isDefault: false,
+    kanban: null,
+    calendar: null,
+    gallery: null,
+  };
+}
+
+const ALL: readonly EntityListLayoutManifest[] = [
+  layout('List'),
+  layout('Kanban'),
+  layout('Calendar'),
+  layout('Gallery'),
+];
+
+describe('EntityViewSwitcher', () => {
+  it('renders nothing when no layouts are registered', () => {
+    const { container } = render(
+      <EntityViewSwitcher layouts={[]} activeKind="List" onChange={vi.fn()} />
+    );
+    expect(container.querySelector('[data-slot="entity-view-switcher"]')).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when only a single layout is registered', () => {
+    const { container } = render(
+      <EntityViewSwitcher layouts={[layout('List')]} activeKind="List" onChange={vi.fn()} />
+    );
+    expect(container.querySelector('[data-slot="entity-view-switcher"]')).toBeNull();
+  });
+
+  it('renders a tablist with one tab per layout when two or more are registered', () => {
+    const { container } = render(
+      <EntityViewSwitcher
+        layouts={[layout('List'), layout('Kanban')]}
+        activeKind="List"
+        onChange={vi.fn()}
+      />
+    );
+    const tablist = container.querySelector('[data-slot="entity-view-switcher"]');
+    expect(tablist).not.toBeNull();
+    expect(tablist?.getAttribute('role')).toBe('tablist');
+    expect(tablist?.getAttribute('aria-label')).toBe('View');
+    expect(container.querySelectorAll('[role="tab"]')).toHaveLength(2);
+  });
+
+  it('renders every kind with its icon and fallback label', () => {
+    const { container } = render(
+      <EntityViewSwitcher layouts={ALL} activeKind="List" onChange={vi.fn()} />
+    );
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs).toHaveLength(4);
+    expect(tabs.map((t) => t.querySelector('span')?.textContent)).toEqual([
+      'List',
+      'Kanban',
+      'Calendar',
+      'Gallery',
+    ]);
+    // Each tab renders exactly one Lucide icon (rendered as an <svg>).
+    for (const tab of tabs) {
+      expect(tab.querySelector('svg')).not.toBeNull();
+    }
+  });
+
+  it('marks the active tab and leaves the others inactive', () => {
+    const { container } = render(
+      <EntityViewSwitcher layouts={ALL} activeKind="Calendar" onChange={vi.fn()} />
+    );
+    const tabs = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="tab"]'));
+    const [list, kanban, calendar, gallery] = tabs;
+
+    expect(calendar.getAttribute('aria-selected')).toBe('true');
+    expect(calendar.getAttribute('data-active')).toBe('true');
+    expect(calendar.className).toContain('border-primary');
+    expect(calendar.className).toContain('text-foreground');
+
+    for (const tab of [list, kanban, gallery]) {
+      expect(tab.getAttribute('aria-selected')).toBe('false');
+      // data-active is set to `undefined` for inactive tabs → attribute absent.
+      expect(tab.hasAttribute('data-active')).toBe(false);
+      expect(tab.className).toContain('border-transparent');
+      expect(tab.className).toContain('text-muted-foreground');
+    }
+  });
+
+  it('invokes onChange with the clicked layout kind', () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <EntityViewSwitcher layouts={ALL} activeKind="List" onChange={onChange} />
+    );
+    const tabs = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="tab"]'));
+    fireEvent.click(tabs[1]);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('Kanban');
+
+    fireEvent.click(tabs[3]);
+    expect(onChange).toHaveBeenNthCalledWith(2, 'Gallery');
+  });
+
+  it('fires onChange even when the already-active tab is clicked', () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <EntityViewSwitcher
+        layouts={[layout('List'), layout('Kanban')]}
+        activeKind="List"
+        onChange={onChange}
+      />
+    );
+    const activeTab = container.querySelector<HTMLButtonElement>('[aria-selected="true"]');
+    fireEvent.click(activeTab as HTMLButtonElement);
+    expect(onChange).toHaveBeenCalledWith('List');
+  });
+
+  it('gives each tab button type=button', () => {
+    const { container } = render(
+      <EntityViewSwitcher layouts={ALL} activeKind="List" onChange={vi.fn()} />
+    );
+    for (const tab of container.querySelectorAll('[role="tab"]')) {
+      expect(tab.getAttribute('type')).toBe('button');
+    }
+  });
+});

--- a/packages/@granit/react-ui-entities/src/form-components/email-form-component.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/form-components/email-form-component.stories.tsx
@@ -1,0 +1,66 @@
+import { mockEntityManifest } from '@granit/react-entities/testing';
+import { fn } from 'storybook/test';
+
+import { EmailFormComponent } from './email-form-component';
+
+import type { EntityFormFieldManifest } from '@granit/entities';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const baseField = mockEntityManifest.forms![0]!.sections[0]!.fields[0]!;
+
+function field(overrides: Partial<EntityFormFieldManifest> = {}): EntityFormFieldManifest {
+  return { ...baseField, propertyName: 'Email', component: 'email', ...overrides };
+}
+
+const meta = {
+  title: 'Entities/EmailFormComponent',
+  component: EmailFormComponent,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Entity-form field renderer for the `email` component. A controlled `type="email"` input with a leading mail icon; emits `null` when cleared and reflects `aria-invalid` when an error message is present.',
+      },
+    },
+  },
+  args: {
+    field: field(),
+    readOnly: false,
+    onChange: fn(),
+  },
+} satisfies Meta<typeof EmailFormComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A bound email address. */
+export const Populated: Story = {
+  args: {
+    value: 'jane.doe@example.com',
+  },
+};
+
+/** No value yet — the input renders empty. */
+export const Empty: Story = {
+  args: {
+    value: '',
+  },
+};
+
+/** Read-only rendering of a bound value. */
+export const ReadOnly: Story = {
+  args: {
+    value: 'jane.doe@example.com',
+    readOnly: true,
+  },
+};
+
+/** Validation error — the input is marked `aria-invalid`. */
+export const WithError: Story = {
+  args: {
+    value: 'not-an-email',
+    errorMessage: 'Enter a valid email address.',
+  },
+};

--- a/packages/@granit/react-ui-entities/src/form-components/email-form-component.test.tsx
+++ b/packages/@granit/react-ui-entities/src/form-components/email-form-component.test.tsx
@@ -1,0 +1,77 @@
+import { mockEntityManifest } from '@granit/react-entities/testing';
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EmailFormComponent } from './email-form-component';
+
+import type { EntityFormFieldManifest } from '@granit/entities';
+
+const baseField = mockEntityManifest.forms![0]!.sections[0]!.fields[0]!;
+
+function field(overrides: Partial<EntityFormFieldManifest> = {}): EntityFormFieldManifest {
+  return { ...baseField, propertyName: 'Email', component: 'email', ...overrides };
+}
+
+function getInput(container: HTMLElement): HTMLInputElement {
+  const el = container.querySelector('input');
+  if (!el) throw new Error('input not found');
+  return el;
+}
+
+describe('EmailFormComponent', () => {
+  it('binds a string value and wires the field id/name', () => {
+    const { container } = render(
+      <EmailFormComponent field={field()} value="a@b.com" onChange={vi.fn()} readOnly={false} />
+    );
+    const input = getInput(container);
+    expect(input.value).toBe('a@b.com');
+    expect(input.id).toBe('field-Email');
+    expect(input.getAttribute('name')).toBe('Email');
+    expect(input.getAttribute('aria-invalid')).toBeNull();
+  });
+
+  it('renders an empty string for a non-string value', () => {
+    const { container } = render(
+      <EmailFormComponent field={field()} value={42} onChange={vi.fn()} readOnly={false} />
+    );
+    expect(getInput(container).value).toBe('');
+  });
+
+  it('marks the input aria-invalid when an error message is present', () => {
+    const { container } = render(
+      <EmailFormComponent
+        field={field()}
+        value=""
+        onChange={vi.fn()}
+        readOnly={false}
+        errorMessage="Bad email"
+      />
+    );
+    expect(getInput(container).getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('emits the typed value on change', () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <EmailFormComponent field={field()} value="" onChange={onChange} readOnly={false} />
+    );
+    fireEvent.change(getInput(container), { target: { value: 'x@y.com' } });
+    expect(onChange).toHaveBeenCalledWith('x@y.com');
+  });
+
+  it('emits null when cleared to an empty string', () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <EmailFormComponent field={field()} value="x@y.com" onChange={onChange} readOnly={false} />
+    );
+    fireEvent.change(getInput(container), { target: { value: '' } });
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('renders read-only when readOnly is set', () => {
+    const { container } = render(
+      <EmailFormComponent field={field()} value="a@b.com" onChange={vi.fn()} readOnly={true} />
+    );
+    expect(getInput(container).readOnly).toBe(true);
+  });
+});

--- a/packages/@granit/react-ui-entities/src/form-components/image-upload-form-component.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/form-components/image-upload-form-component.stories.tsx
@@ -1,0 +1,153 @@
+import { createApiClient } from '@granit/api-client';
+import { BlobStorageProvider } from '@granit/react-blob-storage';
+import { mockEntityManifest } from '@granit/react-entities/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { fn } from 'storybook/test';
+
+import { ImageUploadFormComponent } from './image-upload-form-component';
+
+import type { BlobConfirmUploadResponse, BlobUploadInitiateResponse } from '@granit/blob-storage';
+import type { EntityFormFieldManifest } from '@granit/entities';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// Providers — the wrapped ImageUploadField pulls its upload/download plumbing
+// from BlobStorageProvider + React Query, and previews existing blobs through
+// the download endpoint. Mirrors the ImageUploadField story harness.
+// ---------------------------------------------------------------------------
+
+const client = createApiClient({ baseURL: '' });
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
+const BASE = '/api/v1/blob-storage';
+
+const uploadHandlers = [
+  http.post<
+    never,
+    { fileName: string; contentType: string; sizeBytes: number; containerName: string }
+  >(`${BASE}/blobs/upload`, async ({ request }) => {
+    const body = await request.json();
+    const blobId = `images/mock-${body.fileName}`;
+    const response: BlobUploadInitiateResponse = {
+      blobId,
+      uploadUrl: `${BASE}/blobs/${encodeURIComponent(blobId)}/_mock-put`,
+      httpMethod: 'PUT',
+      expiresAt: '2099-01-01T00:00:00Z' as never,
+      requiredHeaders: {},
+    };
+    return HttpResponse.json(response);
+  }),
+  http.put(`${BASE}/blobs/:id/_mock-put`, () => new HttpResponse(null, { status: 200 })),
+  http.post(`${BASE}/blobs/:id/confirm`, ({ params }) => {
+    const blobId = decodeURIComponent(params.id as string);
+    const response: BlobConfirmUploadResponse = {
+      blobId,
+      isValid: true,
+      status: 'Valid',
+      verifiedContentType: 'image/png',
+      sizeBytes: 204800,
+      rejectionReason: null,
+    };
+    return HttpResponse.json(response);
+  }),
+  // BlobImage renders an existing value through the download endpoint.
+  http.get(`${BASE}/blobs/:id/download`, () =>
+    HttpResponse.arrayBuffer(
+      Uint8Array.from(
+        atob(
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+        ),
+        (c) => c.codePointAt(0)!
+      ).buffer,
+      { headers: { 'Content-Type': 'image/png' } }
+    )
+  ),
+];
+
+function Wrapper({ children }: { readonly children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <BlobStorageProvider config={{ client }}>
+        <div className="p-4">{children}</div>
+      </BlobStorageProvider>
+    </QueryClientProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Field manifest factory — reuses the canonical fixture field (indexed access,
+// as in the sibling test) and overrides it into an `image` component field.
+// ---------------------------------------------------------------------------
+
+const baseField = mockEntityManifest.forms![0]!.sections[0]!.fields[0]!;
+
+function field(overrides: Partial<EntityFormFieldManifest> = {}): EntityFormFieldManifest {
+  return { ...baseField, propertyName: 'Avatar', component: 'image', config: null, ...overrides };
+}
+
+const meta = {
+  title: 'Entities/ImageUploadFormComponent',
+  component: ImageUploadFormComponent,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    msw: { handlers: uploadHandlers },
+    docs: {
+      description: {
+        component:
+          'EntityForm field wrapper that maps an `image` field manifest onto the blob-storage `ImageUploadField` (default `images` container; optional `aspectRatio` / `maxSizeMb` from `field.config`).',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Wrapper>
+        <Story />
+      </Wrapper>
+    ),
+  ],
+  args: {
+    onChange: fn(),
+    readOnly: false,
+  },
+} satisfies Meta<typeof ImageUploadFormComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Populated — an existing blob id renders through the preview frame. */
+export const Populated: Story = {
+  args: {
+    field: field(),
+    value: 'images/avatar-mock-id',
+  },
+};
+
+/** Empty — no blob set, default `images` container and 1:1 avatar frame. */
+export const Empty: Story = {
+  args: {
+    field: field(),
+    value: null,
+  },
+};
+
+/** Config-driven — 16:9 frame, `avatars` container and a 2 MB client cap. */
+export const WithConfig: Story = {
+  args: {
+    field: field({ config: { containerName: 'avatars', aspectRatio: '16:9', maxSizeMb: 2 } }),
+    value: null,
+  },
+};
+
+/** Read-only — the picker and clear controls are disabled. */
+export const ReadOnly: Story = {
+  args: {
+    field: field(),
+    value: 'images/avatar-mock-id',
+    readOnly: true,
+  },
+};

--- a/packages/@granit/react-ui-entities/src/form-components/image-upload-form-component.test.tsx
+++ b/packages/@granit/react-ui-entities/src/form-components/image-upload-form-component.test.tsx
@@ -1,0 +1,103 @@
+import { mockEntityManifest } from '@granit/react-entities/testing';
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ImageUploadFormComponent } from './image-upload-form-component';
+
+import type { EntityFormFieldManifest } from '@granit/entities';
+
+interface LeafMockProps {
+  readonly id?: string;
+  readonly name?: string;
+  readonly value: string | null;
+  readonly onChange: (next: string | null) => void;
+  readonly disabled?: boolean;
+  readonly containerName: string;
+  readonly aspectRatio?: string;
+  readonly maxSizeBytes?: number;
+}
+
+vi.mock('@granit/react-ui-blob-storage', () => ({
+  ImageUploadField: ({
+    id,
+    name,
+    value,
+    onChange,
+    disabled,
+    containerName,
+    aspectRatio,
+    maxSizeBytes,
+  }: LeafMockProps) => (
+    <div
+      data-testid="leaf"
+      data-id={id}
+      data-name={name}
+      data-value={value ?? 'NULL'}
+      data-disabled={String(Boolean(disabled))}
+      data-container={containerName}
+      data-aspect={aspectRatio ?? 'NONE'}
+      data-maxbytes={maxSizeBytes === undefined ? 'NONE' : String(maxSizeBytes)}
+    >
+      <button type="button" data-testid="emit" onClick={() => onChange('blob-1')} />
+    </div>
+  ),
+}));
+
+const baseField = mockEntityManifest.forms![0]!.sections[0]!.fields[0]!;
+
+function field(overrides: Partial<EntityFormFieldManifest> = {}): EntityFormFieldManifest {
+  return { ...baseField, propertyName: 'Avatar', component: 'image', config: null, ...overrides };
+}
+
+describe('ImageUploadFormComponent', () => {
+  it('applies default container and omits aspect/max-size when config is null', () => {
+    const { getByTestId } = render(
+      <ImageUploadFormComponent
+        field={field()}
+        value="blob-existing"
+        onChange={vi.fn()}
+        readOnly={false}
+      />
+    );
+    const leaf = getByTestId('leaf');
+    expect(leaf.getAttribute('data-container')).toBe('images');
+    expect(leaf.getAttribute('data-aspect')).toBe('NONE');
+    expect(leaf.getAttribute('data-maxbytes')).toBe('NONE');
+    expect(leaf.getAttribute('data-value')).toBe('blob-existing');
+    expect(leaf.getAttribute('data-id')).toBe('field-Avatar');
+    expect(leaf.getAttribute('data-name')).toBe('Avatar');
+    expect(leaf.getAttribute('data-disabled')).toBe('false');
+  });
+
+  it('maps config container/aspectRatio and converts maxSizeMb to bytes', () => {
+    const { getByTestId } = render(
+      <ImageUploadFormComponent
+        field={field({ config: { containerName: 'avatars', aspectRatio: '16:9', maxSizeMb: 2 } })}
+        value={42}
+        onChange={vi.fn()}
+        readOnly={false}
+      />
+    );
+    const leaf = getByTestId('leaf');
+    expect(leaf.getAttribute('data-container')).toBe('avatars');
+    expect(leaf.getAttribute('data-aspect')).toBe('16:9');
+    expect(leaf.getAttribute('data-maxbytes')).toBe(String(2 * 1024 * 1024));
+    expect(leaf.getAttribute('data-value')).toBe('NULL');
+  });
+
+  it('forwards the onChange callback directly', () => {
+    const onChange = vi.fn();
+    const { getByTestId } = render(
+      <ImageUploadFormComponent field={field()} value={null} onChange={onChange} readOnly={false} />
+    );
+    fireEvent.click(getByTestId('emit'));
+    expect(onChange).toHaveBeenCalledWith('blob-1');
+  });
+
+  it('disables the field when readOnly is set', () => {
+    const { getByTestId } = render(
+      <ImageUploadFormComponent field={field()} value={null} onChange={vi.fn()} readOnly={true} />
+    );
+    expect(getByTestId('leaf').getAttribute('data-disabled')).toBe('true');
+  });
+});

--- a/packages/@granit/react-ui-entities/src/form-components/language-form-component.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/form-components/language-form-component.stories.tsx
@@ -1,0 +1,85 @@
+import { mockEntityManifest } from '@granit/react-entities/testing';
+import { mockLanguages } from '@granit/react-localization/testing';
+import { LanguagesContext } from '@granit/react-ui-localization';
+import { fn } from 'storybook/test';
+
+import { LanguageFormComponent } from './language-form-component';
+
+import type { EntityFormFieldManifest } from '@granit/entities';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const baseField = mockEntityManifest.forms![0]!.sections[0]!.fields[0]!;
+
+function field(overrides: Partial<EntityFormFieldManifest> = {}): EntityFormFieldManifest {
+  return { ...baseField, propertyName: 'Culture', component: 'language', ...overrides };
+}
+
+const meta = {
+  title: 'Entities/LanguageFormComponent',
+  component: LanguageFormComponent,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Entity-form field renderer for the `language` component. Binds a culture-name string to a `<Select>` populated from `useLanguages()` (the host-provided `LanguagesContext`).',
+      },
+    },
+  },
+  args: {
+    field: field(),
+    readOnly: false,
+    onChange: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <LanguagesContext.Provider value={mockLanguages}>
+        <div className="w-64">
+          <Story />
+        </div>
+      </LanguagesContext.Provider>
+    ),
+  ],
+} satisfies Meta<typeof LanguageFormComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A culture already selected — the Select reflects the bound value. */
+export const Populated: Story = {
+  args: {
+    value: 'fr',
+  },
+};
+
+/** No selection yet — the placeholder is shown. */
+export const Empty: Story = {
+  args: {
+    value: '',
+  },
+};
+
+/** Read-only binding — the Select is disabled and cannot be changed. */
+export const ReadOnly: Story = {
+  args: {
+    value: 'fr',
+    readOnly: true,
+  },
+};
+
+/** A single available language — only one option is offered. */
+export const SingleLanguage: Story = {
+  args: {
+    value: 'en',
+  },
+  decorators: [
+    (Story) => (
+      <LanguagesContext.Provider value={[mockLanguages[0]!]}>
+        <div className="w-64">
+          <Story />
+        </div>
+      </LanguagesContext.Provider>
+    ),
+  ],
+};

--- a/packages/@granit/react-ui-entities/src/form-components/language-form-component.test.tsx
+++ b/packages/@granit/react-ui-entities/src/form-components/language-form-component.test.tsx
@@ -1,0 +1,109 @@
+import { mockEntityManifest } from '@granit/react-entities/testing';
+import { fireEvent, render } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LanguageFormComponent } from './language-form-component';
+
+import type { EntityFormFieldManifest } from '@granit/entities';
+import type { LanguageInfo } from '@granit/localization';
+
+const { mockUseLanguages } = vi.hoisted(() => ({
+  mockUseLanguages: vi.fn<() => LanguageInfo[]>(),
+}));
+
+vi.mock('@granit/react-ui-localization', () => ({
+  useLanguages: () => mockUseLanguages(),
+}));
+
+interface SelectMockProps {
+  readonly value: string;
+  readonly onValueChange: (next: string) => void;
+  readonly disabled?: boolean;
+  readonly children: ReactNode;
+}
+interface ItemMockProps {
+  readonly value: string;
+  readonly children: ReactNode;
+}
+
+vi.mock('@granit/react-ui', () => ({
+  Select: ({ value, onValueChange, disabled, children }: SelectMockProps) => (
+    <div data-testid="select" data-value={value} data-disabled={String(Boolean(disabled))}>
+      <button type="button" data-testid="pick-fr" onClick={() => onValueChange('fr')} />
+      <button type="button" data-testid="pick-empty" onClick={() => onValueChange('')} />
+      {children}
+    </div>
+  ),
+  SelectTrigger: ({ children }: { readonly children: ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { readonly children: ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ value, children }: ItemMockProps) => (
+    <div data-testid={`item-${value}`}>{children}</div>
+  ),
+  SelectValue: ({ placeholder }: { readonly placeholder?: string }) => <span>{placeholder}</span>,
+}));
+
+const baseField = mockEntityManifest.forms![0]!.sections[0]!.fields[0]!;
+
+function field(overrides: Partial<EntityFormFieldManifest> = {}): EntityFormFieldManifest {
+  return { ...baseField, propertyName: 'Culture', component: 'language', ...overrides };
+}
+
+const LANGUAGES: LanguageInfo[] = [
+  { cultureName: 'fr', displayName: 'Français', isDefault: true },
+  { cultureName: 'en', displayName: 'English', isDefault: false },
+];
+
+describe('LanguageFormComponent', () => {
+  beforeEach(() => {
+    mockUseLanguages.mockReturnValue(LANGUAGES);
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders one item per language from the languages context', () => {
+    const { getByTestId } = render(
+      <LanguageFormComponent field={field()} value="" onChange={vi.fn()} readOnly={false} />
+    );
+    expect(getByTestId('item-fr').textContent).toBe('Français');
+    expect(getByTestId('item-en').textContent).toBe('English');
+  });
+
+  it('binds a string value as the current selection', () => {
+    const { getByTestId } = render(
+      <LanguageFormComponent field={field()} value="en" onChange={vi.fn()} readOnly={false} />
+    );
+    expect(getByTestId('select').getAttribute('data-value')).toBe('en');
+  });
+
+  it('collapses a non-string value to an empty selection', () => {
+    const { getByTestId } = render(
+      <LanguageFormComponent field={field()} value={99} onChange={vi.fn()} readOnly={false} />
+    );
+    expect(getByTestId('select').getAttribute('data-value')).toBe('');
+  });
+
+  it('emits the chosen culture on change', () => {
+    const onChange = vi.fn();
+    const { getByTestId } = render(
+      <LanguageFormComponent field={field()} value="" onChange={onChange} readOnly={false} />
+    );
+    fireEvent.click(getByTestId('pick-fr'));
+    expect(onChange).toHaveBeenCalledWith('fr');
+  });
+
+  it('emits null when the selection is cleared to empty', () => {
+    const onChange = vi.fn();
+    const { getByTestId } = render(
+      <LanguageFormComponent field={field()} value="fr" onChange={onChange} readOnly={false} />
+    );
+    fireEvent.click(getByTestId('pick-empty'));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('disables the select when readOnly is set', () => {
+    const { getByTestId } = render(
+      <LanguageFormComponent field={field()} value="fr" onChange={vi.fn()} readOnly={true} />
+    );
+    expect(getByTestId('select').getAttribute('data-disabled')).toBe('true');
+  });
+});

--- a/packages/@granit/react-ui-entities/src/form-components/money-form-component.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/form-components/money-form-component.stories.tsx
@@ -1,0 +1,75 @@
+import { mockEntityManifest } from '@granit/react-entities/testing';
+import { fn } from 'storybook/test';
+
+import { MoneyFormComponent } from './money-form-component';
+
+import type { EntityFormFieldManifest } from '@granit/entities';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const baseField = mockEntityManifest.forms![0]!.sections[0]!.fields[0]!;
+
+function field(overrides: Partial<EntityFormFieldManifest> = {}): EntityFormFieldManifest {
+  return {
+    ...baseField,
+    propertyName: 'Amount',
+    component: 'currency',
+    config: null,
+    ...overrides,
+  };
+}
+
+const meta = {
+  title: 'Entities/MoneyFormComponent',
+  component: MoneyFormComponent,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Entity form field wrapper for money values. Amounts stay on the wire as Int64 minor units (cents); the input renders and accepts decimal major units, round-tripping through 100×. An optional currency hint is read from `field.config.currencyCode` (or `currencyProperty`).',
+      },
+    },
+  },
+  args: {
+    onChange: fn(),
+    readOnly: false,
+  },
+} satisfies Meta<typeof MoneyFormComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Populated value (1234 minor units → "12.34") with a EUR currency hint. */
+export const Populated: Story = {
+  args: {
+    field: field({ config: { currencyCode: 'EUR' } }),
+    value: 1234,
+  },
+};
+
+/** Empty value — non-number collapses to a blank input and the hint is omitted. */
+export const Empty: Story = {
+  args: {
+    field: field(),
+    value: null,
+  },
+};
+
+/** Read-only rendering of a populated value. */
+export const ReadOnly: Story = {
+  args: {
+    field: field({ config: { currencyCode: 'USD' } }),
+    value: 5000,
+    readOnly: true,
+  },
+};
+
+/** Invalid state — an error message marks the input `aria-invalid`. */
+export const WithError: Story = {
+  args: {
+    field: field({ config: { currencyCode: 'EUR' } }),
+    value: 100,
+    errorMessage: 'Required',
+  },
+};

--- a/packages/@granit/react-ui-entities/src/form-components/money-form-component.test.tsx
+++ b/packages/@granit/react-ui-entities/src/form-components/money-form-component.test.tsx
@@ -1,0 +1,113 @@
+import { mockEntityManifest } from '@granit/react-entities/testing';
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MoneyFormComponent } from './money-form-component';
+
+import type { EntityFormFieldManifest } from '@granit/entities';
+
+const baseField = mockEntityManifest.forms![0]!.sections[0]!.fields[0]!;
+
+function field(overrides: Partial<EntityFormFieldManifest> = {}): EntityFormFieldManifest {
+  return {
+    ...baseField,
+    propertyName: 'Amount',
+    component: 'currency',
+    config: null,
+    ...overrides,
+  };
+}
+
+function getInput(container: HTMLElement): HTMLInputElement {
+  const el = container.querySelector('input');
+  if (!el) throw new Error('input not found');
+  return el;
+}
+
+describe('MoneyFormComponent', () => {
+  it('renders minor units as a two-decimal major-unit string and shows the currencyCode hint', () => {
+    const { container } = render(
+      <MoneyFormComponent
+        field={field({ config: { currencyCode: 'EUR' } })}
+        value={1234}
+        onChange={vi.fn()}
+        readOnly={false}
+      />
+    );
+    expect(getInput(container).value).toBe('12.34');
+    const hint = container.querySelector('[aria-label="currency"]');
+    expect(hint?.textContent).toBe('EUR');
+    expect(getInput(container).getAttribute('aria-invalid')).toBeNull();
+  });
+
+  it('collapses a non-number value to an empty display and omits the hint when config is null', () => {
+    const { container } = render(
+      <MoneyFormComponent field={field()} value={null} onChange={vi.fn()} readOnly={false} />
+    );
+    expect(getInput(container).value).toBe('');
+    expect(container.querySelector('[aria-label="currency"]')).toBeNull();
+  });
+
+  it('falls back to currencyProperty when currencyCode is absent', () => {
+    const { container } = render(
+      <MoneyFormComponent
+        field={field({ config: { currencyProperty: 'PriceCurrency' } })}
+        value={0}
+        onChange={vi.fn()}
+        readOnly={false}
+      />
+    );
+    expect(container.querySelector('[aria-label="currency"]')?.textContent).toBe('PriceCurrency');
+    expect(getInput(container).value).toBe('0.00');
+  });
+
+  it('omits the hint when config carries neither currency key', () => {
+    const { container } = render(
+      <MoneyFormComponent
+        field={field({ config: {} })}
+        value={500}
+        onChange={vi.fn()}
+        readOnly={false}
+      />
+    );
+    expect(container.querySelector('[aria-label="currency"]')).toBeNull();
+  });
+
+  it('marks the input aria-invalid when an error message is present', () => {
+    const { container } = render(
+      <MoneyFormComponent
+        field={field()}
+        value={100}
+        onChange={vi.fn()}
+        readOnly={false}
+        errorMessage="Required"
+      />
+    );
+    expect(getInput(container).getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('emits null when cleared to an empty string', () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <MoneyFormComponent field={field()} value={1234} onChange={onChange} readOnly={false} />
+    );
+    fireEvent.change(getInput(container), { target: { value: '' } });
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('rounds a decimal entry to Int64 minor units', () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <MoneyFormComponent field={field()} value={null} onChange={onChange} readOnly={false} />
+    );
+    fireEvent.change(getInput(container), { target: { value: '10.5' } });
+    expect(onChange).toHaveBeenCalledWith(1050);
+  });
+
+  it('renders read-only when readOnly is set', () => {
+    const { container } = render(
+      <MoneyFormComponent field={field()} value={100} onChange={vi.fn()} readOnly={true} />
+    );
+    expect(getInput(container).readOnly).toBe(true);
+  });
+});

--- a/packages/@granit/react-ui-entities/src/form-components/phone-form-component.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/form-components/phone-form-component.stories.tsx
@@ -1,0 +1,60 @@
+import { mockEntityManifest } from '@granit/react-entities/testing';
+import { fn } from 'storybook/test';
+
+import { PhoneFormComponent } from './phone-form-component';
+
+import type { EntityFormFieldManifest } from '@granit/entities';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const baseField = mockEntityManifest.forms![0]!.sections[0]!.fields[0]!;
+
+function field(overrides: Partial<EntityFormFieldManifest> = {}): EntityFormFieldManifest {
+  return { ...baseField, propertyName: 'Phone', component: 'phone', ...overrides };
+}
+
+const meta = {
+  title: 'Entities/PhoneFormComponent',
+  component: PhoneFormComponent,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Entity form field wrapper for phone numbers. Delegates to `PhoneInput` (country selector + national input) and stores the value as an E.164 string; non-string values collapse to `null`, and `readOnly` disables the control.',
+      },
+    },
+  },
+  args: {
+    onChange: fn(),
+    readOnly: false,
+  },
+} satisfies Meta<typeof PhoneFormComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Populated E.164 value — country inferred (BE) and the national part rendered. */
+export const Populated: Story = {
+  args: {
+    field: field(),
+    value: '+3212345',
+  },
+};
+
+/** Empty value — the input falls back to the default country with a blank national part. */
+export const Empty: Story = {
+  args: {
+    field: field(),
+    value: null,
+  },
+};
+
+/** Read-only rendering of a populated value — both the country trigger and input are disabled. */
+export const ReadOnly: Story = {
+  args: {
+    field: field(),
+    value: '+3212345',
+    readOnly: true,
+  },
+};

--- a/packages/@granit/react-ui-entities/src/form-components/phone-form-component.test.tsx
+++ b/packages/@granit/react-ui-entities/src/form-components/phone-form-component.test.tsx
@@ -1,0 +1,81 @@
+import { mockEntityManifest } from '@granit/react-entities/testing';
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PhoneFormComponent } from './phone-form-component';
+
+import type { EntityFormFieldManifest } from '@granit/entities';
+
+interface LeafMockProps {
+  readonly id?: string;
+  readonly name?: string;
+  readonly value: string | null;
+  readonly onChange: (next: string | null) => void;
+  readonly disabled?: boolean;
+}
+
+vi.mock('@granit/react-ui-kit', () => ({
+  PhoneInput: ({ id, name, value, onChange, disabled }: LeafMockProps) => (
+    <div
+      data-testid="leaf"
+      data-id={id}
+      data-name={name}
+      data-value={value ?? 'NULL'}
+      data-disabled={String(Boolean(disabled))}
+    >
+      <button type="button" data-testid="emit-value" onClick={() => onChange('+3212345')} />
+      <button type="button" data-testid="emit-null" onClick={() => onChange(null)} />
+    </div>
+  ),
+}));
+
+const baseField = mockEntityManifest.forms![0]!.sections[0]!.fields[0]!;
+
+function field(overrides: Partial<EntityFormFieldManifest> = {}): EntityFormFieldManifest {
+  return { ...baseField, propertyName: 'Phone', component: 'phone', ...overrides };
+}
+
+describe('PhoneFormComponent', () => {
+  it('forwards a string value and the field id/name', () => {
+    const { getByTestId } = render(
+      <PhoneFormComponent field={field()} value="+3212345" onChange={vi.fn()} readOnly={false} />
+    );
+    const leaf = getByTestId('leaf');
+    expect(leaf.getAttribute('data-value')).toBe('+3212345');
+    expect(leaf.getAttribute('data-id')).toBe('field-Phone');
+    expect(leaf.getAttribute('data-name')).toBe('Phone');
+    expect(leaf.getAttribute('data-disabled')).toBe('false');
+  });
+
+  it('passes null for a non-string value', () => {
+    const { getByTestId } = render(
+      <PhoneFormComponent field={field()} value={123} onChange={vi.fn()} readOnly={false} />
+    );
+    expect(getByTestId('leaf').getAttribute('data-value')).toBe('NULL');
+  });
+
+  it('forwards an emitted value', () => {
+    const onChange = vi.fn();
+    const { getByTestId } = render(
+      <PhoneFormComponent field={field()} value={null} onChange={onChange} readOnly={false} />
+    );
+    fireEvent.click(getByTestId('emit-value'));
+    expect(onChange).toHaveBeenCalledWith('+3212345');
+  });
+
+  it('coerces an emitted null through the nullish guard', () => {
+    const onChange = vi.fn();
+    const { getByTestId } = render(
+      <PhoneFormComponent field={field()} value="+3212345" onChange={onChange} readOnly={false} />
+    );
+    fireEvent.click(getByTestId('emit-null'));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('disables the input when readOnly is set', () => {
+    const { getByTestId } = render(
+      <PhoneFormComponent field={field()} value={null} onChange={vi.fn()} readOnly={true} />
+    );
+    expect(getByTestId('leaf').getAttribute('data-disabled')).toBe('true');
+  });
+});

--- a/packages/@granit/react-ui-entities/src/form-components/timezone-form-component.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/form-components/timezone-form-component.stories.tsx
@@ -1,0 +1,58 @@
+import { mockEntityManifest } from '@granit/react-entities/testing';
+import { fn } from 'storybook/test';
+
+import { TimezoneFormComponent } from './timezone-form-component';
+
+import type { EntityFormFieldManifest } from '@granit/entities';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const baseField = mockEntityManifest.forms![0]!.sections[0]!.fields[0]!;
+
+function field(overrides: Partial<EntityFormFieldManifest> = {}): EntityFormFieldManifest {
+  return { ...baseField, propertyName: 'Timezone', component: 'timezone', ...overrides };
+}
+
+const meta = {
+  title: 'Entities/TimezoneFormComponent',
+  component: TimezoneFormComponent,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'EntityForm field wrapper around `TimezonePicker`. Forwards the field id/name, coerces a non-string value to `null`, marks the picker clearable and disables it in read-only mode.',
+      },
+    },
+  },
+  args: {
+    field: field(),
+    onChange: fn(),
+    readOnly: false,
+  },
+} satisfies Meta<typeof TimezoneFormComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A populated IANA timezone value is forwarded straight to the picker. */
+export const Populated: Story = {
+  args: {
+    value: 'Europe/Brussels',
+  },
+};
+
+/** No value — the picker shows its placeholder (and self-defaults to the user zone). */
+export const Empty: Story = {
+  args: {
+    value: null,
+  },
+};
+
+/** Read-only — the picker is rendered disabled. */
+export const ReadOnly: Story = {
+  args: {
+    value: 'Asia/Tokyo',
+    readOnly: true,
+  },
+};

--- a/packages/@granit/react-ui-entities/src/form-components/timezone-form-component.test.tsx
+++ b/packages/@granit/react-ui-entities/src/form-components/timezone-form-component.test.tsx
@@ -1,0 +1,94 @@
+import { mockEntityManifest } from '@granit/react-entities/testing';
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TimezoneFormComponent } from './timezone-form-component';
+
+import type { EntityFormFieldManifest } from '@granit/entities';
+
+interface LeafMockProps {
+  readonly id?: string;
+  readonly name?: string;
+  readonly value: string | null;
+  readonly onChange: (next: string | null) => void;
+  readonly disabled?: boolean;
+  readonly clearable?: boolean;
+}
+
+vi.mock('@granit/react-ui-kit', () => ({
+  TimezonePicker: ({ id, name, value, onChange, disabled, clearable }: LeafMockProps) => (
+    <div
+      data-testid="leaf"
+      data-id={id}
+      data-name={name}
+      data-value={value ?? 'NULL'}
+      data-disabled={String(Boolean(disabled))}
+      data-clearable={String(Boolean(clearable))}
+    >
+      <button type="button" data-testid="emit-value" onClick={() => onChange('Europe/Brussels')} />
+      <button type="button" data-testid="emit-null" onClick={() => onChange(null)} />
+    </div>
+  ),
+}));
+
+const baseField = mockEntityManifest.forms![0]!.sections[0]!.fields[0]!;
+
+function field(overrides: Partial<EntityFormFieldManifest> = {}): EntityFormFieldManifest {
+  return { ...baseField, propertyName: 'Timezone', component: 'timezone', ...overrides };
+}
+
+describe('TimezoneFormComponent', () => {
+  it('forwards a string value, field id/name and the clearable flag', () => {
+    const { getByTestId } = render(
+      <TimezoneFormComponent
+        field={field()}
+        value="Europe/Brussels"
+        onChange={vi.fn()}
+        readOnly={false}
+      />
+    );
+    const leaf = getByTestId('leaf');
+    expect(leaf.getAttribute('data-value')).toBe('Europe/Brussels');
+    expect(leaf.getAttribute('data-id')).toBe('field-Timezone');
+    expect(leaf.getAttribute('data-name')).toBe('Timezone');
+    expect(leaf.getAttribute('data-clearable')).toBe('true');
+    expect(leaf.getAttribute('data-disabled')).toBe('false');
+  });
+
+  it('passes null for a non-string value', () => {
+    const { getByTestId } = render(
+      <TimezoneFormComponent field={field()} value={0} onChange={vi.fn()} readOnly={false} />
+    );
+    expect(getByTestId('leaf').getAttribute('data-value')).toBe('NULL');
+  });
+
+  it('forwards an emitted value', () => {
+    const onChange = vi.fn();
+    const { getByTestId } = render(
+      <TimezoneFormComponent field={field()} value={null} onChange={onChange} readOnly={false} />
+    );
+    fireEvent.click(getByTestId('emit-value'));
+    expect(onChange).toHaveBeenCalledWith('Europe/Brussels');
+  });
+
+  it('coerces an emitted null through the nullish guard', () => {
+    const onChange = vi.fn();
+    const { getByTestId } = render(
+      <TimezoneFormComponent
+        field={field()}
+        value="Europe/Brussels"
+        onChange={onChange}
+        readOnly={false}
+      />
+    );
+    fireEvent.click(getByTestId('emit-null'));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('disables the picker when readOnly is set', () => {
+    const { getByTestId } = render(
+      <TimezoneFormComponent field={field()} value={null} onChange={vi.fn()} readOnly={true} />
+    );
+    expect(getByTestId('leaf').getAttribute('data-disabled')).toBe('true');
+  });
+});

--- a/packages/@granit/react-ui-entities/src/form-components/url-form-component.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/form-components/url-form-component.stories.tsx
@@ -1,0 +1,68 @@
+import { mockEntityManifest } from '@granit/react-entities/testing';
+import { fn } from 'storybook/test';
+
+import { UrlFormComponent } from './url-form-component';
+
+import type { EntityFormFieldManifest } from '@granit/entities';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const baseField = mockEntityManifest.forms![0]!.sections[0]!.fields[0]!;
+
+function field(overrides: Partial<EntityFormFieldManifest> = {}): EntityFormFieldManifest {
+  return { ...baseField, propertyName: 'Website', component: 'url', ...overrides };
+}
+
+const meta = {
+  title: 'Entities/UrlFormComponent',
+  component: UrlFormComponent,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Entity form field wrapper for URL values. Delegates to the `UrlInput` primitive (a protocol dropdown + host input) and stores a single `scheme://rest` string. Non-string values collapse to `null`; an emitted empty value is coerced back to `null`.',
+      },
+    },
+  },
+  args: {
+    onChange: fn(),
+    readOnly: false,
+  },
+} satisfies Meta<typeof UrlFormComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Populated https value — the protocol dropdown detects `https` and the host fills the input. */
+export const Populated: Story = {
+  args: {
+    field: field(),
+    value: 'https://example.com',
+  },
+};
+
+/** An http value — the dropdown reflects the non-default scheme parsed from the string. */
+export const HttpProtocol: Story = {
+  args: {
+    field: field(),
+    value: 'http://legacy.internal',
+  },
+};
+
+/** Empty value — a non-string collapses to `null` and the input renders blank. */
+export const Empty: Story = {
+  args: {
+    field: field(),
+    value: null,
+  },
+};
+
+/** Read-only rendering — the protocol dropdown and host input are both disabled. */
+export const ReadOnly: Story = {
+  args: {
+    field: field(),
+    value: 'https://example.com',
+    readOnly: true,
+  },
+};

--- a/packages/@granit/react-ui-entities/src/form-components/url-form-component.test.tsx
+++ b/packages/@granit/react-ui-entities/src/form-components/url-form-component.test.tsx
@@ -1,0 +1,95 @@
+import { mockEntityManifest } from '@granit/react-entities/testing';
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { UrlFormComponent } from './url-form-component';
+
+import type { EntityFormFieldManifest } from '@granit/entities';
+
+interface LeafMockProps {
+  readonly id?: string;
+  readonly name?: string;
+  readonly value: string | null;
+  readonly onChange: (next: string | null) => void;
+  readonly disabled?: boolean;
+}
+
+vi.mock('@granit/react-ui-kit', () => ({
+  UrlInput: ({ id, name, value, onChange, disabled }: LeafMockProps) => (
+    <div
+      data-testid="leaf"
+      data-id={id}
+      data-name={name}
+      data-value={value ?? 'NULL'}
+      data-disabled={String(Boolean(disabled))}
+    >
+      <button
+        type="button"
+        data-testid="emit-value"
+        onClick={() => onChange('https://example.com')}
+      />
+      <button type="button" data-testid="emit-null" onClick={() => onChange(null)} />
+    </div>
+  ),
+}));
+
+const baseField = mockEntityManifest.forms![0]!.sections[0]!.fields[0]!;
+
+function field(overrides: Partial<EntityFormFieldManifest> = {}): EntityFormFieldManifest {
+  return { ...baseField, propertyName: 'Website', component: 'url', ...overrides };
+}
+
+describe('UrlFormComponent', () => {
+  it('forwards a string value and the field id/name', () => {
+    const { getByTestId } = render(
+      <UrlFormComponent
+        field={field()}
+        value="https://example.com"
+        onChange={vi.fn()}
+        readOnly={false}
+      />
+    );
+    const leaf = getByTestId('leaf');
+    expect(leaf.getAttribute('data-value')).toBe('https://example.com');
+    expect(leaf.getAttribute('data-id')).toBe('field-Website');
+    expect(leaf.getAttribute('data-name')).toBe('Website');
+    expect(leaf.getAttribute('data-disabled')).toBe('false');
+  });
+
+  it('passes null for a non-string value', () => {
+    const { getByTestId } = render(
+      <UrlFormComponent field={field()} value={{}} onChange={vi.fn()} readOnly={false} />
+    );
+    expect(getByTestId('leaf').getAttribute('data-value')).toBe('NULL');
+  });
+
+  it('forwards an emitted value', () => {
+    const onChange = vi.fn();
+    const { getByTestId } = render(
+      <UrlFormComponent field={field()} value={null} onChange={onChange} readOnly={false} />
+    );
+    fireEvent.click(getByTestId('emit-value'));
+    expect(onChange).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('coerces an emitted null through the nullish guard', () => {
+    const onChange = vi.fn();
+    const { getByTestId } = render(
+      <UrlFormComponent
+        field={field()}
+        value="https://example.com"
+        onChange={onChange}
+        readOnly={false}
+      />
+    );
+    fireEvent.click(getByTestId('emit-null'));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('disables the input when readOnly is set', () => {
+    const { getByTestId } = render(
+      <UrlFormComponent field={field()} value={null} onChange={vi.fn()} readOnly={true} />
+    );
+    expect(getByTestId('leaf').getAttribute('data-disabled')).toBe('true');
+  });
+});

--- a/packages/@granit/react-ui-entities/src/side-peek-drawer.test.tsx
+++ b/packages/@granit/react-ui-entities/src/side-peek-drawer.test.tsx
@@ -1,0 +1,148 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { EntityRendererProvider } from '@granit/react-entities';
+import {
+  ENTITIES_BASE_PATH,
+  SAMPLE_ENTITY_ID,
+  SAMPLE_ENTITY_NAME,
+  createEntitiesHandlers,
+} from '@granit/react-entities/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { MemoryRouter } from 'react-router-dom';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { SidePeekDrawer } from './side-peek-drawer';
+
+import type { ReactNode } from 'react';
+import type * as ReactRouterDom from 'react-router-dom';
+
+const navigateSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactRouterDom>();
+  return { ...actual, useNavigate: () => navigateSpy };
+});
+
+const ORIGIN = 'http://localhost';
+const PARTY_ROW = '/api/v1/parties';
+
+// Absolute-URL handlers so the axios `baseURL` origin is matched by MSW.
+function baseHandlers() {
+  return [
+    ...createEntitiesHandlers(`${ORIGIN}${ENTITIES_BASE_PATH}`),
+    http.get(`${ORIGIN}${PARTY_ROW}/:id`, () =>
+      HttpResponse.json({ id: SAMPLE_ENTITY_ID, number: 'P-001', kind: 'Company' })
+    ),
+  ];
+}
+
+const server = setupServer(...baseHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers(...baseHandlers());
+  navigateSpy.mockReset();
+});
+afterAll(() => server.close());
+
+const PEEK_SEARCH = `?peek=${encodeURIComponent(SAMPLE_ENTITY_NAME)}:${encodeURIComponent(
+  SAMPLE_ENTITY_ID
+)}`;
+
+function renderDrawer(
+  options: { readonly search?: string; readonly activeWorkspaceName?: string | null } = {}
+) {
+  const { search = '', activeWorkspaceName } = options;
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: ORIGIN });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[`/parties${search}`]}>
+      <QueryClientProvider client={queryClient}>
+        <GranitClientProvider client={apiClient}>
+          <EntityRendererProvider>{children}</EntityRendererProvider>
+        </GranitClientProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+  return render(<SidePeekDrawer activeWorkspaceName={activeWorkspaceName} />, { wrapper });
+}
+
+describe('SidePeekDrawer', () => {
+  it('stays closed when the URL carries no peek parameter', () => {
+    renderDrawer();
+    expect(document.querySelector('[data-slot="side-peek-drawer"]')).toBeNull();
+  });
+
+  it('opens the drawer and shows a loading skeleton before the entity resolves', () => {
+    renderDrawer({ search: PEEK_SEARCH });
+    const drawer = document.querySelector('[data-slot="side-peek-drawer"]');
+    expect(drawer).not.toBeNull();
+    // EntityDetailContent has not resolved yet — populated body absent.
+    expect(document.querySelector('[data-slot="entity-detail-content"]')).toBeNull();
+  });
+
+  it('renders the entity detail body once the manifest and row resolve', async () => {
+    renderDrawer({ search: PEEK_SEARCH });
+    await waitFor(() =>
+      expect(document.querySelector('[data-slot="entity-detail-content"]')).not.toBeNull()
+    );
+  });
+
+  it('navigates to the workspace-scoped relation URL when a workspace is active', async () => {
+    renderDrawer({ search: PEEK_SEARCH, activeWorkspaceName: 'parties' });
+    const button = await waitFor(() => {
+      const el = document.querySelector('[data-relation="Invoices"]');
+      expect(el).not.toBeNull();
+      return el as HTMLButtonElement;
+    });
+    fireEvent.click(button);
+    expect(navigateSpy).toHaveBeenCalledWith(
+      `/w/${encodeURIComponent('parties')}/${encodeURIComponent(
+        'Granit.Invoicing.Invoice'
+      )}?source=${encodeURIComponent(SAMPLE_ENTITY_ID)}`
+    );
+  });
+
+  it('closes the peek without a workspace navigation when no workspace is active', async () => {
+    renderDrawer({ search: PEEK_SEARCH, activeWorkspaceName: null });
+    const button = await waitFor(() => {
+      const el = document.querySelector('[data-relation="Invoices"]');
+      expect(el).not.toBeNull();
+      return el as HTMLButtonElement;
+    });
+    fireEvent.click(button);
+    // No `/w/...` deep-link — only the closePeek replace-navigation fires.
+    const workspaceCall = navigateSpy.mock.calls.find(
+      (call) => typeof call[0] === 'string' && (call[0] as string).startsWith('/w/')
+    );
+    expect(workspaceCall).toBeUndefined();
+    expect(navigateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ pathname: '/parties', search: '' }),
+      expect.objectContaining({ replace: true })
+    );
+  });
+
+  it('closes the peek when the Sheet requests dismissal via Escape (onOpenChange)', async () => {
+    renderDrawer({ search: PEEK_SEARCH });
+    await waitFor(() =>
+      expect(document.querySelector('[data-slot="side-peek-drawer"]')).not.toBeNull()
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(navigateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ pathname: '/parties', search: '' }),
+      expect.objectContaining({ replace: true })
+    );
+  });
+
+  it('expands the top peek to the full detail page via the keyboard shortcut', async () => {
+    renderDrawer({ search: PEEK_SEARCH });
+    await waitFor(() =>
+      expect(document.querySelector('[data-slot="side-peek-drawer"]')).not.toBeNull()
+    );
+    fireEvent.keyDown(document, { key: '.', metaKey: true, shiftKey: true });
+    expect(navigateSpy).toHaveBeenCalledWith(`/entity/${encodeURIComponent(SAMPLE_ENTITY_ID)}`);
+  });
+});

--- a/packages/@granit/react-ui-entities/src/workspace-entity-detail-page.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/workspace-entity-detail-page.stories.tsx
@@ -1,0 +1,134 @@
+import { createApiClient } from '@granit/api-client';
+import { GranitClientProvider } from '@granit/react-api-client';
+import { EntityRendererProvider } from '@granit/react-entities';
+import {
+  ENTITIES_BASE_PATH,
+  SAMPLE_ENTITY_ID,
+  SAMPLE_ENTITY_NAME,
+  createEntitiesHandlers,
+} from '@granit/react-entities/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { delay, http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { WorkspaceEntityDetailPage } from './workspace-entity-detail-page';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ComponentType } from 'react';
+
+// ---------------------------------------------------------------------------
+// Harness — mirrors `workspace-entity-detail-page.test.tsx`. The detail body
+// (`<EntityDetailContent />`) drives discovery, the per-entity manifest,
+// relation aggregates and the single-row read; reuse the shared entities
+// handlers plus the row endpoint hanging off `links.list` (`/api/v1/parties`).
+// Relative paths let the MSW addon match against the Storybook origin.
+// ---------------------------------------------------------------------------
+
+const ROW_BASE_PATH = '/api/v1/parties';
+
+/** Raw camelCase wire row returned by `GET /api/v1/parties/{id}`. */
+const ROW: Record<string, unknown> = { number: 'P-001', kind: 'Company' };
+
+const mockApiClient = createApiClient({ baseURL: '' });
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+function loadedHandlers() {
+  return [
+    ...createEntitiesHandlers(ENTITIES_BASE_PATH),
+    http.get(`${ROW_BASE_PATH}/:id`, () => HttpResponse.json(ROW)),
+  ];
+}
+
+// The route supplies `/w/:workspace/:entity/:id` params, exactly like the test.
+const DETAIL_PATH = '/w/:workspace/:entity/:id';
+const WORKSPACE = 'acme';
+const detailEntry = `/w/${WORKSPACE}/${SAMPLE_ENTITY_NAME}/${SAMPLE_ENTITY_ID}`;
+
+/**
+ * Router decorator factory — mounts the page under a `<Route>` whose path
+ * carries the params `useParams()` reads. Providers come from the meta
+ * decorator, so this only owns the routing context.
+ */
+function routerDecorator(initialEntry: string, routePath: string) {
+  return function RouterDecorator(Story: ComponentType) {
+    return (
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path={routePath} element={<Story />} />
+        </Routes>
+      </MemoryRouter>
+    );
+  };
+}
+
+const meta = {
+  title: 'Entities/WorkspaceEntityDetailPage',
+  component: WorkspaceEntityDetailPage,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Workspace-scoped entity detail route (`/w/:workspace/:entity/:id`). Wraps `<EntityDetailContent />` in the unified `<EntityPageLayout />` shell (back button + comfortable width). Guards on the three route params; a missing one renders the missing-parameter shell.',
+      },
+    },
+  },
+  decorators: [
+    (Story: ComponentType) => (
+      <QueryClientProvider client={makeQueryClient()}>
+        <GranitClientProvider client={mockApiClient}>
+          <EntityRendererProvider>
+            <Story />
+          </EntityRendererProvider>
+        </GranitClientProvider>
+      </QueryClientProvider>
+    ),
+  ],
+} satisfies Meta<typeof WorkspaceEntityDetailPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Every route param resolves — the detail shell mounts with its back-button
+ * slot and the manifest-driven detail body (header, sections, relations).
+ */
+export const Default: Story = {
+  parameters: { msw: { handlers: loadedHandlers() } },
+  decorators: [routerDecorator(detailEntry, DETAIL_PATH)],
+};
+
+/**
+ * Discovery + manifest requests stay pending — the detail body shows its
+ * skeleton placeholder while the params themselves are fully resolved.
+ */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(ENTITIES_BASE_PATH, async () => {
+          await delay('infinite');
+        }),
+        http.get(`${ENTITIES_BASE_PATH}/:name`, async () => {
+          await delay('infinite');
+        }),
+      ],
+    },
+  },
+  decorators: [routerDecorator(detailEntry, DETAIL_PATH)],
+};
+
+/**
+ * The `id` route param is absent — the guard short-circuits and the
+ * missing-parameter shell renders instead of the detail body (no fetches).
+ */
+export const MissingParameter: Story = {
+  parameters: { msw: { handlers: [] } },
+  decorators: [routerDecorator(`/w/${WORKSPACE}/${SAMPLE_ENTITY_NAME}`, '/w/:workspace/:entity')],
+};

--- a/packages/@granit/react-ui-entities/src/workspace-entity-detail-page.test.tsx
+++ b/packages/@granit/react-ui-entities/src/workspace-entity-detail-page.test.tsx
@@ -1,0 +1,162 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { EntityRendererProvider } from '@granit/react-entities';
+import {
+  ENTITIES_BASE_PATH,
+  SAMPLE_ENTITY_ID,
+  SAMPLE_ENTITY_NAME,
+  createEntitiesHandlers,
+} from '@granit/react-entities/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { WorkspaceEntityDetailPage } from './workspace-entity-detail-page';
+
+import type { ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// MSW — the detail body (`<EntityDetailContent />`) drives discovery, the
+// per-entity manifest, relation aggregates and the single-row read. Reuse the
+// shared handlers plus the row endpoint hanging off `links.list`.
+// ---------------------------------------------------------------------------
+
+const ORIGIN = 'http://localhost';
+const ROW_BASE_PATH = '/api/v1/parties';
+
+/** Raw camelCase wire row returned by `GET /api/v1/parties/{id}`. */
+const ROW: Record<string, unknown> = { number: 'P-001', kind: 'Company' };
+
+function rowHandler(row: Record<string, unknown> = ROW) {
+  return http.get(`${ORIGIN}${ROW_BASE_PATH}/:id`, () => HttpResponse.json(row));
+}
+
+function baseHandlers() {
+  return [...createEntitiesHandlers(`${ORIGIN}${ENTITIES_BASE_PATH}`), rowHandler()];
+}
+
+const server = setupServer(...baseHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers(...baseHandlers()));
+afterAll(() => server.close());
+
+// ---------------------------------------------------------------------------
+// Render harness — QueryClient + Granit axios client + entity renderer +
+// a router that supplies the `/w/:workspace/:entity/:id` route params. The
+// probe mirrors the live location so back / relation navigations are
+// observable without mocking `useNavigate`.
+// ---------------------------------------------------------------------------
+
+let lastLocation = '';
+function LocationProbe() {
+  const loc = useLocation();
+  lastLocation = `${loc.pathname}${loc.search}`;
+  return null;
+}
+
+function renderAt(
+  initialEntry: string,
+  routePath: string,
+  ui: ReactNode = <WorkspaceEntityDetailPage />
+) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: ORIGIN });
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <QueryClientProvider client={queryClient}>
+        <GranitClientProvider client={apiClient}>
+          <EntityRendererProvider>
+            <Routes>
+              <Route path={routePath} element={ui} />
+            </Routes>
+            <LocationProbe />
+          </EntityRendererProvider>
+        </GranitClientProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+const DETAIL_PATH = '/w/:workspace/:entity/:id';
+const WORKSPACE = 'acme';
+const detailEntry = `/w/${WORKSPACE}/${SAMPLE_ENTITY_NAME}/${SAMPLE_ENTITY_ID}`;
+
+describe('WorkspaceEntityDetailPage', () => {
+  it('renders the missing-parameter shell when all route params are absent', () => {
+    const { container } = renderAt('/detail', '/detail');
+    const layout = container.querySelector('[data-slot="entity-page-layout"]');
+    expect(layout).not.toBeNull();
+    expect(layout?.getAttribute('data-content-width')).toBe('comfortable');
+    // The missing-param shell renders its own title header and no back slot.
+    expect(container.querySelector('[data-slot="entity-page-header"] h1')).not.toBeNull();
+    expect(container.querySelector('[data-slot="workspace-entity-detail-page"]')).toBeNull();
+    expect(container.querySelector('[data-slot="entity-page-back"]')).toBeNull();
+  });
+
+  it('renders the missing-parameter shell when only the entity + id are absent', () => {
+    // workspace resolves, entity/id do not => second operand of the guard.
+    const { container } = renderAt(`/w/${WORKSPACE}`, '/w/:workspace');
+    expect(container.querySelector('[data-slot="entity-page-layout"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="workspace-entity-detail-page"]')).toBeNull();
+  });
+
+  it('renders the missing-parameter shell when only the id is absent', () => {
+    // workspace + entity resolve, id does not => third operand of the guard.
+    const { container } = renderAt(
+      `/w/${WORKSPACE}/${SAMPLE_ENTITY_NAME}`,
+      '/w/:workspace/:entity'
+    );
+    expect(container.querySelector('[data-slot="entity-page-layout"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="workspace-entity-detail-page"]')).toBeNull();
+  });
+
+  it('mounts the detail shell (back slot + detail content) when every param resolves', async () => {
+    const { container } = renderAt(detailEntry, DETAIL_PATH);
+    const shell = container.querySelector('[data-slot="workspace-entity-detail-page"]');
+    expect(shell).not.toBeNull();
+    expect(shell?.getAttribute('data-content-width')).toBe('comfortable');
+    // Back-button slot is mounted; the detail body owns its own title header.
+    expect(container.querySelector('[data-slot="entity-page-back"] button')).not.toBeNull();
+    expect(container.querySelector('[data-slot="entity-page-header"]')).toBeNull();
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="entity-detail-content"]')).not.toBeNull()
+    );
+  });
+
+  it('navigates back to the workspace list when the back button is clicked', async () => {
+    const { container } = renderAt(detailEntry, DETAIL_PATH);
+    await waitFor(() =>
+      expect(container.querySelector('[data-slot="entity-detail-content"]')).not.toBeNull()
+    );
+    const backButton = container.querySelector(
+      '[data-slot="entity-page-back"] button'
+    ) as HTMLButtonElement;
+    fireEvent.click(backButton);
+    await waitFor(() =>
+      expect(lastLocation).toBe(
+        `/w/${encodeURIComponent(WORKSPACE)}/${encodeURIComponent(SAMPLE_ENTITY_NAME)}`
+      )
+    );
+  });
+
+  it('navigates to the relation target with the source id when a relation is clicked', async () => {
+    const { container } = renderAt(detailEntry, DETAIL_PATH);
+    // The shared manifest declares a SmartButton relation (Invoices).
+    const relation = await waitFor(() => {
+      const el = container.querySelector('[data-granit-relation-item]');
+      expect(el).not.toBeNull();
+      return el as Element;
+    });
+    fireEvent.click(relation);
+    const target = encodeURIComponent('Granit.Invoicing.Invoice');
+    await waitFor(() =>
+      expect(lastLocation).toBe(
+        `/w/${encodeURIComponent(WORKSPACE)}/${target}?source=${encodeURIComponent(SAMPLE_ENTITY_ID)}`
+      )
+    );
+  });
+});

--- a/packages/@granit/react-ui-entities/src/workspace-entity-form-page.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/workspace-entity-form-page.stories.tsx
@@ -1,0 +1,138 @@
+import { createApiClient } from '@granit/api-client';
+import { GranitClientProvider } from '@granit/react-api-client';
+import { EntityRendererProvider } from '@granit/react-entities';
+import {
+  SAMPLE_ENTITY_ID,
+  SAMPLE_ENTITY_NAME,
+  createEntitiesHandlers,
+} from '@granit/react-entities/testing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { delay, http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { WorkspaceEntityFormPage } from './workspace-entity-form-page';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+// Base path the sample entity's rows hang off — `links.list` for
+// `Granit.Parties.Party` in the discovery fixture (`createEntitiesHandlers`).
+const LIST_PATH = '/api/v1/parties';
+
+// camelCase wire row served on the edit path; `toPascalCaseKeys` flips it to
+// the manifest's `Number` / `Kind` fields before it seeds React Hook Form.
+const existingRow = { id: SAMPLE_ENTITY_ID, number: 'P-100', kind: 'Company' };
+
+const mockApiClient = createApiClient({ baseURL: '' });
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+const meta = {
+  title: 'Entities/WorkspaceEntityFormPage',
+  component: WorkspaceEntityFormPage,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Workspace-scoped entity create / edit page. Resolves the manifest (`useEntityMetadata`), the REST base path (`useEntityDiscovery`) and — in edit mode — the existing row (`useEntity`) from the route `:workspace` / `:entity` / `:id` params, then mounts a manifest-driven `<EntityForm />` wired to React Hook Form.',
+      },
+    },
+  },
+  decorators: [
+    // Provider stack that mirrors the sibling test harness: the entity hooks
+    // need a Granit client + React Query cache, and `<EntityForm />` reads its
+    // component catalog from `<EntityRendererProvider>`. A fresh QueryClient
+    // per render keeps the loading variant deterministic.
+    (Story) => (
+      <QueryClientProvider client={makeQueryClient()}>
+        <GranitClientProvider client={mockApiClient}>
+          <EntityRendererProvider>
+            <Story />
+          </EntityRendererProvider>
+        </GranitClientProvider>
+      </QueryClientProvider>
+    ),
+  ],
+} satisfies Meta<typeof WorkspaceEntityFormPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Create mode — the manifest's `default` form variant renders empty. The
+ * submit button stays disabled until the form is dirty. Route supplies
+ * `:workspace` + `:entity` (no `:id`).
+ */
+export const Default: Story = {
+  args: { mode: 'create' },
+  parameters: { msw: { handlers: createEntitiesHandlers() } },
+  decorators: [
+    (Story) => (
+      <MemoryRouter initialEntries={[`/w/acme/${SAMPLE_ENTITY_NAME}`]}>
+        <Routes>
+          <Route path="/w/:workspace/:entity" element={<Story />} />
+        </Routes>
+      </MemoryRouter>
+    ),
+  ],
+};
+
+/**
+ * Edit mode — the existing row is fetched from `${LIST_PATH}/{id}`, remapped
+ * to PascalCase and seeded into the form fields. The heading switches to
+ * "Edit" and the submit label to "Save". Route supplies `:id`.
+ */
+export const Edit: Story = {
+  args: { mode: 'edit' },
+  parameters: {
+    msw: {
+      handlers: [
+        ...createEntitiesHandlers(),
+        http.get(`${LIST_PATH}/${SAMPLE_ENTITY_ID}`, () => HttpResponse.json(existingRow)),
+      ],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <MemoryRouter initialEntries={[`/w/acme/${SAMPLE_ENTITY_NAME}/${SAMPLE_ENTITY_ID}/edit`]}>
+        <Routes>
+          <Route path="/w/:workspace/:entity/:id/edit" element={<Story />} />
+        </Routes>
+      </MemoryRouter>
+    ),
+  ],
+};
+
+/**
+ * Loading state — the discovery + manifest requests stay pending, so the page
+ * renders its skeleton placeholders instead of the form.
+ */
+export const Loading: Story = {
+  args: { mode: 'create' },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/v1/entities', async () => {
+          await delay('infinite');
+        }),
+        http.get('/api/v1/entities/:name', async () => {
+          await delay('infinite');
+        }),
+      ],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <MemoryRouter initialEntries={[`/w/acme/${SAMPLE_ENTITY_NAME}`]}>
+        <Routes>
+          <Route path="/w/:workspace/:entity" element={<Story />} />
+        </Routes>
+      </MemoryRouter>
+    ),
+  ],
+};

--- a/packages/@granit/react-ui-entities/src/workspace-entity-form-page.test.tsx
+++ b/packages/@granit/react-ui-entities/src/workspace-entity-form-page.test.tsx
@@ -1,0 +1,368 @@
+import {
+  SAMPLE_ENTITY_ID,
+  SAMPLE_ENTITY_NAME,
+  mockEntityDiscovery,
+  mockEntityManifest,
+} from '@granit/react-entities/testing';
+import { fireEvent, render, screen } from '@testing-library/react';
+import i18next from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { WorkspaceEntityFormPage } from './workspace-entity-form-page';
+
+import type { WorkspaceEntityFormPageProps } from './workspace-entity-form-page';
+import type { ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// Mocks — the page is a thin orchestrator over headless entity hooks, RHF and
+// two heavy children (`<EntityForm />`, `<CollectionSectionCard />`). Both
+// children have their own suites, so they are stubbed here to keep the test
+// focused on this file's branches (params guard, loading / not-found / no-
+// variant early returns, create vs edit submit paths, disabled states).
+// ---------------------------------------------------------------------------
+
+const {
+  mockNavigate,
+  mockUseParams,
+  mockUseEntityMetadata,
+  mockUseEntityDiscovery,
+  mockUseEntity,
+  mockUseEntityForm,
+  mockUseCreateEntity,
+  mockUseUpdateEntity,
+  mockCreateMutate,
+  mockUpdateMutate,
+} = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockUseParams: vi.fn(),
+  mockUseEntityMetadata: vi.fn(),
+  mockUseEntityDiscovery: vi.fn(),
+  mockUseEntity: vi.fn(),
+  mockUseEntityForm: vi.fn(),
+  mockUseCreateEntity: vi.fn(),
+  mockUseUpdateEntity: vi.fn(),
+  mockCreateMutate: vi.fn(),
+  mockUpdateMutate: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, useNavigate: () => mockNavigate, useParams: mockUseParams };
+});
+
+vi.mock('@granit/react-entities', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  EntityForm: () => <div data-testid="entity-form-stub" />,
+  useEntityMetadata: mockUseEntityMetadata,
+  useEntityDiscovery: mockUseEntityDiscovery,
+  useEntity: mockUseEntity,
+  useEntityForm: mockUseEntityForm,
+  useCreateEntity: mockUseCreateEntity,
+  useUpdateEntity: mockUseUpdateEntity,
+}));
+
+vi.mock('./collection-section-card', () => ({
+  CollectionSectionCard: ({ section }: { readonly section: { readonly key: string } }) => (
+    <div data-testid="collection-section-stub" data-key={section.key} />
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// i18n — empty flat bundle: `t(key, fallback)` returns the fallback (with
+// `{{title}}` interpolation), matching how the app renders before backend
+// bundles load. `resolveLabel(displayKey, name)` has no `t`, so it returns the
+// key's last segment (`DisplayName`).
+// ---------------------------------------------------------------------------
+
+const testI18n = i18next.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  ns: ['translation'],
+  defaultNS: 'translation',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: {} } },
+  interpolation: { escapeValue: false },
+});
+
+function wrapper({ children }: { readonly children: ReactNode }) {
+  return <I18nextProvider i18n={testI18n}>{children}</I18nextProvider>;
+}
+
+function renderPage(mode: WorkspaceEntityFormPageProps['mode']) {
+  return render(<WorkspaceEntityFormPage mode={mode} />, { wrapper });
+}
+
+function formApi(isDirty: boolean, submitValues: Readonly<Record<string, unknown>> = {}) {
+  return {
+    formProps: { values: {}, onChange: vi.fn(), errors: {} },
+    isDirty,
+    handleSubmit:
+      (cb: (values: Readonly<Record<string, unknown>>) => void) =>
+      (event?: { preventDefault?: () => void }) => {
+        event?.preventDefault?.();
+        cb(submitValues);
+      },
+  };
+}
+
+const LIST_PATH = `/w/acme/${SAMPLE_ENTITY_NAME}`;
+const existingEntity = { id: SAMPLE_ENTITY_ID, number: 'P-1', kind: 'Company' };
+
+function submitForm() {
+  const form = document.querySelector('[data-slot="workspace-entity-form"]');
+  if (!form) throw new Error('form not rendered');
+  fireEvent.submit(form);
+}
+
+beforeEach(() => {
+  mockUseParams.mockReturnValue({ workspace: 'acme', entity: SAMPLE_ENTITY_NAME, id: undefined });
+  mockUseEntityMetadata.mockReturnValue({ data: mockEntityManifest, isLoading: false });
+  mockUseEntityDiscovery.mockReturnValue({ data: mockEntityDiscovery });
+  mockUseEntity.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+  mockUseEntityForm.mockReturnValue(formApi(false));
+  mockUseCreateEntity.mockReturnValue({ mutate: mockCreateMutate, isPending: false });
+  mockUseUpdateEntity.mockReturnValue({ mutate: mockUpdateMutate, isPending: false });
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe('WorkspaceEntityFormPage', () => {
+  describe('parameter guard', () => {
+    it('renders the missing-parameter notice when the workspace param is absent', () => {
+      mockUseParams.mockReturnValue({ workspace: undefined, entity: SAMPLE_ENTITY_NAME });
+      renderPage('create');
+      const root = document.querySelector('[data-slot="workspace-entity-form-page"]');
+      expect(root).toBeInTheDocument();
+      expect(screen.getByText('Missing entity parameter')).toBeInTheDocument();
+    });
+
+    it('renders the missing-parameter notice in edit mode when the id is absent', () => {
+      mockUseParams.mockReturnValue({
+        workspace: 'acme',
+        entity: SAMPLE_ENTITY_NAME,
+        id: undefined,
+      });
+      renderPage('edit');
+      expect(screen.getByText('Missing entity parameter')).toBeInTheDocument();
+    });
+
+    it('tolerates an absent entity param (empty-string hook fallback, no base path)', () => {
+      mockUseParams.mockReturnValue({ workspace: 'acme', entity: undefined, id: undefined });
+      renderPage('create');
+      expect(screen.getByText('Missing entity parameter')).toBeInTheDocument();
+      expect(mockUseEntityMetadata).toHaveBeenCalledWith('');
+    });
+  });
+
+  describe('loading state', () => {
+    it('renders skeletons while the manifest is loading', () => {
+      mockUseEntityMetadata.mockReturnValue({ data: undefined, isLoading: true });
+      renderPage('create');
+      expect(document.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+      expect(document.querySelector('[data-slot="workspace-entity-form-page"]')).toBeNull();
+    });
+
+    it('renders skeletons in edit mode while the existing entity is loading', () => {
+      mockUseParams.mockReturnValue({
+        workspace: 'acme',
+        entity: SAMPLE_ENTITY_NAME,
+        id: SAMPLE_ENTITY_ID,
+      });
+      mockUseEntity.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+      renderPage('edit');
+      expect(document.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('not-found state', () => {
+    it('renders the not-found notice and navigates back when the manifest is null', () => {
+      mockUseEntityMetadata.mockReturnValue({ data: undefined, isLoading: false });
+      renderPage('create');
+      expect(screen.getByText('Could not load record')).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: 'Back to list' }));
+      expect(mockNavigate).toHaveBeenCalledWith(LIST_PATH);
+    });
+
+    it('renders the not-found notice in edit mode when the entity query errors', () => {
+      mockUseParams.mockReturnValue({
+        workspace: 'acme',
+        entity: SAMPLE_ENTITY_NAME,
+        id: SAMPLE_ENTITY_ID,
+      });
+      mockUseEntity.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+      renderPage('edit');
+      expect(screen.getByText('Could not load record')).toBeInTheDocument();
+    });
+  });
+
+  describe('no-variant state', () => {
+    it('renders the no-variant notice when the manifest declares no forms', () => {
+      mockUseEntityMetadata.mockReturnValue({
+        data: { ...mockEntityManifest, forms: [] },
+        isLoading: false,
+      });
+      renderPage('create');
+      expect(screen.getByText('No form variant')).toBeInTheDocument();
+    });
+  });
+
+  describe('create mode', () => {
+    it('renders the create heading, subtitle, form and action buttons', () => {
+      renderPage('create');
+      expect(screen.getByText('New DisplayName')).toBeInTheDocument();
+      expect(screen.getByText('DisplayName')).toBeInTheDocument();
+      const form = document.querySelector('[data-slot="workspace-entity-form"]');
+      expect(form).toHaveAttribute('data-mode', 'create');
+      expect(screen.getByTestId('entity-form-stub')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument();
+    });
+
+    it('disables the submit button when the form is pristine and enables it when dirty', () => {
+      const { rerender } = renderPage('create');
+      expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+
+      mockUseEntityForm.mockReturnValue(formApi(true));
+      rerender(<WorkspaceEntityFormPage mode="create" />);
+      expect(screen.getByRole('button', { name: 'Create' })).toBeEnabled();
+    });
+
+    it('creates the entity and navigates to its detail page on success', () => {
+      mockUseEntityForm.mockReturnValue(formApi(true, { number: 'P-9' }));
+      mockCreateMutate.mockImplementation(
+        (_values: unknown, opts: { onSuccess: (data: Record<string, unknown>) => void }) => {
+          opts.onSuccess({ id: 'created-id' });
+        }
+      );
+      renderPage('create');
+      submitForm();
+      expect(mockCreateMutate).toHaveBeenCalledWith(
+        { number: 'P-9' },
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
+      expect(mockNavigate).toHaveBeenCalledWith(`${LIST_PATH}/created-id`);
+    });
+
+    it('stays on the page when the create response carries no id', () => {
+      mockUseEntityForm.mockReturnValue(formApi(true));
+      mockCreateMutate.mockImplementation(
+        (_values: unknown, opts: { onSuccess: (data: Record<string, unknown>) => void }) => {
+          opts.onSuccess({});
+        }
+      );
+      renderPage('create');
+      submitForm();
+      expect(mockCreateMutate).toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('shows the saving label and disables the submit while the create mutation is pending', () => {
+      mockUseEntityForm.mockReturnValue(formApi(true));
+      mockUseCreateEntity.mockReturnValue({ mutate: mockCreateMutate, isPending: true });
+      renderPage('create');
+      const submit = screen.getByRole('button', { name: 'Saving…' });
+      expect(submit).toBeDisabled();
+    });
+
+    it('falls back to the first form variant when no "default" variant exists', () => {
+      const custom = mockEntityManifest.forms[0];
+      mockUseEntityMetadata.mockReturnValue({
+        data: { ...mockEntityManifest, forms: [{ ...custom, name: 'custom' }] },
+        isLoading: false,
+      });
+      renderPage('create');
+      expect(screen.getByTestId('entity-form-stub')).toBeInTheDocument();
+    });
+
+    it('falls back to the entity name in the title when the manifest has no identity', () => {
+      mockUseEntityMetadata.mockReturnValue({
+        data: { ...mockEntityManifest, identity: null },
+        isLoading: false,
+      });
+      renderPage('create');
+      expect(screen.getByText(`New ${SAMPLE_ENTITY_NAME}`)).toBeInTheDocument();
+    });
+
+    it('resolves an undefined base path when discovery has no matching entity', () => {
+      mockUseParams.mockReturnValue({ workspace: 'acme', entity: 'Unknown.Entity', id: undefined });
+      renderPage('create');
+      expect(screen.getByTestId('entity-form-stub')).toBeInTheDocument();
+      expect(mockUseCreateEntity).toHaveBeenCalledWith(
+        'Unknown.Entity',
+        expect.objectContaining({ basePath: undefined })
+      );
+    });
+
+    it('navigates to the list from the cancel and back buttons', () => {
+      renderPage('create');
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(mockNavigate).toHaveBeenCalledWith(LIST_PATH);
+      mockNavigate.mockClear();
+      fireEvent.click(screen.getByRole('button', { name: 'Back to list' }));
+      expect(mockNavigate).toHaveBeenCalledWith(LIST_PATH);
+    });
+  });
+
+  describe('edit mode', () => {
+    const extendedManifest = {
+      ...mockEntityManifest,
+      collectionSections: [
+        { key: 'lines', labelKey: null, order: 2, propertyName: 'lines', columns: [] },
+        { key: 'addresses', labelKey: null, order: 1, propertyName: 'addresses', columns: [] },
+      ],
+    };
+
+    beforeEach(() => {
+      mockUseParams.mockReturnValue({
+        workspace: 'acme',
+        entity: SAMPLE_ENTITY_NAME,
+        id: SAMPLE_ENTITY_ID,
+      });
+      mockUseEntity.mockReturnValue({ data: existingEntity, isLoading: false, isError: false });
+    });
+
+    it('renders the edit heading, the save label and the collection sections sorted by order', () => {
+      mockUseEntityMetadata.mockReturnValue({ data: extendedManifest, isLoading: false });
+      renderPage('edit');
+      expect(screen.getByText('Edit DisplayName')).toBeInTheDocument();
+      expect(document.querySelector('[data-slot="workspace-entity-form"]')).toHaveAttribute(
+        'data-mode',
+        'edit'
+      );
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+      const cards = screen.getAllByTestId('collection-section-stub');
+      expect(cards.map((card) => card.getAttribute('data-key'))).toEqual(['addresses', 'lines']);
+    });
+
+    it('updates the entity and navigates using the route id on success', () => {
+      mockUseEntityForm.mockReturnValue(formApi(true, { number: 'P-2' }));
+      mockUpdateMutate.mockImplementation(
+        (_arg: unknown, opts: { onSuccess: (data: Record<string, unknown>) => void }) => {
+          opts.onSuccess({});
+        }
+      );
+      renderPage('edit');
+      submitForm();
+      expect(mockUpdateMutate).toHaveBeenCalledWith(
+        { id: SAMPLE_ENTITY_ID, values: { number: 'P-2' } },
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
+      expect(mockNavigate).toHaveBeenCalledWith(`${LIST_PATH}/${SAMPLE_ENTITY_ID}`);
+    });
+
+    it('shows the saving label while the update mutation is pending', () => {
+      mockUseEntityForm.mockReturnValue(formApi(true));
+      mockUseUpdateEntity.mockReturnValue({ mutate: mockUpdateMutate, isPending: true });
+      renderPage('edit');
+      expect(screen.getByRole('button', { name: 'Saving…' })).toBeDisabled();
+    });
+
+    it('renders no collection sections when the manifest declares none', () => {
+      renderPage('edit');
+      expect(screen.queryByTestId('collection-section-stub')).toBeNull();
+    });
+  });
+});

--- a/packages/@granit/react-ui-entities/src/workspace-entity-page.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/workspace-entity-page.stories.tsx
@@ -1,0 +1,180 @@
+import { createApiClient } from '@granit/api-client';
+import { GranitClientProvider } from '@granit/react-api-client';
+import {
+  ENTITIES_BASE_PATH,
+  SAMPLE_ENTITY_NAME,
+  createEntitiesHandlers,
+} from '@granit/react-entities/testing';
+import { buildEmptyQueryMeta, createQueryMetaHandler } from '@granit/react-query-engine/testing';
+import { pagedResponse } from '@granit/testing/msw';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { EntityActionScopeProvider } from './entity-action-scope';
+import { WorkspaceEntityPage } from './workspace-entity-page';
+
+import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
+import type { RequestHandler } from 'msw';
+
+// ---------------------------------------------------------------------------
+// Route wiring
+//
+// The page reads `:workspace` / `:entity` via `useParams` and resolves its
+// REST base path from the entity-discovery tree. `Granit.Parties.Party` is
+// routable (discovery exposes `links.list = /api/v1/parties`);
+// `Granit.Parties.Contact` is registered but has `links.list = null`, which
+// drives the "not yet routable" guard.
+// ---------------------------------------------------------------------------
+const ROUTE_PATH = '/w/:workspace/:entity';
+const PARTY_ROUTE = `/w/sales/${SAMPLE_ENTITY_NAME}`;
+const CONTACT_ROUTE = '/w/sales/Granit.Parties.Contact';
+
+const client = createApiClient({ baseURL: '' });
+
+function withEntityRoute(initialEntry: string): Decorator {
+  return function EntityRouteDecorator(Story) {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    return (
+      <QueryClientProvider client={queryClient}>
+        <GranitClientProvider client={client}>
+          <MemoryRouter initialEntries={[initialEntry]}>
+            <Routes>
+              <Route
+                path={ROUTE_PATH}
+                element={
+                  <EntityActionScopeProvider>
+                    <Story />
+                  </EntityActionScopeProvider>
+                }
+              />
+            </Routes>
+          </MemoryRouter>
+        </GranitClientProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MSW handlers
+//
+// `createEntitiesHandlers` serves discovery + per-entity manifest. The
+// query-engine grid then hits `{list}/meta` (columns) and `{list}` (rows) at
+// the discovered base path `/api/v1/parties`.
+// ---------------------------------------------------------------------------
+const PARTIES_BASE_PATH = '/api/v1/parties';
+
+const partyMeta = buildEmptyQueryMeta({
+  columns: [
+    {
+      name: 'kind',
+      label: 'Kind',
+      type: 'String',
+      order: 0,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'number',
+      label: 'Number',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  groupByFields: [{ name: 'kind', type: 'String' }],
+  presetFilterGroups: [
+    {
+      name: 'g',
+      label: 'Kind',
+      presets: [{ name: 'customer', label: 'Customers', isDefault: false }],
+    },
+  ],
+});
+
+const partyRows: ReadonlyArray<Record<string, unknown>> = [
+  { id: 'party-1', kind: 'Customer', number: 'PTY-0001' },
+  { id: 'party-2', kind: 'Supplier', number: 'PTY-0002' },
+  { id: 'party-3', kind: 'Customer', number: 'PTY-0003' },
+];
+
+function partiesListHandler(rows: ReadonlyArray<Record<string, unknown>>): RequestHandler {
+  return http.get(PARTIES_BASE_PATH, () => pagedResponse(rows, rows.length));
+}
+
+const baseHandlers: RequestHandler[] = [
+  ...createEntitiesHandlers(ENTITIES_BASE_PATH),
+  createQueryMetaHandler(PARTIES_BASE_PATH, partyMeta),
+];
+
+const populatedHandlers: RequestHandler[] = [...baseHandlers, partiesListHandler(partyRows)];
+const emptyHandlers: RequestHandler[] = [...baseHandlers, partiesListHandler([])];
+
+// ---------------------------------------------------------------------------
+// Meta
+// ---------------------------------------------------------------------------
+const meta = {
+  title: 'Entities/WorkspaceEntityPage',
+  component: WorkspaceEntityPage,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Route-level, 100% manifest-driven entity list page (`/w/:workspace/:entity`). Resolves its REST base path from entity discovery, builds columns from QueryMetadata and renders the manifest-declared layouts, selection bar and row actions.',
+      },
+    },
+  },
+  args: {
+    // Storage-agnostic image slot for the gallery layout — the host injects it.
+    renderImage: () => null,
+  },
+  decorators: [withEntityRoute(PARTY_ROUTE)],
+} satisfies Meta<typeof WorkspaceEntityPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/**
+ * Loaded list view for a routable entity: create action, smart-filter bar,
+ * sort / group-by selectors, preset chips and per-row open/edit actions,
+ * populated from the mocked `/api/v1/parties` grid.
+ */
+export const Default: Story = {
+  parameters: {
+    msw: { handlers: populatedHandlers },
+  },
+};
+
+/**
+ * Same manifest, but the grid resolves to zero rows — the toolbar stays
+ * mounted and the record count collapses to `0`.
+ */
+export const EmptyList: Story = {
+  parameters: {
+    msw: { handlers: emptyHandlers },
+  },
+};
+
+/**
+ * `Granit.Parties.Contact` is registered in the discovery tree but exposes no
+ * list endpoint (`links.list = null`), so the page renders the
+ * "not yet routable" guard instead of a grid.
+ */
+export const NotRoutable: Story = {
+  decorators: [withEntityRoute(CONTACT_ROUTE)],
+  parameters: {
+    msw: { handlers: baseHandlers },
+  },
+};

--- a/packages/@granit/react-ui-entities/src/workspace-entity-page.test.tsx
+++ b/packages/@granit/react-ui-entities/src/workspace-entity-page.test.tsx
@@ -1,0 +1,927 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import {
+  ENTITIES_BASE_PATH,
+  SAMPLE_ENTITY_NAME,
+  createEntitiesHandlers,
+  mockEntityManifest,
+} from '@granit/react-entities/testing';
+import { buildEmptyQueryMeta } from '@granit/react-query-engine/testing';
+import { toast, TooltipProvider } from '@granit/react-ui';
+import { createMswServer } from '@granit/testing/msw-server';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+import i18next from 'i18next';
+import { http, HttpResponse } from 'msw';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntityActionScopeProvider } from './entity-action-scope';
+import { WorkspaceEntityPage } from './workspace-entity-page';
+
+import type { GalleryRenderImage } from './entity-gallery-view';
+import type {
+  EntityActionManifest,
+  EntityListLayoutManifest,
+  EntityManifestResponse,
+  EntitySelectionActionManifest,
+} from '@granit/entities';
+import type { QueryMetadata } from '@granit/query-engine';
+import type { EntitySelectionBarRecap } from '@granit/react-entities';
+import type { ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// Mutable query-engine state shared with the vi.mock factory below. Each test
+// mutates `qe.*` before rendering; the mocked hooks read the current value.
+// ---------------------------------------------------------------------------
+const qe = vi.hoisted(() => ({
+  meta: { data: undefined as unknown, isLoading: false },
+  endpoint: {
+    params: {
+      page: 1,
+      pageSize: 20,
+      sort: [] as unknown[],
+      groupBy: undefined as string | undefined,
+    },
+    query: {
+      data: { items: [] as ReadonlyArray<Record<string, unknown>>, totalCount: 0 },
+      isLoading: false,
+      isFetching: false,
+    } as {
+      data: { items: ReadonlyArray<Record<string, unknown>>; totalCount: number } | undefined;
+      isLoading: boolean;
+      isFetching: boolean;
+    },
+    groupedQuery: {
+      data: { groups: [] as unknown[], totalCount: 0 } as
+        { groups: unknown[]; totalCount: number } | undefined,
+      isLoading: false,
+    },
+    isGrouped: false,
+    setPage: vi.fn(),
+    setPageSize: vi.fn(),
+    toggleSort: vi.fn(),
+    setGroupBy: vi.fn(),
+    setSearch: vi.fn(),
+  },
+  smartFilter: {
+    filters: [] as unknown[],
+    search: '',
+    presets: {} as Record<string, unknown>,
+    quickFilters: [] as unknown[],
+    tokens: [] as unknown[],
+    setSearch: vi.fn(),
+    addFilter: vi.fn(),
+    removeFilter: vi.fn(),
+    clearFilters: vi.fn(),
+    removeToken: vi.fn(),
+  },
+}));
+
+vi.mock('@granit/react-query-engine', () => ({
+  QueryProvider: ({ children }: { readonly children: ReactNode }) => children,
+  QueryEndpointStateProvider: ({ children }: { readonly children: ReactNode }) => children,
+  useQueryMeta: () => qe.meta,
+  useQueryEndpoint: () => qe.endpoint,
+  useSmartFilter: () => qe.smartFilter,
+  formatCell: ({
+    row,
+    column,
+    currencyResolver,
+  }: {
+    readonly row: Record<string, unknown>;
+    readonly column: { readonly name: string };
+    readonly currencyResolver?: (row: Readonly<Record<string, unknown>>) => string;
+  }) => {
+    // Exercise the page's currency-resolver so its fallback chain is covered.
+    currencyResolver?.(row);
+    return String(row[column.name] ?? '');
+  },
+}));
+
+vi.mock('@granit/react-ui-kit', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useOperatorLabels: () => ({}),
+    useSmartFilterSync: () => ({ handlePresetToggle: vi.fn() }),
+  };
+});
+
+// Stub the heavy alternate-layout renderers so the switch branches in
+// `renderLayoutBody` are exercised without dragging in their own data layers.
+vi.mock('./entity-calendar-view', () => ({
+  EntityCalendarView: () => <div data-testid="calendar-view" />,
+}));
+vi.mock('./entity-kanban-view', () => ({
+  EntityKanbanView: () => <div data-testid="kanban-view" />,
+}));
+vi.mock('./entity-gallery-view', () => ({
+  EntityGalleryView: () => <div data-testid="gallery-view" />,
+}));
+
+// Replace the page-header + selection-bar with markers. The bar exposes buttons
+// that invoke the `confirm` / `onComplete` callbacks the page wires up, so the
+// recap-toast and confirm-dialog branches are drivable from the test.
+vi.mock('@granit/react-entities', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const action: EntitySelectionActionManifest = {
+    name: 'Approve',
+    displayKey: 'Act.Approve',
+    icon: null,
+    confirmationKey: 'Act.Confirm',
+    contributorAssemblyName: null,
+  };
+  const actionNoKey: EntitySelectionActionManifest = { ...action, confirmationKey: null };
+  const actionNoDisplay: EntitySelectionActionManifest = { ...action, displayKey: null };
+  const navTemplated: EntityActionManifest = {
+    name: 'Go',
+    kind: 'Navigate',
+    displayKey: null,
+    icon: null,
+    order: 0,
+    urlTemplate: '/w/x/{id}',
+    httpMethod: null,
+    confirmationKey: null,
+    workflowTransitionName: null,
+    contributorAssemblyName: null,
+  };
+  const navPlain: EntityActionManifest = { ...navTemplated, urlTemplate: '/w/plain' };
+  const navNoUrl: EntityActionManifest = { ...navTemplated, urlTemplate: null };
+  return {
+    ...actual,
+    EntityListPageHeader: () => <div data-testid="list-header" />,
+    EntitySelectionBar: (props: {
+      readonly confirm: (
+        a: EntitySelectionActionManifest,
+        ids: ReadonlySet<string>
+      ) => Promise<boolean>;
+      readonly onComplete: (
+        a: EntitySelectionActionManifest,
+        recap: EntitySelectionBarRecap
+      ) => void;
+      readonly handlers?: {
+        readonly navigate?: (action: EntityActionManifest, rowId: string | null) => void;
+      };
+    }) => (
+      <div data-testid="selection-bar">
+        <button
+          type="button"
+          data-testid="bar-success-nokey"
+          onClick={() =>
+            props.onComplete(actionNoDisplay, { succeeded: ['a'], failed: [], parents: undefined })
+          }
+        >
+          success-nokey
+        </button>
+        <button
+          type="button"
+          data-testid="bar-nav-id"
+          onClick={() => props.handlers?.navigate?.(navTemplated, 'row-9')}
+        >
+          nav-id
+        </button>
+        <button
+          type="button"
+          data-testid="bar-nav-noid"
+          onClick={() => props.handlers?.navigate?.(navPlain, null)}
+        >
+          nav-noid
+        </button>
+        <button
+          type="button"
+          data-testid="bar-nav-nourl"
+          onClick={() => props.handlers?.navigate?.(navNoUrl, 'row-9')}
+        >
+          nav-nourl
+        </button>
+        <button
+          type="button"
+          data-testid="bar-confirm"
+          onClick={() => {
+            void props.confirm(action, new Set(['a', 'b']));
+          }}
+        >
+          confirm
+        </button>
+        <button
+          type="button"
+          data-testid="bar-confirm-nokey"
+          onClick={() => {
+            void props.confirm(actionNoKey, new Set(['a']));
+          }}
+        >
+          confirm-nokey
+        </button>
+        <button
+          type="button"
+          data-testid="bar-success"
+          onClick={() =>
+            props.onComplete(action, { succeeded: ['a', 'b'], failed: [], parents: undefined })
+          }
+        >
+          success
+        </button>
+        <button
+          type="button"
+          data-testid="bar-fail"
+          onClick={() =>
+            props.onComplete(action, {
+              succeeded: [],
+              failed: [{ id: 'a', error: 'x' }],
+              parents: [],
+            })
+          }
+        >
+          fail
+        </button>
+        <button
+          type="button"
+          data-testid="bar-partial"
+          onClick={() =>
+            props.onComplete(action, {
+              succeeded: ['a'],
+              failed: [{ id: 'b', error: 'y' }],
+              parents: ['Granit.Parties.Party:123'],
+            })
+          }
+        >
+          partial
+        </button>
+      </div>
+    ),
+  };
+});
+
+vi.mock('@granit/react-ui', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures & harness
+// ---------------------------------------------------------------------------
+const MANIFEST_URL = 'http://localhost/api/v1/entities/:name';
+
+const server = createMswServer(
+  { onUnhandledRequest: 'error' },
+  ...createEntitiesHandlers(`http://localhost${ENTITIES_BASE_PATH}`)
+);
+
+const renderImage: GalleryRenderImage = () => null;
+
+const i18n = i18next.createInstance();
+void i18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  resources: { en: { translation: {} } },
+  interpolation: { escapeValue: false },
+});
+
+function LocationProbe() {
+  const loc = useLocation();
+  return (
+    <div data-testid="loc">
+      {loc.pathname}
+      {loc.search}
+    </div>
+  );
+}
+
+function renderPage(
+  route = `/w/sales/${encodeURIComponent(SAMPLE_ENTITY_NAME)}`,
+  path = '/w/:workspace/:entity'
+) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>
+        <I18nextProvider i18n={i18n}>
+          <TooltipProvider>
+            <MemoryRouter initialEntries={[route]}>
+              <LocationProbe />
+              <Routes>
+                <Route
+                  path={path}
+                  element={
+                    <EntityActionScopeProvider>
+                      <WorkspaceEntityPage renderImage={renderImage} />
+                    </EntityActionScopeProvider>
+                  }
+                />
+              </Routes>
+            </MemoryRouter>
+          </TooltipProvider>
+        </I18nextProvider>
+      </GranitClientProvider>
+    </QueryClientProvider>
+  );
+}
+
+function fullMeta(overrides?: Partial<QueryMetadata>): QueryMetadata {
+  return buildEmptyQueryMeta({
+    columns: [
+      {
+        name: 'kind',
+        label: 'Kind',
+        type: 'String',
+        order: 0,
+        isSortable: true,
+        isFilterable: true,
+        isVisible: true,
+      },
+      {
+        name: 'number',
+        label: 'Number',
+        type: 'String',
+        order: 1,
+        isSortable: true,
+        isFilterable: true,
+        isVisible: true,
+      },
+      {
+        name: 'secret',
+        label: 'Secret',
+        type: 'String',
+        order: 2,
+        isSortable: false,
+        isFilterable: false,
+        isVisible: false,
+      },
+    ],
+    groupByFields: [{ name: 'kind', type: 'String' }],
+    presetFilterGroups: [
+      { name: 'g', label: 'Group', presets: [{ name: 'p', label: 'Preset', isDefault: false }] },
+    ],
+    ...overrides,
+  });
+}
+
+function resetEndpoint() {
+  qe.endpoint.params = { page: 1, pageSize: 20, sort: [], groupBy: undefined };
+  qe.endpoint.query = {
+    data: {
+      items: [
+        { id: 'row-1', kind: 'A', number: 'INV-1' },
+        { id: 'row-2', kind: 'B', number: 'INV-2' },
+        { kind: 'C', number: 'no-id' },
+      ],
+      totalCount: 3,
+    },
+    isLoading: false,
+    isFetching: false,
+  };
+  qe.endpoint.groupedQuery = { data: { groups: [], totalCount: 0 }, isLoading: false };
+  qe.endpoint.isGrouped = false;
+}
+
+function buildManifest(over: {
+  readonly permissions?: EntityManifestResponse['permissions'];
+  readonly selectionActions?: readonly EntitySelectionActionManifest[];
+  readonly listLayouts?: readonly EntityListLayoutManifest[];
+}): EntityManifestResponse {
+  const c = mockEntityManifest.collections;
+  return {
+    ...mockEntityManifest,
+    permissions: over.permissions ?? mockEntityManifest.permissions,
+    collections: c
+      ? {
+          ...c,
+          selectionActions: over.selectionActions ?? c.selectionActions,
+          listLayouts: over.listLayouts ?? c.listLayouts,
+        }
+      : c,
+  };
+}
+
+function serveManifest(manifest: EntityManifestResponse) {
+  server.use(
+    http.get(MANIFEST_URL, ({ params }) =>
+      typeof params.name === 'string' && params.name.length > 0
+        ? HttpResponse.json(manifest, { headers: { ETag: '"custom"' } })
+        : new HttpResponse(null, { status: 404 })
+    )
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  qe.meta = { data: fullMeta(), isLoading: false };
+  resetEndpoint();
+  qe.smartFilter = {
+    filters: [],
+    search: '',
+    presets: {},
+    quickFilters: [],
+    tokens: [],
+    setSearch: vi.fn(),
+    addFilter: vi.fn(),
+    removeFilter: vi.fn(),
+    clearFilters: vi.fn(),
+    removeToken: vi.fn(),
+  };
+});
+
+afterEach(() => {
+  vi.mocked(toast.success).mockClear();
+});
+
+const calendarCfg = {
+  startPropertyName: 'start',
+  endPropertyName: null,
+  titlePropertyName: null,
+  colorByPropertyName: null,
+  actions: [],
+};
+const kanbanCfg = {
+  groupByPropertyName: 'kind',
+  groupByClrTypeName: 'String',
+  card: { titleProperty: null, fields: [], relations: [], actions: [] },
+  columns: [],
+};
+const galleryCfg = {
+  imagePropertyName: 'image',
+  titlePropertyName: null,
+  subtitlePropertyName: null,
+  groupByPropertyName: null,
+  cardSize: 'Medium' as const,
+  actions: [],
+};
+
+// ---------------------------------------------------------------------------
+// Early-return branches on the exported page
+// ---------------------------------------------------------------------------
+describe('WorkspaceEntityPage — guards', () => {
+  it('renders the missing-parameter view when route params are absent', async () => {
+    renderPage('/plain', '/plain');
+    expect(await screen.findByText('Missing entity parameter')).toBeInTheDocument();
+    expect(screen.queryByTestId('selection-bar')).toBeNull();
+  });
+
+  it('renders the loading view while manifest/discovery are pending', () => {
+    const { container } = renderPage();
+    // Synchronous first paint: queries still in flight → skeleton, no content.
+    expect(container.querySelector('[data-slot="skeleton"]')).not.toBeNull();
+    expect(screen.queryByTestId('selection-bar')).toBeNull();
+  });
+
+  it('renders the not-found view when the manifest request errors', async () => {
+    server.use(http.get(MANIFEST_URL, () => new HttpResponse(null, { status: 500 })));
+    renderPage();
+    expect(await screen.findByText('Entity not found')).toBeInTheDocument();
+  });
+
+  it('renders the not-routable view when discovery exposes no list endpoint', async () => {
+    renderPage('/w/sales/Granit.Parties.Contact');
+    expect(await screen.findByText('Entity is not yet routable')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Populated List view + toolbar gating
+// ---------------------------------------------------------------------------
+describe('WorkspaceEntityPage — list view', () => {
+  it('mounts the manifest-driven list with create action, toolbar and row actions', async () => {
+    renderPage();
+    await screen.findByTestId('selection-bar');
+
+    expect(document.querySelector('[data-slot="workspace-entity-create"]')).not.toBeNull();
+    expect(document.querySelector('[data-slot="smart-filter-bar"]')).not.toBeNull();
+    expect(document.querySelector('[data-slot="sort-selector"]')).not.toBeNull();
+    expect(document.querySelector('[data-slot="group-by-selector"]')).not.toBeNull();
+    expect(document.querySelector('[data-slot="filter-presets"]')).not.toBeNull();
+
+    // Two rows carry an id (the third is id-less) → two open + two edit buttons.
+    expect(screen.getAllByLabelText('Open')).toHaveLength(2);
+    expect(screen.getAllByLabelText('Edit')).toHaveLength(2);
+
+    const count = document.querySelector('.ml-auto');
+    expect(count?.textContent).toContain('3');
+  });
+
+  it('shows the spinner while the query metadata is loading', async () => {
+    qe.meta = { data: undefined, isLoading: true };
+    renderPage();
+    await waitFor(() =>
+      expect(document.querySelector('[data-slot="workspace-entity-loading"]')).not.toBeNull()
+    );
+    expect(screen.queryByTestId('selection-bar')).toBeNull();
+  });
+
+  it('hides create and edit actions when permissions deny them', async () => {
+    serveManifest(
+      buildManifest({
+        permissions: {
+          canRead: true,
+          canCreate: false,
+          canUpdate: false,
+          canDelete: false,
+          canManage: false,
+          canExecute: false,
+        },
+      })
+    );
+    renderPage();
+    await screen.findByTestId('selection-bar');
+
+    expect(document.querySelector('[data-slot="workspace-entity-create"]')).toBeNull();
+    expect(screen.queryByLabelText('Edit')).toBeNull();
+    // Open (view) stays available regardless of update permission.
+    expect(screen.getAllByLabelText('Open')).toHaveLength(2);
+  });
+
+  it('reads the grouped total count and forwards groups to the table', async () => {
+    qe.endpoint.isGrouped = true;
+    qe.endpoint.groupedQuery = { data: { groups: [], totalCount: 7 }, isLoading: false };
+    renderPage();
+    await screen.findByTestId('selection-bar');
+
+    expect(document.querySelector('.ml-auto')?.textContent).toContain('7');
+  });
+
+  it('omits the group-by and preset controls when the metadata declares none', async () => {
+    qe.meta = { data: fullMeta({ groupByFields: [], presetFilterGroups: [] }), isLoading: false };
+    renderPage();
+    await screen.findByTestId('selection-bar');
+
+    expect(document.querySelector('[data-slot="sort-selector"]')).not.toBeNull();
+    expect(document.querySelector('[data-slot="group-by-selector"]')).toBeNull();
+    expect(document.querySelector('[data-slot="filter-presets"]')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Selection column (resolveSelectAllChecked + toggle/clear)
+// ---------------------------------------------------------------------------
+describe('WorkspaceEntityPage — selection column', () => {
+  it('drives select-all, per-row toggle and clear through the checkbox states', async () => {
+    const user = userEvent.setup();
+    serveManifest(
+      buildManifest({
+        selectionActions: [
+          {
+            name: 'Approve',
+            displayKey: 'Act.Approve',
+            icon: null,
+            confirmationKey: null,
+            contributorAssemblyName: null,
+          },
+        ],
+      })
+    );
+    renderPage();
+    await screen.findByTestId('selection-bar');
+
+    const selectAll = () => screen.getByLabelText('Select all');
+    // 0 selected → unchecked
+    expect(selectAll()).toHaveAttribute('data-state', 'unchecked');
+    expect(screen.getAllByLabelText('Select row')).toHaveLength(2);
+
+    // Select all → 2/2 → checked
+    await user.click(selectAll());
+    await waitFor(() => expect(selectAll()).toHaveAttribute('data-state', 'checked'));
+
+    // Toggle one row off → 1/2 → indeterminate
+    await user.click(screen.getAllByLabelText('Select row')[0] as HTMLElement);
+    await waitFor(() => expect(selectAll()).toHaveAttribute('data-state', 'indeterminate'));
+
+    // From indeterminate, clicking re-selects everything → checked
+    await user.click(selectAll());
+    await waitFor(() => expect(selectAll()).toHaveAttribute('data-state', 'checked'));
+
+    // From checked, clicking clears the selection → unchecked
+    await user.click(selectAll());
+    await waitFor(() => expect(selectAll()).toHaveAttribute('data-state', 'unchecked'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Alternate layouts (renderLayoutBody switch + view-kind gating)
+// ---------------------------------------------------------------------------
+describe('WorkspaceEntityPage — layouts', () => {
+  it('switches between list, kanban, calendar and gallery renderers', async () => {
+    const user = userEvent.setup();
+    serveManifest(
+      buildManifest({
+        listLayouts: [
+          { kind: 'List', isDefault: true, kanban: null, calendar: null, gallery: null },
+          { kind: 'Kanban', isDefault: false, kanban: kanbanCfg, calendar: null, gallery: null },
+          {
+            kind: 'Calendar',
+            isDefault: false,
+            kanban: null,
+            calendar: calendarCfg,
+            gallery: null,
+          },
+          { kind: 'Gallery', isDefault: false, kanban: null, calendar: null, gallery: galleryCfg },
+        ],
+      })
+    );
+    renderPage();
+    await screen.findByTestId('selection-bar');
+
+    const tabs = screen.getByRole('tablist');
+
+    // Calendar → view mounts, sort + group-by suppressed.
+    await user.click(within(tabs).getByRole('tab', { name: /Calendar/ }));
+    await screen.findByTestId('calendar-view');
+    expect(document.querySelector('[data-slot="sort-selector"]')).toBeNull();
+    expect(document.querySelector('[data-slot="group-by-selector"]')).toBeNull();
+
+    // Kanban → view mounts, sort back but group-by still suppressed.
+    await user.click(within(tabs).getByRole('tab', { name: /Kanban/ }));
+    await screen.findByTestId('kanban-view');
+    expect(document.querySelector('[data-slot="sort-selector"]')).not.toBeNull();
+    expect(document.querySelector('[data-slot="group-by-selector"]')).toBeNull();
+
+    // Gallery → view mounts, all controls visible.
+    await user.click(within(tabs).getByRole('tab', { name: /Gallery/ }));
+    await screen.findByTestId('gallery-view');
+    expect(document.querySelector('[data-slot="sort-selector"]')).not.toBeNull();
+    expect(document.querySelector('[data-slot="group-by-selector"]')).not.toBeNull();
+  });
+
+  it('renders nothing for a layout whose per-kind config is null', async () => {
+    const user = userEvent.setup();
+    serveManifest(
+      buildManifest({
+        listLayouts: [
+          { kind: 'List', isDefault: true, kanban: null, calendar: null, gallery: null },
+          { kind: 'Kanban', isDefault: false, kanban: null, calendar: null, gallery: null },
+          { kind: 'Calendar', isDefault: false, kanban: null, calendar: null, gallery: null },
+          { kind: 'Gallery', isDefault: false, kanban: null, calendar: null, gallery: null },
+        ],
+      })
+    );
+    renderPage();
+    await screen.findByTestId('selection-bar');
+    const tabs = screen.getByRole('tablist');
+
+    await user.click(within(tabs).getByRole('tab', { name: /Calendar/ }));
+    expect(screen.queryByTestId('calendar-view')).toBeNull();
+
+    await user.click(within(tabs).getByRole('tab', { name: /Kanban/ }));
+    expect(screen.queryByTestId('kanban-view')).toBeNull();
+
+    await user.click(within(tabs).getByRole('tab', { name: /Gallery/ }));
+    expect(screen.queryByTestId('gallery-view')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bulk recap toasts + confirm dialog
+// ---------------------------------------------------------------------------
+describe('WorkspaceEntityPage — bulk recap & confirmation', () => {
+  it('reports an all-succeeded recap as a success toast', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByTestId('bar-success'));
+    expect(vi.mocked(toast.success)).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports an all-failed recap as an error toast', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByTestId('bar-fail'));
+    expect(vi.mocked(toast.error)).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a partial recap as a warning toast and invalidates impacted parents', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByTestId('bar-partial'));
+    expect(vi.mocked(toast.warning)).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the confirm dialog and resolves on confirm', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByTestId('bar-confirm'));
+
+    const dialog = await screen.findByRole('alertdialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Confirm' }));
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+  });
+
+  it('closes the confirm dialog on cancel', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByTestId('bar-confirm'));
+
+    const dialog = await screen.findByRole('alertdialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+  });
+
+  it('opens the confirm dialog for an action without a confirmation key', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByTestId('bar-confirm-nokey'));
+    expect(await screen.findByRole('alertdialog')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Navigation callbacks
+// ---------------------------------------------------------------------------
+describe('WorkspaceEntityPage — navigation', () => {
+  it('navigates to the create route from the create button', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByTestId('selection-bar');
+    await user.click(
+      document.querySelector('[data-slot="workspace-entity-create"]') as HTMLElement
+    );
+    expect(screen.getByTestId('loc').textContent).toContain('/new');
+  });
+
+  it('navigates to the edit route from a row edit button', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByTestId('selection-bar');
+    await user.click(screen.getAllByLabelText('Edit')[0] as HTMLElement);
+    expect(screen.getByTestId('loc').textContent).toContain('/row-1/edit');
+  });
+
+  it('opens a side-peek (peek query param) from a row open button', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByTestId('selection-bar');
+    await user.click(screen.getAllByLabelText('Open')[0] as HTMLElement);
+    await waitFor(() => expect(screen.getByTestId('loc').textContent).toContain('peek'));
+  });
+
+  it('routes an in-app navigate action with row-id substitution', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByTestId('bar-nav-id'));
+    expect(screen.getByTestId('loc').textContent).toContain('/w/x/row-9');
+  });
+
+  it('routes an in-app navigate action that carries no row id', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByTestId('bar-nav-noid'));
+    expect(screen.getByTestId('loc').textContent).toContain('/w/plain');
+  });
+
+  it('ignores a navigate action whose url template is absent', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByTestId('selection-bar');
+    const before = screen.getByTestId('loc').textContent;
+    await user.click(screen.getByTestId('bar-nav-nourl'));
+    expect(screen.getByTestId('loc').textContent).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Manifest-shape fallbacks (absent optional facets / null field component)
+// ---------------------------------------------------------------------------
+describe('WorkspaceEntityPage — manifest fallbacks', () => {
+  it('renders when every optional manifest facet is absent', async () => {
+    const bare: EntityManifestResponse = {
+      schemaVersion: 1,
+      identity: null,
+      permissions: null,
+      forms: null,
+      details: null,
+      collections: null,
+      relations: null,
+      actions: null,
+      activities: null,
+    };
+    serveManifest(bare);
+    renderPage();
+    await screen.findByTestId('selection-bar');
+
+    // permissions null → no create, no edit; identity null → title falls
+    // back to the entity name.
+    expect(document.querySelector('[data-slot="workspace-entity-create"]')).toBeNull();
+    expect(screen.queryByLabelText('Edit')).toBeNull();
+    expect(screen.getByRole('heading', { name: SAMPLE_ENTITY_NAME })).toBeInTheDocument();
+  });
+
+  it('skips form fields that declare no component when collecting hints', async () => {
+    const manifest: EntityManifestResponse = {
+      ...mockEntityManifest,
+      forms: [
+        {
+          name: 'default',
+          customizable: true,
+          hiddenByOverride: null,
+          sections: [
+            {
+              key: 's',
+              labelKey: null,
+              order: 0,
+              collapsedByDefault: false,
+              ownedCollection: null,
+              fields: [
+                {
+                  propertyName: 'NoComp',
+                  clrTypeName: 'String',
+                  component: null,
+                  config: null,
+                  labelKey: null,
+                  helpKey: null,
+                  order: 0,
+                  readOnly: false,
+                  visibleIf: null,
+                  lookup: null,
+                  provenance: null,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    serveManifest(manifest);
+    renderPage();
+    await screen.findByTestId('selection-bar');
+    expect(screen.getAllByLabelText('Open')).toHaveLength(2);
+  });
+
+  it('derives the active kind from the first layout when none is default', async () => {
+    serveManifest(
+      buildManifest({
+        listLayouts: [
+          { kind: 'Kanban', isDefault: false, kanban: kanbanCfg, calendar: null, gallery: null },
+        ],
+      })
+    );
+    renderPage();
+    await screen.findByTestId('kanban-view');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty / undefined query result sets (nullish fallbacks)
+// ---------------------------------------------------------------------------
+describe('WorkspaceEntityPage — empty result sets', () => {
+  it('falls back to an empty list and zero total when the query result is undefined', async () => {
+    qe.endpoint.query = { data: undefined, isLoading: false, isFetching: false };
+    renderPage();
+    await screen.findByTestId('selection-bar');
+    expect(document.querySelector('.ml-auto')?.textContent).toContain('0');
+    expect(screen.queryByLabelText('Open')).toBeNull();
+  });
+
+  it('defaults the grouped total to zero when the grouped result is undefined', async () => {
+    qe.endpoint.isGrouped = true;
+    qe.endpoint.groupedQuery = { data: undefined, isLoading: false };
+    renderPage();
+    await screen.findByTestId('selection-bar');
+    expect(document.querySelector('.ml-auto')?.textContent).toContain('0');
+  });
+
+  it('passes an empty row set to the kanban view when the query result is undefined', async () => {
+    qe.endpoint.query = { data: undefined, isLoading: false, isFetching: false };
+    serveManifest(
+      buildManifest({
+        listLayouts: [
+          { kind: 'Kanban', isDefault: true, kanban: kanbanCfg, calendar: null, gallery: null },
+        ],
+      })
+    );
+    renderPage();
+    await screen.findByTestId('kanban-view');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Currency resolver + recap without a display key
+// ---------------------------------------------------------------------------
+describe('WorkspaceEntityPage — cell + recap fallbacks', () => {
+  it('resolves a row currency from explicit, default and hard-coded fallbacks', async () => {
+    qe.endpoint.query = {
+      data: {
+        items: [
+          { id: 'c1', kind: 'A', number: 'N1', currency: 'USD' },
+          { id: 'c2', kind: 'B', number: 'N2', defaultCurrency: 'GBP' },
+          { id: 'c3', kind: 'C', number: 'N3' },
+        ],
+        totalCount: 3,
+      },
+      isLoading: false,
+      isFetching: false,
+    };
+    renderPage();
+    await screen.findByTestId('selection-bar');
+    expect(screen.getAllByLabelText('Open')).toHaveLength(3);
+  });
+
+  it('uses the action name in the recap toast when it has no display key', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(await screen.findByTestId('bar-success-nokey'));
+    expect(vi.mocked(toast.success)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/@granit/react-ui-timeline/src/__tests__/entity-timeline.test.tsx
+++ b/packages/@granit/react-ui-timeline/src/__tests__/entity-timeline.test.tsx
@@ -1,143 +1,576 @@
-import { screen } from '@testing-library/react';
+import { toast } from '@granit/react-ui';
+import {
+  TimelineEntryNotEditableReason,
+  TimelineEntryOrigin,
+  TimelineEntryType,
+  toReactionEmoji,
+} from '@granit/timeline';
+import { toEntityId, toISODateString } from '@granit/types';
+import { act, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { EntityTimeline } from '../entity-timeline';
 
 import { renderWithProviders } from './test-utils';
 
+import type { TimelineComposerProps } from '../timeline-composer';
+import type {
+  ReactionMap,
+  ReactionToggleResponse,
+  TimelineStreamEntryResponse,
+} from '@granit/timeline';
 
-// Mock @granit/react-timeline (hooks + provider)
-const { mockUseTimeline, mockUseTimelineActions, mockUseTimelineFollowers } = vi.hoisted(() => ({
+// --- Mocks --------------------------------------------------------------
+
+// Latest-mounted composer props are captured so tests can drive the
+// add / reply / edit submit callbacks without a real ProseMirror editor.
+const composerHolder = vi.hoisted(() => ({
+  current: null as TimelineComposerProps | null,
+}));
+
+const {
+  mockUseTimeline,
+  mockUseTimelineActions,
+  mockUseTimelineFollowers,
+  mockUpdateBody,
+  mockToggleReaction,
+  mockApplyToggleResult,
+  mockIsAxiosError,
+} = vi.hoisted(() => ({
   mockUseTimeline: vi.fn(),
   mockUseTimelineActions: vi.fn(),
   mockUseTimelineFollowers: vi.fn(),
+  mockUpdateBody: { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false },
+  mockToggleReaction: { mutate: vi.fn() },
+  mockApplyToggleResult: vi.fn((reactions: unknown) => reactions),
+  mockIsAxiosError: vi.fn(
+    (err: unknown) => Boolean(err) && typeof err === 'object' && err !== null && 'response' in err
+  ),
 }));
 
 vi.mock('@granit/react-timeline', () => ({
   useTimeline: mockUseTimeline,
   useTimelineActions: mockUseTimelineActions,
   useTimelineFollowers: mockUseTimelineFollowers,
-  useToggleReaction: () => ({ mutate: vi.fn() }),
-  useUpdateEntryBody: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
-  applyToggleResult: vi.fn((reactions: unknown, _result: unknown) => reactions),
+  useToggleReaction: () => mockToggleReaction,
+  useAnchorEntry: () => ({ mutate: vi.fn(), mutateAsync: vi.fn() }),
+  useUpdateEntryBody: () => mockUpdateBody,
+  applyToggleResult: mockApplyToggleResult,
+  isAxiosError: mockIsAxiosError,
 }));
 
-vi.mock('@granit/timeline', () => ({
-  TimelineEntryType: { Comment: 'Comment', InternalNote: 'InternalNote', SystemLog: 'SystemLog' },
-  TimelineEntryOrigin: { Native: 'Native', External: 'External' },
+vi.mock('../timeline-composer', () => ({
+  TimelineComposer: (props: TimelineComposerProps) => {
+    composerHolder.current = props;
+    return (
+      <div
+        data-testid="mock-composer"
+        data-initial={props.initialBody ?? ''}
+        data-parent={props.parentEntryId ?? ''}
+      />
+    );
+  },
 }));
 
-const defaultTimeline = {
-  entries: [],
-  totalCount: 0,
-  loading: false,
-  loadingMore: false,
-  error: null,
-  hasMore: false,
-  loadMore: vi.fn(),
-  refresh: vi.fn(),
-  addOptimisticEntry: vi.fn(),
-  removeOptimisticEntry: vi.fn(),
-  patchEntry: vi.fn(),
-  degradedSources: [],
-};
+// --- Fixtures -----------------------------------------------------------
 
-const defaultActions = {
-  postEntry: vi.fn().mockResolvedValue({ id: 'new' }),
-  removeEntry: vi.fn().mockResolvedValue(undefined),
-  posting: false,
-  deleting: false,
-  error: null,
-};
+const NOW_ISO = new Date().toISOString();
 
-const defaultFollowers = {
-  followers: [],
-  isFollowing: false,
-  loading: false,
-  follow: vi.fn().mockResolvedValue(undefined),
-  unfollow: vi.fn().mockResolvedValue(undefined),
-};
+function makeEntry(
+  overrides: Partial<TimelineStreamEntryResponse> = {}
+): TimelineStreamEntryResponse {
+  return {
+    id: toEntityId<'TimelineStreamEntryResponse'>('e-1'),
+    occurredAt: toISODateString(NOW_ISO),
+    entryType: TimelineEntryType.Comment,
+    authorId: toEntityId<'User'>('a-1'),
+    authorName: 'Admin',
+    body: 'hello',
+    attachments: [],
+    parentEntryId: null,
+    origin: TimelineEntryOrigin.Native,
+    editedAt: null,
+    reactions: null,
+    ...overrides,
+  };
+}
+
+function timeline(overrides: Record<string, unknown> = {}) {
+  return {
+    entries: [] as readonly TimelineStreamEntryResponse[],
+    totalCount: 0,
+    loading: false,
+    loadingMore: false,
+    error: null,
+    hasMore: false,
+    loadMore: vi.fn(),
+    refresh: vi.fn(),
+    addOptimisticEntry: vi.fn(),
+    removeOptimisticEntry: vi.fn(),
+    patchEntry: vi.fn((_id: unknown, updater: (entry: unknown) => unknown) => updater({})),
+    degradedSources: [] as readonly string[],
+    ...overrides,
+  };
+}
+
+function actions(overrides: Record<string, unknown> = {}) {
+  return {
+    postEntry: vi.fn().mockResolvedValue({ id: 'new' }),
+    removeEntry: vi.fn().mockResolvedValue(undefined),
+    posting: false,
+    deleting: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+function followers(overrides: Record<string, unknown> = {}) {
+  return {
+    followers: [] as readonly unknown[],
+    isFollowing: false,
+    loading: false,
+    follow: vi.fn().mockResolvedValue(undefined),
+    unfollow: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+interface SetupOverrides {
+  timeline?: Record<string, unknown>;
+  actions?: Record<string, unknown>;
+  followers?: Record<string, unknown>;
+}
+
+function setup(
+  props: Partial<React.ComponentProps<typeof EntityTimeline>> = {},
+  over: SetupOverrides = {}
+) {
+  const timelineState = timeline(over.timeline);
+  const actionsState = actions(over.actions);
+  const followersState = followers(over.followers);
+  mockUseTimeline.mockReturnValue(timelineState);
+  mockUseTimelineActions.mockReturnValue(actionsState);
+  mockUseTimelineFollowers.mockReturnValue(followersState);
+  const view = renderWithProviders(<EntityTimeline entityType="User" entityId="u-1" {...props} />);
+  return { ...view, timelineState, actionsState, followersState };
+}
+
+function composer(): TimelineComposerProps {
+  const current = composerHolder.current;
+  if (!current) throw new Error('composer not mounted');
+  return current;
+}
+
+async function submitComposer(body: string, parentEntryId?: string) {
+  await act(async () => {
+    await composer().onSubmit({
+      entryType: TimelineEntryType.Comment,
+      body,
+      parentEntryId,
+    });
+  });
+}
+
+// --- Tests --------------------------------------------------------------
 
 describe('EntityTimeline', () => {
+  beforeEach(() => {
+    composerHolder.current = null;
+    mockUpdateBody.mutateAsync.mockReset();
+    mockToggleReaction.mutate.mockReset();
+    mockApplyToggleResult.mockClear();
+    mockIsAxiosError.mockClear();
+  });
   afterEach(() => vi.clearAllMocks());
 
-  it('should display the Timeline title', () => {
-    mockUseTimeline.mockReturnValue(defaultTimeline);
-    mockUseTimelineActions.mockReturnValue(defaultActions);
-    mockUseTimelineFollowers.mockReturnValue(defaultFollowers);
-    renderWithProviders(<EntityTimeline entityType="User" entityId="u-1" />);
-    expect(screen.getByText('Timeline')).toBeInTheDocument();
-  });
-
-  it('should display the empty message when there are no entries', () => {
-    mockUseTimeline.mockReturnValue(defaultTimeline);
-    mockUseTimelineActions.mockReturnValue(defaultActions);
-    mockUseTimelineFollowers.mockReturnValue(defaultFollowers);
-    renderWithProviders(<EntityTimeline entityType="User" entityId="u-1" />);
-    expect(screen.getByText('No timeline entries yet.')).toBeInTheDocument();
-  });
-
-  it('should display the error state when loading fails', () => {
-    mockUseTimeline.mockReturnValue({
-      ...defaultTimeline,
-      error: new Error('Network error'),
+  describe('render states', () => {
+    it('displays the Timeline title', () => {
+      setup();
+      expect(screen.getByText('Timeline')).toBeInTheDocument();
     });
-    mockUseTimelineActions.mockReturnValue(defaultActions);
-    mockUseTimelineFollowers.mockReturnValue(defaultFollowers);
-    renderWithProviders(<EntityTimeline entityType="User" entityId="u-1" />);
-    expect(screen.getByText('Failed to load timeline')).toBeInTheDocument();
+
+    it('displays the empty message when there are no entries', () => {
+      setup();
+      expect(screen.getByText('No timeline entries yet.')).toBeInTheDocument();
+    });
+
+    it('displays the error state when the initial load fails', () => {
+      setup({}, { timeline: { error: new Error('boom') } });
+      expect(screen.getByText('Failed to load timeline')).toBeInTheDocument();
+      expect(screen.getByText('Could not load timeline entries.')).toBeInTheDocument();
+    });
+
+    it('still renders the feed when an error arrives alongside cached entries', () => {
+      setup(
+        {},
+        { timeline: { error: new Error('boom'), entries: [makeEntry({ body: 'cached' })] } }
+      );
+      expect(screen.queryByText('Failed to load timeline')).not.toBeInTheDocument();
+      expect(screen.getByText('cached')).toBeInTheDocument();
+    });
+
+    it('displays the spinner during the initial load', () => {
+      setup({}, { timeline: { loading: true } });
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+
+    it('skips the initial-load layout when loading alongside cached entries', () => {
+      setup({}, { timeline: { loading: true, entries: [makeEntry({ body: 'cached' })] } });
+      // past the `loading && entries.length === 0` guard: full card chrome renders
+      expect(screen.getByTestId('timeline-add-button')).toBeInTheDocument();
+    });
+
+    it('renders the entries', () => {
+      setup({}, { timeline: { entries: [makeEntry({ body: 'First comment' })], totalCount: 1 } });
+      expect(screen.getByText('First comment')).toBeInTheDocument();
+    });
+
+    it('forwards entityType / entityId to the data hooks', () => {
+      setup();
+      expect(mockUseTimeline).toHaveBeenCalledWith(
+        expect.objectContaining({ entityType: 'User', entityId: 'u-1' })
+      );
+      expect(mockUseTimelineActions).toHaveBeenCalledWith(
+        expect.objectContaining({ entityType: 'User', entityId: 'u-1' })
+      );
+    });
+
+    it('exposes the data-slot attribute', () => {
+      setup();
+      expect(document.querySelector('[data-slot="entity-timeline"]')).toBeInTheDocument();
+    });
   });
 
-  it('should display the spinner during initial loading', () => {
-    mockUseTimeline.mockReturnValue({ ...defaultTimeline, loading: true });
-    mockUseTimelineActions.mockReturnValue(defaultActions);
-    mockUseTimelineFollowers.mockReturnValue(defaultFollowers);
-    renderWithProviders(<EntityTimeline entityType="User" entityId="u-1" />);
-    expect(screen.getByRole('status')).toBeInTheDocument();
+  describe('degraded sources banner', () => {
+    it('shows the banner when sources are degraded', () => {
+      setup({}, { timeline: { degradedSources: ['auditing', 'workflow'] } });
+      expect(screen.getByTestId('timeline-degraded-banner')).toBeInTheDocument();
+    });
+
+    it('omits the banner when no sources are degraded', () => {
+      setup();
+      expect(screen.queryByTestId('timeline-degraded-banner')).not.toBeInTheDocument();
+    });
   });
 
-  it('should display the timeline entries', () => {
-    mockUseTimeline.mockReturnValue({
-      ...defaultTimeline,
-      entries: [
+  describe('follow toggle', () => {
+    it('follows when not currently following', async () => {
+      const { followersState, user } = setup();
+      const btn = screen.getByTestId('timeline-follow-button');
+      expect(btn).toHaveAttribute('aria-pressed', 'false');
+      await user.click(btn);
+      expect(followersState.follow).toHaveBeenCalledOnce();
+      expect(followersState.unfollow).not.toHaveBeenCalled();
+    });
+
+    it('unfollows and shows the follower count when already following', async () => {
+      const { followersState, user } = setup(
+        {},
+        { followers: { isFollowing: true, followers: [{ id: 'x' }, { id: 'y' }] } }
+      );
+      const btn = screen.getByTestId('timeline-follow-button');
+      expect(btn).toHaveAttribute('aria-pressed', 'true');
+      expect(btn).toHaveTextContent('(2)');
+      await user.click(btn);
+      expect(followersState.unfollow).toHaveBeenCalledOnce();
+    });
+
+    it('disables the follow button while followers are loading', async () => {
+      const { followersState, user } = setup({}, { followers: { loading: true } });
+      const btn = screen.getByTestId('timeline-follow-button');
+      expect(btn).toBeDisabled();
+      await user.click(btn);
+      expect(followersState.follow).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('body renderer', () => {
+    it('renders a mention as an in-app link surrounded by prose', () => {
+      const body = 'hi @[Alice](user:11111111-1111-4111-8111-111111111111) end';
+      setup({}, { timeline: { entries: [makeEntry({ body })] } });
+      const link = screen.getByTestId('timeline-mention-link');
+      expect(link).toHaveAttribute('href', '/identity/users/11111111-1111-4111-8111-111111111111');
+      expect(link).toHaveTextContent('@Alice');
+      const bodyNode = screen.getByTestId('timeline-entry-body');
+      expect(bodyNode).toHaveTextContent('hi');
+      expect(bodyNode).toHaveTextContent('end');
+    });
+
+    it('renders same-origin URLs as router links and cross-origin URLs as external anchors', () => {
+      const origin = globalThis.location.origin;
+      const body = `${origin}/local and https://external.example.test/p.`;
+      setup({}, { timeline: { entries: [makeEntry({ body })] } });
+      const links = screen.getAllByTestId('timeline-url-link');
+      expect(links).toHaveLength(2);
+      const external = links.find((l) => l.hasAttribute('data-external'));
+      const internal = links.find((l) => !l.hasAttribute('data-external'));
+      expect(external).toHaveAttribute('href', 'https://external.example.test/p');
+      expect(external).toHaveAttribute('rel', 'noopener noreferrer');
+      expect(internal).toBeDefined();
+      // trailing punctuation is stripped off the URL and kept as prose
+      expect(screen.getByTestId('timeline-entry-body')).toHaveTextContent('.');
+    });
+
+    it('leaves a URL-shaped token that fails to parse as plain text', () => {
+      const body = 'bad http://[ end';
+      setup({}, { timeline: { entries: [makeEntry({ body })] } });
+      expect(screen.queryByTestId('timeline-url-link')).not.toBeInTheDocument();
+      expect(screen.getByTestId('timeline-entry-body')).toHaveTextContent('http://[');
+    });
+
+    it('renders a plain-text body unchanged and an empty body without crashing', () => {
+      setup(
+        {},
         {
-          id: 'e-1',
-          body: 'First comment',
-          entryType: 'Comment',
-          authorName: 'Admin',
-          occurredAt: '2026-01-01T00:00:00Z',
-          entityType: 'User',
-          entityId: 'u-1',
-          authorId: 'a-1',
-          parentEntryId: null,
-          attachments: [],
-        },
-      ],
-      totalCount: 1,
+          timeline: {
+            entries: [
+              makeEntry({ id: toEntityId<'TimelineStreamEntryResponse'>('e-empty'), body: '' }),
+            ],
+          },
+        }
+      );
+      expect(screen.getByTestId('timeline-entry-body')).toBeInTheDocument();
     });
-    mockUseTimelineActions.mockReturnValue(defaultActions);
-    mockUseTimelineFollowers.mockReturnValue(defaultFollowers);
-    renderWithProviders(<EntityTimeline entityType="User" entityId="u-1" />);
-    expect(screen.getByText('First comment')).toBeInTheDocument();
   });
 
-  it('should pass entityType and entityId to hooks', () => {
-    mockUseTimeline.mockReturnValue(defaultTimeline);
-    mockUseTimelineActions.mockReturnValue(defaultActions);
-    mockUseTimelineFollowers.mockReturnValue(defaultFollowers);
-    renderWithProviders(<EntityTimeline entityType="User" entityId="u-1" />);
-    expect(mockUseTimeline).toHaveBeenCalledWith(
-      expect.objectContaining({ entityType: 'User', entityId: 'u-1' })
-    );
-    expect(mockUseTimelineActions).toHaveBeenCalledWith(
-      expect.objectContaining({ entityType: 'User', entityId: 'u-1' })
-    );
+  describe('add composer dialog', () => {
+    it('opens the add dialog and posts an entry on submit', async () => {
+      const { actionsState, user } = setup();
+      expect(screen.queryByTestId('mock-composer')).not.toBeInTheDocument();
+      await user.click(screen.getByTestId('timeline-add-button'));
+      const mounted = await screen.findByTestId('mock-composer');
+      expect(mounted).toHaveAttribute('data-parent', '');
+      expect(screen.getByText('Add timeline entry')).toBeInTheDocument();
+
+      await submitComposer('A new comment');
+      expect(actionsState.postEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ body: 'A new comment' })
+      );
+      await waitFor(() => expect(screen.queryByTestId('mock-composer')).not.toBeInTheDocument());
+    });
+
+    it('clears reply context after the composer dialog is dismissed', async () => {
+      const entry = makeEntry({ body: 'root comment' });
+      const { user } = setup({}, { timeline: { entries: [entry] } });
+      await user.click(screen.getByTestId('timeline-reply-btn'));
+      await screen.findByTestId('mock-composer');
+      expect(screen.getByTestId('mock-composer')).toHaveAttribute('data-parent', 'e-1');
+      expect(screen.getByText('Reply to entry')).toBeInTheDocument();
+
+      await user.keyboard('{Escape}');
+      await waitFor(() => expect(screen.queryByTestId('mock-composer')).not.toBeInTheDocument());
+
+      // reopening via Add must not carry the previous reply target
+      await user.click(screen.getByTestId('timeline-add-button'));
+      const reopened = await screen.findByTestId('mock-composer');
+      expect(reopened).toHaveAttribute('data-parent', '');
+    });
   });
 
-  it('should have the data-slot attribute', () => {
-    mockUseTimeline.mockReturnValue(defaultTimeline);
-    mockUseTimelineActions.mockReturnValue(defaultActions);
-    mockUseTimelineFollowers.mockReturnValue(defaultFollowers);
-    renderWithProviders(<EntityTimeline entityType="User" entityId="u-1" />);
-    expect(document.querySelector('[data-slot="entity-timeline"]')).toBeInTheDocument();
+  describe('reply and delete actions', () => {
+    it('deletes an entry via the entry delete action', async () => {
+      const { actionsState, user } = setup({}, { timeline: { entries: [makeEntry()] } });
+      await user.click(screen.getByTestId('timeline-delete-btn'));
+      expect(actionsState.removeEntry).toHaveBeenCalledWith('e-1');
+    });
+  });
+
+  describe('edit gating (canEditEntry)', () => {
+    it('renders no edit action when currentUserId is absent', () => {
+      setup({}, { timeline: { entries: [makeEntry({ authorId: toEntityId<'User'>('me') })] } });
+      expect(screen.queryByTestId('timeline-edit-btn')).not.toBeInTheDocument();
+    });
+
+    it("only exposes the edit action for the author's recent native non-system entry", () => {
+      const editable = makeEntry({
+        id: toEntityId<'TimelineStreamEntryResponse'>('editable'),
+        authorId: toEntityId<'User'>('me'),
+        body: 'mine recent',
+      });
+      const external = makeEntry({
+        id: toEntityId<'TimelineStreamEntryResponse'>('external'),
+        authorId: toEntityId<'User'>('me'),
+        origin: TimelineEntryOrigin.External,
+        body: 'external',
+      });
+      const systemLog = makeEntry({
+        id: toEntityId<'TimelineStreamEntryResponse'>('sys'),
+        authorId: toEntityId<'User'>('me'),
+        entryType: TimelineEntryType.SystemLog,
+        body: 'system',
+      });
+      const otherAuthor = makeEntry({
+        id: toEntityId<'TimelineStreamEntryResponse'>('other'),
+        authorId: toEntityId<'User'>('someone-else'),
+        body: 'theirs',
+      });
+      const stale = makeEntry({
+        id: toEntityId<'TimelineStreamEntryResponse'>('stale'),
+        authorId: toEntityId<'User'>('me'),
+        occurredAt: toISODateString('2020-01-01T00:00:00Z'),
+        body: 'old',
+      });
+      setup(
+        { currentUserId: 'me' },
+        { timeline: { entries: [editable, external, systemLog, otherAuthor, stale] } }
+      );
+      expect(screen.getAllByTestId('timeline-edit-btn')).toHaveLength(1);
+    });
+  });
+
+  describe('edit dialog submit', () => {
+    const ORIGINAL = 'editable body';
+
+    async function openEditor(user: ReturnType<typeof setup>['user']) {
+      await user.click(screen.getByTestId('timeline-edit-btn'));
+      const mounted = await screen.findByTestId('mock-composer');
+      expect(mounted).toHaveAttribute('data-initial', ORIGINAL);
+    }
+
+    function editableSetup() {
+      const editable = makeEntry({
+        id: toEntityId<'TimelineStreamEntryResponse'>('editable'),
+        authorId: toEntityId<'User'>('me'),
+        body: ORIGINAL,
+        // omit origin → exercises the `origin ?? Native` fallback in canEditEntry
+        origin: undefined,
+      });
+      return setup({ currentUserId: 'me' }, { timeline: { entries: [editable] } });
+    }
+
+    it('closes without saving when the edited body is blank', async () => {
+      const { user } = editableSetup();
+      await openEditor(user);
+      await submitComposer('   ');
+      expect(mockUpdateBody.mutateAsync).not.toHaveBeenCalled();
+      await waitFor(() => expect(screen.queryByTestId('mock-composer')).not.toBeInTheDocument());
+    });
+
+    it('closes without saving when the body is unchanged', async () => {
+      const { user } = editableSetup();
+      await openEditor(user);
+      await submitComposer(ORIGINAL);
+      expect(mockUpdateBody.mutateAsync).not.toHaveBeenCalled();
+      await waitFor(() => expect(screen.queryByTestId('mock-composer')).not.toBeInTheDocument());
+    });
+
+    it('persists a changed body and patches the entry', async () => {
+      mockUpdateBody.mutateAsync.mockResolvedValue(undefined);
+      const { timelineState, user } = editableSetup();
+      await openEditor(user);
+      await submitComposer('a fresh body');
+      expect(mockUpdateBody.mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ entityType: 'User', entityId: 'u-1', body: 'a fresh body' })
+      );
+      expect(timelineState.patchEntry).toHaveBeenCalled();
+      await waitFor(() => expect(screen.queryByTestId('mock-composer')).not.toBeInTheDocument());
+    });
+
+    it('surfaces a localised toast on a 403 not-editable rejection with a reason', async () => {
+      const toastSpy = vi.spyOn(toast, 'error');
+      mockUpdateBody.mutateAsync.mockRejectedValue({
+        response: {
+          status: 403,
+          data: {
+            type: 'timeline-entry-not-editable',
+            extensions: { reason: TimelineEntryNotEditableReason.NotAuthor },
+          },
+        },
+      });
+      const { user } = editableSetup();
+      await openEditor(user);
+      await submitComposer('rejected body');
+      expect(toastSpy).toHaveBeenCalledOnce();
+    });
+
+    it('falls back to a generic message when the rejection carries no reason', async () => {
+      const toastSpy = vi.spyOn(toast, 'error');
+      mockUpdateBody.mutateAsync.mockRejectedValue({
+        response: { status: 403, data: { type: 'timeline-entry-not-editable' } },
+      });
+      const { user } = editableSetup();
+      await openEditor(user);
+      await submitComposer('rejected body');
+      expect(toastSpy).toHaveBeenCalledOnce();
+    });
+
+    it('does not toast when the 403 problem type is unrelated', async () => {
+      const toastSpy = vi.spyOn(toast, 'error');
+      mockUpdateBody.mutateAsync.mockRejectedValue({
+        response: { status: 403, data: { type: 'something-else' } },
+      });
+      const { user } = editableSetup();
+      await openEditor(user);
+      await submitComposer('rejected body');
+      expect(toastSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not toast when the failure is not a 403', async () => {
+      const toastSpy = vi.spyOn(toast, 'error');
+      mockUpdateBody.mutateAsync.mockRejectedValue({ response: { status: 500 } });
+      const { user } = editableSetup();
+      await openEditor(user);
+      await submitComposer('rejected body');
+      expect(toastSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not toast when the failure is not an axios error', async () => {
+      const toastSpy = vi.spyOn(toast, 'error');
+      mockUpdateBody.mutateAsync.mockRejectedValue(new Error('network'));
+      const { user } = editableSetup();
+      await openEditor(user);
+      await submitComposer('rejected body');
+      expect(toastSpy).not.toHaveBeenCalled();
+    });
+
+    it('closes the edit dialog when dismissed without saving', async () => {
+      const { user } = editableSetup();
+      await openEditor(user);
+      await user.keyboard('{Escape}');
+      await waitFor(() => expect(screen.queryByTestId('mock-composer')).not.toBeInTheDocument());
+    });
+
+    it('ignores a late composer submit once the edit target has been cleared', async () => {
+      mockUpdateBody.mutateAsync.mockResolvedValue(undefined);
+      const { user } = editableSetup();
+      await openEditor(user);
+      // Dismissing the dialog clears `editingEntry`; the composer is re-seeded
+      // with the null-target submit handler (initialBody undefined) before it
+      // unmounts, so `composer()` now holds that stale handler.
+      await user.keyboard('{Escape}');
+      await waitFor(() => expect(screen.queryByTestId('mock-composer')).not.toBeInTheDocument());
+      expect(composer().initialBody).toBeUndefined();
+      // A submit racing the close must hit the `!editingEntry` guard and
+      // short-circuit — no PATCH is issued even though the body differs.
+      await submitComposer('a late body after close');
+      expect(mockUpdateBody.mutateAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reaction toggle', () => {
+    it('patches the entry after a reaction resolves', async () => {
+      const reactions: ReactionMap = {
+        [toReactionEmoji('👍')]: { count: 2, byCurrentUser: false, displayEmoji: '👍' },
+      };
+      const result: ReactionToggleResponse = {
+        entryId: 'e-1',
+        emoji: toReactionEmoji('👍'),
+        count: 3,
+        currentUserHasReacted: true,
+      };
+      mockToggleReaction.mutate.mockImplementation(
+        (_vars: unknown, opts: { onSuccess?: (r: ReactionToggleResponse) => void }) => {
+          opts.onSuccess?.(result);
+        }
+      );
+      const { timelineState, user } = setup(
+        { canReact: true },
+        { timeline: { entries: [makeEntry({ reactions })] } }
+      );
+      await user.click(screen.getByRole('button', { name: /react with/i }));
+      await waitFor(() => expect(mockToggleReaction.mutate).toHaveBeenCalled());
+      expect(timelineState.patchEntry).toHaveBeenCalled();
+      expect(mockApplyToggleResult).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/@granit/react-ui-timeline/src/emoji-picker.test.tsx
+++ b/packages/@granit/react-ui-timeline/src/emoji-picker.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EmojiPicker } from './emoji-picker';
+
+// Mutable theme state driven per-test to exercise the three resolveTheme
+// branches (dark / light / auto) without relying on next-themes' flaky
+// jsdom system-theme resolution.
+const themeState = vi.hoisted(() => ({ resolvedTheme: undefined as string | undefined }));
+const i18nState = vi.hoisted(() => ({ language: 'en' }));
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: themeState.resolvedTheme }),
+}));
+
+vi.mock('@granit/react-localization', () => ({
+  useTranslation: () => ({ i18n: { language: i18nState.language } }),
+}));
+
+// Stub the emoji-mart picker + its Twitter data bundle so the lazy chunk
+// resolves synchronously to a controllable button that echoes the props the
+// component wires and fires onEmojiSelect on click.
+vi.mock('@emoji-mart/react', () => ({
+  default: (props: {
+    onEmojiSelect?: (emoji: { native: string }) => void;
+    theme?: string;
+    locale?: string;
+    set?: string;
+  }) => (
+    <button
+      type="button"
+      data-testid="picker"
+      data-theme={props.theme}
+      data-locale={props.locale}
+      data-set={props.set}
+      onClick={() => props.onEmojiSelect?.({ native: '😀' })}
+    >
+      pick
+    </button>
+  ),
+}));
+
+vi.mock('@emoji-mart/data/sets/15/twitter.json', () => ({ default: {} }));
+
+beforeEach(() => {
+  themeState.resolvedTheme = undefined;
+  i18nState.language = 'en';
+});
+
+describe('EmojiPicker', () => {
+  it('renders the slot wrapper synchronously and mounts the picker after the lazy chunk resolves', async () => {
+    const { container } = render(<EmojiPicker onSelect={vi.fn()} />);
+    expect(container.querySelector('[data-slot="emoji-picker"]')).not.toBeNull();
+    const picker = await screen.findByTestId('picker');
+    expect(picker.getAttribute('data-set')).toBe('twitter');
+  });
+
+  it('forwards the picked native grapheme to onSelect', async () => {
+    const onSelect = vi.fn();
+    render(<EmojiPicker onSelect={onSelect} />);
+    const picker = await screen.findByTestId('picker');
+    picker.click();
+    expect(onSelect).toHaveBeenCalledWith('😀');
+  });
+
+  it('maps a dark resolved theme to the picker dark theme', async () => {
+    themeState.resolvedTheme = 'dark';
+    render(<EmojiPicker onSelect={vi.fn()} />);
+    const picker = await screen.findByTestId('picker');
+    expect(picker.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('maps a light resolved theme to the picker light theme', async () => {
+    themeState.resolvedTheme = 'light';
+    render(<EmojiPicker onSelect={vi.fn()} />);
+    const picker = await screen.findByTestId('picker');
+    expect(picker.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('falls back to auto when the resolved theme is undefined', async () => {
+    render(<EmojiPicker onSelect={vi.fn()} />);
+    const picker = await screen.findByTestId('picker');
+    expect(picker.getAttribute('data-theme')).toBe('auto');
+  });
+
+  it('derives the picker locale from the i18next language base tag', async () => {
+    i18nState.language = 'fr-BE';
+    render(<EmojiPicker onSelect={vi.fn()} />);
+    const picker = await screen.findByTestId('picker');
+    expect(picker.getAttribute('data-locale')).toBe('fr');
+  });
+
+  it('closes on Escape when an onClose callback is provided', async () => {
+    const onClose = vi.fn();
+    render(<EmojiPicker onSelect={vi.fn()} onClose={onClose} />);
+    await screen.findByTestId('picker');
+    globalThis.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores non-Escape keys', async () => {
+    const onClose = vi.fn();
+    render(<EmojiPicker onSelect={vi.fn()} onClose={onClose} />);
+    await screen.findByTestId('picker');
+    globalThis.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('registers no key listener when onClose is omitted', async () => {
+    const addSpy = vi.spyOn(globalThis, 'addEventListener');
+    render(<EmojiPicker onSelect={vi.fn()} />);
+    await screen.findByTestId('picker');
+    expect(addSpy.mock.calls.some(([type]) => type === 'keydown')).toBe(false);
+    addSpy.mockRestore();
+  });
+
+  it('removes the key listener on unmount', async () => {
+    const onClose = vi.fn();
+    const removeSpy = vi.spyOn(globalThis, 'removeEventListener');
+    const { unmount } = render(<EmojiPicker onSelect={vi.fn()} onClose={onClose} />);
+    await screen.findByTestId('picker');
+    unmount();
+    await waitFor(() =>
+      expect(removeSpy.mock.calls.some(([type]) => type === 'keydown')).toBe(true)
+    );
+    removeSpy.mockRestore();
+  });
+});

--- a/packages/@granit/react-ui-timeline/src/mention-editor.test.tsx
+++ b/packages/@granit/react-ui-timeline/src/mention-editor.test.tsx
@@ -1,0 +1,355 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { MentionEditor } from './mention-editor';
+
+import type { MentionSuggestion } from '@granit/timeline';
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills for ProseMirror / Tippy geometry.
+// ProseMirror measures the caret (coordsAtPos → getClientRects) on selection
+// changes, and Tippy positions the popup against document.body's bounding box.
+// jsdom implements no layout, so both APIs are missing on some targets; stub
+// them so the suggestion lifecycle can run without throwing.
+// ---------------------------------------------------------------------------
+const ZERO_RECT: DOMRect = {
+  top: 0,
+  left: 0,
+  bottom: 0,
+  right: 0,
+  width: 0,
+  height: 0,
+  x: 0,
+  y: 0,
+  toJSON: () => ({}),
+};
+const EMPTY_RECTS = { length: 0, item: () => null } as unknown as DOMRectList;
+
+function installGeometryPolyfills() {
+  for (const proto of [Element.prototype, Range.prototype]) {
+    const target = proto as unknown as {
+      getClientRects?: () => DOMRectList;
+      getBoundingClientRect?: () => DOMRect;
+    };
+    target.getClientRects = () => EMPTY_RECTS;
+    target.getBoundingClientRect = () => ZERO_RECT;
+  }
+
+  // ProseMirror re-anchors the DOM selection after a mention insert; with no
+  // layout, jsdom's Selection throws "There is no selection to collapse". These
+  // calls are display-only in tests, so swallow the layout-driven failures.
+  const selectionProto = (globalThis as { Selection?: { prototype: object } }).Selection?.prototype;
+  if (selectionProto) {
+    const guarded = ['collapse', 'collapseToEnd', 'collapseToStart', 'extend', 'setBaseAndExtent'];
+    const methods = selectionProto as Record<string, (...args: unknown[]) => unknown>;
+    for (const name of guarded) {
+      const original = methods[name];
+      if (typeof original !== 'function') continue;
+      methods[name] = function patched(this: unknown, ...args: unknown[]): unknown {
+        try {
+          return original.apply(this, args);
+        } catch {
+          return undefined;
+        }
+      };
+    }
+  }
+}
+
+const BOB_ID = '8c6b1e10-0000-4000-8000-000000000001';
+const ALICE_ID = '8c6b1e10-0000-4000-8000-000000000002';
+
+const SUGGESTIONS: readonly MentionSuggestion[] = [
+  { id: BOB_ID, displayName: 'Bob' },
+  { id: ALICE_ID, displayName: 'Alice' },
+];
+
+function pasteText(pm: HTMLElement, text: string) {
+  const clipboardData = {
+    getData: (type: string) => (type === 'text/plain' ? text : ''),
+    types: ['text/plain'],
+    files: [],
+    items: [],
+  };
+  fireEvent.paste(pm, { clipboardData });
+}
+
+async function mount(props: Partial<Parameters<typeof MentionEditor>[0]> = {}) {
+  const onChange = props.onChange ?? vi.fn();
+  const result = render(<MentionEditor onChange={onChange} {...props} />);
+  await waitFor(() => expect(result.container.querySelector('.ProseMirror')).not.toBeNull());
+  const pm = result.container.querySelector('.ProseMirror') as HTMLElement;
+  return { ...result, pm, onChange };
+}
+
+function tick(ms = 60) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+beforeAll(() => {
+  installGeometryPolyfills();
+});
+
+afterEach(() => {
+  // Tippy appends the suggestion popup to document.body outside the RTL
+  // container; clear it so popups do not leak between tests.
+  document.querySelectorAll('[data-tippy-root]').forEach((el) => el.remove());
+});
+
+describe('MentionEditor', () => {
+  it('renders the editable surface with the merged className', async () => {
+    const { container } = await mount({ className: 'custom-surface' });
+    const root = container.querySelector('[data-testid="mention-editor"]') as HTMLElement;
+    expect(root).not.toBeNull();
+    expect(root.className).toContain('custom-surface');
+    expect(container.querySelector('.ProseMirror')?.getAttribute('contenteditable')).toBe('true');
+  });
+
+  it('seeds a multi-line body into one paragraph per line, dropping empty lines to bare paragraphs', async () => {
+    const { pm } = await mount({ initialBody: 'first\n\nthird' });
+    const paragraphs = pm.querySelectorAll('p');
+    expect(paragraphs).toHaveLength(3);
+    expect(paragraphs[0]?.textContent).toBe('first');
+    // Middle line was empty → paragraph with no inline content.
+    expect(paragraphs[1]?.textContent).toBe('');
+    expect(paragraphs[2]?.textContent).toBe('third');
+  });
+
+  it('materialises a mention chip with surrounding text from the seeded markdown', async () => {
+    const { pm } = await mount({ initialBody: `Hi @[Bob](user:${BOB_ID}) there` });
+    const chip = pm.querySelector('[data-testid="mention-editor-chip"]');
+    expect(chip).not.toBeNull();
+    expect(chip?.textContent).toContain('Bob');
+    expect(pm.textContent).toContain('Hi');
+    expect(pm.textContent).toContain('there');
+  });
+
+  it('materialises a mention chip when the mention is the first token (no leading text)', async () => {
+    const { pm } = await mount({ initialBody: `@[Alice](user:${ALICE_ID}) hello` });
+    const chips = pm.querySelectorAll('[data-testid="mention-editor-chip"]');
+    expect(chips).toHaveLength(1);
+    expect(chips[0]?.textContent).toContain('Alice');
+  });
+
+  it('exposes the placeholder as the empty-doc decoration attribute', async () => {
+    const { pm } = await mount({ placeholder: 'Write a note…' });
+    const emptyParagraph = pm.querySelector('p');
+    expect(emptyParagraph?.getAttribute('data-placeholder')).toBe('Write a note…');
+  });
+
+  it('renders a non-editable surface when disabled and re-enables it on prop change', async () => {
+    const onChange = vi.fn();
+    const { container, rerender } = render(
+      <MentionEditor onChange={onChange} disabled initialBody="locked" />
+    );
+    await waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull());
+    expect(container.querySelector('.ProseMirror')?.getAttribute('contenteditable')).toBe('false');
+
+    rerender(<MentionEditor onChange={onChange} disabled={false} initialBody="locked" />);
+    await waitFor(() =>
+      expect(container.querySelector('.ProseMirror')?.getAttribute('contenteditable')).toBe('true')
+    );
+  });
+
+  it('serialises the document back to markdown on edit via onChange', async () => {
+    const { pm, onChange } = await mount({ initialBody: 'world' });
+    pasteText(pm, 'hello ');
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe('hello world');
+  });
+
+  it('round-trips a mention chip through markdown serialisation on edit', async () => {
+    const { pm, onChange } = await mount({ initialBody: `@[Bob](user:${BOB_ID})` });
+    pasteText(pm, 'X ');
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe(`X @[Bob](user:${BOB_ID})`);
+  });
+
+  it('submits on Enter, ignores Shift+Enter, and is inert without an onSubmit handler', async () => {
+    const onSubmit = vi.fn();
+    const { pm, rerender, container } = await mount({ onSubmit, initialBody: 'x' });
+
+    fireEvent.keyDown(pm, { key: 'Enter' });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(pm, { key: 'Enter', shiftKey: true });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    // A non-Enter key never reaches the submit branch.
+    fireEvent.keyDown(pm, { key: 'a' });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    // Without onSubmit, Enter is a no-op (no throw).
+    const onChange = vi.fn();
+    rerender(<MentionEditor onChange={onChange} initialBody="x" />);
+    const pm2 = container.querySelector('.ProseMirror') as HTMLElement;
+    expect(() => fireEvent.keyDown(pm2, { key: 'Enter' })).not.toThrow();
+  });
+
+  it('opens the mention popup on "@" and lists suggestions from searchMentions', async () => {
+    const searchMentions = vi.fn(async () => [...SUGGESTIONS]);
+    const { pm } = await mount({ searchMentions });
+    pasteText(pm, '@Bob');
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="mention-editor-listbox"]')).not.toBeNull()
+    );
+    expect(searchMentions).toHaveBeenCalled();
+    const options = document.querySelectorAll('[data-testid="mention-editor-option"]');
+    expect(options).toHaveLength(2);
+    // First option is active by default.
+    expect(options[0]?.getAttribute('data-active')).toBe('');
+    expect(options[1]?.hasAttribute('data-active')).toBe(false);
+  });
+
+  it('opens the popup but lists nothing when no searchMentions source is wired', async () => {
+    const { pm } = await mount({});
+    pasteText(pm, '@Bob');
+    await tick();
+    // items resolve to [] → MentionList renders null, so no listbox appears.
+    expect(document.querySelector('[data-testid="mention-editor-option"]')).toBeNull();
+  });
+
+  it('inserts a mention chip when an option is clicked', async () => {
+    const searchMentions = vi.fn(async () => [...SUGGESTIONS]);
+    const { pm, onChange } = await mount({ searchMentions });
+    pasteText(pm, '@');
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="mention-editor-option"]')).not.toBeNull()
+    );
+    const secondOption = document.querySelectorAll(
+      '[data-testid="mention-editor-option"]'
+    )[1] as HTMLButtonElement;
+    // Hover moves the active highlight (onMouseEnter → setSelectedIndex).
+    fireEvent.mouseEnter(secondOption);
+    fireEvent.mouseDown(secondOption);
+    fireEvent.click(secondOption);
+    await waitFor(() =>
+      expect(pm.querySelector('[data-testid="mention-editor-chip"]')).not.toBeNull()
+    );
+    expect(onChange.mock.calls.at(-1)?.[0]).toContain(`@[Alice](user:${ALICE_ID})`);
+  });
+
+  it('navigates options with arrow keys and selects the highlighted one on Enter', async () => {
+    const searchMentions = vi.fn(async () => [...SUGGESTIONS]);
+    const { pm, onChange } = await mount({ searchMentions });
+    pasteText(pm, '@');
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="mention-editor-option"]')).not.toBeNull()
+    );
+
+    // A key the listbox does not handle is delegated back to ProseMirror.
+    fireEvent.keyDown(pm, { key: 'ArrowLeft' });
+
+    // ArrowDown wraps the highlight to the second option.
+    fireEvent.keyDown(pm, { key: 'ArrowDown' });
+    await waitFor(() => {
+      const opts = document.querySelectorAll('[data-testid="mention-editor-option"]');
+      expect(opts[1]?.getAttribute('data-active')).toBe('');
+    });
+
+    // ArrowUp returns it to the first option.
+    fireEvent.keyDown(pm, { key: 'ArrowUp' });
+    await waitFor(() => {
+      const opts = document.querySelectorAll('[data-testid="mention-editor-option"]');
+      expect(opts[0]?.getAttribute('data-active')).toBe('');
+    });
+
+    // Enter (while the popup owns it) selects the highlighted suggestion.
+    fireEvent.keyDown(pm, { key: 'Enter' });
+    await waitFor(() =>
+      expect(pm.querySelector('[data-testid="mention-editor-chip"]')).not.toBeNull()
+    );
+    expect(onChange.mock.calls.at(-1)?.[0]).toContain(`@[Bob](user:${BOB_ID})`);
+  });
+
+  it('swallows Enter (no submit) while the mention popup is open with nothing to select', async () => {
+    // Empty suggestion source: the popup is active (so Enter belongs to it) but
+    // the listbox has no item to select, exercising the popup-open guard in the
+    // editor's own key handler rather than the submit path.
+    const searchMentions = vi.fn(async (): Promise<MentionSuggestion[]> => []);
+    const onSubmit = vi.fn();
+    const { pm } = await mount({ searchMentions, onSubmit });
+    pasteText(pm, '@zzz');
+    await waitFor(() => expect(searchMentions).toHaveBeenCalled());
+    await tick();
+    fireEvent.keyDown(pm, { key: 'Enter' });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('closes the popup on Escape without inserting a mention', async () => {
+    const searchMentions = vi.fn(async () => [...SUGGESTIONS]);
+    const { pm } = await mount({ searchMentions });
+    pasteText(pm, '@Bob');
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="mention-editor-listbox"]')).not.toBeNull()
+    );
+    fireEvent.keyDown(pm, { key: 'Escape' });
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="mention-editor-listbox"]')).toBeNull()
+    );
+    expect(pm.querySelector('[data-testid="mention-editor-chip"]')).toBeNull();
+  });
+
+  it('re-queries the source as the mention query grows (popup onUpdate)', async () => {
+    const searchMentions = vi.fn(async () => [...SUGGESTIONS]);
+    const { pm } = await mount({ searchMentions });
+    pasteText(pm, '@Bo');
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="mention-editor-listbox"]')).not.toBeNull()
+    );
+    const callsAfterOpen = searchMentions.mock.calls.length;
+    pasteText(pm, 'b');
+    await waitFor(() => expect(searchMentions.mock.calls.length).toBeGreaterThan(callsAfterOpen));
+  });
+
+  it('serialises an empty interior paragraph on edit (block with no inline content)', async () => {
+    // The middle line is blank → its ProseMirror paragraph carries no `content`
+    // array, exercising the `block.content ?? []` fallback in docToMarkdown.
+    const { pm, onChange } = await mount({ initialBody: 'a\n\nb' });
+    pasteText(pm, 'X');
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+    const last = onChange.mock.calls.at(-1)?.[0];
+    expect(last).toContain('\n\n');
+    expect(last).toContain('b');
+  });
+
+  it('destroys the suggestion popup when the editor unmounts while it is open', async () => {
+    // Unmounting tears down the editor → the suggestion plugin runs its
+    // `destroy()` → our `onExit` fires with a live (non-destroyed) Tippy
+    // instance, so the `instance.destroy()` branch is taken.
+    const searchMentions = vi.fn(async () => [...SUGGESTIONS]);
+    const { pm, unmount } = await mount({ searchMentions });
+    pasteText(pm, '@Bob');
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="mention-editor-listbox"]')).not.toBeNull()
+    );
+    expect(() => unmount()).not.toThrow();
+  });
+
+  it('no-ops popup update and Escape once the Tippy instance is already destroyed', async () => {
+    // Force the popup instance to be destroyed out from under the editor, then
+    // drive both an onUpdate (query grows) and an Escape keypress. Both guard
+    // clauses that check `instance.state.isDestroyed` must short-circuit.
+    const searchMentions = vi.fn(async () => [...SUGGESTIONS]);
+    const { pm } = await mount({ searchMentions });
+    pasteText(pm, '@Bob');
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="mention-editor-listbox"]')).not.toBeNull()
+    );
+    const body = document.body as HTMLElement & {
+      _tippy?: { destroy: () => void; state: { isDestroyed: boolean } };
+    };
+    const instance = body._tippy;
+    expect(instance).toBeDefined();
+    instance?.destroy();
+    expect(instance?.state.isDestroyed).toBe(true);
+
+    // onUpdate path: growing the query re-runs the plugin update; the destroyed
+    // instance guard returns before `setProps` would throw.
+    expect(() => pasteText(pm, 'b')).not.toThrow();
+    await tick();
+
+    // onKeyDown Escape path: destroyed instance → the `hide()` branch is skipped.
+    expect(() => fireEvent.keyDown(pm, { key: 'Escape' })).not.toThrow();
+  });
+});

--- a/packages/@granit/react-ui-timeline/src/reaction-strip.test.tsx
+++ b/packages/@granit/react-ui-timeline/src/reaction-strip.test.tsx
@@ -1,0 +1,217 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { ReactionStrip } from './reaction-strip';
+
+import type { EmojiPickerProps } from './emoji-picker';
+import type { ReactionMap, TimelineEntryId } from '@granit/timeline';
+
+// Replace the emoji-mart-backed picker (lazy chunk + next-themes) with a
+// synchronous stand-in that exposes the `onSelect` / `onClose` callbacks as
+// buttons — this drives `handlePick`'s branches deterministically.
+vi.mock('./emoji-picker', () => ({
+  EmojiPicker: ({ onSelect, onClose }: EmojiPickerProps) => (
+    <div data-testid="mock-emoji-picker">
+      <button type="button" data-testid="pick-valid" onClick={() => onSelect('🎉')}>
+        valid
+      </button>
+      <button type="button" data-testid="pick-invalid" onClick={() => onSelect('not-emoji')}>
+        invalid
+      </button>
+      <button type="button" data-testid="pick-close" onClick={() => onClose?.()}>
+        close
+      </button>
+    </div>
+  ),
+}));
+
+// Radix Popover relies on Pointer Events APIs jsdom doesn't implement.
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+    Element.prototype.setPointerCapture = () => undefined;
+    Element.prototype.releasePointerCapture = () => undefined;
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => undefined;
+  }
+});
+
+const ENTRY_ID = '8c6b1e10-0000-4000-8000-000000000001' as TimelineEntryId;
+
+function reactionMap(
+  entries: Record<string, { count: number; byCurrentUser: boolean; displayEmoji: string }>
+): ReactionMap {
+  return entries as ReactionMap;
+}
+
+// jsdom's nwsapi selector engine can't match astral-plane emoji inside an
+// attribute-value selector, so resolve chips by iterating + getAttribute.
+function chip(root: ParentNode, emoji: string): HTMLButtonElement | null {
+  return (
+    Array.from(root.querySelectorAll<HTMLButtonElement>('button[data-emoji]')).find(
+      (b) => b.getAttribute('data-emoji') === emoji
+    ) ?? null
+  );
+}
+
+describe('ReactionStrip', () => {
+  it('renders nothing when read-only and there are no reactions', () => {
+    const { container } = render(<ReactionStrip entryId={ENTRY_ID} reactions={{}} />);
+    expect(container.querySelector('[data-slot="reaction-strip"]')).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when read-only and reactions is undefined', () => {
+    const { container } = render(<ReactionStrip entryId={ENTRY_ID} reactions={undefined} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('exposes the entry id and merges the className on the root', () => {
+    const { container } = render(
+      <ReactionStrip
+        entryId={ENTRY_ID}
+        reactions={reactionMap({ '👍': { count: 1, byCurrentUser: false, displayEmoji: '👍' } })}
+        className="mt-2"
+      />
+    );
+    const root = container.querySelector('[data-slot="reaction-strip"]') as HTMLElement;
+    expect(root.getAttribute('data-entry-id')).toBe(ENTRY_ID);
+    expect(root.hasAttribute('data-granit-reaction-strip')).toBe(true);
+    expect(root.className).toContain('mt-2');
+  });
+
+  it('renders a chip per reaction with count and display emoji', () => {
+    const { container } = render(
+      <ReactionStrip
+        entryId={ENTRY_ID}
+        reactions={reactionMap({
+          '👍': { count: 3, byCurrentUser: false, displayEmoji: '👍' },
+          '❤️': { count: 7, byCurrentUser: false, displayEmoji: '❤️' },
+        })}
+      />
+    );
+    const chips = container.querySelectorAll('button[data-emoji]');
+    expect(chips).toHaveLength(2);
+    const thumbs = chip(container, '👍');
+    expect(thumbs?.querySelector('span')?.textContent).toBe('3');
+    expect(thumbs?.querySelector('img')?.getAttribute('alt')).toBe('👍');
+  });
+
+  it('reflects byCurrentUser via aria-pressed and the data-has-reacted marker', () => {
+    const { container } = render(
+      <ReactionStrip
+        entryId={ENTRY_ID}
+        reactions={reactionMap({
+          '👍': { count: 1, byCurrentUser: true, displayEmoji: '👍' },
+          '😀': { count: 1, byCurrentUser: false, displayEmoji: '😀' },
+        })}
+      />
+    );
+    const reacted = chip(container, '👍');
+    const notReacted = chip(container, '😀');
+    expect(reacted?.getAttribute('aria-pressed')).toBe('true');
+    expect(reacted?.hasAttribute('data-has-reacted')).toBe(true);
+    expect(notReacted?.getAttribute('aria-pressed')).toBe('false');
+    expect(notReacted?.hasAttribute('data-has-reacted')).toBe(false);
+  });
+
+  it('renders read-only chips as disabled with no picker button', () => {
+    const { container } = render(
+      <ReactionStrip
+        entryId={ENTRY_ID}
+        reactions={reactionMap({ '👍': { count: 1, byCurrentUser: false, displayEmoji: '👍' } })}
+      />
+    );
+    const thumbs = chip(container, '👍');
+    expect(thumbs?.disabled).toBe(true);
+    expect(thumbs?.className).toContain('cursor-default');
+    expect(container.querySelector('[data-granit-reaction-strip-picker]')).toBeNull();
+  });
+
+  it('does not fire onToggle when a read-only chip is clicked', () => {
+    const onToggle = vi.fn();
+    const { container } = render(
+      <ReactionStrip
+        entryId={ENTRY_ID}
+        reactions={reactionMap({ '👍': { count: 1, byCurrentUser: false, displayEmoji: '👍' } })}
+      />
+    );
+    fireEvent.click(chip(container, '👍') as HTMLElement);
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('renders the picker (and no chips) when interactive with empty reactions', () => {
+    const { container } = render(
+      <ReactionStrip entryId={ENTRY_ID} reactions={{}} onToggle={vi.fn()} />
+    );
+    expect(container.querySelector('[data-slot="reaction-strip"]')).not.toBeNull();
+    expect(container.querySelector('button[data-emoji]')).toBeNull();
+    expect(container.querySelector('[data-granit-reaction-strip-picker]')).not.toBeNull();
+  });
+
+  it('fires onToggle with the branded emoji when an interactive chip is clicked', () => {
+    const onToggle = vi.fn();
+    const { container } = render(
+      <ReactionStrip
+        entryId={ENTRY_ID}
+        reactions={reactionMap({ '👍': { count: 1, byCurrentUser: false, displayEmoji: '👍' } })}
+        onToggle={onToggle}
+      />
+    );
+    const thumbs = chip(container, '👍');
+    expect(thumbs?.disabled).toBe(false);
+    fireEvent.click(thumbs as HTMLElement);
+    expect(onToggle).toHaveBeenCalledWith({ entryId: ENTRY_ID, emoji: '👍' });
+  });
+
+  it('swallows the click when the chip key is not a valid emoji', () => {
+    const onToggle = vi.fn();
+    const { container } = render(
+      <ReactionStrip
+        entryId={ENTRY_ID}
+        reactions={reactionMap({ x: { count: 1, byCurrentUser: false, displayEmoji: 'x' } })}
+        onToggle={onToggle}
+      />
+    );
+    fireEvent.click(chip(container, 'x') as HTMLElement);
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('toggles the reaction picked from the popover and closes it', async () => {
+    const onToggle = vi.fn();
+    const { container, getByTestId } = render(
+      <ReactionStrip entryId={ENTRY_ID} reactions={{}} onToggle={onToggle} />
+    );
+    fireEvent.click(container.querySelector('[data-granit-reaction-strip-picker]') as HTMLElement);
+    await waitFor(() => expect(getByTestId('mock-emoji-picker')).not.toBeNull());
+    fireEvent.click(getByTestId('pick-valid'));
+    expect(onToggle).toHaveBeenCalledWith({ entryId: ENTRY_ID, emoji: '🎉' });
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="mock-emoji-picker"]')).toBeNull()
+    );
+  });
+
+  it('ignores a picked value that is not a valid emoji', async () => {
+    const onToggle = vi.fn();
+    const { container, getByTestId } = render(
+      <ReactionStrip entryId={ENTRY_ID} reactions={{}} onToggle={onToggle} />
+    );
+    fireEvent.click(container.querySelector('[data-granit-reaction-strip-picker]') as HTMLElement);
+    await waitFor(() => expect(getByTestId('mock-emoji-picker')).not.toBeNull());
+    fireEvent.click(getByTestId('pick-invalid'));
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('closes the popover via the picker onClose callback', async () => {
+    const { container, getByTestId } = render(
+      <ReactionStrip entryId={ENTRY_ID} reactions={{}} onToggle={vi.fn()} />
+    );
+    fireEvent.click(container.querySelector('[data-granit-reaction-strip-picker]') as HTMLElement);
+    await waitFor(() => expect(getByTestId('mock-emoji-picker')).not.toBeNull());
+    fireEvent.click(getByTestId('pick-close'));
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="mock-emoji-picker"]')).toBeNull()
+    );
+  });
+});

--- a/packages/@granit/react-ui-timeline/src/timeline-composer.test.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-composer.test.tsx
@@ -1,0 +1,256 @@
+import { fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from './__tests__/test-utils';
+import { TimelineComposer } from './timeline-composer';
+
+import type { MentionEditorProps } from './mention-editor';
+import type { TimelineEntryType } from '@granit/timeline';
+
+// Replace the TipTap-backed editor with a plain controlled <textarea>. The
+// composer is a pure controlled form; mocking the child keeps every branch
+// (body content, Enter-to-submit, disabled propagation) deterministic without
+// dragging ProseMirror/Tippy into the assertions.
+vi.mock('./mention-editor', () => ({
+  MentionEditor: function MockMentionEditor({
+    initialBody,
+    onChange,
+    onSubmit,
+    disabled,
+    placeholder,
+    searchMentions,
+  }: MentionEditorProps) {
+    return (
+      <textarea
+        data-testid="mock-mention-editor"
+        defaultValue={initialBody}
+        disabled={disabled}
+        placeholder={placeholder}
+        data-has-search={searchMentions ? 'yes' : 'no'}
+        onChange={(e) => onChange(e.currentTarget.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            onSubmit?.();
+          }
+        }}
+      />
+    );
+  },
+}));
+
+const COMMENT: TimelineEntryType = 'Comment';
+const INTERNAL: TimelineEntryType = 'InternalNote';
+const SYSTEM: TimelineEntryType = 'SystemLog';
+
+function form(container: HTMLElement): HTMLFormElement {
+  return container.querySelector('[data-testid="timeline-composer"]') as HTMLFormElement;
+}
+
+function submitButton(container: HTMLElement): HTMLButtonElement {
+  return container.querySelector('[data-testid="timeline-composer-submit"]') as HTMLButtonElement;
+}
+
+function editor(container: HTMLElement): HTMLTextAreaElement {
+  return container.querySelector('[data-testid="mock-mention-editor"]') as HTMLTextAreaElement;
+}
+
+function radios(container: HTMLElement): HTMLButtonElement[] {
+  return Array.from(container.querySelectorAll('[role="radio"]'));
+}
+
+describe('TimelineComposer', () => {
+  it('renders the composer shell with submit disabled while the body is empty', () => {
+    const { container } = renderWithProviders(
+      <TimelineComposer onSubmit={vi.fn().mockResolvedValue(undefined)} />
+    );
+    expect(container.querySelector('[data-slot="timeline-composer"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="timeline-composer-footer"]')).not.toBeNull();
+    expect(submitButton(container).disabled).toBe(true);
+  });
+
+  it('enables submit once the body has content and posts the trimmed body with the default type and parentEntryId', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const { container } = renderWithProviders(
+      <TimelineComposer onSubmit={onSubmit} parentEntryId="p-1" />
+    );
+    fireEvent.change(editor(container), { target: { value: '  Hello world  ' } });
+    expect(submitButton(container).disabled).toBe(false);
+    fireEvent.click(submitButton(container));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith({
+      entryType: COMMENT,
+      body: 'Hello world',
+      parentEntryId: 'p-1',
+    });
+  });
+
+  it('clears the body after a successful submit (submit disables again)', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const { container } = renderWithProviders(<TimelineComposer onSubmit={onSubmit} />);
+    fireEvent.change(editor(container), { target: { value: 'Draft body' } });
+    fireEvent.click(submitButton(container));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    await waitFor(() => expect(submitButton(container).disabled).toBe(true));
+  });
+
+  it('ignores an Enter submit when the body is only whitespace', () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const { container } = renderWithProviders(<TimelineComposer onSubmit={onSubmit} />);
+    fireEvent.change(editor(container), { target: { value: '    ' } });
+    expect(submitButton(container).disabled).toBe(true);
+    fireEvent.keyDown(editor(container), { key: 'Enter' });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('submits via the Enter key forwarded from the editor', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const { container } = renderWithProviders(<TimelineComposer onSubmit={onSubmit} />);
+    fireEvent.change(editor(container), { target: { value: 'Hi' } });
+    fireEvent.keyDown(editor(container), { key: 'Enter' });
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ body: 'Hi' }));
+  });
+
+  it('shows the sending state and disables the editor while the submit promise is pending', async () => {
+    let resolveSubmit: (() => void) | undefined;
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSubmit = resolve;
+        })
+    );
+    const { container } = renderWithProviders(<TimelineComposer onSubmit={onSubmit} />);
+    fireEvent.change(editor(container), { target: { value: 'Pending' } });
+    fireEvent.click(submitButton(container));
+
+    await waitFor(() => expect(submitButton(container).disabled).toBe(true));
+    expect(submitButton(container).textContent).toContain('Sending');
+    expect(editor(container).disabled).toBe(true);
+
+    resolveSubmit?.();
+    await waitFor(() => expect(editor(container).disabled).toBe(false));
+  });
+
+  it('renders a radio per allowed type and toggles the active type (internal-note styling)', () => {
+    const { container } = renderWithProviders(
+      <TimelineComposer onSubmit={vi.fn().mockResolvedValue(undefined)} />
+    );
+    const selector = container.querySelector('[data-testid="timeline-composer-type-selector"]');
+    expect(selector).not.toBeNull();
+    const options = radios(container);
+    expect(options).toHaveLength(2);
+    expect(options[0]?.getAttribute('aria-checked')).toBe('true');
+    expect(options[1]?.getAttribute('aria-checked')).toBe('false');
+    expect(form(container).className).not.toContain('border-primary/30');
+
+    fireEvent.click(options[1] as HTMLButtonElement);
+    expect(radios(container)[1]?.getAttribute('aria-checked')).toBe('true');
+    expect(form(container).className).toContain('border-primary/30');
+  });
+
+  it('posts the entry type selected in the radiogroup', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const { container } = renderWithProviders(<TimelineComposer onSubmit={onSubmit} />);
+    fireEvent.click(radios(container)[1] as HTMLButtonElement);
+    fireEvent.change(editor(container), { target: { value: 'Note' } });
+    fireEvent.click(submitButton(container));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ entryType: INTERNAL }));
+  });
+
+  it('hides the selector when hideEntryTypeSelector is set even with multiple types', () => {
+    const { container } = renderWithProviders(
+      <TimelineComposer onSubmit={vi.fn().mockResolvedValue(undefined)} hideEntryTypeSelector />
+    );
+    expect(container.querySelector('[data-testid="timeline-composer-type-selector"]')).toBeNull();
+  });
+
+  it('hides the selector when only one entry type is allowed', () => {
+    const { container } = renderWithProviders(
+      <TimelineComposer onSubmit={vi.fn().mockResolvedValue(undefined)} entryTypes={[COMMENT]} />
+    );
+    expect(container.querySelector('[data-testid="timeline-composer-type-selector"]')).toBeNull();
+  });
+
+  it('pre-selects a valid initialEntryType and applies the internal-note styling on mount', () => {
+    const { container } = renderWithProviders(
+      <TimelineComposer
+        onSubmit={vi.fn().mockResolvedValue(undefined)}
+        entryTypes={[COMMENT, INTERNAL]}
+        initialEntryType={INTERNAL}
+      />
+    );
+    const options = radios(container);
+    expect(options[0]?.getAttribute('aria-checked')).toBe('false');
+    expect(options[1]?.getAttribute('aria-checked')).toBe('true');
+    expect(form(container).className).toContain('border-primary/30');
+  });
+
+  it('falls back to the first type when initialEntryType is not in the allowed list and renders the SystemLog label', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const { container } = renderWithProviders(
+      <TimelineComposer
+        onSubmit={onSubmit}
+        entryTypes={[COMMENT, SYSTEM]}
+        initialEntryType={INTERNAL}
+      />
+    );
+    const options = radios(container);
+    expect(options).toHaveLength(2);
+    expect(options[0]?.getAttribute('aria-checked')).toBe('true');
+    // SystemLog branch of pickEntryTypeLabel — key resolves to its raw form.
+    expect(options[1]?.textContent).toContain('SystemLog');
+
+    fireEvent.change(editor(container), { target: { value: 'x' } });
+    fireEvent.click(submitButton(container));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ entryType: COMMENT }));
+  });
+
+  it('forwards className, placeholder, submitLabel and searchMentions', () => {
+    const { container } = renderWithProviders(
+      <TimelineComposer
+        onSubmit={vi.fn().mockResolvedValue(undefined)}
+        className="my-composer"
+        placeholder="Type here…"
+        submitLabel="Post"
+        searchMentions={vi.fn().mockResolvedValue([])}
+      />
+    );
+    expect(form(container).className).toContain('my-composer');
+    expect(submitButton(container).textContent).toBe('Post');
+    expect(editor(container).getAttribute('placeholder')).toBe('Type here…');
+    expect(editor(container).getAttribute('data-has-search')).toBe('yes');
+  });
+
+  it('swallows a rejected submit from the button path and keeps the body for retry', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('boom'));
+    const { container } = renderWithProviders(<TimelineComposer onSubmit={onSubmit} />);
+    fireEvent.change(editor(container), { target: { value: 'Keep me' } });
+    fireEvent.click(submitButton(container));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    // Rejection is swallowed; body is untouched so submit re-enables for a retry.
+    await waitFor(() => expect(submitButton(container).disabled).toBe(false));
+  });
+
+  it('swallows a rejected submit from the Enter path', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('boom'));
+    const { container } = renderWithProviders(<TimelineComposer onSubmit={onSubmit} />);
+    fireEvent.change(editor(container), { target: { value: 'Retry via enter' } });
+    fireEvent.keyDown(editor(container), { key: 'Enter' });
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    await waitFor(() => expect(submitButton(container).disabled).toBe(false));
+  });
+
+  it('seeds the body from initialBody so submit is enabled on mount', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const { container } = renderWithProviders(
+      <TimelineComposer onSubmit={onSubmit} initialBody="Existing draft" />
+    );
+    expect(submitButton(container).disabled).toBe(false);
+    fireEvent.click(submitButton(container));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ body: 'Existing draft' }));
+  });
+});

--- a/packages/@granit/react-ui-timeline/src/timeline-entry.test.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-entry.test.tsx
@@ -1,0 +1,345 @@
+import { TimelineEntryType, TimelineEntryOrigin } from '@granit/timeline';
+import { toEntityId, toISODateString } from '@granit/types';
+import { screen, waitFor } from '@testing-library/react';
+
+import { renderWithProviders } from './__tests__/test-utils';
+import { TimelineEntry } from './timeline-entry';
+
+import type {
+  ReactionEmoji,
+  ReactionMap,
+  ReactionToggleResponse,
+  TimelineStreamEntryResponse,
+} from '@granit/timeline';
+
+// Only the two mutation hooks TimelineEntry imports are mocked; the rest of
+// the render path (ReactionStrip, avatar, formatting) runs for real so the
+// component's branches are genuinely exercised.
+const hoisted = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  mutateAsync: vi.fn(),
+}));
+
+vi.mock('@granit/react-timeline', () => ({
+  useToggleReaction: () => ({ mutate: hoisted.mutate }),
+  useAnchorEntry: () => ({ mutateAsync: hoisted.mutateAsync }),
+}));
+
+const THUMBS_UP = '👍' as ReactionEmoji;
+const PARTY = '🎉' as ReactionEmoji;
+
+const reactions: ReactionMap = {
+  [THUMBS_UP]: { count: 3, byCurrentUser: true, displayEmoji: '👍' },
+  [PARTY]: { count: 1, byCurrentUser: false, displayEmoji: '🎉' },
+} as ReactionMap;
+
+function makeEntry(
+  overrides: Partial<TimelineStreamEntryResponse> = {}
+): TimelineStreamEntryResponse {
+  return {
+    id: toEntityId<'TimelineStreamEntryResponse'>('tl-1'),
+    entryType: TimelineEntryType.Comment,
+    body: 'Account created and initial roles assigned.',
+    authorId: toEntityId<'User'>('admin-001'),
+    authorName: 'System Admin',
+    parentEntryId: null,
+    occurredAt: toISODateString('2026-05-10T09:30:00Z'),
+    attachments: [],
+    ...overrides,
+  };
+}
+
+const toggleResult: ReactionToggleResponse = {
+  emoji: THUMBS_UP,
+  count: 4,
+  currentUserHasReacted: true,
+} as ReactionToggleResponse;
+
+beforeEach(() => {
+  hoisted.mutate.mockReset();
+  hoisted.mutateAsync.mockReset();
+  // Default: invoke onSuccess synchronously so onReactionToggled fires.
+  hoisted.mutate.mockImplementation(
+    (_vars: unknown, opts?: { onSuccess?: (result: ReactionToggleResponse) => void }) => {
+      opts?.onSuccess?.(toggleResult);
+    }
+  );
+  hoisted.mutateAsync.mockResolvedValue(toEntityId<'TimelineStreamEntryResponse'>('tl-shadow'));
+});
+
+describe('TimelineEntry', () => {
+  it('renders a comment entry with author, body and comment type', () => {
+    renderWithProviders(<TimelineEntry entry={makeEntry()} />);
+    const article = screen.getByTestId('timeline-entry');
+    expect(article).toHaveAttribute('data-entry-type', 'comment');
+    expect(article).toHaveAttribute('data-depth', '0');
+    expect(article.getAttribute('style') ?? '').not.toContain('margin-left');
+    expect(screen.getByTestId('timeline-entry-author')).toHaveTextContent('System Admin');
+    expect(screen.getByTestId('timeline-entry-body')).toHaveTextContent(
+      'Account created and initial roles assigned.'
+    );
+  });
+
+  it('renders internal-note type', () => {
+    renderWithProviders(
+      <TimelineEntry entry={makeEntry({ entryType: TimelineEntryType.InternalNote })} />
+    );
+    expect(screen.getByTestId('timeline-entry')).toHaveAttribute(
+      'data-entry-type',
+      'internal-note'
+    );
+  });
+
+  it('falls back to "unknown" for an unrecognised entry type', () => {
+    renderWithProviders(
+      <TimelineEntry
+        entry={makeEntry({
+          entryType: 'Mystery' as TimelineStreamEntryResponse['entryType'],
+        })}
+      />
+    );
+    expect(screen.getByTestId('timeline-entry')).toHaveAttribute('data-entry-type', 'unknown');
+    // Not a system log → actions footer present.
+    expect(screen.queryByTestId('timeline-entry-actions')).toBeInTheDocument();
+  });
+
+  it('hides reactions and actions for a system-log entry', () => {
+    renderWithProviders(
+      <TimelineEntry
+        entry={makeEntry({ entryType: TimelineEntryType.SystemLog, reactions })}
+        onReply={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('timeline-entry')).toHaveAttribute('data-entry-type', 'system-log');
+    expect(screen.queryByTestId('timeline-entry-actions')).not.toBeInTheDocument();
+    expect(document.querySelector('[data-slot="reaction-strip"]')).toBeNull();
+  });
+
+  it('renders the edited badge only when editedAt is set', () => {
+    const { rerender } = renderWithProviders(<TimelineEntry entry={makeEntry()} />);
+    expect(screen.queryByTestId('timeline-entry-edited-badge')).not.toBeInTheDocument();
+    rerender(
+      <TimelineEntry entry={makeEntry({ editedAt: toISODateString('2026-05-10T10:00:00Z') })} />
+    );
+    expect(screen.getByTestId('timeline-entry-edited-badge')).toBeInTheDocument();
+  });
+
+  it('applies a left margin when depth > 0', () => {
+    renderWithProviders(<TimelineEntry entry={makeEntry()} depth={2} />);
+    const article = screen.getByTestId('timeline-entry');
+    expect(article).toHaveAttribute('data-depth', '2');
+    expect(article).toHaveStyle({ marginLeft: '48px' });
+  });
+
+  it('renders body through a custom renderBody callback', () => {
+    const renderBody = vi.fn((body: string) => <em data-testid="custom-body">{body}</em>);
+    renderWithProviders(<TimelineEntry entry={makeEntry()} renderBody={renderBody} />);
+    expect(screen.getByTestId('custom-body')).toBeInTheDocument();
+    expect(renderBody).toHaveBeenCalledWith('Account created and initial roles assigned.');
+  });
+
+  it('shows "System" and a fallback avatar when author info is missing', () => {
+    renderWithProviders(<TimelineEntry entry={makeEntry({ authorId: null, authorName: null })} />);
+    expect(screen.getByTestId('timeline-entry-author')).toHaveTextContent('System');
+    expect(screen.getByTestId('timeline-entry-avatar')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['System Admin', 'SA'],
+    ['Alice', 'A'],
+    ['   ', '?'],
+  ])('derives initials %s -> %s', (authorName, expected) => {
+    renderWithProviders(<TimelineEntry entry={makeEntry({ authorName })} />);
+    expect(screen.getByTestId('timeline-entry-avatar')).toHaveTextContent(expected);
+  });
+
+  describe('action callbacks', () => {
+    it('does not render any action button when no callbacks are passed', () => {
+      renderWithProviders(<TimelineEntry entry={makeEntry()} />);
+      expect(screen.queryByTestId('timeline-reply-btn')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('timeline-edit-btn')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('timeline-delete-btn')).not.toBeInTheDocument();
+    });
+
+    it('fires onReply with the entry id', async () => {
+      const onReply = vi.fn();
+      const { user } = renderWithProviders(<TimelineEntry entry={makeEntry()} onReply={onReply} />);
+      await user.click(screen.getByTestId('timeline-reply-btn'));
+      expect(onReply).toHaveBeenCalledWith('tl-1');
+    });
+
+    it('fires onEdit with id, body and entry type', async () => {
+      const onEdit = vi.fn();
+      const { user } = renderWithProviders(<TimelineEntry entry={makeEntry()} onEdit={onEdit} />);
+      await user.click(screen.getByTestId('timeline-edit-btn'));
+      expect(onEdit).toHaveBeenCalledWith(
+        'tl-1',
+        'Account created and initial roles assigned.',
+        TimelineEntryType.Comment
+      );
+    });
+
+    it('fires onDelete with the entry id', async () => {
+      const onDelete = vi.fn();
+      const { user } = renderWithProviders(
+        <TimelineEntry entry={makeEntry()} onDelete={onDelete} />
+      );
+      await user.click(screen.getByTestId('timeline-delete-btn'));
+      expect(onDelete).toHaveBeenCalledWith('tl-1');
+    });
+  });
+
+  describe('read-only reaction strip', () => {
+    it('renders a non-interactive strip when canReact is false', () => {
+      renderWithProviders(<TimelineEntry entry={makeEntry({ reactions })} />);
+      const strip = document.querySelector('[data-slot="reaction-strip"]');
+      expect(strip).not.toBeNull();
+      const chip = strip?.querySelector('button[data-emoji]');
+      expect(chip).toHaveAttribute('disabled');
+      // No add-reaction picker in read-only mode.
+      expect(document.querySelector('[data-granit-reaction-strip-picker]')).toBeNull();
+    });
+
+    it('renders a read-only strip when canReact is true but entity context is missing', () => {
+      renderWithProviders(<TimelineEntry entry={makeEntry({ reactions })} canReact />);
+      const chip = document.querySelector('[data-slot="reaction-strip"] button[data-emoji]');
+      expect(chip).toHaveAttribute('disabled');
+    });
+  });
+
+  describe('interactive reaction bar', () => {
+    it('renders an interactive strip and toggles a native-origin reaction', async () => {
+      const onReactionToggled = vi.fn();
+      const { user } = renderWithProviders(
+        <TimelineEntry
+          entry={makeEntry({ reactions })}
+          entityType="User"
+          entityId="user-001"
+          canReact
+          onReactionToggled={onReactionToggled}
+        />
+      );
+      const chip = document.querySelector<HTMLButtonElement>(
+        '[data-slot="reaction-strip"] button[data-emoji]'
+      );
+      expect(chip).not.toBeNull();
+      expect(chip).not.toHaveAttribute('disabled');
+      // Picker present in interactive mode.
+      expect(document.querySelector('[data-granit-reaction-strip-picker]')).not.toBeNull();
+
+      await user.click(chip!);
+
+      // Native origin → no anchor materialisation, direct toggle.
+      expect(hoisted.mutateAsync).not.toHaveBeenCalled();
+      await waitFor(() => expect(hoisted.mutate).toHaveBeenCalled());
+      expect(hoisted.mutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entityType: 'User',
+          entityId: 'user-001',
+          entryId: 'tl-1',
+          emoji: THUMBS_UP,
+        }),
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
+      // onSuccess relayed to the consumer callback.
+      await waitFor(() => expect(onReactionToggled).toHaveBeenCalledWith('tl-1', toggleResult));
+    });
+
+    it('materialises the anchor shadow id for an external-origin entry', async () => {
+      const { user } = renderWithProviders(
+        <TimelineEntry
+          entry={makeEntry({
+            reactions,
+            origin: TimelineEntryOrigin.External,
+            sourceKey: 'auditing',
+            sourceId: 'audit-42',
+          })}
+          entityType="User"
+          entityId="user-001"
+          canReact
+        />
+      );
+      const chip = document.querySelector<HTMLButtonElement>(
+        '[data-slot="reaction-strip"] button[data-emoji]'
+      );
+      await user.click(chip!);
+
+      await waitFor(() =>
+        expect(hoisted.mutateAsync).toHaveBeenCalledWith({
+          entityType: 'User',
+          entityId: 'user-001',
+          sourceKey: 'auditing',
+          sourceId: 'audit-42',
+        })
+      );
+      // Toggle then targets the resolved shadow id, keeping the original entryId
+      // for the local cache patch relayed back via onSuccess.
+      await waitFor(() =>
+        expect(hoisted.mutate).toHaveBeenCalledWith(
+          expect.objectContaining({ entryId: 'tl-shadow' }),
+          expect.any(Object)
+        )
+      );
+    });
+
+    it('treats an external entry without source coordinates as non-anchored', async () => {
+      const { user } = renderWithProviders(
+        <TimelineEntry
+          entry={makeEntry({
+            reactions,
+            origin: TimelineEntryOrigin.External,
+            sourceKey: '',
+            sourceId: null,
+          })}
+          entityType="User"
+          entityId="user-001"
+          canReact
+        />
+      );
+      const chip = document.querySelector<HTMLButtonElement>(
+        '[data-slot="reaction-strip"] button[data-emoji]'
+      );
+      await user.click(chip!);
+
+      await waitFor(() => expect(hoisted.mutate).toHaveBeenCalled());
+      expect(hoisted.mutateAsync).not.toHaveBeenCalled();
+      expect(hoisted.mutate).toHaveBeenCalledWith(
+        expect.objectContaining({ entryId: 'tl-1' }),
+        expect.any(Object)
+      );
+    });
+
+    it('renders an interactive strip with no chips when reactions are null', () => {
+      renderWithProviders(
+        <TimelineEntry
+          entry={makeEntry({ reactions: null })}
+          entityType="User"
+          entityId="user-001"
+          canReact
+        />
+      );
+      // Interactive (picker present) but no reaction chips to click.
+      expect(document.querySelector('[data-granit-reaction-strip-picker]')).not.toBeNull();
+      expect(document.querySelector('[data-slot="reaction-strip"] button[data-emoji]')).toBeNull();
+      expect(hoisted.mutate).not.toHaveBeenCalled();
+    });
+
+    it('toggles without a consumer callback (onReactionToggled omitted)', async () => {
+      const { user } = renderWithProviders(
+        <TimelineEntry
+          entry={makeEntry({ reactions })}
+          entityType="User"
+          entityId="user-001"
+          canReact
+        />
+      );
+      const chip = document.querySelector<HTMLButtonElement>(
+        '[data-slot="reaction-strip"] button[data-emoji]'
+      );
+      await user.click(chip!);
+      await waitFor(() => expect(hoisted.mutate).toHaveBeenCalled());
+    });
+  });
+});

--- a/packages/@granit/react-ui-timeline/src/timeline-stream.test.tsx
+++ b/packages/@granit/react-ui-timeline/src/timeline-stream.test.tsx
@@ -1,0 +1,229 @@
+import { fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from './__tests__/test-utils';
+import { TimelineStream } from './timeline-stream';
+
+import type { TimelineEntryProps } from './timeline-entry';
+import type { TimelineStreamEntryResponse, TimelineEntryId } from '@granit/timeline';
+import type { ISODateString } from '@granit/types';
+
+let seq = 0;
+
+function makeEntry(
+  overrides: Partial<TimelineStreamEntryResponse> = {}
+): TimelineStreamEntryResponse {
+  seq += 1;
+  return {
+    id: `e-${seq}` as TimelineEntryId,
+    occurredAt: '2026-01-01T00:00:00Z' as ISODateString,
+    entryType: 'Comment',
+    authorId: null,
+    authorName: 'Alice',
+    body: 'Hello world',
+    attachments: [],
+    parentEntryId: null,
+    ...overrides,
+  };
+}
+
+/** Captures the props each entry is rendered with, bypassing the real
+ * <TimelineEntry> so branch logic (threading depth, onEdit gating,
+ * context forwarding) can be asserted directly on the forwarded props. */
+function makeCapture() {
+  const captured: TimelineEntryProps[] = [];
+  const renderEntry = (props: TimelineEntryProps) => {
+    captured.push(props);
+    return (
+      <div data-testid="custom-entry" data-entry-id={props.entry.id} data-depth={props.depth} />
+    );
+  };
+  return { captured, renderEntry };
+}
+
+describe('TimelineStream', () => {
+  it('renders the loading state with a spinner and no entries', () => {
+    const { renderEntry, captured } = makeCapture();
+    const { container } = renderWithProviders(
+      <TimelineStream entries={[makeEntry()]} loading renderEntry={renderEntry} />
+    );
+    const output = container.querySelector('output[aria-label="Loading timeline"]');
+    expect(output).not.toBeNull();
+    expect(container.querySelector('[data-testid="timeline-loading"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="timeline-stream"]')).toBeNull();
+    expect(captured).toHaveLength(0);
+  });
+
+  it('forwards className onto the loading output', () => {
+    const { container } = renderWithProviders(
+      <TimelineStream entries={[]} loading className="my-loader" />
+    );
+    expect(container.querySelector('output.my-loader')).not.toBeNull();
+  });
+
+  it('renders the empty state with the default message when there are no entries', () => {
+    const { container } = renderWithProviders(<TimelineStream entries={[]} />);
+    const empty = container.querySelector('[data-testid="timeline-empty"]');
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent).toBe('No entries yet.');
+  });
+
+  it('renders a custom empty message', () => {
+    const { container } = renderWithProviders(
+      <TimelineStream entries={[]} emptyMessage="Nothing here" className="empty-cls" />
+    );
+    const empty = container.querySelector('[data-testid="timeline-empty"]');
+    expect(empty?.textContent).toBe('Nothing here');
+    expect(empty?.classList.contains('empty-cls')).toBe(true);
+  });
+
+  it('treats a stream whose entries are all unreachable orphans as empty', () => {
+    // parentEntryId points at an id that is not itself an entry → dropped.
+    const orphan = makeEntry({ parentEntryId: 'missing-parent' as TimelineEntryId });
+    const { container } = renderWithProviders(<TimelineStream entries={[orphan]} />);
+    expect(container.querySelector('[data-testid="timeline-empty"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="timeline-stream"]')).toBeNull();
+  });
+
+  it('flattens the thread depth-first and assigns increasing depth to descendants', () => {
+    const root = makeEntry({ body: 'root' });
+    const child = makeEntry({ parentEntryId: root.id, body: 'child' });
+    const grandchild = makeEntry({ parentEntryId: child.id, body: 'grandchild' });
+    const secondRoot = makeEntry({ body: 'root2' });
+    const { renderEntry, captured } = makeCapture();
+    renderWithProviders(
+      <TimelineStream entries={[root, child, grandchild, secondRoot]} renderEntry={renderEntry} />
+    );
+    expect(captured.map((p) => p.entry.body)).toEqual(['root', 'child', 'grandchild', 'root2']);
+    expect(captured.map((p) => p.depth)).toEqual([0, 1, 2, 0]);
+  });
+
+  it('renders each entry through renderEntry inside the timeline-stream section', () => {
+    const { renderEntry } = makeCapture();
+    const { container } = renderWithProviders(
+      <TimelineStream entries={[makeEntry(), makeEntry()]} renderEntry={renderEntry} />
+    );
+    const section = container.querySelector('[data-testid="timeline-stream"]');
+    expect(section?.getAttribute('aria-label')).toBe('Timeline');
+    expect(container.querySelectorAll('[data-testid="custom-entry"]')).toHaveLength(2);
+  });
+
+  it('renders the built-in TimelineEntry when no renderEntry is provided', () => {
+    const { container } = renderWithProviders(
+      <TimelineStream entries={[makeEntry({ body: 'native render' })]} />
+    );
+    const entries = container.querySelectorAll('[data-testid="timeline-entry"]');
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.getAttribute('data-depth')).toBe('0');
+    expect(container.textContent).toContain('native render');
+  });
+
+  it('forwards stream context (entityType, entityId, canReact, renderBody) to each entry', () => {
+    const { renderEntry, captured } = makeCapture();
+    const renderBody = (body: string) => <span>{body}</span>;
+    renderWithProviders(
+      <TimelineStream
+        entries={[makeEntry()]}
+        entityType="User"
+        entityId="u-1"
+        canReact
+        renderBody={renderBody}
+        renderEntry={renderEntry}
+      />
+    );
+    const props = captured[0];
+    expect(props?.entityType).toBe('User');
+    expect(props?.entityId).toBe('u-1');
+    expect(props?.canReact).toBe(true);
+    expect(props?.renderBody).toBe(renderBody);
+  });
+
+  it('does not forward onEdit when the callback is absent', () => {
+    const { renderEntry, captured } = makeCapture();
+    renderWithProviders(<TimelineStream entries={[makeEntry()]} renderEntry={renderEntry} />);
+    expect(captured[0]?.onEdit).toBeUndefined();
+  });
+
+  it('forwards onEdit to every entry when no canEdit predicate is supplied', () => {
+    const onEdit = vi.fn();
+    const { renderEntry, captured } = makeCapture();
+    renderWithProviders(
+      <TimelineStream
+        entries={[makeEntry(), makeEntry()]}
+        onEdit={onEdit}
+        renderEntry={renderEntry}
+      />
+    );
+    expect(captured.every((p) => p.onEdit === onEdit)).toBe(true);
+  });
+
+  it('gates onEdit per entry via the canEdit predicate', () => {
+    const onEdit = vi.fn();
+    const editable = makeEntry({ body: 'editable' });
+    const locked = makeEntry({ body: 'locked' });
+    const canEdit = vi.fn((entry: TimelineStreamEntryResponse) => entry.body === 'editable');
+    const { renderEntry, captured } = makeCapture();
+    renderWithProviders(
+      <TimelineStream
+        entries={[editable, locked]}
+        onEdit={onEdit}
+        canEdit={canEdit}
+        renderEntry={renderEntry}
+      />
+    );
+    expect(canEdit).toHaveBeenCalledTimes(2);
+    expect(captured[0]?.onEdit).toBe(onEdit);
+    expect(captured[1]?.onEdit).toBeUndefined();
+  });
+
+  it('omits the load-more control when hasMore is false', () => {
+    const { renderEntry } = makeCapture();
+    const { container } = renderWithProviders(
+      <TimelineStream entries={[makeEntry()]} renderEntry={renderEntry} />
+    );
+    expect(container.querySelector('[data-testid="timeline-load-more"]')).toBeNull();
+  });
+
+  it('shows an enabled load-more button and fires onLoadMore on click', () => {
+    const onLoadMore = vi.fn();
+    const { renderEntry } = makeCapture();
+    const { container } = renderWithProviders(
+      <TimelineStream
+        entries={[makeEntry()]}
+        hasMore
+        onLoadMore={onLoadMore}
+        renderEntry={renderEntry}
+      />
+    );
+    const btn = container.querySelector(
+      '[data-testid="timeline-load-more-btn"]'
+    ) as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    expect(btn.textContent).toContain('Load more');
+    fireEvent.click(btn);
+    expect(onLoadMore).toHaveBeenCalledOnce();
+  });
+
+  it('disables the load-more button and swaps the label while loadingMore', () => {
+    const { renderEntry } = makeCapture();
+    const { container } = renderWithProviders(
+      <TimelineStream entries={[makeEntry()]} hasMore loadingMore renderEntry={renderEntry} />
+    );
+    const btn = container.querySelector(
+      '[data-testid="timeline-load-more-btn"]'
+    ) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.textContent).toContain('Loading');
+  });
+
+  it('does not throw when load-more is clicked without an onLoadMore handler', () => {
+    const { renderEntry } = makeCapture();
+    const { container } = renderWithProviders(
+      <TimelineStream entries={[makeEntry()]} hasMore renderEntry={renderEntry} />
+    );
+    const btn = container.querySelector(
+      '[data-testid="timeline-load-more-btn"]'
+    ) as HTMLButtonElement;
+    expect(() => fireEvent.click(btn)).not.toThrow();
+  });
+});

--- a/packages/@granit/react-ui-timeline/src/twemoji-image.test.tsx
+++ b/packages/@granit/react-ui-timeline/src/twemoji-image.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { emojiToTwemojiCodepoints, TwemojiImage } from './twemoji-image';
+
+const CDN_BASE = 'https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/svg';
+
+describe('emojiToTwemojiCodepoints', () => {
+  it('maps a simple single-codepoint emoji', () => {
+    expect(emojiToTwemojiCodepoints('👍')).toBe('1f44d');
+  });
+
+  it('strips VS-16 from a sequence without a ZWJ (keycap)', () => {
+    expect(emojiToTwemojiCodepoints('1️⃣')).toBe('31-20e3');
+  });
+
+  it('preserves VS-16 and ZWJ in a family sequence', () => {
+    expect(emojiToTwemojiCodepoints('👨‍👩‍👧')).toBe('1f468-200d-1f469-200d-1f467');
+  });
+
+  it('keeps skin-tone modifiers (no VS-16 present)', () => {
+    expect(emojiToTwemojiCodepoints('👍🏽')).toBe('1f44d-1f3fd');
+  });
+
+  it('returns an empty string for an empty input', () => {
+    expect(emojiToTwemojiCodepoints('')).toBe('');
+  });
+});
+
+describe('TwemojiImage', () => {
+  it('renders an <img> pointing at the CDN with default size', () => {
+    const { getByRole } = render(<TwemojiImage emoji="👍" />);
+    const img = getByRole('img') as HTMLImageElement;
+    expect(img.tagName).toBe('IMG');
+    expect(img.getAttribute('src')).toBe(`${CDN_BASE}/1f44d.svg`);
+    expect(img.getAttribute('alt')).toBe('👍');
+    expect(img.getAttribute('data-emoji')).toBe('👍');
+    expect(img.getAttribute('width')).toBe('18');
+    expect(img.getAttribute('height')).toBe('18');
+    expect(img.getAttribute('loading')).toBe('lazy');
+    expect(img.getAttribute('decoding')).toBe('async');
+    expect(img.getAttribute('draggable')).toBe('false');
+  });
+
+  it('honours a custom size', () => {
+    const { getByRole } = render(<TwemojiImage emoji="👍" size={32} />);
+    const img = getByRole('img');
+    expect(img.getAttribute('width')).toBe('32');
+    expect(img.getAttribute('height')).toBe('32');
+  });
+
+  it('merges a custom className and applies inline style', () => {
+    const { getByRole } = render(
+      <TwemojiImage emoji="👍" className="my-emoji" style={{ opacity: 0.5 }} />
+    );
+    const img = getByRole('img');
+    expect(img.className).toContain('my-emoji');
+    expect(img.className).toContain('inline-block');
+    expect((img as HTMLElement).style.opacity).toBe('0.5');
+  });
+
+  it('renders the img with no inline style when style prop is absent', () => {
+    const { getByRole } = render(<TwemojiImage emoji="👍" />);
+    const img = getByRole('img');
+    expect(img.getAttribute('style')).toBeNull();
+  });
+
+  it('falls back to a native glyph <span> when the SVG errors', () => {
+    const { getByRole, container } = render(<TwemojiImage emoji="👍" />);
+    const img = getByRole('img');
+    fireEvent.error(img);
+
+    const span = container.querySelector('[data-slot="twemoji-image"]');
+    expect(span).not.toBeNull();
+    expect(span?.tagName).toBe('SPAN');
+    expect(span?.getAttribute('aria-label')).toBe('👍');
+    expect(span?.getAttribute('data-emoji')).toBe('👍');
+    expect(span?.textContent).toBe('👍');
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('applies size and merged className/style on the fallback span', () => {
+    const { getByRole, container } = render(
+      <TwemojiImage emoji="🎉" size={24} className="fallback-cls" style={{ color: 'red' }} />
+    );
+    fireEvent.error(getByRole('img'));
+
+    const span = container.querySelector('[data-slot="twemoji-image"]') as HTMLElement;
+    expect(span.className).toContain('fallback-cls');
+    expect(span.style.fontSize).toBe('24px');
+    expect(span.style.lineHeight).toBe('24px');
+    expect(span.style.color).toBe('red');
+  });
+});


### PR DESCRIPTION
## Why

The workspace coverage gate (80% on all four metrics) was failing on **functions (77.5%)** and **branches (74%)** — lines (82.8%) and statements (81.5%) already passed. Root cause: **`react-ui-entities` was almost entirely untested** (~2% functions / ~2% branches across 26 files), with `react-ui-timeline` also low (~16%/22%).

## What

Render + interaction tests for the previously-untested view components, reusing the shared MSW handlers + fixtures from `@granit/react-entities/testing` and the `@granit/react-testing` helpers (no hand-rolled DTOs):

- **react-ui-entities**: entity calendar / kanban / gallery / detail views, workspace entity pages (list / detail / form), action modal & drawer, collection section card, page layout, view switcher, side-peek drawer, and the 7 form-component field wrappers.
- **react-ui-timeline**: entity timeline, composer, entry, mention editor, reaction strip, emoji picker, timeline stream, twemoji image.

Tests drive conditional paths (loading / empty / error / populated, mode toggles, action menus, optional-prop present/absent) to lift **branch** coverage, not just smoke renders.

## Result

- **459 tests**, all green.
- `react-ui-entities` + `react-ui-timeline`: **~99% functions / ~97% branches** (from ~2–16%).
- Workspace gate projected back over 80% on functions **and** branches.

`mention-editor` sits at ~90% branches — the remainder are `contenteditable` selection edge-cases not reachable in jsdom.

## Verification

- `vitest run` both packages: 459 passed.
- Pre-commit `tsc -r` (workspace-wide typecheck) + `eslint --max-warnings 0` clean.