### PR TITLE
fix(auditing)!: correlation endpoint returns paged summary (granit-dotnet#2956)

### DIFF
--- a/contracts/openapi/auditing.json
+++ b/contracts/openapi/auditing.json
@@ -394,7 +394,7 @@
       "get": {
         "tags": ["Audit Log"],
         "summary": "Returns audit entries matching a distributed tracing correlation ID.",
-        "description": "Returns all audit log entries that share the given correlation ID, ordered by timestamp descending. This is essential for distributed tracing investigation — correlating audit events across multiple services or operations that belong to the same logical transaction. The correlation ID is limited to 256 characters.",
+        "description": "Returns the audit log entries that share the given correlation ID, paginated and ordered by timestamp descending. This is essential for distributed tracing investigation — correlating audit events across multiple services or operations that belong to the same logical transaction. The correlation ID is limited to 256 characters.",
         "operationId": "GetAuditEntriesByCorrelationId",
         "parameters": [
           {
@@ -405,6 +405,24 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           }
         ],
         "responses": {
@@ -413,10 +431,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AuditEntryDetailResponse"
-                  }
+                  "$ref": "#/components/schemas/PagedResultOfAuditEntryResponse"
                 }
               }
             }
@@ -769,7 +784,7 @@
             "type": "string"
           },
           "changeType": {
-            "type": "string"
+            "$ref": "#/components/schemas/AuditChangeType"
           },
           "propertyChanges": {
             "type": "array",
@@ -843,7 +858,7 @@
             "type": ["null", "string"]
           },
           "category": {
-            "type": "string"
+            "$ref": "#/components/schemas/AuditCategory"
           },
           "ipAddress": {
             "type": ["null", "string"]
@@ -864,6 +879,30 @@
               "$ref": "#/components/schemas/AuditEntityChangeResponse"
             }
           }
+        },
+        "example": {
+          "id": "b3f7a1c2-9d4e-4f8a-b6c5-1e2d3f4a5b6c",
+          "timestamp": "2026-03-17T10:15:30+00:00",
+          "userId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "userName": "Jane Doe",
+          "category": "DataMutation",
+          "ipAddress": "198.51.100.42",
+          "tenantId": "d4e5f6a7-b8c9-0123-4567-89abcdef0123",
+          "correlationId": "req-abc123def456",
+          "entityChanges": [
+            {
+              "entityType": "Patient",
+              "entityId": "42",
+              "changeType": "Modified",
+              "propertyChanges": [
+                {
+                  "propertyName": "Email",
+                  "originalValue": "old@example.com",
+                  "newValue": "new@example.com"
+                }
+              ]
+            }
+          ]
         }
       },
       "AuditEntryResponse": {
@@ -911,6 +950,17 @@
             "type": "integer",
             "format": "int32"
           }
+        },
+        "example": {
+          "id": "b3f7a1c2-9d4e-4f8a-b6c5-1e2d3f4a5b6c",
+          "timestamp": "2026-03-17T10:15:30+00:00",
+          "userId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "userName": "Jane Doe",
+          "category": "DataMutation",
+          "ipAddress": "198.51.100.42",
+          "tenantId": "d4e5f6a7-b8c9-0123-4567-89abcdef0123",
+          "correlationId": "req-abc123def456",
+          "entityChangeCount": 2
         }
       },
       "AuditPropertyChangeResponse": {
@@ -964,6 +1014,22 @@
             "type": "boolean"
           },
           "format": {
+            "type": ["null", "string"]
+          },
+          "valueKind": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ValueKind"
+              }
+            ]
+          },
+          "currencyCode": {
+            "type": ["null", "string"]
+          },
+          "currencyCodeField": {
             "type": ["null", "string"]
           }
         }
@@ -1322,6 +1388,17 @@
                   "type": "integer",
                   "format": "int32"
                 }
+              },
+              "example": {
+                "id": "b3f7a1c2-9d4e-4f8a-b6c5-1e2d3f4a5b6c",
+                "timestamp": "2026-03-17T10:15:30+00:00",
+                "userId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "userName": "Jane Doe",
+                "category": "DataMutation",
+                "ipAddress": "198.51.100.42",
+                "tenantId": "d4e5f6a7-b8c9-0123-4567-89abcdef0123",
+                "correlationId": "req-abc123def456",
+                "entityChangeCount": 2
               }
             }
           },
@@ -1484,6 +1561,33 @@
             "type": "string"
           }
         }
+      },
+      "ValueKind": {
+        "enum": [
+          "Count",
+          "Number",
+          "Currency",
+          "Percentage",
+          "Duration",
+          "Date",
+          "Url",
+          "Email",
+          "Phone",
+          "Bytes",
+          "DateTime",
+          "Boolean",
+          "Enum",
+          "RelativeTime",
+          "Time",
+          "Color",
+          "Image",
+          "Json",
+          "Markdown",
+          "Tags",
+          "Rating",
+          "Identifier",
+          null
+        ]
       }
     }
   },

--- a/packages/@granit/auditing/src/__tests__/audit-log-api.test.ts
+++ b/packages/@granit/auditing/src/__tests__/audit-log-api.test.ts
@@ -75,15 +75,37 @@ describe('audit-log-api', () => {
   });
 
   describe('getAuditEntriesByCorrelationId', () => {
-    it('should GET the correlation endpoint with an encoded id and return the array', async () => {
+    it('should GET the correlation endpoint with an encoded id and return a page', async () => {
       const client = createMockClient();
-      const details: AuditEntryDetailResponse[] = [];
-      vi.mocked(client.get).mockResolvedValue(axiosResponse(details));
+      const page: AuditPage = {
+        items: [
+          {
+            id: toEntityId<'AuditEntry'>('abc-123'),
+            timestamp: toISODateString('2026-03-17T10:00:00Z'),
+            userId: toEntityId<'User'>('user-1'),
+            userName: 'admin',
+            category: AuditCategory.DataMutation,
+            ipAddress: '127.0.0.1',
+            tenantId: null,
+            correlationId: null,
+            entityChangeCount: 3,
+          },
+        ],
+        totalCount: 1,
+        hasMore: false,
+        nextCursor: null,
+      };
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(page));
 
-      const result = await getAuditEntriesByCorrelationId(client, basePath, 'corr/42');
+      const result = await getAuditEntriesByCorrelationId(client, basePath, 'corr/42', {
+        page: 1,
+        pageSize: 10,
+      });
 
-      expect(client.get).toHaveBeenCalledWith('/audit-log/correlation/corr%2F42');
-      expect(result).toBe(details);
+      expect(client.get).toHaveBeenCalledWith('/audit-log/correlation/corr%2F42', {
+        params: { page: 1, pageSize: 10 },
+      });
+      expect(result).toBe(page);
     });
   });
 });

--- a/packages/@granit/auditing/src/api/audit-log-api.ts
+++ b/packages/@granit/auditing/src/api/audit-log-api.ts
@@ -19,20 +19,22 @@ export async function getAuditLogEntry(
 }
 
 /**
- * Get all audit log entries sharing a distributed-tracing correlation ID.
+ * Get the audit entries sharing a distributed-tracing correlation ID (paginated).
  *
- * Returns full detail entries (with entity changes), ordered newest-first.
- * Not paginated — the backend returns the complete correlated set.
+ * Returns summary projections, ordered newest-first. Fetch a single entry's
+ * full detail (with entity changes) by id.
  *
  * `GET {basePath}/correlation/{correlationId}`
  */
 export async function getAuditEntriesByCorrelationId(
   client: AxiosInstance,
   basePath: string,
-  correlationId: string
-): Promise<readonly AuditEntryDetailResponse[]> {
-  const { data } = await client.get<readonly AuditEntryDetailResponse[]>(
-    `${basePath}/correlation/${encodeURIComponent(correlationId)}`
+  correlationId: string,
+  params?: PaginationParams
+): Promise<AuditPage> {
+  const { data } = await client.get<AuditPage>(
+    `${basePath}/correlation/${encodeURIComponent(correlationId)}`,
+    { params }
   );
   return data;
 }

--- a/packages/@granit/react-auditing/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-auditing/src/__tests__/testing-handlers.test.ts
@@ -57,13 +57,15 @@ describe('createAuditHandlers — audit-entries', () => {
     expect(response.status).toBe(404);
   });
 
-  it('returns correlated detail entries', async () => {
+  it('returns a correlated summary page', async () => {
     server.use(...createAuditHandlers(BASE));
     const response = await fetch(`${BASE}/audit-entries/correlation/corr-1`);
-    const details = (await response.json()) as AuditEntryDetailResponse[];
-    expect(Array.isArray(details)).toBe(true);
-    expect(details.length).toBe(2);
-    expect(details[0]).toHaveProperty('entityChanges');
+    const page = (await response.json()) as AuditPage;
+    expect(page.totalCount).toBe(2);
+    expect(page.items.length).toBe(2);
+    // Summary projection — no full entity-change hierarchy, just the count.
+    expect(page.items[0]).toHaveProperty('entityChangeCount');
+    expect(page.items[0]).not.toHaveProperty('entityChanges');
   });
 
   it('returns a per-entity audit trail page', async () => {

--- a/packages/@granit/react-auditing/src/__tests__/use-audit-query-engine.test.tsx
+++ b/packages/@granit/react-auditing/src/__tests__/use-audit-query-engine.test.tsx
@@ -13,7 +13,7 @@ import {
 import { AuditEntityChangesProvider } from '../providers/audit-entity-changes-provider';
 import { AuditLogProvider } from '../providers/audit-log-provider';
 
-import type { AuditEntryDetailResponse, AuditPage } from '@granit/auditing';
+import type { AuditPage } from '@granit/auditing';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -76,17 +76,19 @@ describe('useAuditEntityChanges (query engine)', () => {
 });
 
 describe('useAuditEntriesByCorrelation', () => {
-  it('fetches correlated detail entries', async () => {
+  it('fetches a correlated summary page', async () => {
     const client = createMockClient();
-    const details: AuditEntryDetailResponse[] = [];
-    vi.mocked(client.get).mockResolvedValue(axiosResponse(details));
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(emptyPage));
 
-    const { result } = renderHook(() => useAuditEntriesByCorrelation('corr-1'), {
+    const { result } = renderHook(() => useAuditEntriesByCorrelation('corr-1', { page: 1 }), {
       wrapper: auditWrapper(client),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/api/v1/auditing/audit-entries/correlation/corr-1');
+    expect(result.current.data).toEqual(emptyPage);
+    expect(client.get).toHaveBeenCalledWith('/api/v1/auditing/audit-entries/correlation/corr-1', {
+      params: { page: 1 },
+    });
   });
 
   it('does not fetch when correlationId is empty', () => {

--- a/packages/@granit/react-auditing/src/hooks/use-audit-log.ts
+++ b/packages/@granit/react-auditing/src/hooks/use-audit-log.ts
@@ -91,10 +91,10 @@ export function useEntityAuditTrail(
 }
 
 /**
- * Get all audit entries sharing a distributed-tracing correlation ID.
+ * Get the audit entries sharing a distributed-tracing correlation ID (paginated).
  *
- * Returns full detail entries (with entity changes), newest-first — useful for
- * tracing a single logical transaction across services.
+ * Returns summary projections, newest-first — useful for tracing a single logical
+ * transaction across services. Fetch a single entry's full detail by id.
  *
  * @example
  * ```tsx
@@ -102,16 +102,17 @@ export function useEntityAuditTrail(
  * ```
  */
 export function useAuditEntriesByCorrelation(
-  correlationId: string
-): UseQueryResult<readonly AuditEntryDetailResponse[]> {
+  correlationId: string,
+  params?: PaginationParams
+): UseQueryResult<AuditPage> {
   const config = useAuditLogConfig();
   const auditEntriesPath = `${config.basePath}/audit-entries`;
 
   return useQuery({
-    queryKey: buildAuditLogQueryKey(config, 'correlation', correlationId),
+    queryKey: buildAuditLogQueryKey(config, 'correlation', correlationId, params),
     queryFn: () => {
       logger.debug('Fetching audit entries by correlation', { correlationId });
-      return getAuditEntriesByCorrelationId(config.client, auditEntriesPath, correlationId);
+      return getAuditEntriesByCorrelationId(config.client, auditEntriesPath, correlationId, params);
     },
     enabled: correlationId.length > 0,
   });

--- a/packages/@granit/react-auditing/src/testing/handlers.ts
+++ b/packages/@granit/react-auditing/src/testing/handlers.ts
@@ -263,10 +263,18 @@ export function createAuditHandlers(baseUrl = DEFAULT_BASE_PATH) {
       );
     }),
 
-    // GET /audit-entries/correlation/:correlationId — correlated detail set
-    http.get(`${auditEntriesUrl}/correlation/:correlationId`, () =>
-      HttpResponse.json(mockAuditEntries.slice(0, 2).map(toDetail))
-    ),
+    // GET /audit-entries/correlation/:correlationId — correlated summary page
+    http.get(`${auditEntriesUrl}/correlation/:correlationId`, ({ request }) => {
+      const url = new URL(request.url);
+      const page = Number(url.searchParams.get('page') ?? 1);
+      const pageSize = Number(url.searchParams.get('pageSize') ?? 25);
+      const correlated = mockAuditEntries.slice(0, 2);
+      const start = (page - 1) * pageSize;
+      return pagedResponse<AuditEntryResponse>(
+        correlated.slice(start, start + pageSize),
+        correlated.length
+      );
+    }),
 
     // POST /audit-entries/pseudonymize/:userId — GDPR pseudonymization (204)
     http.post(


### PR DESCRIPTION
## Context

Backend PR **granit-dotnet#2956** (merged) refactored the Granit.Auditing pipeline. The only contract change touching the front is the correlation endpoint:

`GET /auditing/audit-entries/correlation/{correlationId}`
- **Before:** unpaginated `List<AuditEntryDetailResponse>` (full detail hierarchy)
- **After:** paginated `PagedResult<AuditEntryResponse>` (summary projection: id, timestamp, userId, userName, category, ipAddress, tenantId, correlationId, entityChangeCount) with `page` / `pageSize` query params

Full detail (with entity changes) is still obtained per-id via `useAuditLogEntry`.

Permissions unchanged. No i18n impact (the front never resolves the backend problem-details keys). The `AuditCategoryValue` / `AuditChangeTypeValue` hand-written unions already model exactly the now-typed OpenAPI enums, so types were left untouched.

## Changes

- `getAuditEntriesByCorrelationId` → returns `AuditPage`, accepts optional `PaginationParams`
- `useAuditEntriesByCorrelation` → `UseQueryResult<AuditPage>`, propagates `params` into the query key + client call
- MSW correlation handler → serves a paged summary honoring `page` / `pageSize`
- Tests updated (core API, hook, MSW handler conformance)
- Resynced `contracts/openapi/auditing.json` from the rebuilt backend generator (paged response schema, typed `AuditCategory` / `AuditChangeType` enum `$ref`s)

## Verification

- ✅ `vitest run` — 633 tests pass (`@granit/auditing`, `@granit/react-auditing`, `@granit/contract-tests`)
- ✅ `tsc --noEmit` clean on both packages
- ✅ `eslint --max-warnings 0` clean

granit-showcase-react needs no mandatory change — it inherits the corrected MSW handler via the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)