### PR TITLE
test(react-blog): serve /grid/meta in blog admin MSW handlers

### DIFF
--- a/packages/@granit/react-blog/src/testing/handlers.ts
+++ b/packages/@granit/react-blog/src/testing/handlers.ts
@@ -83,6 +83,25 @@ export function createBlogAdminHandlers(baseUrl = '/api/blog'): RequestHandler[]
   const find = (id: string | readonly string[] | undefined) => posts.find((post) => post.id === id);
 
   return [
+    http.get(`${baseUrl}/grid/meta`, () =>
+      HttpResponse.json({
+        columns: [],
+        filterableFields: [],
+        sortableFields: [],
+        presetFilterGroups: [],
+        quickFilters: [],
+        dateFilters: [],
+        groupByFields: [],
+        pagination: {
+          defaultPageSize: 20,
+          maxPageSize: 100,
+          maxStreamSize: 10000,
+          supportsCursor: false,
+        },
+        defaultSort: '-createdAt',
+      })
+    ),
+
     http.get(`${baseUrl}/grid`, ({ request }) => {
       const url = new URL(request.url);
       const page = Number(url.searchParams.get('page') ?? '1');


### PR DESCRIPTION
Follow-up to #936. Adds a `/grid/meta` handler to `createBlogAdminHandlers` so
consumers (e.g. the showcase blog admin grid) don't 404 on `usePostsGridMeta`
and fall back to the static default sort. Keeps all Blog mock behaviour in
granit-front's `@granit/react-blog/testing` factory (the showcase only binds it).

tsc + lint clean.