### PR TITLE
fix(react-ui-ai): align react-hook-form to 7.81, restore form type compat

### DIFF
--- a/packages/@granit/react-entities/package.json
+++ b/packages/@granit/react-entities/package.json
@@ -28,7 +28,7 @@
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.14.6",
     "react": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "react-i18next": "^17.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/@granit/react-ui-ai/src/components/workspace-form.tsx
+++ b/packages/@granit/react-ui-ai/src/components/workspace-form.tsx
@@ -23,13 +23,12 @@ import {
   Textarea,
 } from '@granit/react-ui';
 import { useMemo, useRef } from 'react';
-import { useForm, useWatch } from 'react-hook-form';
+import { useForm, useWatch, type Resolver } from 'react-hook-form';
 
 import {
   createWorkspaceResolver,
   type CreateWorkspaceFormValues,
   type EditWorkspaceFormValues,
-  type WorkspaceFormValues,
 } from '../validation';
 
 import { WorkspaceCapabilities } from './workspace-capabilities';
@@ -68,6 +67,24 @@ interface EditWorkspaceFormProps extends WorkspaceFormBaseProps {
 
 type WorkspaceFormProps = CreateWorkspaceFormProps | EditWorkspaceFormProps;
 
+/**
+ * Concrete superset shape backing the react-hook-form instance. RHF 7.81 makes
+ * `Control<T>` invariant, so the `CreateWorkspaceFormValues | EditWorkspaceFormValues`
+ * union no longer satisfies the form/provider generics. The form is driven by this
+ * single shape (mode-specific `key`/`activated` optional) and narrowed back to the
+ * discriminated union at the submit boundary.
+ */
+interface WorkspaceFormShape {
+  key?: string;
+  provider: string;
+  model: string;
+  displayName?: string;
+  systemPrompt?: string;
+  temperature?: number | string;
+  maxOutputTokens?: number | string;
+  activated?: boolean;
+}
+
 export function WorkspaceForm(props: Readonly<WorkspaceFormProps>) {
   const { mode, onCancel, isPending = false } = props;
   const { t } = useTranslation();
@@ -78,8 +95,8 @@ export function WorkspaceForm(props: Readonly<WorkspaceFormProps>) {
     [isCreate, t]
   );
 
-  const form = useForm<WorkspaceFormValues>({
-    resolver: formResolver,
+  const form = useForm<WorkspaceFormShape>({
+    resolver: formResolver as unknown as Resolver<WorkspaceFormShape>,
     defaultValues: {
       provider: '',
       model: '',
@@ -329,7 +346,7 @@ export function WorkspaceForm(props: Readonly<WorkspaceFormProps>) {
                 render={({ field }) => (
                   <FormItem className="flex items-center gap-3">
                     <FormControl>
-                      <Switch checked={field.value as boolean} onCheckedChange={field.onChange} />
+                      <Switch checked={field.value ?? false} onCheckedChange={field.onChange} />
                     </FormControl>
                     <FormLabel className="!mt-0 cursor-pointer">
                       {t('AI.Workspaces.Form.IsActive')}

--- a/packages/@granit/react-ui-authentication-api-keys/package.json
+++ b/packages/@granit/react-ui-authentication-api-keys/package.json
@@ -27,7 +27,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "react-router-dom": "^7.18.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-ui-authentication-local/package.json
+++ b/packages/@granit/react-ui-authentication-local/package.json
@@ -27,7 +27,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "react-router-dom": "^7.18.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-ui-blog/package.json
+++ b/packages/@granit/react-ui-blog/package.json
@@ -33,7 +33,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0"
+    "react-hook-form": "^7.81.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-catalog/package.json
+++ b/packages/@granit/react-ui-catalog/package.json
@@ -29,7 +29,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "react-router-dom": "^7.18.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-ui-cms-hostnames/package.json
+++ b/packages/@granit/react-ui-cms-hostnames/package.json
@@ -24,7 +24,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "react-router-dom": "^7.18.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-ui-cms-menus/package.json
+++ b/packages/@granit/react-ui-cms-menus/package.json
@@ -27,7 +27,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "react-router-dom": "^7.18.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-ui-cms-redirects/package.json
+++ b/packages/@granit/react-ui-cms-redirects/package.json
@@ -23,7 +23,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "react-router-dom": "^7.18.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-ui-cms-releases/package.json
+++ b/packages/@granit/react-ui-cms-releases/package.json
@@ -26,7 +26,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "react-router-dom": "^7.18.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-ui-cms-sites/package.json
+++ b/packages/@granit/react-ui-cms-sites/package.json
@@ -26,7 +26,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "react-router-dom": "^7.18.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-ui-customer-balance/package.json
+++ b/packages/@granit/react-ui-customer-balance/package.json
@@ -26,7 +26,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0"
+    "react-hook-form": "^7.81.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-ui-hostnames/package.json
+++ b/packages/@granit/react-ui-hostnames/package.json
@@ -24,7 +24,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "react-router-dom": "^7.18.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-ui-iot/package.json
+++ b/packages/@granit/react-ui-iot/package.json
@@ -26,7 +26,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "react-router-dom": "^7.18.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-ui-kit/package.json
+++ b/packages/@granit/react-ui-kit/package.json
@@ -29,7 +29,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "react-i18next": "^17.0.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-ui-metering/package.json
+++ b/packages/@granit/react-ui-metering/package.json
@@ -28,7 +28,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "react-router-dom": "^7.18.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-ui-payments/package.json
+++ b/packages/@granit/react-ui-payments/package.json
@@ -27,7 +27,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "react-router-dom": "^7.18.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-ui-subscriptions/package.json
+++ b/packages/@granit/react-ui-subscriptions/package.json
@@ -29,7 +29,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "react-router-dom": "^7.18.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-ui-tax/package.json
+++ b/packages/@granit/react-ui-tax/package.json
@@ -27,7 +27,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "react-router-dom": "^7.18.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-ui/package.json
+++ b/packages/@granit/react-ui/package.json
@@ -24,7 +24,7 @@
     "radix-ui": "^1.6.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.80.0",
+    "react-hook-form": "^7.81.0",
     "sonner": "^2.0.7",
     "tw-animate-css": "^1.4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2443,8 +2443,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
       react-i18next:
         specifier: ^17.0.0
         version: 17.0.8(i18next@26.3.4(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
@@ -3702,8 +3702,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -4140,8 +4140,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -4335,8 +4335,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -4625,8 +4625,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -4722,8 +4722,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -4798,8 +4798,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -4856,8 +4856,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -4990,8 +4990,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -5045,8 +5045,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -5179,8 +5179,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -5255,8 +5255,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -5832,8 +5832,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -6032,8 +6032,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -6102,8 +6102,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
       react-i18next:
         specifier: ^17.0.0
         version: 17.0.8(i18next@26.3.4(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
@@ -6300,8 +6300,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -6662,8 +6662,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -7130,8 +7130,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -7203,8 +7203,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
       react-hook-form:
-        specifier: ^7.80.0
-        version: 7.80.0(react@19.2.7)
+        specifier: ^7.81.0
+        version: 7.81.0(react@19.2.7)
       react-router-dom:
         specifier: ^7.18.0
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -13033,12 +13033,6 @@ packages:
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
-
-  react-hook-form@7.80.0:
-    resolution: {integrity: sha512-4P+fk6oXsxY+6xSj7Euhc2sumQD8zQqCuVHoJwoyp9EchP+IUW9OESB7uHFJOKsIBQ4MQqYE84INJFqUCYNoOg==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: ^19.0.0
 
   react-hook-form@7.81.0:
     resolution: {integrity: sha512-ocbmr2p5KBMoAfj4WCUvped33lVi1Kd5DuDUvQDnB6VEAacOjPI/jMbtDdbhco4y9ct4xUuCmMY0b/C9L0QHjw==}
@@ -19357,10 +19351,6 @@ snapshots:
       react-draggable: 4.7.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-resizable: 3.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       resize-observer-polyfill: 1.5.1
-
-  react-hook-form@7.80.0(react@19.2.7):
-    dependencies:
-      react: 19.2.7
 
   react-hook-form@7.81.0(react@19.2.7):
     dependencies:


### PR DESCRIPTION
## Contexte — develop rouge

Après le merge de #941, deux PR dependabot ont cassé `develop` :

- **#939** `bump react-hook-form in the react group` n'a bumpé qu'une partie du
  workspace vers `^7.81.0`, laissant **19 packages à `^7.80.0`**.

Ce split provoquait **deux échecs CI** :

1. **arch-test `uniformity`** : `shared-dep-version-drift` sur `react-hook-form`
   (19× `^7.80.0` vs 26× `^7.81.0`).
2. **`pnpm tsc`** : le split résolvait **deux copies physiques** de react-hook-form
   (7.80 + 7.81). Le formulaire de `@granit/react-ui-ai` (7.81) ne matchait plus le
   `Form` provider de `@granit/react-ui` (7.80) → incompatibilité `Control<T>`.
   De plus, react-hook-form 7.81 rend `Control<T>` **invariant**, donc l'union
   `CreateWorkspaceFormValues | EditWorkspaceFormValues` ne satisfait plus les
   génériques du form (erreurs sur `<Form {...form}>`, `name="key"`, `name="activated"`).

## Correctif

- **Alignement** des 45 contraintes `react-hook-form` sur `^7.81.0` (= version déjà
  installée + direction dependabot) → une seule copie résolue, drift éliminé.
- **`workspace-form.tsx`** : le form est piloté par une **forme superset concrète**
  (`WorkspaceFormShape`, avec `key`/`activated` optionnels) au lieu de l'union, et
  re-narrowé vers l'union discriminée à la frontière de submit. Aucune API publique
  touchée (`WorkspaceFormValues`, `createWorkspaceResolver` inchangés).

## Vérifications

| Check | Résultat |
| --- | --- |
| `pnpm tsc` (237 packages) | ✅ exit 0 |
| arch-tests (dont `uniformity`) | ✅ 14 suites / 3313 tests |
| `@granit/react-ui-ai` | ✅ 21 fichiers / 178 tests |
| ESLint (`--max-warnings 0`) | ✅ |

## Note

`@codemirror/state` a aussi un léger drift (`^6.6.0` vs `^6.7.1`, PR #940) mais il
n'est **pas** dans la liste des deps suivies par l'arch-test `uniformity` — il ne
casse pas la CI et sort du périmètre de ce hotfix. À aligner dans un bump groupé
ultérieur si souhaité.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
