### PR TITLE
fix: resolve SonarQube code smells across framework packages

### DIFF
--- a/packages/@granit/react-ui-analytics/src/components/chart-config-form.tsx
+++ b/packages/@granit/react-ui-analytics/src/components/chart-config-form.tsx
@@ -1,5 +1,6 @@
 import { useQueryFieldMetadata } from '@granit/react-analytics';
 import { Button, Checkbox } from '@granit/react-ui';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -53,6 +54,31 @@ const SERIES_CAPABLE: ReadonlySet<ChartType> = new Set([
 const STACK_CAPABLE: ReadonlySet<ChartType> = new Set(['Bar', 'HorizontalBar', 'Line', 'Area']);
 
 /**
+ * Stable per-row keys for the combo measures. `ChartComboSeries` mirrors a backend
+ * DTO and carries no id, so we mint client-side keys and keep them aligned with the
+ * list through structural edits — the array index would misassign React per-row
+ * control state when a measure is removed from the middle of the list.
+ */
+function useMeasureKeys(count: number) {
+  const [keys, setKeys] = useState<string[]>(() =>
+    Array.from({ length: count }, () => crypto.randomUUID())
+  );
+  // Reconcile if the list length changed outside our handlers (e.g. widget reload).
+  if (keys.length !== count) {
+    setKeys((prev) => {
+      const next = prev.slice(0, count);
+      while (next.length < count) next.push(crypto.randomUUID());
+      return next;
+    });
+  }
+  return {
+    keys,
+    added: () => setKeys((prev) => [...prev, crypto.randomUUID()]),
+    removed: (index: number) => setKeys((prev) => prev.filter((_, i) => i !== index)),
+  };
+}
+
+/**
  * Built-in config form for {@link ChartWidgetDefinition}. Edits the
  * essential fields needed to bind a query: queryName, groupBy, the
  * aggregation function, the optional aggregated field, and the chart
@@ -80,10 +106,19 @@ export function ChartConfigForm({
   const hasSeriesBy = widget.seriesBy != null && widget.seriesBy !== '';
 
   const measures = widget.comboSeries ?? [];
+  const measureKeys = useMeasureKeys(measures.length);
   const setMeasures = (next: readonly ChartComboSeries[]) =>
     onChange({ ...widget, comboSeries: next });
   const updateMeasure = (index: number, patch: Partial<ChartComboSeries>) =>
     setMeasures(measures.map((m, i) => (i === index ? { ...m, ...patch } : m)));
+  const addMeasure = () => {
+    setMeasures([...measures, DEFAULT_COMBO_MEASURE]);
+    measureKeys.added();
+  };
+  const removeMeasure = (index: number) => {
+    setMeasures(measures.filter((_, i) => i !== index));
+    measureKeys.removed(index);
+  };
 
   return (
     <div data-slot="chart-config-form" className="space-y-3">
@@ -158,7 +193,11 @@ export function ChartConfigForm({
           {measures.map((measure, index) => {
             const measureIsCount = measure.aggregation === 'Count';
             return (
-              <div key={index} className="flex items-center gap-1" data-slot="chart-combo-measure">
+              <div
+                key={measureKeys.keys[index]}
+                className="flex items-center gap-1"
+                data-slot="chart-combo-measure"
+              >
                 <EnumSelect
                   slot="combo-aggregation"
                   value={measure.aggregation}
@@ -193,19 +232,14 @@ export function ChartConfigForm({
                     defaultValue: 'Remove measure',
                   })}
                   disabled={measures.length <= 1}
-                  onClick={() => setMeasures(measures.filter((_, i) => i !== index))}
+                  onClick={() => removeMeasure(index)}
                 >
                   ×
                 </Button>
               </div>
             );
           })}
-          <Button
-            type="button"
-            variant="outline"
-            size="xs"
-            onClick={() => setMeasures([...measures, DEFAULT_COMBO_MEASURE])}
-          >
+          <Button type="button" variant="outline" size="xs" onClick={addMeasure}>
             {t('Dashboard:Widget.Chart.ComboSeries.Add', { defaultValue: 'Add measure' })}
           </Button>
         </div>

--- a/packages/@granit/react-ui-cms-pages/src/components/page-form-page.tsx
+++ b/packages/@granit/react-ui-cms-pages/src/components/page-form-page.tsx
@@ -77,6 +77,49 @@ function useDefaultParentSelection(
 }
 
 /**
+ * Link-out to the visual block editor (granit-cms-renderer). Enabled only when a
+ * renderer URL is configured (`VITE_CMS_RENDERER_URL`); otherwise a disabled button
+ * explains why. Lives outside {@link PageFormPage} to keep its cognitive load down.
+ */
+function PageContentEditorSection({ editorUrl }: { readonly editorUrl: string | null }) {
+  const { t } = useTranslation();
+  return (
+    <div className="space-y-2 rounded-md border border-border bg-muted/30 p-4">
+      <p className="text-sm font-medium text-foreground">
+        {t('cms:Pages.Content.Title', 'Page content')}
+      </p>
+      <p className="text-xs text-muted-foreground">
+        {t(
+          'cms:Pages.Content.Description',
+          'Block content is authored in the visual editor (granit-cms-renderer).'
+        )}
+      </p>
+      {editorUrl ? (
+        <Button variant="outline" size="sm" asChild>
+          <a href={editorUrl} target="_blank" rel="noopener noreferrer">
+            <ExternalLink className="mr-2 h-4 w-4" />
+            {t('cms:Pages.Content.EditContent', 'Edit content')}
+          </a>
+        </Button>
+      ) : (
+        <Button
+          variant="outline"
+          size="sm"
+          disabled
+          title={t(
+            'cms:Pages.Content.NoRenderer',
+            'Set VITE_CMS_RENDERER_URL to enable content editing.'
+          )}
+        >
+          <ExternalLink className="mr-2 h-4 w-4" />
+          {t('cms:Pages.Content.EditContent', 'Edit content')}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+/**
  * Create / rename a CMS page *structure* node (slug + parent + layout).
  *
  * Page *content* (blocks) is authored in the granit-cms-renderer Puck editor —
@@ -311,40 +354,7 @@ export function PageFormPage() {
           )}
         </div>
 
-        {isEdit && (
-          <div className="space-y-2 rounded-md border border-border bg-muted/30 p-4">
-            <p className="text-sm font-medium text-foreground">
-              {t('cms:Pages.Content.Title', 'Page content')}
-            </p>
-            <p className="text-xs text-muted-foreground">
-              {t(
-                'cms:Pages.Content.Description',
-                'Block content is authored in the visual editor (granit-cms-renderer).'
-              )}
-            </p>
-            {editorUrl ? (
-              <Button variant="outline" size="sm" asChild>
-                <a href={editorUrl} target="_blank" rel="noopener noreferrer">
-                  <ExternalLink className="mr-2 h-4 w-4" />
-                  {t('cms:Pages.Content.EditContent', 'Edit content')}
-                </a>
-              </Button>
-            ) : (
-              <Button
-                variant="outline"
-                size="sm"
-                disabled
-                title={t(
-                  'cms:Pages.Content.NoRenderer',
-                  'Set VITE_CMS_RENDERER_URL to enable content editing.'
-                )}
-              >
-                <ExternalLink className="mr-2 h-4 w-4" />
-                {t('cms:Pages.Content.EditContent', 'Edit content')}
-              </Button>
-            )}
-          </div>
-        )}
+        {isEdit && <PageContentEditorSection editorUrl={editorUrl} />}
 
         <div className="flex gap-3">
           <Button type="submit" disabled={isPending || isSiteRoot}>

--- a/packages/@granit/react-ui-entities/src/entity-gallery-view.tsx
+++ b/packages/@granit/react-ui-entities/src/entity-gallery-view.tsx
@@ -312,10 +312,10 @@ function GroupedCard({
 function renderGroupHeader(value: unknown, count: number, key: number): ReactNode {
   const label = stringifyGroupValue(value);
   return (
-    <li
+    <li // NOSONAR jsx-a11y/prefer-tag-over-role: group separator inside the gallery list must not be announced as a list item; no native tag fits
       key={`granit-gallery-group-header-${key}`}
       data-granit-gallery-group-header=""
-      role="presentation" // NOSONAR(jsx-a11y/prefer-tag-over-role)
+      role="presentation"
     >
       <span data-granit-gallery-group-label="">{label}</span>
       <span data-granit-gallery-group-count="">{count}</span>

--- a/packages/@granit/react-ui-entities/src/form-components/url-form-component.stories.tsx
+++ b/packages/@granit/react-ui-entities/src/form-components/url-form-component.stories.tsx
@@ -46,7 +46,7 @@ export const Populated: Story = {
 export const HttpProtocol: Story = {
   args: {
     field: field(),
-    value: 'http://legacy.internal',
+    value: 'http://legacy.internal', // NOSONAR S5332: story fixture demonstrating how the input parses a non-default (non-https) scheme; not a live endpoint
   },
 };
 

--- a/packages/@granit/react-ui-geocoding/src/components/address-autocomplete-input.tsx
+++ b/packages/@granit/react-ui-geocoding/src/components/address-autocomplete-input.tsx
@@ -182,7 +182,7 @@ export function AddressAutocompleteInput(props: AddressAutocompleteInputProps): 
       ) : null}
 
       {showList ? (
-        <ul
+        <ul // NOSONAR jsx-a11y/prefer-tag-over-role: async autocomplete combobox pattern — native <select>/<datalist> cannot render server-fetched suggestions
           id={listboxId}
           role="listbox"
           className="absolute z-50 mt-1 max-h-72 w-full overflow-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"

--- a/packages/@granit/react-ui-iot/src/components/telemetry-page.tsx
+++ b/packages/@granit/react-ui-iot/src/components/telemetry-page.tsx
@@ -4,7 +4,29 @@ import { QueryEndpointDataTable } from '@granit/react-ui-kit';
 import { useMemo } from 'react';
 
 import type { TelemetryPoint } from '@granit/iot';
-import type { ColumnDef } from '@tanstack/react-table';
+import type { CellContext, ColumnDef } from '@tanstack/react-table';
+
+type TelemetryCell = CellContext<TelemetryPoint, unknown>;
+
+function DeviceCell({ row }: TelemetryCell) {
+  return <span className="font-mono text-xs text-muted-foreground">{row.original.deviceId}</span>;
+}
+
+function RecordedAtCell({ row }: TelemetryCell) {
+  const { formatDateTime } = useDateFormatter();
+  return <span className="text-sm text-foreground">{formatDateTime(row.original.recordedAt)}</span>;
+}
+
+function SourceCell({ row }: TelemetryCell) {
+  return <span className="text-sm text-muted-foreground">{row.original.source ?? '—'}</span>;
+}
+
+function IngestedAtCell({ row }: TelemetryCell) {
+  const { formatDateTime } = useDateFormatter();
+  return (
+    <span className="text-sm text-muted-foreground">{formatDateTime(row.original.createdAt)}</span>
+  );
+}
 
 /**
  * Telemetry explorer grid. The telemetry QueryEngine scope (a sibling surface to
@@ -21,7 +43,6 @@ export function TelemetryPage() {
 
 function TelemetryContent() {
   const { t } = useTranslation();
-  const { formatDateTime } = useDateFormatter();
   const queryEndpoint = useTelemetryQuery();
 
   const columns = useMemo<ColumnDef<TelemetryPoint, unknown>[]>(
@@ -31,41 +52,31 @@ function TelemetryContent() {
         accessorKey: 'deviceId',
         header: t('IoT.Telemetry.Columns.Device'),
         enableSorting: true,
-        cell: ({ row }) => (
-          <span className="font-mono text-xs text-muted-foreground">{row.original.deviceId}</span>
-        ),
+        cell: DeviceCell,
       },
       {
         id: 'recordedAt',
         accessorKey: 'recordedAt',
         header: t('IoT.Telemetry.Columns.RecordedAt'),
         enableSorting: true,
-        cell: ({ row }) => (
-          <span className="text-sm text-foreground">{formatDateTime(row.original.recordedAt)}</span>
-        ),
+        cell: RecordedAtCell,
       },
       {
         id: 'source',
         accessorKey: 'source',
         header: t('IoT.Telemetry.Columns.Source'),
         enableSorting: true,
-        cell: ({ row }) => (
-          <span className="text-sm text-muted-foreground">{row.original.source ?? '—'}</span>
-        ),
+        cell: SourceCell,
       },
       {
         id: 'createdAt',
         accessorKey: 'createdAt',
         header: t('IoT.Telemetry.Columns.IngestedAt'),
         enableSorting: true,
-        cell: ({ row }) => (
-          <span className="text-sm text-muted-foreground">
-            {formatDateTime(row.original.createdAt)}
-          </span>
-        ),
+        cell: IngestedAtCell,
       },
     ],
-    [t, formatDateTime]
+    [t]
   );
 
   return (

--- a/packages/@granit/react-ui-kit/src/inputs/phone-input.tsx
+++ b/packages/@granit/react-ui-kit/src/inputs/phone-input.tsx
@@ -207,9 +207,9 @@ export function PhoneInput({
     <div data-slot="phone-input" className={cn('flex w-full', disabled && 'opacity-60', className)}>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <button
+          <button // NOSONAR jsx-a11y/prefer-tag-over-role: custom typeahead combobox — native <input list>/<select> cannot model the rich country selector
             type="button"
-            role="combobox" // NOSONAR(jsx-a11y/prefer-tag-over-role): custom typeahead combobox — native <input list>/<select> cannot model the rich country selector
+            role="combobox"
             aria-expanded={open}
             aria-controls="phone-input-country-list"
             aria-label={ariaLabelCountry ?? t('Common.Phone.Country', 'Select country')}

--- a/packages/@granit/react-ui-kit/src/layout/top-progress-bar.tsx
+++ b/packages/@granit/react-ui-kit/src/layout/top-progress-bar.tsx
@@ -74,9 +74,9 @@ export function TopProgressBar() {
     // Custom top-loading bar (nProgress-style). `<progress>` would be
     // ideal but its native styling cannot be themed reliably across
     // browsers; the visual fill is a child div animating its width.
-    <div
+    <div // NOSONAR jsx-a11y/prefer-tag-over-role: native <progress> styling cannot be themed reliably across browsers; the fill is a child div animating its width
       data-slot="top-progress-bar"
-      role="progressbar" // NOSONAR(jsx-a11y/prefer-tag-over-role)
+      role="progressbar"
       aria-hidden={!visible}
       aria-valuemin={0}
       aria-valuemax={100}

--- a/packages/@granit/react-ui/src/tree.tsx
+++ b/packages/@granit/react-ui/src/tree.tsx
@@ -34,8 +34,8 @@ function TreeGroup({ className, ...props }: React.ComponentProps<'ul'>) {
   // role="group" is mandated by the WAI-ARIA tree pattern for nested item sets;
   // the suggested native tags (details/fieldset/optgroup) cannot model a subtree.
   return (
-    <ul
-      role="group" // NOSONAR(jsx-a11y/prefer-tag-over-role)
+    <ul // NOSONAR jsx-a11y/prefer-tag-over-role: WAI-ARIA tree pattern mandates role="group" for nested item sets; details/fieldset/optgroup cannot model a subtree
+      role="group"
       data-slot="tree-group"
       className={cn(className)}
       {...props}


### PR DESCRIPTION
## Summary

Resolves 12 open SonarQube issues across framework packages. No behavioural change beyond the combo-measure key fix.

## Accessibility roles (5) — suppressions made effective

These `role=*` usages are the correct WAI-ARIA authoring patterns (no native element fits). The team's `// NOSONAR` comments already existed but sat on the `role=` attribute line, whereas Sonar anchors each issue to the **opening-tag line** — so the suppressions never applied. Moved each onto the anchor line and replaced the parenthesised `(jsx-a11y/…)` selector (which Sonar may read as a non-matching rule key) with a plain-text justification.

- `react-ui/tree.tsx` — `role="group"` (subtree; WAI-ARIA tree pattern)
- `react-ui-kit/top-progress-bar.tsx` — `role="progressbar"`
- `react-ui-kit/phone-input.tsx` — `role="combobox"` (typeahead)
- `react-ui-entities/entity-gallery-view.tsx` — `role="presentation"`
- `react-ui-geocoding/address-autocomplete-input.tsx` — `role="listbox"` (added the missing NOSONAR)

## Structural fixes (7)

- **telemetry-page.tsx** (4×) — extracted the four `cell` renderers into module-level components; each calls `useDateFormatter` itself.
- **chart-config-form.tsx** — array-index keys → client-side `crypto.randomUUID` keys kept in lockstep with add/remove (`ChartComboSeries` is an id-less backend DTO), matching the `metadata-tab.tsx` idiom.
- **page-form-page.tsx** — extracted `PageContentEditorSection`, bringing `PageFormPage` cognitive complexity 16 → 15.
- **url-form-component.stories.tsx** — `NOSONAR S5332` on the `http` fixture demonstrating non-https scheme parsing (Storybook fixture, not a live endpoint).

## Verification

- `pnpm tsc` (workspace) — clean
- ESLint on all 9 files — clean
- `vitest run` react-ui-analytics + react-ui-iot — 29 passed