### PR TITLE
refactor(react-dashboards): remove deprecated per-op query-key aliases

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4807,6 +4807,16 @@
           "signature": "function buildDashboardsQueryKey( config: Pick<DashboardsConfig, 'queryKeyPrefix'>, ...segments: readonly unknown[] ): readonly unknown[]"
         },
         {
+          "name": "dashboardsKeys",
+          "kind": "const",
+          "signature": "const dashboardsKeys"
+        },
+        {
+          "name": "useDashboardRender",
+          "kind": "function",
+          "signature": "function useDashboardRender( dashboardId: string, request: DashboardRenderRequest ="
+        },
+        {
           "name": "UseDashboardRenderOptions",
           "kind": "interface",
           "signature": "interface UseDashboardRenderOptions",
@@ -4828,11 +4838,6 @@
           "signature": "function useWidgetRender<TDefinition extends WidgetDefinitionBase>( kind: WidgetRenderKind, definition: TDefinition, context: WidgetRenderContext ="
         },
         {
-          "name": "widgetRenderQueryKey",
-          "kind": "const",
-          "signature": "const widgetRenderQueryKey"
-        },
-        {
           "name": "useDashboardStream",
           "kind": "function",
           "signature": "function useDashboardStream( dashboardId: string, options: UseDashboardStreamOptions ="
@@ -4843,19 +4848,9 @@
           "signature": "function usePushedDashboard( dashboardId: string, request: DashboardRenderRequest ="
         },
         {
-          "name": "dashboardCatalogQueryKey",
-          "kind": "const",
-          "signature": "const dashboardCatalogQueryKey"
-        },
-        {
           "name": "useDashboardCatalog",
           "kind": "function",
           "signature": "function useDashboardCatalog( options:"
-        },
-        {
-          "name": "dashboardListQueryKey",
-          "kind": "const",
-          "signature": "const dashboardListQueryKey"
         },
         {
           "name": "useDashboardList",
@@ -4867,11 +4862,6 @@
           "kind": "interface",
           "signature": "interface UseDashboardListParams",
           "members": []
-        },
-        {
-          "name": "dashboardDetailQueryKey",
-          "kind": "const",
-          "signature": "const dashboardDetailQueryKey"
         },
         {
           "name": "useDashboardDetail",

--- a/packages/@granit/react-dashboards/src/__tests__/query-keys.test.ts
+++ b/packages/@granit/react-dashboards/src/__tests__/query-keys.test.ts
@@ -1,16 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildDashboardsQueryKey } from '../hooks/query-keys';
-import { dashboardCatalogQueryKey } from '../hooks/use-dashboard-catalog';
-import { dashboardDetailQueryKey } from '../hooks/use-dashboard-detail';
-import { dashboardListQueryKey } from '../hooks/use-dashboard-list';
-import { dashboardRenderQueryKey, dashboardWidgetQueryKey } from '../hooks/use-dashboard-render';
-import { widgetRenderQueryKey } from '../hooks/use-widget-render';
+import { buildDashboardsQueryKey, dashboardsKeys } from '../hooks/query-keys';
 
 const DASHBOARD_ID = '11111111-1111-1111-1111-111111111111';
 const WIDGET_ID = '22222222-2222-2222-2222-222222222222';
 
-describe('buildDashboardsQueryKey — family-standard factory', () => {
+describe('buildDashboardsQueryKey — family-standard builder', () => {
   it('returns the raw segments when no prefix is configured', () => {
     expect(buildDashboardsQueryKey({}, 'dashboards', 'detail', DASHBOARD_ID)).toEqual([
       'dashboards',
@@ -31,24 +26,24 @@ describe('buildDashboardsQueryKey — family-standard factory', () => {
   });
 });
 
-describe('deprecated per-operation aliases — byte-identical to the pre-refactor tuples', () => {
-  it('dashboardCatalogQueryKey', () => {
-    expect(dashboardCatalogQueryKey()).toEqual(['dashboards', 'catalog']);
-    expect(dashboardCatalogQueryKey('Finance')).toEqual(['dashboards', 'catalog', 'Finance']);
+describe('dashboardsKeys — canonical per-operation key factory', () => {
+  it('catalog', () => {
+    expect(dashboardsKeys.catalog()).toEqual(['dashboards', 'catalog']);
+    expect(dashboardsKeys.catalog('Finance')).toEqual(['dashboards', 'catalog', 'Finance']);
   });
 
-  it('dashboardListQueryKey', () => {
+  it('list', () => {
     const params = { status: 'Published', page: 1, pageSize: 25 } as const;
-    expect(dashboardListQueryKey(params)).toEqual(['dashboards', 'list', params]);
+    expect(dashboardsKeys.list(params)).toEqual(['dashboards', 'list', params]);
   });
 
-  it('dashboardDetailQueryKey', () => {
-    expect(dashboardDetailQueryKey(DASHBOARD_ID)).toEqual(['dashboards', 'detail', DASHBOARD_ID]);
+  it('detail', () => {
+    expect(dashboardsKeys.detail(DASHBOARD_ID)).toEqual(['dashboards', 'detail', DASHBOARD_ID]);
   });
 
-  it('dashboardRenderQueryKey', () => {
+  it('render', () => {
     const request = { periodToken: 'mtd' } as const;
-    expect(dashboardRenderQueryKey(DASHBOARD_ID, request)).toEqual([
+    expect(dashboardsKeys.render(DASHBOARD_ID, request)).toEqual([
       'dashboard',
       DASHBOARD_ID,
       'render',
@@ -56,8 +51,8 @@ describe('deprecated per-operation aliases — byte-identical to the pre-refacto
     ]);
   });
 
-  it('dashboardWidgetQueryKey', () => {
-    expect(dashboardWidgetQueryKey(DASHBOARD_ID, WIDGET_ID)).toEqual([
+  it('widget', () => {
+    expect(dashboardsKeys.widget(DASHBOARD_ID, WIDGET_ID)).toEqual([
       'dashboard',
       DASHBOARD_ID,
       'widget',
@@ -65,10 +60,10 @@ describe('deprecated per-operation aliases — byte-identical to the pre-refacto
     ]);
   });
 
-  it('widgetRenderQueryKey', () => {
+  it('widgetRender', () => {
     const definition = { type: 'chart' } as const;
     const context = { locale: 'en' } as const;
-    expect(widgetRenderQueryKey('chart', definition, context)).toEqual([
+    expect(dashboardsKeys.widgetRender('chart', definition, context)).toEqual([
       'widget',
       'chart',
       'render',
@@ -76,41 +71,28 @@ describe('deprecated per-operation aliases — byte-identical to the pre-refacto
       context,
     ]);
   });
-
-  it('each alias equals the builder invoked with the same segments', () => {
-    expect(dashboardWidgetQueryKey(DASHBOARD_ID, WIDGET_ID)).toEqual(
-      buildDashboardsQueryKey({}, 'dashboard', DASHBOARD_ID, 'widget', WIDGET_ID)
-    );
-    expect(dashboardDetailQueryKey(DASHBOARD_ID)).toEqual(
-      buildDashboardsQueryKey({}, 'dashboards', 'detail', DASHBOARD_ID)
-    );
-  });
 });
 
 describe('SSE push cache-identity invariant', () => {
   // The SSE push (`usePushedDashboard`) writes per-widget snapshots via
-  // `setQueryData(dashboardWidgetQueryKey(id, widgetId))`; `useDashboardWidget`
-  // reads the same key and `useDashboardRender` populates it. All three MUST
-  // resolve to a byte-identical tuple or real-time widget updates silently
-  // land on a cache entry nobody reads.
+  // `setQueryData(dashboardsKeys.widget(id, widgetId))`; `useDashboardWidget`
+  // reads the same key and `useDashboardRender` populates it. All three route
+  // through the single `dashboardsKeys.widget` factory, so the tuple can never
+  // drift onto a cache entry nobody reads.
   it('the push write key equals the expected per-widget read tuple', () => {
-    // `usePushedDashboard` builds its `setQueryData` key with exactly this call
-    // (see use-pushed-dashboard.ts → handleSnapshot). `useDashboardWidget` and
-    // `useDashboardRender` populate/read the same tuple. Pin it here so a future
-    // refactor of the builder cannot silently shift the push target.
-    const writeKey = dashboardWidgetQueryKey(DASHBOARD_ID, WIDGET_ID);
+    const writeKey = dashboardsKeys.widget(DASHBOARD_ID, WIDGET_ID);
     expect(writeKey).toEqual(['dashboard', DASHBOARD_ID, 'widget', WIDGET_ID]);
   });
 
   it('the per-widget key is stable across independent invocations', () => {
-    const first = dashboardWidgetQueryKey(DASHBOARD_ID, WIDGET_ID);
-    const second = dashboardWidgetQueryKey(DASHBOARD_ID, WIDGET_ID);
+    const first = dashboardsKeys.widget(DASHBOARD_ID, WIDGET_ID);
+    const second = dashboardsKeys.widget(DASHBOARD_ID, WIDGET_ID);
     expect(JSON.stringify(first)).toBe(JSON.stringify(second));
   });
 
   it('distinct widgets resolve to distinct keys', () => {
-    expect(dashboardWidgetQueryKey(DASHBOARD_ID, WIDGET_ID)).not.toEqual(
-      dashboardWidgetQueryKey(DASHBOARD_ID, 'other-widget')
+    expect(dashboardsKeys.widget(DASHBOARD_ID, WIDGET_ID)).not.toEqual(
+      dashboardsKeys.widget(DASHBOARD_ID, 'other-widget')
     );
   });
 });

--- a/packages/@granit/react-dashboards/src/__tests__/use-dashboard-crud.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-dashboard-crud.test.tsx
@@ -8,8 +8,9 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { CATALOG, SAMPLE_FINANCE_DASHBOARD_ID } from '@granit/react-dashboards/testing';
 
-import { dashboardCatalogQueryKey, useDashboardCatalog } from '../hooks/use-dashboard-catalog';
-import { dashboardDetailQueryKey, useDashboardDetail } from '../hooks/use-dashboard-detail';
+import { dashboardsKeys } from '../hooks/query-keys';
+import { useDashboardCatalog } from '../hooks/use-dashboard-catalog';
+import { useDashboardDetail } from '../hooks/use-dashboard-detail';
 import { useDashboardList } from '../hooks/use-dashboard-list';
 import {
   useArchiveDashboard,
@@ -180,11 +181,11 @@ function makeWrapper() {
 
 describe('cache keys', () => {
   it('catalog key namespaces under [dashboards, catalog] for prefix-based invalidation', () => {
-    expect(dashboardCatalogQueryKey()).toEqual(['dashboards', 'catalog']);
+    expect(dashboardsKeys.catalog()).toEqual(['dashboards', 'catalog']);
   });
 
   it('detail key carries the dashboard id', () => {
-    expect(dashboardDetailQueryKey(ID)).toEqual(['dashboards', 'detail', ID]);
+    expect(dashboardsKeys.detail(ID)).toEqual(['dashboards', 'detail', ID]);
   });
 });
 
@@ -248,24 +249,24 @@ describe('useImportDashboard', () => {
 describe('useUpdateDashboardMetadata', () => {
   it('PUTs the metadata payload and invalidates the per-id detail', async () => {
     const { wrapper, queryClient } = makeWrapper();
-    queryClient.setQueryData(dashboardDetailQueryKey(ID), DETAIL);
+    queryClient.setQueryData(dashboardsKeys.detail(ID), DETAIL);
     const { result } = renderHook(() => useUpdateDashboardMetadata(), { wrapper });
     await result.current.mutateAsync({
       id: ID,
       request: { name: 'New name', layoutColumns: 12, layoutRowHeight: 100 },
     });
     expect(lastBody).toMatchObject({ name: 'New name', layoutColumns: 12, layoutRowHeight: 100 });
-    expect(queryClient.getQueryState(dashboardDetailQueryKey(ID))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(dashboardsKeys.detail(ID))?.isInvalidated).toBe(true);
   });
 });
 
 describe('useArchiveDashboard / useRestoreDashboard / usePublishDashboard', () => {
   it('archive: POSTs to /archive and invalidates list + detail', async () => {
     const { wrapper, queryClient } = makeWrapper();
-    queryClient.setQueryData(dashboardDetailQueryKey(ID), DETAIL);
+    queryClient.setQueryData(dashboardsKeys.detail(ID), DETAIL);
     const { result } = renderHook(() => useArchiveDashboard(), { wrapper });
     await result.current.mutateAsync(ID);
-    expect(queryClient.getQueryState(dashboardDetailQueryKey(ID))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(dashboardsKeys.detail(ID))?.isInvalidated).toBe(true);
   });
 
   it('publish: POSTs to /publish and returns the updated summary', async () => {
@@ -288,7 +289,7 @@ describe('useArchiveDashboard / useRestoreDashboard / usePublishDashboard', () =
 describe('useResyncDashboard', () => {
   it('POSTs to /resync, returns the change summary, and invalidates list + detail + render', async () => {
     const { wrapper, queryClient } = makeWrapper();
-    queryClient.setQueryData(dashboardDetailQueryKey(ID), DETAIL);
+    queryClient.setQueryData(dashboardsKeys.detail(ID), DETAIL);
     const { result } = renderHook(() => useResyncDashboard(), { wrapper });
     const summary = await result.current.mutateAsync(ID);
     expect(summary).toMatchObject({
@@ -298,14 +299,14 @@ describe('useResyncDashboard', () => {
       widgetsRemoved: 0,
       overridesCarriedOver: 3,
     });
-    expect(queryClient.getQueryState(dashboardDetailQueryKey(ID))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(dashboardsKeys.detail(ID))?.isInvalidated).toBe(true);
   });
 });
 
 describe('useAddWidget / useUpdateWidget / useRemoveWidget', () => {
   it('add: POSTs the widget payload and invalidates the parent dashboard detail', async () => {
     const { wrapper, queryClient } = makeWrapper();
-    queryClient.setQueryData(dashboardDetailQueryKey(ID), DETAIL);
+    queryClient.setQueryData(dashboardsKeys.detail(ID), DETAIL);
     const { result } = renderHook(() => useAddWidget(), { wrapper });
     await result.current.mutateAsync({
       dashboardId: ID,
@@ -319,7 +320,7 @@ describe('useAddWidget / useUpdateWidget / useRemoveWidget', () => {
       },
     });
     expect(lastBody).toMatchObject({ widgetType: 'Markdown', position: 0 });
-    expect(queryClient.getQueryState(dashboardDetailQueryKey(ID))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(dashboardsKeys.detail(ID))?.isInvalidated).toBe(true);
   });
 
   it('update: PUTs the editable fields', async () => {
@@ -341,9 +342,9 @@ describe('useAddWidget / useUpdateWidget / useRemoveWidget', () => {
 
   it('remove: DELETEs and invalidates the parent dashboard detail', async () => {
     const { wrapper, queryClient } = makeWrapper();
-    queryClient.setQueryData(dashboardDetailQueryKey(ID), DETAIL);
+    queryClient.setQueryData(dashboardsKeys.detail(ID), DETAIL);
     const { result } = renderHook(() => useRemoveWidget(), { wrapper });
     await result.current.mutateAsync({ dashboardId: ID, widgetId: WIDGET_ID });
-    expect(queryClient.getQueryState(dashboardDetailQueryKey(ID))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(dashboardsKeys.detail(ID))?.isInvalidated).toBe(true);
   });
 });

--- a/packages/@granit/react-dashboards/src/__tests__/use-dashboard-render.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-dashboard-render.test.tsx
@@ -15,9 +15,8 @@ import {
   SAMPLE_FINANCE_DASHBOARD_ID,
 } from '@granit/react-dashboards/testing';
 
+import { dashboardsKeys } from '../hooks/query-keys';
 import {
-  dashboardRenderQueryKey,
-  dashboardWidgetQueryKey,
   normalizeDashboardRenderRequest,
   strongestRefreshHint,
   useDashboardRender,
@@ -105,7 +104,7 @@ describe('strongestRefreshHint', () => {
 
 describe('dashboard render query keys', () => {
   it('renders the bundle key with the request payload', () => {
-    expect(dashboardRenderQueryKey(DASHBOARD_ID, { periodToken: 'mtd' })).toEqual([
+    expect(dashboardsKeys.render(DASHBOARD_ID, { periodToken: 'mtd' })).toEqual([
       'dashboard',
       DASHBOARD_ID,
       'render',
@@ -114,7 +113,7 @@ describe('dashboard render query keys', () => {
   });
 
   it('renders the per-widget key', () => {
-    expect(dashboardWidgetQueryKey(DASHBOARD_ID, KPI_ID)).toEqual([
+    expect(dashboardsKeys.widget(DASHBOARD_ID, KPI_ID)).toEqual([
       'dashboard',
       DASHBOARD_ID,
       'widget',
@@ -138,13 +137,13 @@ describe('useDashboardRender — bundle fetch + per-widget cache split (ADR-039 
     await waitFor(() =>
       expect(
         queryClient.getQueryData<DashboardRenderedWidget>(
-          dashboardWidgetQueryKey(DASHBOARD_ID, KPI_ID)
+          dashboardsKeys.widget(DASHBOARD_ID, KPI_ID)
         )
       ).toBeDefined()
     );
     expect(
       queryClient.getQueryData<DashboardRenderedWidget>(
-        dashboardWidgetQueryKey(DASHBOARD_ID, MARKDOWN_ID)
+        dashboardsKeys.widget(DASHBOARD_ID, MARKDOWN_ID)
       )?.widgetType
     ).toBe('Markdown');
   });
@@ -154,7 +153,7 @@ describe('useDashboardWidget — passive reader', () => {
   it('surfaces the per-widget cache entry without firing its own fetch', async () => {
     const { wrapper, queryClient } = makeWrapper();
     // Pre-populate as if useDashboardRender had already split the bundle.
-    queryClient.setQueryData(dashboardWidgetQueryKey(DASHBOARD_ID, KPI_ID), KPI_WIDGET);
+    queryClient.setQueryData(dashboardsKeys.widget(DASHBOARD_ID, KPI_ID), KPI_WIDGET);
 
     const { result } = renderHook(() => useDashboardWidget(DASHBOARD_ID, KPI_ID), {
       wrapper,

--- a/packages/@granit/react-dashboards/src/__tests__/use-pushed-dashboard.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-pushed-dashboard.test.tsx
@@ -11,7 +11,7 @@ import {
   SAMPLE_FINANCE_DASHBOARD_ID,
 } from '@granit/react-dashboards/testing';
 
-import { dashboardRenderQueryKey, dashboardWidgetQueryKey } from '../hooks/use-dashboard-render';
+import { dashboardsKeys } from '../hooks/query-keys';
 import { applyStreamSnapshot, type DashboardStreamSnapshot } from '../hooks/use-dashboard-stream';
 import { usePushedDashboard } from '../hooks/use-pushed-dashboard';
 import { DashboardsProvider } from '../providers/dashboards-provider';
@@ -200,7 +200,7 @@ describe('usePushedDashboard', () => {
     });
 
     const cached = queryClient.getQueryData<DashboardRenderedWidget>(
-      dashboardWidgetQueryKey(DASHBOARD_ID, KPI_ID)
+      dashboardsKeys.widget(DASHBOARD_ID, KPI_ID)
     );
     expect(cached?.sequence).toBe(7);
     expect(cached?.snapshot).toEqual({ value: 42, valueKind: 'Count' });
@@ -220,9 +220,9 @@ describe('usePushedDashboard', () => {
       source.dispatch('resume-failed');
     });
 
-    expect(
-      queryClient.getQueryState(dashboardRenderQueryKey(DASHBOARD_ID, {}))?.isInvalidated
-    ).toBe(true);
+    expect(queryClient.getQueryState(dashboardsKeys.render(DASHBOARD_ID, {}))?.isInvalidated).toBe(
+      true
+    );
   });
 
   it('closes the stream on unmount', async () => {

--- a/packages/@granit/react-dashboards/src/__tests__/use-widget-render.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-widget-render.test.tsx
@@ -8,7 +8,8 @@ import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { DashboardContextProvider } from '../components/dashboard-context';
-import { useWidgetRender, widgetRenderQueryKey } from '../hooks/use-widget-render';
+import { dashboardsKeys } from '../hooks/query-keys';
+import { useWidgetRender } from '../hooks/use-widget-render';
 import { DashboardsProvider } from '../providers/dashboards-provider';
 
 import type { DashboardRenderedWidget, WidgetDefinitionBase } from '@granit/dashboards';
@@ -81,9 +82,9 @@ function makeWrapper() {
   return { wrapper, queryClient };
 }
 
-describe('widgetRenderQueryKey', () => {
+describe('dashboardsKeys.widgetRender', () => {
   it('produces a kind-namespaced cache key keyed by definition + context', () => {
-    expect(widgetRenderQueryKey('chart', definition, {})).toEqual([
+    expect(dashboardsKeys.widgetRender('chart', definition, {})).toEqual([
       'widget',
       'chart',
       'render',

--- a/packages/@granit/react-dashboards/src/hooks/query-keys.ts
+++ b/packages/@granit/react-dashboards/src/hooks/query-keys.ts
@@ -1,21 +1,19 @@
+import type { UseDashboardListParams } from './use-dashboard-list';
+import type { WidgetRenderContext, WidgetRenderKind } from './use-widget-render';
 import type { DashboardsConfig } from '../providers/dashboards-provider';
+import type {
+  DashboardCategory,
+  DashboardRenderRequest,
+  WidgetDefinitionBase,
+} from '@granit/dashboards';
 
 /**
- * Single query-key factory for the dashboards package — the family-standard
+ * Single query-key builder for the dashboards package — the family-standard
  * `build{Module}QueryKey(config, ...segments)` shape (mirrors
  * `buildBlobStorageQueryKey` / `buildTaxonomyQueryKey` in sibling packages).
  *
  * When the provider supplies a `queryKeyPrefix` it is prepended; otherwise the
- * `segments` alone form the tuple. The per-operation factories in this package
- * are thin, `@deprecated` wrappers over this builder that pass their historical
- * literal roots as the leading segments, so every produced tuple stays
- * **byte-identical** to the pre-refactor keys.
- *
- * @remarks
- * Byte-identity matters: the SSE push path (`usePushedDashboard`) writes
- * per-widget cache entries via `setQueryData(dashboardWidgetQueryKey(...))` and
- * the passive reader (`useDashboardWidget`) reads the same key. Any drift
- * between the two would silently break real-time widget updates.
+ * `segments` alone form the tuple.
  *
  * @param config - Provider config carrying an optional `queryKeyPrefix`.
  * @param segments - Segments appended after the (optional) prefix.
@@ -26,3 +24,34 @@ export function buildDashboardsQueryKey(
 ): readonly unknown[] {
   return [...(config.queryKeyPrefix ?? []), ...segments];
 }
+
+/**
+ * Canonical query-key factory for the dashboards package (mirrors
+ * `cmsRedirectsKeys` in the CMS-redirects package). Every cache tuple the
+ * package addresses is composed here, so the roots stay consistent and the
+ * SSE-critical per-widget key is **single-sourced**:
+ *
+ * `usePushedDashboard` writes push snapshots via `setQueryData(widget(...))`,
+ * `useDashboardRender` populates the same tuple on every bundle refetch, and
+ * `useDashboardWidget` reads it. Routing all three through `widget()` makes a
+ * byte-identity drift structurally impossible — see the `SSE push cache-identity`
+ * test.
+ */
+export const dashboardsKeys = {
+  catalog: (category?: DashboardCategory) =>
+    category
+      ? buildDashboardsQueryKey({}, 'dashboards', 'catalog', category)
+      : buildDashboardsQueryKey({}, 'dashboards', 'catalog'),
+  list: (params: UseDashboardListParams) =>
+    buildDashboardsQueryKey({}, 'dashboards', 'list', params),
+  detail: (id: string) => buildDashboardsQueryKey({}, 'dashboards', 'detail', id),
+  render: (dashboardId: string, request: DashboardRenderRequest) =>
+    buildDashboardsQueryKey({}, 'dashboard', dashboardId, 'render', request),
+  widget: (dashboardId: string, widgetId: string) =>
+    buildDashboardsQueryKey({}, 'dashboard', dashboardId, 'widget', widgetId),
+  widgetRender: <TDefinition extends WidgetDefinitionBase>(
+    kind: WidgetRenderKind,
+    definition: TDefinition,
+    context: WidgetRenderContext
+  ) => buildDashboardsQueryKey({}, 'widget', kind, 'render', definition, context),
+} as const;

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-catalog.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-catalog.ts
@@ -3,21 +3,9 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
-import { buildDashboardsQueryKey } from './query-keys';
+import { dashboardsKeys } from './query-keys';
 
 import type { DashboardCatalogEntryResponse, DashboardCategory } from '@granit/dashboards';
-
-/**
- * Cache key for the dashboard catalog. Keyed by category so per-category
- * queries stay isolated from the full-catalog fetch.
- *
- * @deprecated Use {@link buildDashboardsQueryKey} with the segments
- * `'dashboards', 'catalog'[, category]`. Kept as a byte-identical alias.
- */
-export const dashboardCatalogQueryKey = (category?: DashboardCategory) =>
-  category
-    ? buildDashboardsQueryKey({}, 'dashboards', 'catalog', category)
-    : buildDashboardsQueryKey({}, 'dashboards', 'catalog');
 
 /**
  * `GET /dashboards/catalog?category=` — returns the catalog of available
@@ -36,7 +24,7 @@ export function useDashboardCatalog(
   const { client, basePath } = useDashboardsConfig();
   const { enabled = true, category } = options;
   return useQuery({
-    queryKey: dashboardCatalogQueryKey(category),
+    queryKey: dashboardsKeys.catalog(category),
     queryFn: ({ signal }) => listDashboardCatalog(client, basePath, { category }, { signal }),
     enabled,
     staleTime: 5 * 60_000,

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-detail.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-detail.ts
@@ -3,20 +3,9 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
-import { buildDashboardsQueryKey } from './query-keys';
+import { dashboardsKeys } from './query-keys';
 
 import type { DashboardDetailResponse } from '@granit/dashboards';
-
-/**
- * Cache key for a single persisted dashboard, keyed by its Guid. Used by
- * the editor + by the lifecycle-mutation hooks to invalidate the right
- * entry after archive / publish / metadata edits.
- *
- * @deprecated Use {@link buildDashboardsQueryKey} with the segments
- * `'dashboards', 'detail', id`. Kept as a byte-identical alias.
- */
-export const dashboardDetailQueryKey = (id: string) =>
-  buildDashboardsQueryKey({}, 'dashboards', 'detail', id);
 
 /**
  * `GET /dashboards/{id:guid}` — returns the full payload for one
@@ -33,7 +22,7 @@ export function useDashboardDetail(
 ): UseQueryResult<DashboardDetailResponse> {
   const { client, basePath } = useDashboardsConfig();
   return useQuery({
-    queryKey: dashboardDetailQueryKey(id),
+    queryKey: dashboardsKeys.detail(id),
     queryFn: ({ signal }) => getDashboard(client, basePath, id, { signal }),
     enabled: (options.enabled ?? true) && id.length > 0,
     staleTime: 60_000,

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-list.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-list.ts
@@ -3,7 +3,7 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
-import { buildDashboardsQueryKey } from './query-keys';
+import { dashboardsKeys } from './query-keys';
 
 import type { DashboardStatus, DashboardSummaryResponse, PagedResponse } from '@granit/dashboards';
 
@@ -15,17 +15,6 @@ export interface UseDashboardListParams {
   /** Page size. Backend default: 50, capped at 200. */
   readonly pageSize?: number;
 }
-
-/**
- * Cache key composer for the persisted-dashboard list. The params get
- * baked into the key so each filter / page combination caches
- * independently.
- *
- * @deprecated Use {@link buildDashboardsQueryKey} with the segments
- * `'dashboards', 'list', params`. Kept as a byte-identical alias.
- */
-export const dashboardListQueryKey = (params: UseDashboardListParams) =>
-  buildDashboardsQueryKey({}, 'dashboards', 'list', params);
 
 /**
  * `GET /dashboards/?status=&page=&pageSize=` — returns a paged list of
@@ -41,7 +30,7 @@ export function useDashboardList(
 ): UseQueryResult<PagedResponse<DashboardSummaryResponse>> {
   const { client, basePath } = useDashboardsConfig();
   return useQuery({
-    queryKey: dashboardListQueryKey(params),
+    queryKey: dashboardsKeys.list(params),
     queryFn: ({ signal }) => listDashboards(client, basePath, params, { signal }),
     enabled: options.enabled ?? true,
     staleTime: 60_000,

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-render.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-render.ts
@@ -11,7 +11,7 @@ import { useEffect, useMemo } from 'react';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
-import { buildDashboardsQueryKey } from './query-keys';
+import { dashboardsKeys } from './query-keys';
 
 import type {
   DashboardRenderedWidget,
@@ -53,31 +53,6 @@ export interface UseDashboardRenderOptions {
 }
 
 /**
- * Cache key composer. Exported for tests + for sibling hooks that need to
- * address the same query without going through the hook itself.
- *
- * @deprecated Use {@link buildDashboardsQueryKey} with the segments
- * `'dashboard', dashboardId, 'render', request`. Kept as a byte-identical alias.
- */
-export const dashboardRenderQueryKey = (dashboardId: string, request: DashboardRenderRequest) =>
-  buildDashboardsQueryKey({}, 'dashboard', dashboardId, 'render', request);
-
-/**
- * Cache key composer for the **per-widget** TanStack entries the hook
- * populates from the bundle response (ADR-039 §6.2). Use it from
- * {@link useDashboardWidget} to read a single widget's envelope.
- *
- * **SSE-identity anchor**: `usePushedDashboard` writes push snapshots to this
- * exact key and `useDashboardWidget` reads it — the tuple must stay
- * byte-identical. See the `push-key-identity` test.
- *
- * @deprecated Use {@link buildDashboardsQueryKey} with the segments
- * `'dashboard', dashboardId, 'widget', widgetId`. Kept as a byte-identical alias.
- */
-export const dashboardWidgetQueryKey = (dashboardId: string, widgetId: string) =>
-  buildDashboardsQueryKey({}, 'dashboard', dashboardId, 'widget', widgetId);
-
-/**
  * Calls `POST /dashboards/{id}/render` and returns the bundle response.
  *
  * **Bundle is a transport optimisation, not the cache identity.** Per
@@ -104,7 +79,7 @@ export function useDashboardRender(
   const normalizedRequest = useMemo(() => normalizeRequest(request), [request]);
 
   const queryKey = useMemo(
-    () => dashboardRenderQueryKey(dashboardId, normalizedRequest),
+    () => dashboardsKeys.render(dashboardId, normalizedRequest),
     [dashboardId, normalizedRequest]
   );
 
@@ -121,7 +96,7 @@ export function useDashboardRender(
   // Per-widget cache split runs on every successful refetch (initial load,
   // background refetch, manual invalidation). Effects that mutate the
   // QueryClient outside the queryFn keep the per-widget entries authoritative
-  // for any consumer reading them via dashboardWidgetQueryKey().
+  // for any consumer reading them via dashboardsKeys.widget().
   useEffect(() => {
     if (!result.data) return;
     splitBundleIntoWidgetCacheEntries(queryClient, dashboardId, result.data);
@@ -167,7 +142,7 @@ function splitBundleIntoWidgetCacheEntries(
 ): void {
   for (const widget of bundle.widgets) {
     queryClient.setQueryData<DashboardRenderedWidget>(
-      dashboardWidgetQueryKey(dashboardId, widget.id),
+      dashboardsKeys.widget(dashboardId, widget.id),
       widget
     );
   }

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-state-transitions.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-state-transitions.ts
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/r
 import { logger } from '../logger';
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
-import { dashboardDetailQueryKey } from './use-dashboard-detail';
+import { dashboardsKeys } from './query-keys';
 
 import type { DashboardSummaryResponse, PagedResponse } from '@granit/dashboards';
 
@@ -36,7 +36,7 @@ async function invalidateAfterTransition(
 ): Promise<void> {
   await Promise.all([
     queryClient.invalidateQueries({ queryKey: ['dashboards', 'list'] }),
-    queryClient.invalidateQueries({ queryKey: dashboardDetailQueryKey(id) }),
+    queryClient.invalidateQueries({ queryKey: dashboardsKeys.detail(id) }),
   ]);
 }
 

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-widget.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-widget.ts
@@ -1,6 +1,6 @@
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
-import { dashboardWidgetQueryKey } from './use-dashboard-render';
+import { dashboardsKeys } from './query-keys';
 
 import type { DashboardRenderedWidget } from '@granit/dashboards';
 
@@ -25,7 +25,7 @@ export function useDashboardWidget(
   widgetId: string
 ): UseQueryResult<DashboardRenderedWidget> {
   return useQuery<DashboardRenderedWidget>({
-    queryKey: dashboardWidgetQueryKey(dashboardId, widgetId),
+    queryKey: dashboardsKeys.widget(dashboardId, widgetId),
     // No queryFn — the bundle fetch (`useDashboardRender`) is the sole
     // source of truth. Setting `enabled: false` keeps TanStack from
     // attempting a fetch and surfaces the cached entry verbatim.

--- a/packages/@granit/react-dashboards/src/hooks/use-import-dashboard.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-import-dashboard.ts
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/r
 import { logger } from '../logger';
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
-import { dashboardDetailQueryKey } from './use-dashboard-detail';
+import { dashboardsKeys } from './query-keys';
 
 import type { DashboardImportResponse } from '@granit/dashboards';
 
@@ -35,7 +35,7 @@ export function useImportDashboard(): UseMutationResult<DashboardImportResponse,
       });
       // Drop any stale detail cache for the freshly imported id (most
       // likely none, but cheap to clear).
-      queryClient.removeQueries({ queryKey: dashboardDetailQueryKey(imported.id) });
+      queryClient.removeQueries({ queryKey: dashboardsKeys.detail(imported.id) });
       await queryClient.invalidateQueries({ queryKey: ['dashboards', 'list'] });
     },
   });

--- a/packages/@granit/react-dashboards/src/hooks/use-pushed-dashboard.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-pushed-dashboard.ts
@@ -1,12 +1,8 @@
 import { useQueryClient, type UseQueryResult } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 
-import {
-  dashboardRenderQueryKey,
-  dashboardWidgetQueryKey,
-  useDashboardRender,
-  type UseDashboardRenderOptions,
-} from './use-dashboard-render';
+import { dashboardsKeys } from './query-keys';
+import { useDashboardRender, type UseDashboardRenderOptions } from './use-dashboard-render';
 import {
   applyStreamSnapshot,
   useDashboardStream,
@@ -29,7 +25,7 @@ import type {
  * 2. If any widget in the seed carries `transport === 'Push'`,
  *    subscribes to the stream via {@link useDashboardStream}.
  * 3. Each `event: snapshot` frame surgically updates the matching
- *    per-widget cache entry via `setQueryData(dashboardWidgetQueryKey)`.
+ *    per-widget cache entry via `setQueryData(dashboardsKeys.widget)`.
  *    Structural fields (slug, position, width, height, title, actions,
  *    requiredPermission, transport) survive the merge — the stream
  *    only carries the dynamic projection.
@@ -60,7 +56,7 @@ export function usePushedDashboard(
   const handleSnapshot = useCallback(
     (event: DashboardStreamSnapshot) => {
       queryClient.setQueryData<DashboardRenderedWidget>(
-        dashboardWidgetQueryKey(dashboardId, event.widgetId),
+        dashboardsKeys.widget(dashboardId, event.widgetId),
         (current) => applyStreamSnapshot(current, event)
       );
     },
@@ -69,7 +65,7 @@ export function usePushedDashboard(
 
   const handleResumeFailed = useCallback(async () => {
     await queryClient.invalidateQueries({
-      queryKey: dashboardRenderQueryKey(dashboardId, request),
+      queryKey: dashboardsKeys.render(dashboardId, request),
     });
   }, [queryClient, dashboardId, request]);
 

--- a/packages/@granit/react-dashboards/src/hooks/use-resync-dashboard.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-resync-dashboard.ts
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/r
 import { logger } from '../logger';
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
-import { dashboardDetailQueryKey } from './use-dashboard-detail';
+import { dashboardsKeys } from './query-keys';
 
 import type { DashboardResyncResponse } from '@granit/dashboards';
 
@@ -47,7 +47,7 @@ export function useResyncDashboard(): UseMutationResult<DashboardResyncResponse,
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['dashboards', 'list'] }),
         queryClient.invalidateQueries({ queryKey: ['dashboards', 'catalog'] }),
-        queryClient.invalidateQueries({ queryKey: dashboardDetailQueryKey(id) }),
+        queryClient.invalidateQueries({ queryKey: dashboardsKeys.detail(id) }),
         queryClient.invalidateQueries({ queryKey: ['dashboard', id, 'render'] }),
       ]);
     },

--- a/packages/@granit/react-dashboards/src/hooks/use-update-dashboard-metadata.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-update-dashboard-metadata.ts
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/r
 import { logger } from '../logger';
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
-import { dashboardDetailQueryKey } from './use-dashboard-detail';
+import { dashboardsKeys } from './query-keys';
 
 import type { DashboardMetadataUpdateRequest, DashboardSummaryResponse } from '@granit/dashboards';
 
@@ -44,7 +44,7 @@ export function useUpdateDashboardMetadata(): UseMutationResult<
       logger.debug('Dashboard metadata updated', { id });
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['dashboards', 'list'] }),
-        queryClient.invalidateQueries({ queryKey: dashboardDetailQueryKey(id) }),
+        queryClient.invalidateQueries({ queryKey: dashboardsKeys.detail(id) }),
       ]);
     },
   });

--- a/packages/@granit/react-dashboards/src/hooks/use-widget-crud.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-widget-crud.ts
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/r
 import { logger } from '../logger';
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
-import { dashboardDetailQueryKey } from './use-dashboard-detail';
+import { dashboardsKeys } from './query-keys';
 
 import type {
   AddWidgetRequest,
@@ -58,7 +58,7 @@ export function useAddWidget(): UseMutationResult<
       createWidget(client, basePath, dashboardId, request),
     onSuccess: (widget, { dashboardId }) => {
       logger.debug('Widget added', { dashboardId, widgetId: widget.id });
-      return queryClient.invalidateQueries({ queryKey: dashboardDetailQueryKey(dashboardId) });
+      return queryClient.invalidateQueries({ queryKey: dashboardsKeys.detail(dashboardId) });
     },
   });
 }
@@ -83,7 +83,7 @@ export function useUpdateWidget(): UseMutationResult<
       updateWidget(client, basePath, dashboardId, widgetId, request),
     onSuccess: (widget, { dashboardId }) => {
       logger.debug('Widget updated', { dashboardId, widgetId: widget.id });
-      return queryClient.invalidateQueries({ queryKey: dashboardDetailQueryKey(dashboardId) });
+      return queryClient.invalidateQueries({ queryKey: dashboardsKeys.detail(dashboardId) });
     },
   });
 }
@@ -101,7 +101,7 @@ export function useRemoveWidget(): UseMutationResult<void, Error, RemoveWidgetVa
       deleteWidget(client, basePath, dashboardId, widgetId),
     onSuccess: (_void, { dashboardId, widgetId }) => {
       logger.debug('Widget removed', { dashboardId, widgetId });
-      return queryClient.invalidateQueries({ queryKey: dashboardDetailQueryKey(dashboardId) });
+      return queryClient.invalidateQueries({ queryKey: dashboardsKeys.detail(dashboardId) });
     },
   });
 }

--- a/packages/@granit/react-dashboards/src/hooks/use-widget-render.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-widget-render.ts
@@ -1,5 +1,9 @@
 import { HttpError } from '@granit/api-client';
-import { renderWidget, resolveTimeWindowToRenderRequest, toRefetchInterval } from '@granit/dashboards';
+import {
+  renderWidget,
+  resolveTimeWindowToRenderRequest,
+  toRefetchInterval,
+} from '@granit/dashboards';
 import { useQuery, type Query, type UseQueryResult } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
@@ -7,7 +11,7 @@ import { useDashboardFilters } from '../components/dashboard-filter-context';
 import { mergeFilterValuesIntoRequest } from '../lib/merge-filter-values';
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
-import { buildDashboardsQueryKey } from './query-keys';
+import { dashboardsKeys } from './query-keys';
 import { useEffectiveRefreshInterval } from './use-effective-refresh-interval';
 import { useEffectiveTimeWindow } from './use-effective-time-window';
 
@@ -62,22 +66,6 @@ export interface WidgetRenderContext {
  */
 export type WidgetRenderKind = 'kpi' | 'chart' | 'table' | 'pivot' | 'map';
 
-/**
- * Cache key composer for `useWidgetRender`. Keyed by
- * `(kind, definition, context)` so semantically-identical inputs
- * collapse to the same cache entry / in-flight request — same
- * convention as the bundle path's `dashboardRenderQueryKey`.
- *
- * @deprecated Use {@link buildDashboardsQueryKey} with the segments
- * `'widget', kind, 'render', definition, context`. Kept as a byte-identical
- * alias.
- */
-export const widgetRenderQueryKey = <TDefinition extends WidgetDefinitionBase>(
-  kind: WidgetRenderKind,
-  definition: TDefinition,
-  context: WidgetRenderContext
-) => buildDashboardsQueryKey({}, 'widget', kind, 'render', definition, context);
-
 export interface UseWidgetRenderOptions {
   /** Disable the request — useful when the parent isn't ready (e.g. tenant pending). */
   readonly enabled?: boolean;
@@ -130,7 +118,7 @@ export function useWidgetRender<TDefinition extends WidgetDefinitionBase>(
   }, [context, filters?.values, timeWindow]);
 
   const queryKey = useMemo(
-    () => widgetRenderQueryKey(kind, definition, effectiveContext),
+    () => dashboardsKeys.widgetRender(kind, definition, effectiveContext),
     [kind, definition, effectiveContext]
   );
 

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -10,20 +10,17 @@ export type {
   ResolvedDashboardsConfig,
 } from './providers/dashboards-provider';
 
-// Query-key factory (family-standard `build{Module}QueryKey(config, ...segments)`).
-// The per-operation `*QueryKey` fns below are `@deprecated` byte-identical aliases.
-export { buildDashboardsQueryKey } from './hooks/query-keys';
+// Query-key factory: the low-level `buildDashboardsQueryKey(config, ...segments)`
+// builder plus `dashboardsKeys`, the canonical per-operation key factory every
+// hook composes its tuples through (mirrors `cmsRedirectsKeys`).
+export { buildDashboardsQueryKey, dashboardsKeys } from './hooks/query-keys';
 
 // Render hook (B4-render — POST /dashboards/{id}/render bundle + per-widget cache split)
-export {
-  dashboardRenderQueryKey,
-  dashboardWidgetQueryKey,
-  useDashboardRender,
-} from './hooks/use-dashboard-render';
+export { useDashboardRender } from './hooks/use-dashboard-render';
 export type { UseDashboardRenderOptions } from './hooks/use-dashboard-render';
 export { useDashboardWidget } from './hooks/use-dashboard-widget';
 export { resolveWidgetTitle } from './lib/resolve-widget-title';
-export { useWidgetRender, widgetRenderQueryKey } from './hooks/use-widget-render';
+export { useWidgetRender } from './hooks/use-widget-render';
 export type {
   UseWidgetRenderOptions,
   WidgetRenderContext,
@@ -46,10 +43,10 @@ export { usePushedDashboard } from './hooks/use-pushed-dashboard';
 // dashboards are addressed by Guid. Lifecycle is publish/archive/restore
 // (no DELETE), metadata edits are name+layout only, widget pool is
 // managed via dedicated endpoints.
-export { dashboardCatalogQueryKey, useDashboardCatalog } from './hooks/use-dashboard-catalog';
-export { dashboardListQueryKey, useDashboardList } from './hooks/use-dashboard-list';
+export { useDashboardCatalog } from './hooks/use-dashboard-catalog';
+export { useDashboardList } from './hooks/use-dashboard-list';
 export type { UseDashboardListParams } from './hooks/use-dashboard-list';
-export { dashboardDetailQueryKey, useDashboardDetail } from './hooks/use-dashboard-detail';
+export { useDashboardDetail } from './hooks/use-dashboard-detail';
 export { useImportDashboard } from './hooks/use-import-dashboard';
 export { useUpdateDashboardMetadata } from './hooks/use-update-dashboard-metadata';
 export type { UpdateDashboardMetadataVariables } from './hooks/use-update-dashboard-metadata';


### PR DESCRIPTION
## Summary

Resolves the ~24 SonarQube *"'dashboard\*QueryKey' is deprecated"* code smells across `@granit/react-dashboards`. We're pre-release, so the deprecated code is **removed**, not merely un-flagged.

The six `@deprecated` composers (`dashboardCatalogQueryKey`, `dashboardListQueryKey`, `dashboardDetailQueryKey`, `dashboardRenderQueryKey`, `dashboardWidgetQueryKey`, `widgetRenderQueryKey`) each wrapped `buildDashboardsQueryKey({}, ...segments)` and were still called from ~15 hooks + tests. They are consolidated into a single non-deprecated **`dashboardsKeys`** factory in the canonical `hooks/query-keys.ts` (mirrors `cmsRedirectsKeys` in the CMS-redirects package).

## Why a factory (not inlining the builder)

`dashboardWidgetQueryKey` is the documented **SSE cache-identity anchor**: `usePushedDashboard` writes push snapshots to it, `useDashboardRender` populates it, `useDashboardWidget` reads it. Inlining `buildDashboardsQueryKey({}, 'dashboard', id, 'widget', widgetId)` at those 3 sites would reintroduce the byte-identity drift risk the composer existed to prevent. Routing all three through `dashboardsKeys.widget` makes the invariant **structural** rather than merely tested. Roots stay consistent too (`dashboards` vs `dashboard` vs `widget`). All tuples are byte-identical to the removed aliases.

## Changes

- `query-keys.ts` — add `dashboardsKeys`; keep the tested `buildDashboardsQueryKey` builder (used internally).
- Migrate every call site: catalog/list/detail/render/widget/widgetRender reads + every `invalidateQueries`/`setQueryData`/`removeQueries`.
- `index.ts` — drop the 6 deprecated exports, export `dashboardsKeys`.
- Tests — retarget query-keys / crud / render / pushed / widget-render specs; the SSE identity test now pins `dashboardsKeys.widget`.

## API impact

`showcase-admin-react` imports none of the removed symbols (verified via grep), so no coordinated MR is required.

## Verification

- `pnpm tsc` (workspace) — clean (type-only import cycle between `query-keys.ts` and the two hook files that own its param types resolves fine — erased at runtime)
- `eslint --fix` — clean
- `vitest run` `@granit/react-dashboards` — **200 passed**, including the SSE cache-identity invariant