### PR TITLE
ci(deps): guard shared-dependency version drift (CI job + pre-push + grouping)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,15 @@ updates:
           - "react-hook-form"
           - "react-router"
           - "react-router-dom"
+      # Singleton libraries the `dep-uniformity` gate requires to stay on one
+      # constraint workspace-wide. Grouping keeps a bump atomic and reviewable as
+      # one unit (React/i18n singletons already travel via the react/i18n groups).
+      shared-runtime:
+        patterns:
+          - "date-fns"
+          - "zod"
+          - "clsx"
+          - "tailwind-merge"
       build:
         patterns:
           - "tsup"
@@ -83,6 +92,10 @@ updates:
           - "react-hook-form"
           - "react-router"
           - "react-router-dom"
+          - "date-fns"
+          - "zod"
+          - "clsx"
+          - "tailwind-merge"
           - "tsup"
           - "typescript"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,25 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
+  # DEP UNIFORMITY: fail fast on shared-dependency version drift (e.g. a partial
+  # Dependabot bump splitting react-hook-form across the workspace). Pure Node,
+  # no install — a dedicated, sub-minute red signal before the full test suite.
+  # ---------------------------------------------------------------------------
+  dep-uniformity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Check shared-dependency version uniformity
+        run: node scripts/check-shared-dep-versions.mjs
+
+  # ---------------------------------------------------------------------------
   # LINT
   # ---------------------------------------------------------------------------
   lint:

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+# Block a push that introduces shared-dependency version drift (e.g. React,
+# react-hook-form, i18next) before it reaches CI. Pure Node, sub-second — the
+# same check runs as the `dep-uniformity` CI job for Dependabot pushes, which
+# never trigger local hooks.
+node scripts/check-shared-dep-versions.mjs || exit 1

--- a/packages/@granit/arch-tests/src/__tests__/uniformity.test.ts
+++ b/packages/@granit/arch-tests/src/__tests__/uniformity.test.ts
@@ -10,6 +10,9 @@ describe('uniformity (delegated to kit)', () => {
     expect(scanReadmePresence(ctx)).toEqual([]);
   });
 
+  // In-suite defense-in-depth mirror of scripts/check-shared-dep-versions.mjs
+  // (the canonical list enforced by the pre-push hook and the dep-uniformity CI
+  // job). Keep the two dep lists in sync when adding a shared singleton.
   it('shared deps use the same version constraint across every package', () => {
     expect(
       scanSharedDepVersions({

--- a/scripts/check-shared-dep-versions.mjs
+++ b/scripts/check-shared-dep-versions.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Fail fast on shared-dependency version drift across the @granit/* workspace.
+//
+// A handful of singleton libraries MUST resolve to a single copy across every
+// package — React and its ecosystem (one renderer instance), the form/i18n/query
+// runtimes, and the class-name helpers behind `cn`. When one package pins a
+// different constraint (typically a partial Dependabot bump that only touched
+// some of the 200+ manifests), pnpm resolves two physical copies and their
+// invariant generic types stop matching across package boundaries — exactly the
+// react-hook-form 7.80/7.81 split that broke `develop`.
+//
+// This is the canonical enforcement used by BOTH the `.husky/pre-push` hook and
+// the `dep-uniformity` CI job. It is pure Node (no install, no deps) so it runs
+// in well under a second. The arch-test `uniformity` (in @granit/arch-tests)
+// keeps its own in-suite copy of this list as defense-in-depth — keep the two in
+// sync when adding a dependency here.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const PACKAGES_DIR = join(REPO_ROOT, 'packages', '@granit');
+
+/**
+ * Dependencies that must carry an identical version constraint in every package
+ * that declares them. Mirrors the `deps` list of the `uniformity` arch-test.
+ */
+export const SHARED_DEP_NAMES = [
+  'react',
+  'react-dom',
+  '@tanstack/react-query',
+  'react-i18next',
+  'react-hook-form',
+  'i18next',
+  'date-fns',
+  'zod',
+  'clsx',
+  'tailwind-merge',
+];
+
+const DEP_BUCKETS = ['dependencies', 'devDependencies', 'peerDependencies'];
+
+/** @returns {Map<string, Map<string, string[]>>} dep -> (constraint -> package names) */
+function collectConstraints() {
+  const byDep = new Map(SHARED_DEP_NAMES.map((name) => [name, new Map()]));
+
+  for (const entry of readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const manifestPath = join(PACKAGES_DIR, entry.name, 'package.json');
+    let manifest;
+    try {
+      manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    } catch {
+      continue; // no package.json (or unreadable) — skip
+    }
+
+    for (const dep of SHARED_DEP_NAMES) {
+      for (const bucket of DEP_BUCKETS) {
+        const constraint = manifest[bucket]?.[dep];
+        if (!constraint) continue;
+        const seen = byDep.get(dep);
+        if (!seen.has(constraint)) seen.set(constraint, []);
+        const pkgs = seen.get(constraint);
+        if (!pkgs.includes(manifest.name)) pkgs.push(manifest.name);
+      }
+    }
+  }
+
+  return byDep;
+}
+
+function main() {
+  const byDep = collectConstraints();
+  const drifted = [];
+
+  for (const [dep, constraints] of byDep) {
+    if (constraints.size <= 1) continue; // absent or uniform
+    // Order by descending package count so the dominant constraint reads first.
+    const ranked = [...constraints.entries()].sort((a, b) => b[1].length - a[1].length);
+    drifted.push({ dep, ranked });
+  }
+
+  if (drifted.length === 0) {
+    console.log(
+      `✓ shared-dep versions uniform across the workspace (${SHARED_DEP_NAMES.length} tracked)`
+    );
+    return;
+  }
+
+  console.error('✗ shared-dependency version drift detected\n');
+  for (const { dep, ranked } of drifted) {
+    console.error(`  ${dep}:`);
+    for (const [constraint, pkgs] of ranked) {
+      const sample = pkgs.slice(0, 3).join(', ');
+      const more = pkgs.length > 3 ? `, +${pkgs.length - 3} more` : '';
+      console.error(`    ${constraint}  (${pkgs.length}×) — ${sample}${more}`);
+    }
+  }
+  console.error(
+    '\nAlign every package to a single constraint (usually the dominant one), then' +
+      '\nrun `pnpm install` so the lockfile resolves one physical copy.'
+  );
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Contexte

Le hotfix #942 a corrigé un drift `react-hook-form` (7.80/7.81) introduit par un
bump Dependabot **partiel** : seuls certains des 200+ manifests avaient été bumpés,
résolvant deux copies physiques de react-hook-form et cassant `develop`. `react-hook-form`
était pourtant **déjà groupé** dans Dependabot — le grouping seul ne prévient pas un
bump partiel de manifestes. Cette PR ajoute une défense réelle en profondeur.

## Trois couches de garde

1. **`scripts/check-shared-dep-versions.mjs`** — scan canonique, pur Node (aucune
   install, sous la seconde) des 10 dépendances singleton partagées qui **doivent**
   rester sur une seule contrainte workspace-wide : écosystème React, runtimes
   form/i18n/query, helpers `cn` (clsx/tailwind-merge). Échoue sur tout drift, avec
   un rapport clair (distribution des contraintes + packages concernés).

2. **Job CI `dep-uniformity`** — exécute le scan **sans install**, en tête de
   pipeline : un signal rouge dédié et sub-minute, **avant** la suite de tests
   (14 min). C'est le gate qui rattrape Dependabot, dont les pushes ne déclenchent
   pas les hooks locaux. À passer en *required check* côté branch protection pour
   bloquer un merge en drift.

3. **`.husky/pre-push`** — même scan en local, feedback rapide pour les pushes humains.

## Dependabot

Groupe `shared-runtime` ajouté (`date-fns`, `zod`, `clsx`, `tailwind-merge`) pour que
ces singletons bumpent **atomiquement**, comme le font déjà les groupes `react`/`i18n`.

## Note d'honnêteté

Le grouping et le hook local ne bloquent pas un merge Dependabot par eux-mêmes (auto-merge
= réglage GitHub, hors fichier). Le **job CI `dep-uniformity` en required check** est le
vrai verrou anti-merge — c'est le réglage à activer côté repo.

## Vérifications

| Check | Résultat |
| --- | --- |
| `check-shared-dep-versions.mjs` (clean develop) | ✅ 10 tracked, uniform |
| Script sur drift simulé | ✅ exit 1 + rapport |
| arch-tests (uniformity incl.) | ✅ 14 suites / 3313 tests |
| ESLint | ✅ |
| YAML (ci + dependabot) valides | ✅ |
| pre-push hook dry-run | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
